### PR TITLE
Retry on 429 response code (throttling)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths=tests

--- a/shimmy.py
+++ b/shimmy.py
@@ -15,104 +15,104 @@ logging.basicConfig(filename='shimmy.log', level=logging.INFO)
 class ShortRetryException(RuntimeError):
     pass
 
-def listen():
+class Shimmy:
+    def __init__(self, settings):
+        self._settings = settings
 
-    global settings
-    settings = settings_lib.get_settings(ENV)
+    def listen(self):
+        conn = boto.sqs.connect_to_region(self._settings.sqs_region,
+                                          aws_access_key_id=self._settings.aws_access_key_id,
+                                          aws_secret_access_key=self._settings.aws_secret_access_key)
+        input_queue = conn.get_queue(self._settings.website_ingest_queue)
+        output_queue = conn.get_queue(self._settings.workflow_starter_queue)
+        if input_queue is not None:
+            while True:
 
-    conn = boto.sqs.connect_to_region(settings.sqs_region,
-                                      aws_access_key_id=settings.aws_access_key_id,
-                                      aws_secret_access_key=settings.aws_secret_access_key)
-    input_queue = conn.get_queue(settings.website_ingest_queue)
-    output_queue = conn.get_queue(settings.workflow_starter_queue)
-    if input_queue is not None:
-        while True:
+                logging.debug('reading queue')
+                queue_message = input_queue.read(visibility_timeout=60, wait_time_seconds=20)
 
-            logging.debug('reading queue')
-            queue_message = input_queue.read(visibility_timeout=60, wait_time_seconds=20)
+                if queue_message is not None:
+                    logging.debug('got message id: %s', queue_message.id)
+                    try:
+                        self.process_message(queue_message, output_queue)
+                        queue_message.delete()
+                    except ShortRetryException as e:
+                        logging.info('short retry: %s because of %s', queue_message.id, e)
+                        queue_message.change_visibility(visibility_timeout=10)
 
-            if queue_message is not None:
-                logging.debug('got message id: %s', queue_message.id)
-                try:
-                    process_message(queue_message, output_queue)
-                    queue_message.delete()
-                except ShortRetryException as e:
-                    logging.info('short retry: %s because of %s', queue_message.id, e)
-                    queue_message.change_visibility(visibility_timeout=10)
-
-    else:
-        logging.error("Could not obtain queue, exiting")
-
-
-def process_message(message, output_queue):
-
-    # extract parameters from message
-    message_data = json.loads(str(message.get_body()))
-    bucket = message_data.get("eif_bucket")
-    filename = message_data.get("eif_filename")
-    passthrough = message_data.get("passthrough")
-
-    if bucket is None or filename is None or passthrough is None:
-        logging.error("Message format incorrect:")
-        logging.error(message_data)
-        return
-
-    # slurp EIF file from S3 into memory
-    eif = slurp_eif(bucket, filename)
-    post_eif(eif, bucket, filename, passthrough, output_queue)
-
-def post_eif(eif, bucket, filename, passthrough, output_queue):
-    # call drupal with EIF
-    ingest_endpoint = settings.drupal_EIF_endpoint
-    auth = None
-    if settings.drupal_update_user and settings.drupal_update_user != '':
-        auth = requests.auth.HTTPBasicAuth(settings.drupal_update_user,
-                                           settings.drupal_update_pass)
-        logging.debug("Requests auth set for user %s", settings.drupal_update_user)
-    headers = {'content-type': 'application/json'}
-    response = requests.post(ingest_endpoint, data=eif, headers=headers, auth=auth)
-    logging.debug("Reponse code was %s . Reason was %s", response.status_code, response.reason)
-
-    if response.status_code == 200:
-
-        ingest_publish = response.json().get('publish')
-        workflow_data = {
-            'eif_filename': filename,
-            'eif_bucket':  bucket,
-            'article_id': passthrough.get("article_id"),
-            'version': passthrough.get("version"),
-            'run': passthrough.get("run"),
-            'article_path': passthrough.get("article_path"),
-            'expanded_folder': passthrough.get("expanded_folder"),
-            'status': passthrough.get("status"),
-            'update_date': passthrough.get("update_date"),
-            'published': ingest_publish
-        }
-        response_message = {
-            "workflow_name": "ArticleInformationSupplier",
-            "workflow_data": workflow_data
-        }
-
-        m = Message()
-        m.set_body(json.dumps(response_message))
-        output_queue.write(m)
-    elif response.status_code == 429:
-        raise ShortRetryException("Response code was %s" % response.status_code)
-    else:
-        logging.error("Status code from ingest is %s", response.status_code)
-        logging.error("Article not sent for ingestion %s", passthrough)
+        else:
+            logging.error("Could not obtain queue, exiting")
 
 
-def slurp_eif(bucketname, filename):
+    def process_message(self, message, output_queue):
 
-    conn = S3Connection(settings.aws_access_key_id,
-                        settings.aws_secret_access_key)
+        # extract parameters from message
+        message_data = json.loads(str(message.get_body()))
+        bucket = message_data.get("eif_bucket")
+        filename = message_data.get("eif_filename")
+        passthrough = message_data.get("passthrough")
 
-    bucket = conn.get_bucket(bucketname)
-    key = Key(bucket)
-    key.key = filename
-    json_output = key.get_contents_as_string()
-    return json_output
+        if bucket is None or filename is None or passthrough is None:
+            logging.error("Message format incorrect:")
+            logging.error(message_data)
+            return
+
+        # slurp EIF file from S3 into memory
+        eif = self.slurp_eif(bucket, filename)
+        self.post_eif(eif, bucket, filename, passthrough, output_queue)
+
+    def post_eif(self, eif, bucket, filename, passthrough, output_queue):
+        # call drupal with EIF
+        ingest_endpoint = self._settings.drupal_EIF_endpoint
+        auth = None
+        if self._settings.drupal_update_user and self._settings.drupal_update_user != '':
+            auth = requests.auth.HTTPBasicAuth(self._settings.drupal_update_user,
+                                               self._settings.drupal_update_pass)
+            logging.debug("Requests auth set for user %s", self._settings.drupal_update_user)
+        headers = {'content-type': 'application/json'}
+        response = requests.post(ingest_endpoint, data=eif, headers=headers, auth=auth)
+        logging.debug("Reponse code was %s . Reason was %s", response.status_code, response.reason)
+
+        if response.status_code == 200:
+
+            ingest_publish = response.json().get('publish')
+            workflow_data = {
+                'eif_filename': filename,
+                'eif_bucket':  bucket,
+                'article_id': passthrough.get("article_id"),
+                'version': passthrough.get("version"),
+                'run': passthrough.get("run"),
+                'article_path': passthrough.get("article_path"),
+                'expanded_folder': passthrough.get("expanded_folder"),
+                'status': passthrough.get("status"),
+                'update_date': passthrough.get("update_date"),
+                'published': ingest_publish
+            }
+            response_message = {
+                "workflow_name": "ArticleInformationSupplier",
+                "workflow_data": workflow_data
+            }
+
+            m = Message()
+            m.set_body(json.dumps(response_message))
+            output_queue.write(m)
+        elif response.status_code == 429:
+            raise ShortRetryException("Response code was %s" % response.status_code)
+        else:
+            logging.error("Status code from ingest is %s", response.status_code)
+            logging.error("Article not sent for ingestion %s", passthrough)
+
+
+    def slurp_eif(self, bucketname, filename):
+
+        conn = S3Connection(self._settings.aws_access_key_id,
+                            self._settings.aws_secret_access_key)
+
+        bucket = conn.get_bucket(bucketname)
+        key = Key(bucket)
+        key.key = filename
+        json_output = key.get_contents_as_string()
+        return json_output
 
 
 if __name__ == "__main__":
@@ -126,4 +126,6 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
     if options.env:
         ENV = options.env
-        listen()
+        settings = settings_lib.get_settings(ENV)
+        shimmy = Shimmy(settings)
+        shimmy.listen()

--- a/shimmy.py
+++ b/shimmy.py
@@ -6,10 +6,8 @@ from boto.s3.connection import S3Connection
 import requests
 from requests.auth import HTTPBasicAuth
 import logging
-import settings as settings_lib
 import json
 
-settings = None
 logging.basicConfig(filename='shimmy.log', level=logging.INFO)
 
 class ShortRetryException(RuntimeError):
@@ -20,6 +18,7 @@ class Shimmy:
         self._settings = settings
 
     def listen(self):
+        logging.info("started")
         conn = boto.sqs.connect_to_region(self._settings.sqs_region,
                                           aws_access_key_id=self._settings.aws_access_key_id,
                                           aws_secret_access_key=self._settings.aws_secret_access_key)
@@ -126,6 +125,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
     if options.env:
         ENV = options.env
+        settings_lib = __import__('settings')
         settings = settings_lib.get_settings(ENV)
         shimmy = Shimmy(settings)
         shimmy.listen()

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -14,9 +14,11 @@ def delete_folder(folder, recursively=False):
         os.rmdir(folder)
 
 
-def delete_files_in_folder(folder):
+def delete_files_in_folder(folder, filter_out=[]):
     file_list = os.listdir(folder)
     for file_name in file_list:
+        if file_name in filter_out:
+            continue
         if os.path.isfile(folder+"/"+file_name):
             os.remove(folder+"/"+file_name)
 

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -3,7 +3,6 @@ from activity.activity_ExpandArticle import activity_ExpandArticle
 from activity.activity import activity
 import settings_mock
 from mock import mock, patch
-from testfixtures import TempDirectory
 from testfixtures import tempdir, compare
 import os
 from classes_mock import FakeStorageContext

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -20,7 +20,7 @@ class TestExpandArticle(unittest.TestCase):
         self.create_temp_folder(testdata.ExpandArticle_path)
 
     def tearDown(self):
-        helpers.delete_files_in_folder('tests/tmp')
+        helpers.delete_files_in_folder('tests/tmp', filter_out=['.keepme'])
         helpers.delete_files_in_folder(testdata.ExpandArticle_files_dest_folder)
         helpers.delete_folder(testdata.ExpandArticle_files_dest_folder)
 

--- a/tests/activity/test_activity_post_eif_bridge.py
+++ b/tests/activity/test_activity_post_eif_bridge.py
@@ -16,6 +16,9 @@ class tests_PostEIFBridge(unittest.TestCase):
     def setUp(self):
         self.activity_PostEIFBridge = activity_PostEIFBridge(settings_mock, None, None, None, None)
 
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
     @patch('boto.sqs.connect_to_region')
     @patch('activity.activity_PostEIFBridge.Message')
     def test_activity_published_article(self, mock_sqs_message, mock_sqs_connect):

--- a/tests/activity/test_activity_prepare_post_eif.py
+++ b/tests/activity/test_activity_prepare_post_eif.py
@@ -7,7 +7,6 @@ from classes_mock import FakeSQSConn
 from classes_mock import FakeSQSMessage
 from classes_mock import FakeSQSQueue
 import classes_mock
-from testfixtures import TempDirectory
 import json
 import base64
 

--- a/tests/test_shimmy.py
+++ b/tests/test_shimmy.py
@@ -2,6 +2,7 @@ import unittest
 import logging
 import requests
 import shimmy
+from shimmy import Shimmy
 import activity
 #from .activity import classes_mock
 from mock import Mock, patch
@@ -17,8 +18,9 @@ class FakeResponse:
 
 class tests_Shimmy(unittest.TestCase):
     def setUp(self):
-        shimmy.settings = Mock()
-        shimmy.settings.drupal_EIF_endpoint = 'http://example.com/article.json'
+        settings = Mock()
+        settings.drupal_EIF_endpoint = 'http://example.com/article.json'
+        self.shimmy = Shimmy(settings)
         self.queue = Mock()
 
     @patch.object(logging, 'error')
@@ -49,7 +51,7 @@ class tests_Shimmy(unittest.TestCase):
         self.queue.write.assert_not_called()
 
     def _post_some_eif(self):
-        return lambda: shimmy.post_eif(
+        return lambda: self.shimmy.post_eif(
             '{"field":"value"}',
             None,
             None,

--- a/tests/test_shimmy.py
+++ b/tests/test_shimmy.py
@@ -1,0 +1,58 @@
+import unittest
+import logging
+import requests
+import shimmy
+import activity
+#from .activity import classes_mock
+from mock import Mock, patch
+from pprint import pprint
+
+class FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.reason = 'This is fake'
+
+    def json(self):
+        return {}
+
+class tests_Shimmy(unittest.TestCase):
+    def setUp(self):
+        shimmy.settings = Mock()
+        shimmy.settings.drupal_EIF_endpoint = 'http://example.com/article.json'
+        self.queue = Mock()
+
+    @patch.object(logging, 'error')
+    @patch.object(requests, 'post')
+    def test_200_response_code(self, post, error):
+        post.return_value = FakeResponse(200)
+        attempt = self._post_some_eif()
+        attempt()
+        error.assert_not_called()
+        assert self.queue.write.called
+
+    @patch.object(logging, 'error')
+    @patch.object(requests, 'post')
+    def test_429_response_code(self, post, error):
+        post.return_value = FakeResponse(429)
+        attempt = self._post_some_eif()
+        self.assertRaises(shimmy.ShortRetryException, attempt)
+        error.assert_not_called()
+        self.queue.write.assert_not_called()
+
+    @patch.object(logging, 'error')
+    @patch.object(requests, 'post')
+    def test_500_response_code(self, post, error):
+        post.return_value = FakeResponse(500)
+        attempt = self._post_some_eif()
+        attempt()
+        assert(error.called)
+        self.queue.write.assert_not_called()
+
+    def _post_some_eif(self):
+        return lambda: shimmy.post_eif(
+            '{"field":"value"}',
+            None,
+            None,
+            { },
+            self.queue
+        )

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e # everything must succeed.
+ln -s settings-example.py settings.py
 pip install -r requirements.txt
 git clone https://github.com/elifesciences/elife-poa-xml-generation.git ../elife-poa-xml-generation
 cp ../elife-poa-xml-generation/example-settings.py ../elife-poa-xml-generation/settings.py

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e # everything must succeed.
-ln -s settings-example.py settings.py
 pip install -r requirements.txt
 git clone https://github.com/elifesciences/elife-poa-xml-generation.git ../elife-poa-xml-generation
 cp ../elife-poa-xml-generation/example-settings.py ../elife-poa-xml-generation/settings.py

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python -m pytest --junitxml=build/junit.xml tests/
+python -m pytest --junitxml=build/junit.xml


### PR DESCRIPTION
The end2end tests evidenced that this can happen, despite the shimmy
being a single process. In this case, we stop processing the message and
let it go back to the queue for a retry.

Testing the logic with unit tests, more difficult to actually test the
integration with SQS. There may be a better way of triggering a retry,
and this logic targets 10 seconds from the 429 error.