### PR TITLE
Removed get_status_from_zip_filename from lettuce tests as it's depre…

### DIFF
--- a/tests/features/060_activity_ExpandArticle.feature
+++ b/tests/features/060_activity_ExpandArticle.feature
@@ -47,20 +47,3 @@ Feature: ExpandArticle activity
     | env | filename                                | version  
     | dev | elife-07702-vor-r4.zip                  | None    
     | dev | elife-00013-vor-v1-20121015000000.zip   | 1
-    
-  Scenario: Get the status from an article zip filename using an ExpandArticle activity object
-    Given I have imported a settings module
-    And I have the settings environment <env>
-    And I get the settings
-    And I have the activity name ExpandArticle
-    And I have the activityId ExpandArticle_test
-    And I have an activity object
-    And I have the filename <filename>
-    When I get status from the filename using the activity object
-    Then I see the string <status>
-  
-  Examples:
-    | env | filename                                | status  
-    | dev | elife-07702-vor-r4.zip                  | vor    
-    | dev | elife-00013-vor-v1-20121015000000.zip   | vor
-    | dev | elife-02112-poa-v1-20140508000000.zip   | poa

--- a/tests/features/activity_steps.py
+++ b/tests/features/activity_steps.py
@@ -265,7 +265,3 @@ def i_get_update_date_from_the_filename_using_the_activity_object(step):
 @step(u'I get version from the filename using the activity object')
 def i_get_version_from_the_filename_using_the_activity_object(step):
     world.string = world.activity_object.get_version_from_zip_filename(world.filename)
-    
-@step(u'I get status from the filename using the activity object')
-def i_get_status_from_the_filename_using_the_activity_object(step):
-    world.string = world.activity_object.get_status_from_zip_filename(world.filename)


### PR DESCRIPTION
…cated

This function used to be used in ExpandArticle and now it's been replaced with ArticleInfo. See https://github.com/elifesciences/elife-bot/commit/ec877df06b0c3cd8b2616c82e88882d163937368

@gnott - I am removing the function from your tests since I don't use it in ExpandArticle anymore. It was removed on this commit https://github.com/elifesciences/elife-bot/commit/ec877df06b0c3cd8b2616c82e88882d163937368