### PR TITLE
In PreparePostEIF, get the update_date value from the session.

### DIFF
--- a/activity/activity_PreparePostEIF.py
+++ b/activity/activity_PreparePostEIF.py
@@ -56,7 +56,7 @@ class activity_PreparePostEIF(activity.activity):
             expanded_folder = session.get_value(run, 'expanded_folder')
             status = session.get_value(run, 'status')
 
-            update_date = data['update_date']
+            update_date = session.get_value(run, 'update_date')
 
             carry_over_data = {
                 'eif_filename': eif_filename,


### PR DESCRIPTION
Doing a silent correction today, the workflow threw an exception. The update_date was not found in data{}. I tracked it down to this hotfix to get it from the session.

To @Jenniferstrej could you please confirm this looks ok?

To @giorgiosironi is this ok still to PR a hotfix directly to the master branch? Is there anything else required to get it applied to master directly? (if we cannot and it must go through develop branch and wait for the next deployment, that's probably ok in this case).