### PR TITLE
version should always be string on the bot

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -82,7 +82,7 @@ def get_xml_file_name(settings, expanded_folder, xml_bucket):
 def lax_token(run, version, expanded_folder, status, eif_location):
     token = {
         'run': run, 
-        'version': str(version),
+        'version': version,
         'expanded_folder': expanded_folder,
         'eif_location': eif_location,
         'status': status,

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -82,7 +82,7 @@ def get_xml_file_name(settings, expanded_folder, xml_bucket):
 def lax_token(run, version, expanded_folder, status, eif_location):
     token = {
         'run': run, 
-        'version': version,
+        'version': str(version),
         'expanded_folder': expanded_folder,
         'eif_location': eif_location,
         'status': status,

--- a/starter/starter_ApproveArticlePublication.py
+++ b/starter/starter_ApproveArticlePublication.py
@@ -38,7 +38,7 @@ class starter_ApproveArticlePublication():
 
         info = {
             'article_id': article_id,
-            'version': version,
+            'version': str(version),
             'run': run,
             'publication_data': publication_data
         }


### PR DESCRIPTION
keeping history:
token version should always be string

The token is a way for bot to keep state between lax calls/workflows. Since version should be always string and message to lax may be triggered by the external apps (the dashboard in this case), I need to make sure version is string in the token.

@giorgiosironi - just a small change explained above.