### PR TITLE
elementtree is in the standard library

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,6 @@ Python dependencies should be installed with `pip` using:
     
     $ pip install -r requirements.txt
 
-And for the library `elementtree` which is not part of Pypi
-
-    $ pip install elementtree --allow-external elementtree --allow-unverified elementtree
-
 # Configure
 
 Resave settings-example.py as settings.py, and enter your aws credentials.

--- a/tests/features/003_reqs.feature
+++ b/tests/features/003_reqs.feature
@@ -19,6 +19,6 @@ Feature: Use python imports and requirements
     | elife-poa-xml-generation
     | git
     | arrow
-    | elementtree
+    | xml.etree
     | PyPDF2
     | wsgiref


### PR DESCRIPTION
The package is called `xml.etree` and indeed Python 2.7 provides it by default. The code of elife-bot correctly refers to it as `xml.etree`.
@gnott 