### PR TITLE
Committing empty root for temporary folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 ftp-credentials.txt
 *.log
 *.pyc
+*.swp
 settings.py
 .boto
-tmp
+tests/tmp/*
 venv
 .idea
 workflow-context/*

--- a/provider/filesystem.py
+++ b/provider/filesystem.py
@@ -195,9 +195,9 @@ class Filesystem(object):
         if self.tmp_dir:
             try:
                 os.mkdir(self.tmp_dir)
-            except OSError:
+            except OSError as e:
                 # Directory may already exist, happens when running tests, check if it exists
                 if os.path.isdir(self.tmp_dir):
-                    self.tmp_dir = self.tmp_dir
+                    return
                 else:
-                    self.tmp_dir = None
+                    raise e


### PR DESCRIPTION
The tests create many temporary folders such as
`tests/tmp/016-05-10.07.52.15.filesystem_unzip`. However, their
parent `tests/tmp/` is not created by default, and the mkdir fails.

The behavior of Filesystem in case of creation error didn't
make sense:
- assignment of a variable to itself
- ignoring the error and nullifying the field in case
it already exists, although its name should be randomly
generated

Finally, .gitignore also precisely ignores the
content of that folder and Vim swap files.