### PR TITLE
Explicit import of provider.article

### DIFF
--- a/provider/article.py
+++ b/provider/article.py
@@ -11,7 +11,6 @@ from boto.s3.connection import S3Connection
 import provider.simpleDB as dblib
 import provider.s3lib as s3lib
 from elifetools import parseJATS as parser
-import lax_provider
 from provider.article_structure import ArticleInfo
 
 """
@@ -156,7 +155,9 @@ class article(object):
         article_id = doi_id
         # Get the highest published version from lax
         try:
-            version = lax_provider.article_highest_version(article_id, self.settings)
+            # hack: work around circular dependency between lax_provider.py and article.py
+            from lax_provider import article_highest_version
+            version = article_highest_version(article_id, self.settings)
             if not isinstance(version, (int,long)):
                 return False
         except:

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -33,7 +33,7 @@ def article_highest_version(article_id, settings, logger=None):
 
 
 def article_next_version(article_id, settings):
-    version = lax_provider.article_highest_version(article_id, settings)
+    version = article_highest_version(article_id, settings)
     if isinstance(version, (int,long)) and version >= 1:
         version = str(version + 1)
     if version is None:

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -1,6 +1,6 @@
 import requests
 import time
-from article import *
+from . import article
 import base64
 import json
 
@@ -85,7 +85,7 @@ def prepare_action_message(settings, article_id, run, expanded_folder, version, 
         return message
 
 def get_xml_file_name(settings, expanded_folder, xml_bucket):
-    Article = article()
+    Article = article.article()
     xml_file_name = Article.get_xml_file_name(settings, expanded_folder, xml_bucket)
     return xml_file_name
 


### PR DESCRIPTION
The problem that the `*` import solves was the circular dependency between `provider.lax_provider` and `provider.article`. The unittest and lettuce test suites can both be run now.
