### PR TITLE
Hotfix poa xml parse

### DIFF
--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -112,7 +112,8 @@ class activity_PublishFinalPOA(activity.activity):
                         # One possible error is an entirely blank XML file or a malformed xml file
                         if self.logger:
                             self.logger.exception("Exception when converting XML for doi %s, %s" %
-                                                  str(doi_id), e.message)
+                                                  (str(doi_id), e.message))
+                        continue
                     
                 revision = self.next_revision_number(doi_id)
                 zip_file_name = self.new_zip_file_name(doi_id, revision)

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -106,7 +106,11 @@ class activity_PublishFinalPOA(activity.activity):
                 
                 if article_xml_file_name:
                     xml_file = self.INPUT_DIR + os.sep + article_xml_file_name
-                    self.convert_xml(doi_id, xml_file, filenames, new_filenames)
+                    try:
+                        self.convert_xml(doi_id, xml_file, filenames, new_filenames)
+                    except ParseError:
+                        # One possible error is an entirely blank XML file or a malformed xml file
+                        continue
                     
                 revision = self.next_revision_number(doi_id)
                 zip_file_name = self.new_zip_file_name(doi_id, revision)

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -108,9 +108,11 @@ class activity_PublishFinalPOA(activity.activity):
                     xml_file = self.INPUT_DIR + os.sep + article_xml_file_name
                     try:
                         self.convert_xml(doi_id, xml_file, filenames, new_filenames)
-                    except ParseError:
+                    except Exception as e:
                         # One possible error is an entirely blank XML file or a malformed xml file
-                        continue
+                        if self.logger:
+                            self.logger.exception("Exception when converting XML for doi %s, %s" %
+                                                  str(doi_id), e.message)
                     
                 revision = self.next_revision_number(doi_id)
                 zip_file_name = self.new_zip_file_name(doi_id, revision)


### PR DESCRIPTION
Issue is if the XML file generated for PoA is empty (0 bytes) then it fails to parse when trying to convert the XML.

This hotfix will ignore the failed XML file and continue to process the good XML files that are part of the daily batch.