### PR TITLE
Test scripts

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,9 @@
 #±/bin/bash
 set -e
-source ../venv/bin/activate
+source venv/bin/activate
+cd tests/
 for i in `ls features/*.feature`; do echo $i; lettuce $i -v 1; done
+cd -
+bash ./travis-test.sh
+ 
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,3 @@
+#±/bin/bash
+source ../venv/bin/activate
+for i in `ls features/*.feature`; do echo $i; lettuce $i -v 1; done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,3 +1,5 @@
 #±/bin/bash
+set -e
 source ../venv/bin/activate
 for i in `ls features/*.feature`; do echo $i; lettuce $i -v 1; done
+


### PR DESCRIPTION
This test script will be used in CI environments. It runs `lettuce` tests one by one to avoid `Segmentation fault` errors, and then the `unittest` ones in `travis-test.sh`.

The script stops at the first error, propagating the exit code indicating the test failure.

@gnott 