### PR TITLE
Pre-deploy tweaks

### DIFF
--- a/activity/activity_PreprocessArticle.py
+++ b/activity/activity_PreprocessArticle.py
@@ -963,8 +963,8 @@ class activity_PreprocessArticle(activity.activity):
                 if href and len(href.split('.')) <= 1:
                     
                     # Default extension
-                    extension = '.tif'
-                    # extension = ''
+                    #extension = '.tif'
+                    extension = ''
                     
                     if int(doi_id) == 2020 or int(doi_id) == 3318:
                         # 02020

--- a/provider/article.py
+++ b/provider/article.py
@@ -624,6 +624,19 @@ class article(object):
     
   def check_is_article_published(self, doi, is_poa, was_ever_poa, article_url = None):
       """
+      NOTE: With a new URL scheme set to launch, this function must be disabled
+      until it can be switched to lax as the data source
+      but we can keep the tests running too for now
+      """
+      if article_url:
+        # Running tests
+        return self.check_is_article_published_by_url(doi, is_poa, was_ever_poa, article_url)
+      else:
+        # Live
+        return False
+      
+  def check_is_article_published_by_url(self, doi, is_poa, was_ever_poa, article_url = None):
+      """
       For each article XML downloaded from S3, check if it is published
       Also needs to know whether the article is POA or was ever POA'ed
         article_url can be supplied for testing without making live HTTP requests

--- a/workflow/workflow_PublishPerfectArticle.py
+++ b/workflow/workflow_PublishPerfectArticle.py
@@ -94,10 +94,10 @@ class workflow_PublishPerfectArticle(workflow.workflow):
                         "version": "1",
                         "input": data,
                         "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
+                        "heartbeat_timeout": 60 * 8,
+                        "schedule_to_close_timeout": 60 * 8,
                         "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
+                        "start_to_close_timeout": 60 * 8
                     },
                     {
                         "activity_type": "DepositAssets",


### PR DESCRIPTION
- Do not add .tif to XML file name ending for now
- Extend ResizeImages from 5 minutes to 8 minute timeout
- Disable the "is article published" during the transition period, because it will not function well with the new URL scheme as written