### PR TITLE
Extend PublishPOA workflow and activity timeout.

### DIFF
--- a/starter/starter_PublishPOA.py
+++ b/starter/starter_PublishPOA.py
@@ -38,7 +38,7 @@ class starter_PublishPOA():
         workflow_name = "PublishPOA"
         workflow_version = "1"
         child_policy = None
-        execution_start_to_close_timeout = None
+        execution_start_to_close_timeout = str(60*35)
         input = None
 
         try:

--- a/workflow/workflow_PublishPOA.py
+++ b/workflow/workflow_PublishPOA.py
@@ -19,7 +19,7 @@ class workflow_PublishPOA(workflow.workflow):
 		self.name = "PublishPOA"
 		self.version = "1"
 		self.description = "Publish POA articles workflow"
-		self.default_execution_start_to_close_timeout = 60*20
+		self.default_execution_start_to_close_timeout = 60*35
 		self.default_task_start_to_close_timeout = 30
 
 		# Get the input from the JSON decision response
@@ -56,10 +56,10 @@ class workflow_PublishPOA(workflow.workflow):
 					"version": "1",
 					"input": data,
 					"control": None,
-					"heartbeat_timeout": 60*15,
-					"schedule_to_close_timeout": 60*15,
+					"heartbeat_timeout": 60*30,
+					"schedule_to_close_timeout": 60*30,
 					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 60*15
+					"start_to_close_timeout": 60*30
 				},
 				{
 					"activity_type": "DepositCrossref",
@@ -67,10 +67,10 @@ class workflow_PublishPOA(workflow.workflow):
 					"version": "1",
 					"input": data,
 					"control": None,
-					"heartbeat_timeout": 60*15,
-					"schedule_to_close_timeout": 60*15,
+					"heartbeat_timeout": 60*5,
+					"schedule_to_close_timeout": 60*5,
 					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 60*15
+					"start_to_close_timeout": 60*5
 				}
 			],
 		


### PR DESCRIPTION
To deliver large data supplement files, the packaging and FTP activity is extended from 15 minutes to 30 minutes. The workflow overall is extended from 20 minutes to 35 minutes.