### PR TITLE
Token seems to be built with concatenation

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -2,6 +2,7 @@ import requests
 import time
 from article import *
 import base64
+import json
 
 def article_versions(article_id, settings):
     url = settings.lax_article_versions.replace('{article_id}', article_id)
@@ -79,10 +80,12 @@ def get_xml_file_name(settings, expanded_folder, xml_bucket):
     return xml_file_name
 
 def lax_token(run, version, expanded_folder, status, eif_location):
-    raw = '{"run": "' + run + '", ' \
-            '"version": "' + version + '", ' \
-            '"expanded_folder": "' + expanded_folder + '", ' \
-            '"eif_location": "' + eif_location + '", ' \
-            '"status": "' + status + '"}'
-    return base64.encodestring(raw)
+    token = {
+        'run': run, 
+        'version': version,
+        'expanded_folder': expanded_folder,
+        'eif_location': eif_location,
+        'status': status,
+    }
+    return base64.encodestring(json.dumps(token))
 

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -54,6 +54,7 @@ def main(flag):
                                       wait_time_seconds=20)
         if messages:
             logger.info(str(len(messages)) + " message received")
+            logger.info('message contents: %s', messages[0])
             process_message(messages[0])
         else:
             logger.debug("No messages received")

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -3,6 +3,7 @@ import provider.lax_provider as lax_provider
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
 import base64
+import json
 
 from mock import mock, patch
 
@@ -51,10 +52,11 @@ class TestLaxProvider(unittest.TestCase):
                                                       "00353", "bb2d37b8-e73c-43b3-a092-d555753316af",
                                                       "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
                                                       "1", "vor", "", "ingest")
+        self.assertIn('token', message)
+        del message['token']
         self.assertDictEqual(message, {'action': 'ingest',
                                        'id': '00353',
                                        'location': 'https://s3.amazonaws.com/origin_bucket/00353.1/bb2d37b8-e73c-43b3-a092-d555753316af/elife-00353-v1.xml',
-                                       'token': 'eyJydW4iOiAiYmIyZDM3YjgtZTczYy00M2IzLWEwOTItZDU1NTc1MzMxNmFmIiwgInZlcnNpb24i\nOiAiMSIsICJleHBhbmRlZF9mb2xkZXIiOiAiMDAzNTMuMS9iYjJkMzdiOC1lNzNjLTQzYjMtYTA5\nMi1kNTU1NzUzMzE2YWYiLCAiZWlmX2xvY2F0aW9uIjogIiIsICJzdGF0dXMiOiAidm9yIn0=\n',
                                        'version': 1})
 
     def test_lax_token(self):
@@ -64,7 +66,7 @@ class TestLaxProvider(unittest.TestCase):
                                        "vor",
                                        "")
 
-        self.assertEqual(token, base64.encodestring('{"run": "bb2d37b8-e73c-43b3-a092-d555753316af", "version": "1", "expanded_folder": "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af", "eif_location": "", "status": "vor"}'))
+        self.assertEqual(json.loads(base64.decodestring(token)), {"run": "bb2d37b8-e73c-43b3-a092-d555753316af", "version": "1", "expanded_folder": "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af", "eif_location": "", "status": "vor"})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Seems that there is an integer hiding in these fields, it may be the `version`:
```
2016-10-19T15:39:54Z ERROR worker_304 Exception when Preparing Publish action for Lax
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_PublishToLax.py", line 57, in do_activity
    article_id, run, expanded_folder, version, status, eif_location, 'publish')
  File "/opt/elife-bot/provider/lax_provider.py", line 71, in prepare_action_message
    'token': lax_token(run, version, expanded_folder, status, eif_location)
  File "/opt/elife-bot/provider/lax_provider.py", line 86, in lax_token
    '"status": "' + status + '"}'
TypeError: coercing to Unicode: need string or buffer, int found
```