### PR TITLE
Uniforming shimmy logs to all the others processes

### DIFF
--- a/log.py
+++ b/log.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import random
 
 def logger(logFile = None, setLevel = "INFO", identity = ""):
     """
@@ -18,3 +19,6 @@ def logger(logFile = None, setLevel = "INFO", identity = ""):
     logger.addHandler(hdlr)
     logger.setLevel(eval("logging." + setLevel))
     return logger
+
+def identity(process_name):
+    return "%s_%s" % (process_name, int(random.random() * 1000))

--- a/shimmy.py
+++ b/shimmy.py
@@ -6,20 +6,23 @@ from boto.s3.connection import S3Connection
 import requests
 from requests.auth import HTTPBasicAuth
 from provider import process
-import logging
+import log
 import json
 
-logging.basicConfig(filename='shimmy.log', level=logging.INFO)
+
+identity = log.identity('shimmy')
+logger = log.logger('shimmy.log', 'INFO', identity)
 
 class ShortRetryException(RuntimeError):
     pass
 
 class Shimmy:
-    def __init__(self, settings):
+    def __init__(self, settings, logger):
         self._settings = settings
+        self.logger = logger
 
     def listen(self, flag):
-        logging.info("started")
+        self.logger.info("started")
         conn = boto.sqs.connect_to_region(self._settings.sqs_region,
                                           aws_access_key_id=self._settings.aws_access_key_id,
                                           aws_secret_access_key=self._settings.aws_secret_access_key)
@@ -28,22 +31,22 @@ class Shimmy:
         if input_queue is not None:
             while flag.green():
 
-                logging.debug('reading queue')
+                self.logger.debug('reading queue')
                 queue_message = input_queue.read(visibility_timeout=60, wait_time_seconds=20)
 
                 if queue_message is not None:
-                    logging.debug('got message id: %s', queue_message.id)
+                    self.logger.debug('got message id: %s', queue_message.id)
                     try:
                         self.process_message(queue_message, output_queue)
                         queue_message.delete()
                     except ShortRetryException as e:
-                        logging.info('short retry: %s because of %s', queue_message.id, e)
+                        self.logger.info('short retry: %s because of %s', queue_message.id, e)
                         queue_message.change_visibility(visibility_timeout=10)
 
             logger.info("graceful shutdown")
 
         else:
-            logging.error("Could not obtain queue, exiting")
+            self.logger.error("Could not obtain queue, exiting")
 
 
     def process_message(self, message, output_queue):
@@ -55,8 +58,8 @@ class Shimmy:
         passthrough = message_data.get("passthrough")
 
         if bucket is None or filename is None or passthrough is None:
-            logging.error("Message format incorrect:")
-            logging.error(message_data)
+            self.logger.error("Message format incorrect:")
+            self.logger.error(message_data)
             return
 
         # slurp EIF file from S3 into memory
@@ -70,10 +73,10 @@ class Shimmy:
         if self._settings.drupal_update_user and self._settings.drupal_update_user != '':
             auth = requests.auth.HTTPBasicAuth(self._settings.drupal_update_user,
                                                self._settings.drupal_update_pass)
-            logging.debug("Requests auth set for user %s", self._settings.drupal_update_user)
+            self.logger.debug("Requests auth set for user %s", self._settings.drupal_update_user)
         headers = {'content-type': 'application/json'}
         response = requests.post(ingest_endpoint, data=eif, headers=headers, auth=auth)
-        logging.debug("Reponse code was %s . Reason was %s", response.status_code, response.reason)
+        self.logger.debug("Reponse code was %s . Reason was %s", response.status_code, response.reason)
 
         if response.status_code == 200:
 
@@ -101,10 +104,10 @@ class Shimmy:
         elif response.status_code == 429:
             raise ShortRetryException("Response code was %s" % response.status_code)
         else:
-            logging.error("Status code from ingest is %s", response.status_code)
-            logging.error("Article not sent for ingestion %s", passthrough.get("article_id"))
-            logging.error("Response body for ingest: %s", response.text)
-            logging.error("Data sent (first 500 characters): %s", str(eif)[:500])
+            self.logger.error("Status code from ingest is %s", response.status_code)
+            self.logger.error("Article not sent for ingestion %s", passthrough.get("article_id"))
+            self.logger.error("Response body for ingest: %s", response.text)
+            self.logger.error("Data sent (first 500 characters): %s", str(eif)[:500])
 
 
     def slurp_eif(self, bucketname, filename):
@@ -131,5 +134,5 @@ if __name__ == "__main__":
     ENV = options.env
     settings_lib = __import__('settings')
     settings = settings_lib.get_settings(ENV)
-    shimmy = Shimmy(settings)
+    shimmy = Shimmy(settings, logger)
     process.monitor_interrupt(lambda flag: shimmy.listen(flag))

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,12 @@
+import logging
+import log
+import unittest
+
+class TestLog(unittest.TestCase):
+    def test_logger_creation(self):
+        logger = log.logger('worker.log', 'INFO', 'worker_123')
+        self.assertIsInstance(logger, logging.Logger)
+
+    def test_identity_generation(self):
+        self.assertRegexpMatches(log.identity('worker'), '^worker_[0-9]+$')
+


### PR DESCRIPTION
While I was debugging 500 errors from the website, I found that this log
lacked the time label over each line, which the other processes have.
So I set out to make it use the same `log` module as them.