### PR TITLE
Uniforming cli interface to accept -f parameter

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -34,6 +34,7 @@ def main():
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
                       help="set the environment to run, either dev or live")
+    parser.add_option("-f", "--forks", default=5, action="store", type="int", dest="forks", help="specify the number of forks to start")
     (options, args) = parser.parse_args()
     if options.env:
         env = options.env
@@ -48,7 +49,7 @@ def main():
     # Simple connect
     queue = get_queue()
 
-    pool = Pool(settings.workflow_starter_queue_pool_size, initialise_pool, [env])
+    pool = Pool(options['forks'], initialise_pool, [env])
 
     while True:
         messages = queue.get_messages(num_messages=settings.workflow_starter_queue_message_count, visibility_timeout=60,

--- a/scripts/run_env.sh
+++ b/scripts/run_env.sh
@@ -11,5 +11,5 @@ alias ..='cd ..'
 source /opt/elife-bot/venv/bin/activate && python decider.py -f 3 -e $1 &
 source /opt/elife-bot/venv/bin/activate && python worker.py -f 5 -e $1 &
 source /opt/elife-bot/venv/bin/activate && python queue_worker.py -f 3 -e $1 &
-source /opt/elife-bot/venv/bin/activate && python queue_workflow_starter.py -e $1 &
+source /opt/elife-bot/venv/bin/activate && python queue_workflow_starter.py -f 5 -e $1 &
 source /opt/elife-bot/venv/bin/activate && python shimmy.py -e $1 &

--- a/shimmy.py
+++ b/shimmy.py
@@ -117,6 +117,7 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
                       help="set the environment to run, either dev or live")
+    parser.add_option("-f", "--forks", default=1, action="store", type="int", dest="forks", help="specify the number of forks to start")
 
     (options, args) = parser.parse_args()
     if options.env:


### PR DESCRIPTION
This is an intermediate step as -f will become always 1 in the future (and hence removed) while upstart manages the number of processes.