### PR TITLE
Elpp 1056

### DIFF
--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -44,7 +44,7 @@ class activity_DepositAssets(activity.activity):
             expanded_bucket = conn.get_bucket(expanded_folder_bucket)
             cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
 
-            no_download_extensions = [x.strip() for x in self.settings.no_download_extensions.split(',')]
+            no_download_extensions = self.get_no_download_extensions(self.settings.no_download_extensions)
 
             keys = self.get_keys(expanded_bucket, expanded_folder_name)
             for key in keys:
@@ -73,6 +73,9 @@ class activity_DepositAssets(activity.activity):
             return False
 
         return True
+
+    def get_no_download_extensions(self, no_download_extensions):
+        return [x.strip() for x in no_download_extensions.split(',')]
 
     @staticmethod
     def get_keys(bucket, expanded_folder_name):

--- a/tests/activity/test_activity_deposit_assets.py
+++ b/tests/activity/test_activity_deposit_assets.py
@@ -1,0 +1,21 @@
+import unittest
+from activity.activity_DepositAssets import activity_DepositAssets
+import settings_mock
+from ddt import ddt, data, unpack
+
+
+@ddt
+class TestDepositAssets(unittest.TestCase):
+    def setUp(self):
+        self.depositassets = activity_DepositAssets(settings_mock, None, None, None, None)
+
+    @unpack
+    @data({'input': '.tif', 'expected': ['.tif']},
+          {'input': '.jpg, .tiff, .png', 'expected':['.jpg', '.tiff', '.png']})
+    def test_get_no_download_extensions(self, input, expected):
+        result = self.depositassets.get_no_download_extensions(input)
+        self.assertListEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/activity/test_schedule_cross_ref.py
+++ b/tests/activity/test_schedule_cross_ref.py
@@ -1,0 +1,25 @@
+import unittest
+from activity.activity_ScheduleCrossref import activity_ScheduleCrossref
+import settings_mock
+
+
+class TestsScheduleCrossRef(unittest.TestCase):
+    def setUp(self):
+        self.schedulecrossref = activity_ScheduleCrossref(settings_mock, None, None, None, None)
+
+    def test_new_crossref_xml_name(self):
+        result = self.schedulecrossref.new_crossref_xml_name(self.schedulecrossref.crossref_outbox_folder,
+                                                             'elife',
+                                                              str('00353').zfill(5))
+
+        self.assertEqual(result, 'crossref/outbox/elife00353.xml')
+
+    def test_new_crossref_xml_name_type_error(self):
+        result = self.schedulecrossref.new_crossref_xml_name(self.schedulecrossref.crossref_outbox_folder,
+                                                             'elife',
+                                                              353)
+        self.assertRaises(TypeError)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/features/060_activity_ExpandArticle.feature
+++ b/tests/features/060_activity_ExpandArticle.feature
@@ -14,36 +14,3 @@ Feature: ExpandArticle activity
   Examples:
     | env          
     | dev          
-
-
-  Scenario: Get the update date from an article zip filename using an ExpandArticle activity object
-    Given I have imported a settings module
-    And I have the settings environment <env>
-    And I get the settings
-    And I have the activity name ExpandArticle
-    And I have the activityId ExpandArticle_test
-    And I have an activity object
-    And I have the filename <filename>
-    When I get update date from the filename using the activity object
-    Then I see the string <update_date>
-  
-  Examples:
-    | env | filename                                | update_date  
-    | dev | elife-07702-vor-r4.zip                  | None    
-    | dev | elife-00013-vor-v1-20121015000000.zip   | 2012-10-15T00:00:00Z
-
-  Scenario: Get the version from an article zip filename using an ExpandArticle activity object
-    Given I have imported a settings module
-    And I have the settings environment <env>
-    And I get the settings
-    And I have the activity name ExpandArticle
-    And I have the activityId ExpandArticle_test
-    And I have an activity object
-    And I have the filename <filename>
-    When I get version from the filename using the activity object
-    Then I see the string <version>
-  
-  Examples:
-    | env | filename                                | version  
-    | dev | elife-07702-vor-r4.zip                  | None    
-    | dev | elife-00013-vor-v1-20121015000000.zip   | 1

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -1,0 +1,26 @@
+import unittest
+from ddt import ddt, data, unpack
+from provider.article_structure import ArticleInfo
+
+
+@ddt
+class TestArticleStructure(unittest.TestCase):
+
+    @unpack
+    @data({'input': 'elife-07702-vor-r4.zip', 'expected': None},
+          {'input': 'elife-00013-vor-v1-20121015000000.zip', 'expected':'2012-10-15T00:00:00Z'})
+    def test_get_update_date_from_zip_filename(self, input, expected):
+        self.articleinfo = ArticleInfo(input)
+        result = self.articleinfo.get_update_date_from_zip_filename()
+        self.assertEqual(result, expected)
+
+    @unpack
+    @data({'input': 'elife-07702-vor-r4.zip', 'expected': None},
+          {'input': 'elife-00013-vor-v1-20121015000000.zip', 'expected': '1'})
+    def test_get_version_from_zip_filename(self, input, expected):
+        self.articleinfo = ArticleInfo(input)
+        result = self.articleinfo.get_version_from_zip_filename()
+        self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -28,3 +28,5 @@ ses_poa_recipient_email = ""
 
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
 verify_ssl = False
+
+no_download_extensions = 'tif'


### PR DESCRIPTION
Some tests for deposit assets, schedule crossref (not many);|
removed lettuce tests that were breaking the build and replaced them with unit test (tests/provider/test_article_structure.py)