### PR TITLE
Crossref report as FAILED if generate_status is False.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -106,7 +106,7 @@ class activity_DepositCrossref(activity.activity):
                 self.outbox_status = True
                             
         # Set the activity status of this activity based on successes
-        if self.publish_status is not False:
+        if self.publish_status is not False and self.generate_status is not False:
             self.activity_status = True
         else:
             self.activity_status = False


### PR DESCRIPTION
On crossref generation failure report as FAILED in the email message.
