### PR TITLE
Fixes for PublicationEmail

### DIFF
--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -56,10 +56,10 @@ class workflow_PublicationEmail(workflow.workflow):
 					"version": "1",
 					"input": data,
 					"control": None,
-					"heartbeat_timeout": 60*5,
-					"schedule_to_close_timeout": 60*5,
+					"heartbeat_timeout": 60*10,
+					"schedule_to_close_timeout": 60*10,
 					"schedule_to_start_timeout": 300,
-					"start_to_close_timeout": 60*5
+					"start_to_close_timeout": 60*10
 				}
 			],
 		


### PR DESCRIPTION
An issue when setting the related article to an article, it now looks for the XML of that related article via HTTP. The old method was depending on and xml.zip file in the elife-articles bucket, which is no longer a reliable source to find the XML file.

Also increased the timeout of PublicationEmail to allow more processing time up to 10 minutes.