### PR TITLE
Elpp 1632

### DIFF
--- a/activity/activity_VersionLookup.py
+++ b/activity/activity_VersionLookup.py
@@ -68,7 +68,7 @@ class activity_VersionLookup(activity.activity):
             self.logger.exception("Exception when trying to Lookup next version")
             self.emit_monitor_event(self.settings, article_structure.article_id, version, data['run'], self.pretty_name,
                                     "error", " ".join(("Error looking up version for article",
-                                                      article_structure.article_id, "message:", e.message)))
+                                                      article_structure.article_id, "message:", str(e))))
             return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
     def get_version(self, settings, article_structure, lookup_function):
@@ -81,7 +81,7 @@ class activity_VersionLookup(activity.activity):
                 return version, "Name '%s' did not match expected pattern for version" % article_structure.full_filename
             return version, None
         except Exception as e:
-            error_message = "Exception when looking up version. Message: " + e.message
+            error_message = "Exception when looking up version. Message: " + str(e)
             return version, error_message
 
     def execute_function(self, the_function, arg1, arg2):

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -12,7 +12,7 @@ from optparse import OptionParser
 from S3utility.s3_notification_info import S3NotificationInfo
 
 """
-Amazon SWF IngestArticleZip starter, preparing article xml for lax.
+Amazon SWF SilentCorrectionsIngest starter, preparing article xml for lax.
 """
 
 


### PR DESCRIPTION
Just to try to avoid the following error, although I couldn't reproduce it locally as my Pycharm does not seem to look at urllib3 exception module...
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_VersionLookup.py", line 50, in do_activity
    version, error = self.get_version(self.settings, article_structure, data['version_lookup_function'])
  File "/opt/elife-bot/activity/activity_VersionLookup.py", line 84, in get_version
    error_message = "Exception when looking up version. Message: " + e.message
TypeError: cannot concatenate 'str' and 'ProtocolError' objects
2016-11-03T11:57:29Z ERROR worker_1075 error executing activity activity_VersionLookup
Traceback (most recent call last):
  File "worker.py", line 68, in work
    activity_result = activity_object.do_activity(data)
  File "/opt/elife-bot/activity/activity_VersionLookup.py", line 69, in do_activity
    self.emit_monitor_event(self.settings, article_structure.article_id, version, data['run'], self.pretty_name,
UnboundLocalError: local variable 'version' referenced before assignment