### PR TITLE
Fix for the caching of old CSV data by PackagePOA activity

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -475,6 +475,8 @@ class activity_PackagePOA(activity.activity):
         # Now we can continue with imports
         self.elife_poa_lib.xml = importlib.import_module(dir_name + ".xml_generation")
         self.reload_module(self.elife_poa_lib.xml)
+        self.elife_poa_lib.csv = importlib.import_module(dir_name + ".parseCSVFiles")
+        self.reload_module(self.elife_poa_lib.csv)
         self.elife_poa_lib.transform = importlib.import_module(dir_name +
                                                                ".transform-ejp-zip-to-hw-zip")
         self.reload_module(self.elife_poa_lib.transform)


### PR DESCRIPTION
In PackagePOA, explicitly reloading the parseCSVFiles module of the elife-poa-xml-generation library has the effect to unmemoize the old cached CSV data from the @memoize decorator. This should fix it so each activity run will start with no memoize data and still use any advantages of memoize when accessing the CSV data.