### PR TITLE
Tweaks to publication email activity

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -139,7 +139,8 @@ class activity_PublicationEmail(activity.activity):
             recipient_authors = self.choose_recipient_authors(
                 authors=authors,
                 article_type=article.article_type,
-                feature_article=self.is_feature_article(article))
+                feature_article=self.is_feature_article(article),
+                related_insight_article=article.related_insight_article)
 
             if recipient_authors is None:
                 self.log_cannot_find_authors(article.doi)
@@ -532,14 +533,17 @@ class activity_PublicationEmail(activity.activity):
                                'author_publication_email_VOR_after_POA']:
                 result = self.send_email(email_type, elife_id, author, article)
 
-    def choose_recipient_authors(self, authors, article_type, feature_article):
+    def choose_recipient_authors(self, authors, article_type, feature_article,
+                                 related_insight_article):
         """
         The recipients of the email will change depending on if it is a
         feature article
         """
-        if feature_article is True:
+        recipient_authors = []
+        if (feature_article is True
+            or article_type == "article-commentary"
+            or related_insight_article is not None):
             # feature article recipients
-            recipient_authors = []
 
             recipient_email_list = []
             # Handle multiple recipients, if specified
@@ -557,6 +561,8 @@ class activity_PublicationEmail(activity.activity):
                 obj = Struct(**feature_author)
                 recipient_authors.append(obj)
 
+        if authors and len(recipient_authors) > 0:
+            recipient_authors = recipient_authors + authors
         else:
             recipient_authors = authors
 

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -605,7 +605,7 @@ class activity_PublicationEmail(activity.activity):
         if duplicate is True:
             if self.logger:
                 log_info = ('Duplicate email: doi_id: %s email_type: %s recipient_email: %s' %
-                            (elife_id, headers["email_type"], author.e_mail))
+                            (str(elife_id), str(headers["email_type"]), str(author.e_mail)))
                 self.admin_email_content += "\n" + log_info
                 self.logger.info(log_info)
 
@@ -617,7 +617,7 @@ class activity_PublicationEmail(activity.activity):
                 if self.logger:
                     log_info = ('Article on do not send list for DOI: doi_id: %s ' +
                                 'email_type: %s recipient_email: %s' %
-                                (elife_id, headers["email_type"], author.e_mail))
+                                (str(elife_id), str(headers["email_type"]), str(author.e_mail)))
                     self.admin_email_content += "\n" + log_info
                     self.logger.info(log_info)
 
@@ -626,8 +626,8 @@ class activity_PublicationEmail(activity.activity):
             # Queue the email
             if self.logger:
                 log_info = ("Sending " + email_type + " type email" +
-                            " for article " + elife_id +
-                            " to recipient_email " + author.e_mail)
+                            " for article " + str(elife_id) +
+                            " to recipient_email " + str(author.e_mail))
                 self.admin_email_content += "\n" + log_info
                 self.logger.info(log_info)
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -254,14 +254,17 @@ class TestPublicationEmail(unittest.TestCase):
 
 
     @data(
-        (None, None, "Author", "author01@example.com"),
-        (None, True, "Features", "features_team@example.org")
+        (None, None, None, "Author", "author01@example.com"),
+        (None, True, None, "Features", "features_team@example.org"),
+        (None, None, "not_none", "Features", "features_team@example.org"),
+        ("article-commentary", False, None, "Features", "features_team@example.org")
     )
     @unpack
-    def test_choose_recipient_authors(self, article_type, feature_article,
+    def test_choose_recipient_authors(self, article_type, feature_article, related_insight_article,
                                       expected_0_first_nm, expected_0_e_mail):
         authors = self.fake_authors()
-        recipient_authors = self.activity.choose_recipient_authors(authors, article_type, feature_article)
+        recipient_authors = self.activity.choose_recipient_authors(authors, article_type,
+                                                                   feature_article, related_insight_article)
         if recipient_authors:
             self.assertEqual(recipient_authors[0].first_nm, expected_0_first_nm)
             self.assertEqual(recipient_authors[0].e_mail, expected_0_e_mail)
@@ -281,8 +284,10 @@ class TestPublicationEmail(unittest.TestCase):
         article_object.parse_article_file("tests/test_data/elife-00353-v1.xml")
         article_type = article_object.article_type
         feature_article = True
+        related_insight_article = None
 
-        recipient_authors = self.activity.choose_recipient_authors(authors, article_type, feature_article)
+        recipient_authors = self.activity.choose_recipient_authors(authors, article_type,
+                                                                   feature_article, related_insight_article)
         author = recipient_authors[0]
 
         format = "html"

--- a/tests/test_data/templates/author_publication_email_Insight_to_VOR.json
+++ b/tests/test_data/templates/author_publication_email_Insight_to_VOR.json
@@ -1,0 +1,5 @@
+{
+ "sender_email": "production@elifesciences.org",
+ "email_type": "author_publication_email_Insight_to_VOR",
+ "subject": "eLife has published an Insight article about your research article: {{ article.article_title }}"
+}


### PR DESCRIPTION
Fixing an exception that continues to return by converting values to string that may be set as None before trying to add them to a log message.

Also, send copies of emails related to Insight articles to the features team too.