### PR TITLE
Logs, emit events to the dashboard, date parsing on lax response adap…

### DIFF
--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -40,7 +40,7 @@ class LaxResponseAdapter:
                         self.logger.info('short retry: %s because of %s', queue_message.id, e)
                         queue_message.change_visibility(visibility_timeout=10)
 
-            logger.info("graceful shutdown")
+            self.logger.info("graceful shutdown")
 
         else:
             self.logger.error("Could not obtain queue, exiting")
@@ -61,7 +61,7 @@ class LaxResponseAdapter:
     def parse_message(self, message):
         try:
 
-            logger.info('got the following message from Lax: %s', message)
+            self.logger.info('got the following message from Lax: %s', message)
 
             message_data = json.loads(message)
             result = message_data['status']

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -2,11 +2,18 @@ import unittest
 from lax_response_adapter import LaxResponseAdapter
 from mock import Mock
 import json
+import base64
+
+fake_token = json.dumps({u'status': u'vor',
+                         u'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                         u'eif_location': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-837411455-v1.json',
+                         u'version': u'1',
+                         u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
 
 fake_lax_message = json.dumps({"status": "published",
                                "requested-action": "publish",
                                "datetime": "2013-03-26T00:00:00+00:00",
-                               "token": "eyJzdGF0dXMiOiAidm9yIiwgImV4cGFuZGVkX2ZvbGRlciI6ICI4Mzc0MTE0NTUuMS9hOGJiMDVk\nZi0yZGY5LTRmY2UtOGY5Zi0yMTlhY2EwYjAxNDgiLCAiZWlmX2xvY2F0aW9uIjogIjgzNzQxMTQ1\nNS4xL2E4YmIwNWRmLTJkZjktNGZjZS04ZjlmLTIxOWFjYTBiMDE0OC9lbGlmZS04Mzc0MTE0NTUt\ndjEuanNvbiIsICJ2ZXJzaW9uIjogIjEiLCAicnVuIjogImE4YmIwNWRmLTJkZjktNGZjZS04Zjlm\nLTIxOWFjYTBiMDE0OCJ9\n",
+                               "token": base64.encodestring(fake_token),
                                "id": "837411455"})
 
 workflow_message_expected = {'workflow_data':

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -1,0 +1,36 @@
+import unittest
+from lax_response_adapter import LaxResponseAdapter
+from mock import Mock
+import json
+
+fake_lax_message = json.dumps({"status": "published", "requested-action": "publish", "datetime": "2013-03-26T00:00:00+00:00",
+                    "token": "eyJzdGF0dXMiOiAidm9yIiwgImV4cGFuZGVkX2ZvbGRlciI6ICI4Mzc0MTE0NTUuMS9hOGJiMDVk\nZi0yZGY5LTRmY2UtOGY5Zi0yMTlhY2EwYjAxNDgiLCAiZWlmX2xvY2F0aW9uIjogIjgzNzQxMTQ1\nNS4xL2E4YmIwNWRmLTJkZjktNGZjZS04ZjlmLTIxOWFjYTBiMDE0OC9lbGlmZS04Mzc0MTE0NTUt\ndjEuanNvbiIsICJ2ZXJzaW9uIjogIjEiLCAicnVuIjogImE4YmIwNWRmLTJkZjktNGZjZS04Zjlm\nLTIxOWFjYTBiMDE0OCJ9\n",
+                    "id": "837411455"})
+
+workflow_message_expected = {'workflow_data':
+                                 {'article_id': u'837411455',
+                                  'eif_location': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-837411455-v1.json',
+                                  'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                                  'message': None,
+                                  'requested_action': u'publish',
+                                  'result': u'published',
+                                  'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                                  'status': u'vor',
+                                  'update_date': '2013-03-26T00:00:00Z',
+                                  'version': u'1'},
+                             'workflow_name': 'PostPerfectPublication'}
+
+class TestLaxResponseAdapter(unittest.TestCase):
+    def setUp(self):
+        settings = Mock()
+        self.logger = Mock()
+        self.laxresponseadapter = LaxResponseAdapter(settings, self.logger)
+
+    def test_parse_message(self):
+        expected_workflow_starter_message = self.laxresponseadapter.parse_message(fake_lax_message)
+        self.assertDictEqual.__self__.maxDiff = None
+        self.assertDictEqual(expected_workflow_starter_message, workflow_message_expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -3,9 +3,11 @@ from lax_response_adapter import LaxResponseAdapter
 from mock import Mock
 import json
 
-fake_lax_message = json.dumps({"status": "published", "requested-action": "publish", "datetime": "2013-03-26T00:00:00+00:00",
-                    "token": "eyJzdGF0dXMiOiAidm9yIiwgImV4cGFuZGVkX2ZvbGRlciI6ICI4Mzc0MTE0NTUuMS9hOGJiMDVk\nZi0yZGY5LTRmY2UtOGY5Zi0yMTlhY2EwYjAxNDgiLCAiZWlmX2xvY2F0aW9uIjogIjgzNzQxMTQ1\nNS4xL2E4YmIwNWRmLTJkZjktNGZjZS04ZjlmLTIxOWFjYTBiMDE0OC9lbGlmZS04Mzc0MTE0NTUt\ndjEuanNvbiIsICJ2ZXJzaW9uIjogIjEiLCAicnVuIjogImE4YmIwNWRmLTJkZjktNGZjZS04Zjlm\nLTIxOWFjYTBiMDE0OCJ9\n",
-                    "id": "837411455"})
+fake_lax_message = json.dumps({"status": "published",
+                               "requested-action": "publish",
+                               "datetime": "2013-03-26T00:00:00+00:00",
+                               "token": "eyJzdGF0dXMiOiAidm9yIiwgImV4cGFuZGVkX2ZvbGRlciI6ICI4Mzc0MTE0NTUuMS9hOGJiMDVk\nZi0yZGY5LTRmY2UtOGY5Zi0yMTlhY2EwYjAxNDgiLCAiZWlmX2xvY2F0aW9uIjogIjgzNzQxMTQ1\nNS4xL2E4YmIwNWRmLTJkZjktNGZjZS04ZjlmLTIxOWFjYTBiMDE0OC9lbGlmZS04Mzc0MTE0NTUt\ndjEuanNvbiIsICJ2ZXJzaW9uIjogIjEiLCAicnVuIjogImE4YmIwNWRmLTJkZjktNGZjZS04Zjlm\nLTIxOWFjYTBiMDE0OCJ9\n",
+                               "id": "837411455"})
 
 workflow_message_expected = {'workflow_data':
                                  {'article_id': u'837411455',


### PR DESCRIPTION
…ter and a unit test for lax_response_adapter

We will now have logs for ArchiveArticle and if there is an error, the workflow will be terminated (not go on until it times out);

I added date parsing for the datetime field and convert it to the string format expected by the bot;
Added a unit test for lax_response_adapter that should cover the datetime parsing.

@giorgiosironi 