### PR TITLE
Publication email related article parsing improvements

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -261,6 +261,10 @@ class activity_PublicationEmail(activity.activity):
               article.set_related_insight_article(related_article)
             else:
               # Could not find the related article
+              if(self.logger):
+                log_info = "Could not build the article related to insight " + doi
+                self.admin_email_content += "\n" + log_info
+                self.logger.info(log_info)
               remove_article_doi.append(article.doi)
             
     # Can remove articles now if required

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -262,7 +262,7 @@ class activity_PublicationEmail(activity.activity):
             else:
               # Could not find the related article
               if(self.logger):
-                log_info = "Could not build the article related to insight " + doi
+                log_info = "Could not build the article related to insight " + article.doi
                 self.admin_email_content += "\n" + log_info
                 self.logger.info(log_info)
               remove_article_doi.append(article.doi)


### PR DESCRIPTION
An occasional error recently, when looking for an article related to a published Insight article, it would not parse. One reason is the related article is still PoA status, and the XML to parse is not available.

This ignores sending email about the Insight if the XML is not available where VoR is found, and it also adds more detail to the log if this happens.