### PR TITLE
Feature image resize to disk

### DIFF
--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -5,6 +5,7 @@ from mimetypes import guess_type
 import activity
 import boto.swf
 import log
+import os
 import provider.imageresize as resizer
 import yaml
 from boto.s3.connection import S3Connection
@@ -108,8 +109,12 @@ class activity_ResizeImages(activity.activity):
             self.generate_images(formats, fp, info, cdn_path)
 
     def get_file_pointer(self, key):
-        fp = StringIO.StringIO()
+        file_name = key.name.split('/')[-1]
+        file_path = self.get_tmp_dir() + os.sep + file_name
+        fp = open(file_path, mode='wb')
         key.get_file(fp)
+        fp.close()
+        fp = open(file_path, mode='r')
         return fp
 
 

--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -109,7 +109,7 @@ class activity_ResizeImages(activity.activity):
             self.generate_images(formats, fp, info, cdn_path)
 
     def get_file_pointer(self, key):
-        file_name = key.name.split('/')[-1]
+        file_name = key.name.replace('/', '-')
         file_path = self.get_tmp_dir() + os.sep + file_name
         fp = open(file_path, mode='wb')
         key.get_file(fp)

--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -114,6 +114,8 @@ class activity_ResizeImages(activity.activity):
         fp = open(file_path, mode='wb')
         key.get_file(fp)
         fp.close()
+        assert key.size == os.path.getsize(file_path), \
+                ("The file size of the local cached copy does not correspond to the original size on S3 of %s. This points to a corrupted download, check what's in %s" % (key.name, file_path))
         fp = open(file_path, mode='r')
         return fp
 

--- a/tests/activity/test_activity_resize_images.py
+++ b/tests/activity/test_activity_resize_images.py
@@ -1,4 +1,7 @@
+import pkgutil
+import sys
 import unittest
+import pytest
 from activity.activity_ResizeImages import activity_ResizeImages
 import settings_mock
 from mock import mock, patch
@@ -9,9 +12,10 @@ import classes_mock
 import shutil
 import unicodedata
 from PIL import Image
-import settings as settingsLib
 from boto.s3.connection import S3Connection
-settings = settingsLib.get_settings()
+if pkgutil.find_loader('settings'):
+    import settings as settingsLib
+    settings = settingsLib.get_settings()
 
 
 class TestResizeImages(unittest.TestCase):
@@ -59,6 +63,7 @@ class TestResizeImages(unittest.TestCase):
                     real_width, real_height = self.get_image_dimensions(fname)
                     self.assertEqual(width, real_width)
 
+    @pytest.mark.skipif('settings' not in sys.modules, reason='settings.py config not available to run the test on a real S3 bucket')
     def test_get_file_pointer_gives_a_local_pointer_to_a_full_copy_of_the_file(self):
         key = self.sample_bucket_key_for_a_tif_file()
         fp = self.resizeimages.get_file_pointer(key)
@@ -97,10 +102,10 @@ class TestResizeImages(unittest.TestCase):
 
     def sample_bucket_key_for_a_tif_file(self):
         conn = S3Connection(settings.aws_access_key_id,
-                        settings.aws_secret_access_key,
-                        host=settings.s3_hostname)
+                            settings.aws_secret_access_key,
+                            host=settings.s3_hostname)
         bucket = conn.get_bucket(settings.publishing_buckets_prefix +
-                                      settings.expanded_bucket)
+                                 settings.expanded_bucket)
         return bucket.get_key('00003.1/4676d5c8-8949-40bf-b055-b51fdffafd0a/elife-00003-fig5-v1.tif')
 
 

--- a/tests/activity/test_activity_resize_images.py
+++ b/tests/activity/test_activity_resize_images.py
@@ -9,6 +9,9 @@ import classes_mock
 import shutil
 import unicodedata
 from PIL import Image
+import settings as settingsLib
+from boto.s3.connection import S3Connection
+settings = settingsLib.get_settings()
 
 
 class TestResizeImages(unittest.TestCase):
@@ -56,6 +59,13 @@ class TestResizeImages(unittest.TestCase):
                     real_width, real_height = self.get_image_dimensions(fname)
                     self.assertEqual(width, real_width)
 
+    def test_get_file_pointer_gives_a_local_pointer_to_a_full_copy_of_the_file(self):
+        key = self.sample_bucket_key_for_a_tif_file()
+        fp = self.resizeimages.get_file_pointer(key)
+        with fp:
+            blob = fp.read()
+            self.assertEqual(key.size, len(blob))
+
     def load_to_cdn(self, filename, image, cdn_path, download):
         with open('tests/test_cdn/' + filename, 'w') as fd:
             image.seek(0)
@@ -84,6 +94,15 @@ class TestResizeImages(unittest.TestCase):
             return width, height
         except Exception as e:
             return
+
+    def sample_bucket_key_for_a_tif_file(self):
+        conn = S3Connection(settings.aws_access_key_id,
+                        settings.aws_secret_access_key,
+                        host=settings.s3_hostname)
+        bucket = conn.get_bucket(settings.publishing_buckets_prefix +
+                                      settings.expanded_bucket)
+        return bucket.get_key('00003.1/4676d5c8-8949-40bf-b055-b51fdffafd0a/elife-00003-fig5-v1.tif')
+
 
 
 class FakeKey:


### PR DESCRIPTION
May improve the reliability of a downloaded image, since in end2end tests we sometimes attempt to resize a corrupted one.