### PR TITLE
PMC revision emails, override the subject line and put the suggested …

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -570,8 +570,11 @@ class activity_PMCDeposit(activity.activity):
         body = self.get_email_body(current_time, journal, volume, fid, revision,
                                    file_name, file_size)
 
-        subject = self.get_email_subject(current_time, journal, volume, fid, revision,
-                                         file_name, file_size)
+        if revision:
+            subject = self.get_revision_email_subject(fid)
+        else:
+            subject = self.get_email_subject(current_time, journal, volume, fid, revision,
+                                             file_name, file_size)
 
         sender_email = self.settings.ses_pmc_sender_email
 
@@ -611,6 +614,13 @@ class activity_PMCDeposit(activity.activity):
 
         return recipient_email_list
 
+    def get_revision_email_subject(self, fid):
+        """
+        Email subject line for notifying production about a PMC revision
+        """
+        subject = "You need to email PMC: article " + str(fid).zfill(5) + "!!!"
+        return subject
+
     def get_email_subject(self, current_time, journal, volume, fid, revision,
                           file_name, file_size):
         date_format = '%Y-%m-%d %H:%M'
@@ -639,6 +649,11 @@ class activity_PMCDeposit(activity.activity):
         # Header
         if self.email_body_revision_header(revision):
             body += self.email_body_revision_header(revision)
+            body += "\n"
+            # Include the subject line to be used
+            revision_email_subject = self.get_email_subject(current_time, journal, volume, fid,
+                                                            revision, file_name, file_size)
+            body += str(revision_email_subject)
             body += "\n"
 
         # Bulk of body

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -124,6 +124,13 @@ class TestPMCDeposit(unittest.TestCase):
                                          file_name, file_size)
         self.assertEqual(subject, expected_subject)
 
+    @data(
+        ("00013", "You need to email PMC: article 00013!!!")
+    )
+    @unpack
+    def test_get_revision_email_subject(self, fid, expected_subject):
+        subject = self.activity.get_revision_email_subject(fid)
+        self.assertEqual(subject, expected_subject)
 
     @data(None, True)
     def test_clean_directories(self, full):


### PR DESCRIPTION
…subject line for the forwarded email in the body.