### PR TITLE
xml_files.txt workflow back on, and a fix for requests library upgrade

### DIFF
--- a/activity/activity_LensXMLFilesList.py
+++ b/activity/activity_LensXMLFilesList.py
@@ -55,8 +55,8 @@ class activity_LensXMLFilesList(activity.activity):
     f.write(xml_list_content)
     f.close
     
-    # Save the document to the elife-lens bucket
-    bucket_name = self.settings.lens_bucket
+    # Save the document to the elife-cdn bucket
+    bucket_name = self.settings.cdn_bucket
     
     # Connect to S3
     s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)

--- a/provider/filesystem.py
+++ b/provider/filesystem.py
@@ -102,7 +102,7 @@ class Filesystem(object):
 			path_array = o.path.split('/')
 			filename = path_array[-1]
 		
-		r = requests.get(document_url, prefetch=False)
+		r = requests.get(document_url, stream=True)
 		mode = "wb"
 		f = self.open_file_from_tmp_dir(filename, mode)
 		for block in r.iter_content(1024):

--- a/workflow/workflow_LensIndexPublish.py
+++ b/workflow/workflow_LensIndexPublish.py
@@ -71,28 +71,6 @@ class workflow_LensIndexPublish(workflow.workflow):
 					"schedule_to_close_timeout": 300,
 					"schedule_to_start_timeout": 300,
 					"start_to_close_timeout": 300
-				},
-				{
-					"activity_type": "LensDocumentsJS",
-					"activity_id": "LensDocumentsJS",
-					"version": "1",
-					"input": data,
-					"control": None,
-					"heartbeat_timeout": 300,
-					"schedule_to_close_timeout": 300,
-					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 300
-				},
-{
-					"activity_type": "LensCDNInvalidation",
-					"activity_id": "LensCDNInvalidation",
-					"version": "1",
-					"input": data,
-					"control": None,
-					"heartbeat_timeout": 300,
-					"schedule_to_close_timeout": 300,
-					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 300
 				}
 			],
 		

--- a/workflow/workflow_PublishArticle.py
+++ b/workflow/workflow_PublishArticle.py
@@ -82,6 +82,17 @@ class workflow_PublishArticle(workflow.workflow):
 					"schedule_to_close_timeout": 60*5,
 					"schedule_to_start_timeout": 300,
 					"start_to_close_timeout": 60*5
+				},
+				{
+					"activity_type": "LensXMLFilesList",
+					"activity_id": "LensXMLFilesList",
+					"version": "1",
+					"input": data,
+					"control": None,
+					"heartbeat_timeout": 60,
+					"schedule_to_close_timeout": 60*5,
+					"schedule_to_start_timeout": 60*5,
+					"start_to_close_timeout": 60*5
 				}
 			],
 		


### PR DESCRIPTION
xml_files.txt file will get generated at the end of two workflows.

Also, old requests library was still around and had a bug. Updating the live environments to requests=2.5.3 with this pull request.