### PR TITLE
Hotfix clean tmp dir

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -123,11 +123,12 @@ class activity_FTPArticle(activity.activity):
                 self.logger.exception('exception in FTPArticle, data: %s' %
                                       json.dumps(data, sort_keys=True, indent=4))
             result = False
+            self.clean_tmp_dir()
             return result
 
         # Return the activity result, True or False
         result = True
-
+        self.clean_tmp_dir()
         return result
 
     def set_ftp_settings(self, doi_id, workflow):

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -118,6 +118,7 @@ class activity_PackagePOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
+        self.clean_tmp_dir()
         return result
 
     def get_doi_id_from_doi(self, doi):

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -118,7 +118,10 @@ class activity_PackagePOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
-        self.clean_tmp_dir()
+
+        if self.activity_status is True:
+            self.clean_tmp_dir()
+
         return result
 
     def get_doi_id_from_doi(self, doi):

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -131,7 +131,7 @@ class activity_PublishFinalPOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
-
+        self.clean_tmp_dir()
         return result
 
     def new_filenames(self, doi_id, filenames):

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -131,7 +131,10 @@ class activity_PublishFinalPOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
-        self.clean_tmp_dir()
+
+        if self.activity_status is True:
+            self.clean_tmp_dir()
+
         return result
 
     def new_filenames(self, doi_id, filenames):

--- a/activity/activity_PublishPOA.py
+++ b/activity/activity_PublishPOA.py
@@ -170,7 +170,7 @@ class activity_PublishPOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
-
+        self.clean_tmp_dir()
         return result
 
     def download_files_from_s3_outbox(self):

--- a/activity/activity_PublishPOA.py
+++ b/activity/activity_PublishPOA.py
@@ -170,7 +170,10 @@ class activity_PublishPOA(activity.activity):
 
         # Return the activity result, True or False
         result = True
-        self.clean_tmp_dir()
+
+        if self.activity_status is True:
+            self.clean_tmp_dir()
+
         return result
 
     def download_files_from_s3_outbox(self):

--- a/activity/activity_UnzipFullArticle.py
+++ b/activity/activity_UnzipFullArticle.py
@@ -76,6 +76,7 @@ class activity_UnzipFullArticle(activity.activity):
         if self.logger:
             self.logger.info('UnzipFullArticle: %s' % self.elife_id)
 
+        self.clean_tmp_dir()
         return True
 
     def is_document_poa_status(self, document):


### PR DESCRIPTION
This hotfix will clean files from the activity tmp dir on a few problem causing activities. Either over a short time, or due to FTP connection issues, the instance disk can fill up to 100% causing everything to grind to a halt. Adding activity self.clean_tmp_dir() at the end of the activity will make this fail more gracefully.

Tested on dev environment and ready to merge into master.
