### PR TITLE
Elpp 469 - article xml updated automatically to github 

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -61,7 +61,8 @@ class activity_UpdateRepository(activity.activity):
 
         try:
             xml_file = article_xml_repo.get_contents(filename)
-        except GithubException:
+        except GithubException as e:
+            self.logger.info("GithubException - description: " + e.message)
             self.logger.info("GithubException: file " + filename + " may not exist in github yet. We will try to add it in the repo.")
             response = article_xml_repo.create_file("/" + filename, "Adds XML first time", content)
             self.logger.info("File " + filename + " successfully added. Commit: " + response)
@@ -78,7 +79,7 @@ class activity_UpdateRepository(activity.activity):
                 return
 
             #there are changes
-            response = article_xml_repo.update_file("/" + filename , "Updates xml 4", content, xml_file.sha)
+            response = article_xml_repo.update_file("/" + filename , "Updates xml", content, xml_file.sha)
             self.logger.info("File " + filename + " successfully updated. Commit: " + response)
             return
 

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -1,0 +1,88 @@
+import activity
+from boto.s3.connection import S3Connection
+import tempfile
+from github import Github
+from github import GithubException
+import base64
+from S3utility.s3_notification_info import S3NotificationInfo
+import requests
+
+"""
+activity_UpdateRepository.py activity
+"""
+
+class activity_UpdateRepository(activity.activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+
+        self.name = "UpdateRepository"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Saves/Updated the XML on a version control repository"
+        self.logger = logger
+
+    def do_activity(self, data=None):
+        try:
+
+            info = S3NotificationInfo.from_dict(data)
+            s3_file_path = info.file_name
+
+            #connect to bucket
+            self.conn = S3Connection(self.settings.aws_access_key_id,
+                                 self.settings.aws_secret_access_key,
+                                 host=self.settings.s3_hostname)
+            bucket = self.conn.get_bucket(self.settings.publishing_buckets_prefix +
+                                      self.settings.cdn_bucket)
+
+            #download xml
+            with tempfile.TemporaryFile(mode='r+') as tmp:
+
+                s3_key = bucket.get_key(s3_file_path)
+                filename = s3_file_path.split('/')[-1]
+                s3_key.get_contents_to_file(tmp)
+                file_content = s3_key.get_contents_as_string()
+                self.update_github(filename, file_content)
+
+
+        except Exception as e:
+            self.logger.info("Exception in do_activity. data: " + data)
+            raise
+
+        return True
+
+    def update_github(self, filename, content):
+
+        g = Github(self.settings.github_token)
+        user = g.get_user()
+        article_xml_repo = user.get_repo(self.settings.git_repo_name)
+
+        try:
+            xml_file = article_xml_repo.get_contents(filename)
+        except GithubException:
+            self.logger.info("GithubException: file " + filename + " may not exist in github yet. We will try to add it in the repo.")
+            response = article_xml_repo.create_file("/" + filename, "Adds XML first time", content)
+            self.logger.info("File " + filename + " successfully added. Commit: " + response)
+            return
+
+        except Exception as e:
+            self.logger.info("Exception: file " + filename + ". Error: " + e.message)
+            raise
+
+        try:
+            #check for changes first
+            if content == xml_file.decoded_content:
+                self.logger.info("No changes in file " + filename)
+                return
+
+            #there are changes
+            response = article_xml_repo.update_file("/" + filename , "Updates xml 4", content, xml_file.sha)
+            self.logger.info("File " + filename + " successfully updated. Commit: " + response)
+            return
+
+        except Exception as e:
+            self.logger.info("Exception: file " + filename + ". Error: " + e.message)
+            raise
+

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -79,7 +79,7 @@ class activity_UpdateRepository(activity.activity):
                 return
 
             #there are changes
-            response = article_xml_repo.update_file("/" + filename , "Updates xml", content, xml_file.sha)
+            response = article_xml_repo.update_file(self.settings.git_repo_path + filename , "Updates xml", content, xml_file.sha)
             self.logger.info("File " + filename + " successfully updated. Commit: " + response)
             return
 

--- a/newFileWorkflows.yaml
+++ b/newFileWorkflows.yaml
@@ -2,3 +2,8 @@ ArticleZip:
   bucket_name_pattern: '.*elife-production-final$'
   file_name_pattern: '.*\.zip'
   starter_name: 'PublishPerfectArticle'
+
+ArticleXML:
+  bucket_name_pattern: '.*elife-cdn$'
+  file_name_pattern: '.*\.xml'
+  starter_name: 'VersionControl'

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -73,8 +73,8 @@ def process_message(message):
         name = message_payload.get('workflow_name')
         data = message_payload.get('workflow_data')
         start_workflow(name, data)
-    except Exception:
-        logger.exception("Exception while processing message")
+    except Exception as e:
+        logger.exception("Exception while processing message. Error: " + e.message)
     message.delete()
 
 
@@ -98,9 +98,14 @@ def process_data_publishperfectarticle(workflow_name, workflow_data):
     data = {'info': S3NotificationInfo.from_dict(workflow_data)}
     return data
 
+def process_data_versioncontrol(workflow_name, workflow_data):
+    data = {'info': S3NotificationInfo.from_dict(workflow_data)}
+    return data
+
 
 workflow_data_processors = {
-    'PublishPerfectArticle': process_data_publishperfectarticle
+    'PublishPerfectArticle': process_data_publishperfectarticle,
+    'VersionControl': process_data_versioncontrol
 }
 
 if __name__ == "__main__":

--- a/register.py
+++ b/register.py
@@ -24,6 +24,7 @@ def start(ENV="dev"):
     conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
     workflow_names = []
+    workflow_names.append("VersionControl")
     workflow_names.append("ArticleInformationSupplier")
     workflow_names.append("Ping")
     workflow_names.append("Sum")
@@ -62,6 +63,7 @@ def start(ENV="dev"):
         print 'got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)
 
     activity_names = []
+    activity_names.append("UpdateRepository")
     activity_names.append("PostEIFBridge")
     activity_names.append("PingWorker")
     activity_names.append("SetPublicationStatus")

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ Pillow==3.2.0
 ndg-httpsclient==0.4.2
 pyasn1==0.1.9
 pyOpenSSL==16.0.0
+pyGithub==1.27.1

--- a/starter/starter_VersionControl.py
+++ b/starter/starter_VersionControl.py
@@ -1,0 +1,55 @@
+import settings as settingsLib
+import random
+import boto.swf
+import log
+import json
+
+"""
+Amazon SWF VersionControl starter.
+"""
+
+
+class starter_VersionControl():
+
+    def start(self, ENV="dev", info=None):
+
+        settings = settingsLib.get_settings(ENV)
+
+        # Log
+        identity = "starter_%s" % int(random.random() * 1000)
+        log_file = "starter.log"
+        # logFile = None
+        logger = log.logger(log_file, settings.setLevel, identity)
+
+        filename = info.file_name
+
+        if filename is None:
+            logger.error("Did not get a filename")
+            return
+
+        # Simple connect
+        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+
+        # Start a workflow execution
+        workflow_id = "VersionControl_%s" % filename.replace('/', '_') + str(int(random.random() * 1000))
+        workflow_name = "VersionControl"
+        workflow_version = "1"
+        child_policy = None
+        execution_start_to_close_timeout = str(60 * 30)
+        workflow_input = json.dumps(info, default=lambda ob: ob.__dict__)
+
+        try:
+            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name, workflow_version,
+                                                     settings.default_task_list, child_policy,
+                                                     execution_start_to_close_timeout, workflow_input)
+
+            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
+
+        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
+            # There is already a running workflow with that ID, cannot start another
+            message = 'SWFWorkflowExecutionAlreadyStartedError: There is already a running workflow with ID %s' % workflow_id
+            logger.info(message)
+
+        except Exception as e:
+            message = 'Exception on VersionControl starter ' + e.message
+            logger.error(message)

--- a/workflow/workflow_VersionControl.py
+++ b/workflow/workflow_VersionControl.py
@@ -1,0 +1,56 @@
+import workflow
+
+"""
+VersionControl workflow
+"""
+
+
+class workflow_VersionControl(workflow.workflow):
+    def __init__(self, settings, logger, conn=None, token=None, decision=None,
+                 maximum_page_size=100):
+        workflow.workflow.__init__(self, settings, logger, conn, token, decision, maximum_page_size)
+
+        # SWF Defaults
+        # (We don't use the timeout values, changing will make no effect to currently registered activities
+        #   they are assigned here because it's required)
+        self.name = "VersionControl"
+        self.version = "1"
+        self.description = "Saves/Updates XML in version control repository"
+        self.default_execution_start_to_close_timeout = 60 * 5
+        self.default_task_start_to_close_timeout = 30
+
+        data = self.get_input()
+
+        workflow_definition = {
+            "name": self.name,
+            "version": self.version,
+            "task_list": self.settings.default_task_list,
+            "input": data,
+
+            "start":
+                {
+                    "requirements": None
+                },
+
+            "steps":
+                [
+                    {
+                        "activity_type": "UpdateRepository",
+                        "activity_id": "UpdateRepository",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 300
+                    }
+                ],
+
+            "finish":
+                {
+                    "requirements": None
+                }
+        }
+
+        self.load_definition(workflow_definition)


### PR DESCRIPTION
@giorgiosironi - once this change is approved, I will need a Github token with "public_repo" access in order to be able to update the repository elife-articles-xml. I will then add the required settings to the builder. Can you provide me with that please?

Fyi The additional settings will be:
github_token
git_repo_name
git_repo_path

the function that does the update of the repo is in the file activity_UpdateRepository.py

We could then have a test with a test cdn s3 bucket (already existent), aws_incoming_queue (permission between them is also necessary). For end2end test I guess we will need a test repository and use that token to try updating it and verifying.

Does it sound right? If there is anything else I can do on my side please let me know. Thanks.
