### PR TITLE
Crossref deposit updates

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -24,6 +24,7 @@ from boto.s3.connection import S3Connection
 
 import provider.simpleDB as dblib
 import provider.article as articlelib
+import provider.s3lib as s3lib
 
 """
 DepositCrossref activity
@@ -150,7 +151,7 @@ class activity_DepositCrossref(activity.activity):
         s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(bucket_name)
         
-        s3_key_names = self.get_s3_key_names_from_bucket(
+        s3_key_names = s3lib.get_s3_key_names_from_bucket(
             bucket          = bucket,
             prefix          = self.outbox_folder,
             file_extensions = file_extensions)
@@ -170,53 +171,6 @@ class activity_DepositCrossref(activity.activity):
             f = open(filename_plus_path, mode)
             s3_key.get_contents_to_file(f)
             f.close()
-        
-    def get_s3_key_names_from_bucket(self, bucket, prefix = None, delimiter = '/', headers = None, file_extensions = None):
-        """
-        Given a connected boto bucket object, and optional parameters,
-        from the prefix (folder name), get the s3 key names for
-        non-folder objects, optionally that match a particular
-        list of file extensions
-        """
-        s3_keys = []
-        s3_key_names = []
-        
-        # Get a list of S3 objects
-        bucketList = bucket.list(prefix = prefix, delimiter = delimiter, headers = headers)
-
-        for item in bucketList:
-          if(isinstance(item, boto.s3.key.Key)):
-            # Can loop through each prefix and search for objects
-            s3_keys.append(item)
-        
-        # Convert to key names instead of objects to make it testable later
-        for key in s3_keys:
-            s3_key_names.append(key.name)
-        
-        # Filter by file_extension
-        if file_extensions is not None:
-            s3_key_names = self.filter_list_by_file_extensions(s3_key_names, file_extensions)
-            
-        return s3_key_names
-    
-    def filter_list_by_file_extensions(self, s3_key_names, file_extensions):
-        """
-        Given a list of s3_key_names, and a list of file_extensions
-        filter out all but the allowed file extensions
-        Each file extension should start with a . dot
-        """
-        good_s3_key_names = []
-        for name in s3_key_names:
-            match = False
-            for ext in file_extensions:
-                # Match file extension as the end of the string and escape the dot
-                pattern = ".*\\" + ext + "$"
-                if(re.search(pattern, name) is not None):
-                    match = True
-            if match is True:
-                good_s3_key_names.append(name)
-        
-        return good_s3_key_names
         
     def parse_article_xml(self, article_xml_files):
         """
@@ -394,7 +348,7 @@ class activity_DepositCrossref(activity.activity):
         s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(bucket_name)
         
-        s3_key_names = self.get_s3_key_names_from_bucket(
+        s3_key_names = s3lib.get_s3_key_names_from_bucket(
             bucket          = bucket,
             prefix          = self.outbox_folder)
         

--- a/cron.py
+++ b/cron.py
@@ -46,6 +46,12 @@ def run_cron(ENV = "dev"):
       workflow_id   = "S3Monitor",
       start_seconds = 60*31)
     
+    workflow_conditional_start(
+      ENV           = ENV,
+      starter_name  = "starter_DepositCrossref",
+      workflow_id   = "DepositCrossref",
+      start_seconds = 60*31)
+    
     pass
   
   elif(current_time.tm_min >= 30 and current_time.tm_min <= 59):


### PR DESCRIPTION
Supports future crossref VoR deposits. The changes here are,
 
- Check the article pub date is either not present,  or today or before today
- Only remove the processed files from the outbox
- One article per batch file (with the latest POA generation library these batch files have a new name)
- Clean up to use the general purpose S3 library code
- Schedule DepositCrossref workflow to happen each hour, instead of only once per day after PoA publication