### PR TITLE
Support for elifetools 0.1.3

### DIFF
--- a/provider/article.py
+++ b/provider/article.py
@@ -712,8 +712,8 @@ class article(object):
     for author in authors:
       if authors_string != "":
         authors_string += ", "
-      if author.get("given_names"):
-        authors_string += author["given_names"] + " "
+      if author.get("given-names"):
+        authors_string += author["given-names"] + " "
       if author.get("surname"):
         authors_string += author["surname"]
       if author.get("collab"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests==2.5.3
 wsgiref==0.1.2
 lxml==3.4.1
 xlrd==0.9.3
-elifetools==0.1.2
+-e git+https://github.com/elifesciences/elife-tools.git@exp#egg=elifetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests==2.5.3
 wsgiref==0.1.2
 lxml==3.4.1
 xlrd==0.9.3
--e git+https://github.com/elifesciences/elife-tools.git@exp#egg=elifetools
+elifetools==0.1.3


### PR DESCRIPTION
For current bot activities running in production this fixes the only known impact: a change to the "given-names" variable name in elifetools 0.1.3.

requirements.txt is bumped to use elifetools==0.1.3 in order to support crossref VoR and future PMC deposit activities.