### PR TITLE
Fixes ApplyVersionNumber error monitor event

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -76,9 +76,10 @@ class activity_ApplyVersionNumber(activity.activity):
         except Exception as e:
             self.logger.exception("Exception when applying version number to article")
             self.emit_monitor_event(self.settings, article_id, version, run,
-                                    "Convert JATS", "error",
+                                    "Apply Version Number", "error",
                                     "Error in applying version number to files for " + article_id +
                                     " message:" + e.message)
+            return False
 
         return True
 


### PR DESCRIPTION
Replaces wrong activity reference with right one. And returns False when there is an exception. 

@gnott , @jhroot 