### PR TITLE
Use pid in logs

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -4,6 +4,7 @@ import log
 import json
 import random
 import importlib
+import os
 import time
 from optparse import OptionParser
 from provider import process
@@ -22,7 +23,7 @@ def decide(ENV, flag):
     maximum_page_size = 100
 
     # Log
-    identity = "decider_%s" % int(random.random() * 1000)
+    identity = "decider_%s" % os.getpid()
     logFile = "decider.log"
     #logFile = None
     logger = log.logger(logFile, settings.setLevel, identity)

--- a/queue_worker.py
+++ b/queue_worker.py
@@ -27,7 +27,7 @@ def work(ENV, flag):
     settings = settings_lib.get_settings(ENV)
 
     # Log
-    identity = "queue_worker_%s" % int(random.random() * 1000)
+    identity = "queue_worker_%s" % os.getpid()
     log_file = "queue_worker.log"
     # logFile = None
     logger = log.logger(log_file, settings.setLevel, identity)

--- a/worker.py
+++ b/worker.py
@@ -24,7 +24,7 @@ def work(ENV, flag):
     settings = settingsLib.get_settings(ENV)
 
     # Log
-    identity = "worker_%s" % int(random.random() * 1000)
+    identity = "worker_%s" % os.getpid()
     logger = log.logger("worker.log", settings.setLevel, identity)
 
     # Simple connect


### PR DESCRIPTION
Useful to correlate Upstart and other system-based logs with the *.log files written by the Python code