### PR TITLE
Separates with a '.' article id and random id in building workflow ids

### DIFF
--- a/starter/starter_ArticleInformationSupplier.py
+++ b/starter/starter_ArticleInformationSupplier.py
@@ -53,7 +53,7 @@ class starter_ArticleInformationSupplier():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "ArticleInformationSupplier_%s" % incoming_data['article_id'] + str(int(random.random() * 1000))
+        workflow_id = "ArticleInformationSupplier_%s.%s" % (incoming_data['article_id'], str(int(random.random() * 1000)))
         workflow_name = "ArticleInformationSupplier"
         workflow_version = "1"
         child_policy = None

--- a/starter/starter_IngestArticleZip.py
+++ b/starter/starter_IngestArticleZip.py
@@ -41,7 +41,7 @@ class starter_IngestArticleZip():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "IngestArticleZip_%s" % filename.replace('/', '_') + str(int(random.random() * 1000))
+        workflow_id = "IngestArticleZip_%s.%s" % (filename.replace('/', '_'), str(int(random.random() * 1000)))
         workflow_name = "IngestArticleZip"
         workflow_version = "1"
         child_policy = None

--- a/starter/starter_NewS3File.py
+++ b/starter/starter_NewS3File.py
@@ -39,7 +39,7 @@ class starter_NewS3File():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "NewS3File_%s" % info.file_name + str(int(random.random() * 1000))
+        workflow_id = "NewS3File_%s.%s" % (info.file_name, str(int(random.random() * 1000)))
         workflow_name = "NewS3File"
         workflow_version = "1"
         child_policy = None

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -37,7 +37,7 @@ class starter_PostPerfectPublication():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "PostPerfectPublication_%s" % info['article_id'] + str(int(random.random() * 1000))
+        workflow_id = "PostPerfectPublication_%s.%s" % (info['article_id'], str(int(random.random() * 1000)))
         workflow_name = "PostPerfectPublication"
         workflow_version = "1"
         child_policy = None

--- a/starter/starter_ProcessArticleZip.py
+++ b/starter/starter_ProcessArticleZip.py
@@ -39,7 +39,7 @@ class starter_ProcessArticleZip():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "ProcessArticleZip_%s" % article_id + str(int(random.random() * 10000))
+        workflow_id = "ProcessArticleZip_%s.%s" % (article_id, str(int(random.random() * 10000)))
         workflow_name = "ProcessArticleZip"
         workflow_version = "1"
         child_policy = None

--- a/starter/starter_PublishPerfectArticle.py
+++ b/starter/starter_PublishPerfectArticle.py
@@ -41,7 +41,7 @@ class starter_PublishPerfectArticle():
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
 
         # Start a workflow execution
-        workflow_id = "PublishPerfectArticle_%s" % filename.replace('/', '_') + str(int(random.random() * 1000))
+        workflow_id = "PublishPerfectArticle_%s.%s" % (filename.replace('/', '_'), str(int(random.random() * 1000)))
         workflow_name = "PublishPerfectArticle"
         workflow_version = "1"
         child_policy = None


### PR DESCRIPTION
ApproveArticlePublication already does this, and it's useful to uniquely determine which article is a workflow referring to
