### PR TITLE
Minimal process management

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string",
                       dest="env", help="set the environment to run, either dev or live")
-    parser.add_option("-f", "--forks", default=10, action="store", type="int",
+    parser.add_option("-f", "--forks", default=1, action="store", type="int",
                       dest="forks", help="specify the number of forks to start")
     (options, args) = parser.parse_args()
     if options.env:

--- a/queue_worker.py
+++ b/queue_worker.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
                       help="set the environment to run, either dev or live")
-    parser.add_option("-f", "--forks", default=10, action="store", type="int", dest="forks",
+    parser.add_option("-f", "--forks", default=1, action="store", type="int", dest="forks",
                       help="specify the number of forks to start")
     (options, args) = parser.parse_args()
     if options.env:

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -48,21 +48,14 @@ def main():
     # Simple connect
     queue = get_queue()
 
-    pool = Pool(settings.workflow_starter_queue_pool_size, initialise_pool, [env])
-
     while True:
-        messages = queue.get_messages(num_messages=settings.workflow_starter_queue_message_count, visibility_timeout=60,
+        messages = queue.get_messages(1, visibility_timeout=60,
                                       wait_time_seconds=20)
-        if messages is not None:
+        if messages:
             logger.info(str(len(messages)) + " message received")
-            pool.map(process_message, messages)
+            process_message(messages[0])
         else:
             logger.debug("No messages received")
-
-def initialise_pool(*args):
-    """ Explicitly set each pool process global variable """
-    global env
-    env = args[0]
 
 def get_queue():
     conn = boto.sqs.connect_to_region(settings.sqs_region,

--- a/worker.py
+++ b/worker.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
     # Add options
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env", help="set the environment to run, either dev or live")
-    parser.add_option("-f", "--forks", default=10, action="store", type="int", dest="forks", help="specify the number of forks to start")
+    parser.add_option("-f", "--forks", default=1, action="store", type="int", dest="forks", help="specify the number of forks to start")
     (options, args) = parser.parse_args()
     if options.env:
         ENV = options.env


### PR DESCRIPTION
Summarizing what we discovered/discussed so far.

- The test pipeline requires deployment to be fully automated, so that at each new push we can run test without someone logging in into a machine and restarting processes.
- Upstart is the standard daemon at this time that Luke chose to automate the long-running processes. The dashboard already uses it.
- Upstart does not play well with processes that create multiple children: to fully manage their start/stop/restart it wants a single layer of processes under it.
- We want to have configuration of the number of processes in one place.
- There aren't costs associated with multiple SWF workers, and there are some in the order of units of dollars/month for multiple SQS workers.

Therefore:
- this minimal change make it so that any of the 5 processes (worker, queue_worker, queue_workflow_starter, decider, shimmy), when called without an `-f` argument, does not create children and stays single-threaded.
- since `queue_workflow_starter` did not have such an argument, I tried to make a temporary change for making it single-process.
- https://github.com/elifesciences/elife-builder/pull/175 can be merged right after this.
- The Salt configuration will provide the number of processes, which will then vanish from the configuration when specified, or become actually configurable if it was hardcoded in the script.
- This is intended as a *minimal* change; if it gets into `develop` I will then go on in cleaning up the related code, greatly simplifying all 5 processes, removing the `-f` argument, modifying/deleting `scripts/run_env.sh` to avoid redundancy.

Take a look around, to bring stability to our deployments I intend to go ahead with the start of next week if there are no objections, in the spirit of Ian's last email on unblocking decisions.