### PR TITLE
Temporary disable ArticleToFluidinfo for incoming JATS format.

### DIFF
--- a/workflow/workflow_PublishArticle.py
+++ b/workflow/workflow_PublishArticle.py
@@ -62,17 +62,6 @@ class workflow_PublishArticle(workflow.workflow):
 					"start_to_close_timeout": 60*5
 				},
 				{
-					"activity_type": "ArticleToFluidinfo",
-					"activity_id": "ArticleToFluidinfo",
-					"version": "1",
-					"input": data,
-					"control": None,
-					"heartbeat_timeout": 300,
-					"schedule_to_close_timeout": 300,
-					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 300
-				},
-				{
 					"activity_type": "LensArticle",
 					"activity_id": "LensArticle",
 					"version": "1",
@@ -104,3 +93,17 @@ class workflow_PublishArticle(workflow.workflow):
 		
 		self.load_definition(workflow_definition)
 
+		"""
+		# Removed from before LensArticle temporarily
+				{
+					"activity_type": "ArticleToFluidinfo",
+					"activity_id": "ArticleToFluidinfo",
+					"version": "1",
+					"input": data,
+					"control": None,
+					"heartbeat_timeout": 300,
+					"schedule_to_close_timeout": 300,
+					"schedule_to_start_timeout": 300,
+					"start_to_close_timeout": 300
+				},
+		"""


### PR DESCRIPTION
Turn off ArticleToFluidinfo until the parser is JATS compatible.
