### PR TITLE
ELPP-851

### DIFF
--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -151,7 +151,7 @@ class activity_ExpandArticle(activity.activity):
 
     def get_next_version(self, article_id):
         url = self.settings.lax_article_versions.replace('{article_id}', article_id)
-        response = requests.get(url)
+        response = requests.get(url, verify=self.settings.verify_ssl)
         if response.status_code == 200:
             high_version = 0
             data = response.json()

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -364,7 +364,7 @@ class activity_PublishFinalPOA(activity.activity):
         date_str = None
         article_id = str(doi_id).zfill(5)
         url = self.settings.lax_article_versions.replace('{article_id}', article_id)
-        response = requests.get(url)
+        response = requests.get(url, verify=self.settings.verify_ssl)
         if response.status_code == 200:
 
             data = response.json()

--- a/activity/activity_UpdateLAX.py
+++ b/activity/activity_UpdateLAX.py
@@ -46,7 +46,7 @@ class activity_UpdateLAX(activity.activity):
             headers = {"Content-type": "application/json", "Accept": "application/json"}
             response = requests.post(lax_update_endpoint, data=eif, headers=headers,
                                      auth=(self.settings.lax_update_user,
-                                           self.settings.lax_update_pass))
+                                           self.settings.lax_update_pass), verify=self.settings.verify_ssl)
 
             if response.status_code is not 200:
                 self.emit_monitor_event(self.settings, article_id, version, run,

--- a/settings-example.py
+++ b/settings-example.py
@@ -52,6 +52,7 @@ class exp():
     lax_update = 'http://2015-09-03.lax.elifesciences.org/api/v1/import/article/'
     lax_update_user = ''
     lax_update_pass = ''
+    verify_ssl = True # False when testing
 
     no_download_extensions = 'tif'
 


### PR DESCRIPTION
request will not verify certificate when we are testing since we can't get a certificate for the test sites.

http://jira.elifesciences.org:8080/browse/ELPP-851?filter=-1

Since there aren't enough certificates available for all sites, Luke requested that we have a flag to not require ssl certificate when in dev.

@gnott , @jhroot 