### PR TITLE
Tweaks for article_structure lettuce tests to pass.

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -36,7 +36,7 @@ class ArticleInfo(object):
         (self.filename, self.extension) = full_filename.rsplit('.', 1)
         parts = self.filename.split('-')
 
-        match = re.match('.*?-[0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)(-([0-9]+))?\.zip', self.full_filename, re.IGNORECASE)
+        match = re.match('.*?-[0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)?(-([0-9]+))?\.zip', self.full_filename, re.IGNORECASE)
         first_other_index = 2
         if match is not None:
             self.status = match.group(1)

--- a/tests/features/101_provider_article_structure.feature
+++ b/tests/features/101_provider_article_structure.feature
@@ -14,6 +14,6 @@ Feature: Use article_structure as to examine filenames
     | elife-00012-vor-r1.zip               | elife-00012-vor-r1    | zip        | ArticleZip  | 00012
     | elife-00123-poa.zip                  | elife-00123-poa       | zip        | ArticleZip  | 00123
     | elife-00288-supp-v1.zip              | elife-00288-supp-v1   | zip        | Other       | 00288
-    | elife-00012-poa.xml                  | elife-00012-poa       | xml        | ArticleXML       | 00012
+    | elife-00012-v1.xml                   | elife-00012-v1        | xml        | ArticleXML  | 00012
     | elife-00012-fig3-figsupp1.tiff  | elife-00012-fig3-figsupp1  | tiff | Figure | 00012
 

--- a/tests/features/article_structure_steps.py
+++ b/tests/features/article_structure_steps.py
@@ -13,6 +13,7 @@ def step_impl(step, filename):
 
 @step("It exposes the correct (\S+), (\S+), (\S+) and (\S+)")
 def step_impl(step, filename, extension, file_type, f_id):
+    assert world.article.filename == filename
     assert world.article.file_type == file_type
     assert world.article.extension == extension
     print world.article.file_type


### PR DESCRIPTION
The main edit is in the regexp in article_structure.py: it makes the -v1 / -r1 file name part optional again. This allows the existing test to pass (even though we do not current read zip files with no r or v value, it was an existing test condition).

The other tweaks were to improve the tests with expected data and checking all attributes.