### PR TITLE
Feature pub router deposits

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -117,7 +117,9 @@ class activity_PubRouterDeposit(activity.activity):
         # Send email to admins with the status
         self.activity_status = True
         self.send_admin_email()
-        self.send_friendly_email(self.workflow, self.articles_approved)
+        
+        if len(self.articles_approved) > 0:
+            self.send_friendly_email(self.workflow, self.articles_approved)
 
         # Return the activity result, True or False
         result = True

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -130,6 +130,10 @@ class activity_PubRouterDeposit(activity.activity):
             return "cengage/outbox/"
         elif workflow == "GoOA":
             return "gooa/outbox/"
+        elif workflow == "WoS":
+            return "wos/outbox/"
+        elif workflow == "Scopus":
+            return "scopus/outbox/"
 
         return None
 
@@ -143,6 +147,10 @@ class activity_PubRouterDeposit(activity.activity):
             return "cengage/published/"
         elif workflow == "GoOA":
             return "gooa/published/"
+        elif workflow == "WoS":
+            return "wos/published/"
+        elif workflow == "Scopus":
+            return "scopus/published/"
 
         return None
 

--- a/cron.py
+++ b/cron.py
@@ -76,6 +76,22 @@ def run_cron(ENV="dev"):
             workflow_id="S3Monitor_FullArticle",
             start_seconds=60 * 31)
 
+        # Web of Science deposits once per day 21:30 UTC
+        if current_time.tm_hour == 21:
+            workflow_conditional_start(
+                ENV=ENV,
+                starter_name="starter_PubRouterDeposit",
+                workflow_id="PubRouterDeposit_WoS",
+                start_seconds=60 * 31)
+
+        # Scopus deposits once per day 22:30 UTC
+        if current_time.tm_hour == 22:
+            workflow_conditional_start(
+                ENV=ENV,
+                starter_name="starter_PubRouterDeposit",
+                workflow_id="PubRouterDeposit_Scopus",
+                start_seconds=60 * 31)
+
     if current_time.tm_min >= 45 and current_time.tm_min <= 59:
         # Bottom quarter of the hour
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -415,6 +415,10 @@ class article(object):
             published_folder = "cengage/published/"
         if workflow == "GoOA":
             published_folder = "gooa/published/"
+        if workflow == "WoS":
+            published_folder = "wos/published/"
+        if workflow == "Scopus":
+            published_folder = "scopus/published/"
 
         file_extensions = []
         file_extensions.append(".xml")

--- a/provider/blacklist.py
+++ b/provider/blacklist.py
@@ -502,4 +502,7 @@ def pub_router_deposit_article_blacklist(workflow):
     elif workflow == "GoOA":
         article_blacklist = []
 
+    else:
+        article_blacklist = []
+
     return article_blacklist

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -63,7 +63,9 @@ class starter_PubRouterDeposit():
 
         if (workflow == 'HEFCE'
                 or workflow == 'Cengage'
-                or workflow == 'GoOA'):
+                or workflow == 'GoOA'
+                or workflow == 'WoS'
+                or workflow == 'Scopus'):
             workflow_id = "PubRouterDeposit_" + workflow
 
         # workflow_id as set above


### PR DESCRIPTION
Automate pub router deposits again.

Use PMC zip file as the initial source of pub router deposits. Send a new friendly email to recipients with a list of DOI processed. Run once a day, as usual.

Also add Web of Science and Scopus as recipients.

This is tested separately and is going into deployment to master directly.