### PR TITLE
ApplyVersionNumber needs to happen in IngestArticleZip since it will …

### DIFF
--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -57,6 +57,17 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "ApplyVersionNumber",
+                        "activity_id": "ApplyVersionNumber",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 10,
+                        "schedule_to_close_timeout": 60 * 10,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 10
+                    },
+                    {
                         "activity_type": "IngestToLax",
                         "activity_id": "IngestToLax",
                         "version": "1",

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -57,17 +57,6 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 10
                     },
                     {
-                        "activity_type": "ApplyVersionNumber",
-                        "activity_id": "ApplyVersionNumber",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-                    {
                         "activity_type": "ScheduleCrossref",
                         "activity_id": "ScheduleCrossref",
                         "version": "1",


### PR DESCRIPTION
…rename the files that will be validated at lax ingest stage

This should fix the problem with the file pattern being wrong. The file is changed during ApplyVersionNumber activity, then it's verified. The error was that the verification with the new bot code was happening before ApplyVersionNumber happened. I just set ApplyVersionNumber to happen right after ExpandArticle, not after ingestion.

@giorgiosironi - I may have a few questions with regards running end2end tests before merging into develop (using continuum env). I am not sure I should start the end2end machines or the continuum ones(?)