### PR TITLE
Adds expiration for redis key

### DIFF
--- a/provider/execution_context.py
+++ b/provider/execution_context.py
@@ -37,10 +37,12 @@ class FileSession(object):
 
 class RedisSession(object):
     def __init__(self, settings):
+        self.expire_key = settings.redis_expire_key
         self.r = redis.StrictRedis(host=settings.redis_host, port=settings.redis_port, db=settings.redis_db)
 
     def store_value(self, execution_id, key, value):
         self.r.hset(execution_id, key, value)
+        self.r.expire(execution_id, self.expire_key)
 
     def get_value(self, execution_id, key):
         return self.r.hget(execution_id,key)

--- a/settings-example.py
+++ b/settings-example.py
@@ -175,6 +175,12 @@ class exp():
     # Session
     session_class = "RedisSession"
 
+    # Redis
+    redis_host = "127.0.0.1"
+    redis_port = 6379
+    redis_db = 0
+    redis_expire_key = 86400  # seconds
+
 
 class dev():
 
@@ -306,6 +312,12 @@ class dev():
     # Session
     session_class = "RedisSession"
 
+    # Redis
+    redis_host = "127.0.0.1"
+    redis_port = 6379
+    redis_db = 0
+    redis_expire_key = 86400  # seconds
+
 
 class live():
     # AWS settings
@@ -435,6 +447,12 @@ class live():
 
     # Session
     session_class = "RedisSession"
+
+    # Redis
+    redis_host = "127.0.0.1"
+    redis_port = 6379
+    redis_db = 0
+    redis_expire_key = 86400  # seconds
 
 
 def get_settings(ENV="dev"):


### PR DESCRIPTION
@jhroot - I set expire to 24h for the redis key (in this case, the execution id)

I also have updated that in the builder.