### PR TITLE
FIX - ELPP-1613 adds execution lax/website on workflow id on PostPerfectPublication + tests

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -106,7 +106,8 @@ def process_data_ingestarticlezip(workflow_name, workflow_data):
             'run': str(uuid.uuid4())}
     return data
 def process_data_postperfectpublication(workflow_name, workflow_data):
-    data = {'info': workflow_data }
+    data = {'info': workflow_data,
+            'settings': settings}
     return data
 
 

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -18,7 +18,7 @@ class NullArticleException(Exception):
 
 class starter_PostPerfectPublication():
 
-    def start(self, info, settings):
+    def start(self, info, settings, ENV="dev"):
 
         # Log
         identity = "starter_%s" % int(random.random() * 1000)

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -21,7 +21,7 @@ class starter_PostPerfectPublication():
     def start(self, info, settings, ENV="dev"):
 
         # Log
-        identity = "starter_%s" % int(random.random() * 1000)
+        identity = "starter_PostPerfectPublication.%s" % os.getpid()
         log_file = "starter.log"
         # logFile = None
         logger = log.logger(log_file, settings.setLevel, identity)
@@ -34,7 +34,7 @@ class starter_PostPerfectPublication():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = self.set_workflow_information("PostPerfectPublication", "1", None, info, os.getpid())
+        workflow_input = self.set_workflow_information("PostPerfectPublication", "1", None, info)
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
@@ -55,9 +55,9 @@ class starter_PostPerfectPublication():
                       'There is already a running workflow with ID %s' % workflow_id
             logger.info(message)
 
-    def set_workflow_information(self, name, workflow_version, child_policy, data, process_id):
+    def set_workflow_information(self, name, workflow_version, child_policy, data):
         publication_from = "lax" if 'requested_action' in data else 'website'
-        workflow_id = "%s_%s.%s.%s" % (name, data['article_id'], process_id, publication_from)
+        workflow_id = "%s_%s.%s" % (name, data['article_id'], publication_from)
         workflow_name = "PostPerfectPublication"
         workflow_version = workflow_version
         child_policy = child_policy

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -4,7 +4,6 @@ parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.sys.path.insert(0, parentdir)
 
 import boto.swf
-import settings as settingsLib
 import log
 import json
 import random
@@ -19,9 +18,7 @@ class NullArticleException(Exception):
 
 class starter_PostPerfectPublication():
 
-    def start(self, info, ENV="dev"):
-        # Specify run environment settings
-        settings = settingsLib.get_settings(ENV)
+    def start(self, info, settings):
 
         # Log
         identity = "starter_%s" % int(random.random() * 1000)

--- a/tests/starter/test_starter_PostPerfectPublication.py
+++ b/tests/starter/test_starter_PostPerfectPublication.py
@@ -1,0 +1,45 @@
+import unittest
+from starter.starter_PostPerfectPublication import starter_PostPerfectPublication
+import tests.test_data as test_data
+import json
+from ddt import ddt, data, unpack
+
+
+example_workflow_name = "PostPerfectPublication"
+example_process_id = "00000"
+example_workflow_id = lambda fe: "PostPerfectPublication_00353.00000." + fe
+
+
+@ddt
+class TestStarterPostPerfectPublication(unittest.TestCase):
+    def setUp(self):
+        self.postperfectpublication = starter_PostPerfectPublication()
+
+    @unpack
+    @data({'data': test_data.data_published_lax, 'execution': 'lax'},
+          {'data': test_data.data_error_lax, 'execution':'lax'},
+          {'data': test_data.data_published_website, 'execution':'website'})
+    def test_set_workflow_information_lax(self, data, execution):
+
+        workflow_id, \
+        workflow_name, \
+        workflow_version, \
+        child_policy, \
+        execution_start_to_close_timeout, \
+        workflow_input = self.postperfectpublication.set_workflow_information(example_workflow_name,
+                                                                              "1",
+                                                                              None,
+                                                                              data,
+                                                                              example_process_id)
+
+        self.assertEqual(example_workflow_id(execution), workflow_id)
+        self.assertEqual(example_workflow_name, workflow_name)
+        self.assertEqual("1", workflow_version)
+        self.assertIsNone(child_policy)
+        self.assertEqual("1800", execution_start_to_close_timeout)
+        self.assertEqual(json.dumps(data), workflow_input)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_PostPerfectPublication.py
+++ b/tests/starter/test_starter_PostPerfectPublication.py
@@ -6,8 +6,7 @@ from ddt import ddt, data, unpack
 
 
 example_workflow_name = "PostPerfectPublication"
-example_process_id = "00000"
-example_workflow_id = lambda fe: "PostPerfectPublication_00353.00000." + fe
+example_workflow_id = lambda fe: "PostPerfectPublication_00353." + fe
 
 
 @ddt
@@ -29,8 +28,7 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
         workflow_input = self.postperfectpublication.set_workflow_information(example_workflow_name,
                                                                               "1",
                                                                               None,
-                                                                              data,
-                                                                              example_process_id)
+                                                                              data)
 
         self.assertEqual(example_workflow_id(execution), workflow_id)
         self.assertEqual(example_workflow_name, workflow_name)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -29,3 +29,40 @@ lax_article_versions_response_data = {u'1':
                                            u'date_rev2_qc': u'2015-11-11', u'date_rev2_decision': u'2015-11-25', u'date_rev4_qc': None,
                                            u'date_full_decision': u'2015-06-15', u'website_path': u'content/4/e08411v1', u'datetime_published': u'2015-12-31T00:00:00Z'}
                                       }
+
+
+data_published_lax = {
+            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "article_id": "00353",
+            "result": "published",
+            "status": "vor",
+            "version": "1",
+            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
+            "requested_action": "publish",
+            "message": None,
+            "update_date": "2012-12-13T00:00:00Z"
+        }
+
+data_published_website = {
+            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "article_id": "00353",
+            "status": "vor",
+            "version": "1",
+            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
+            "update_date": "2012-12-13T00:00:00Z"
+        }
+
+data_error_lax = {
+            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "article_id": "00353",
+            "result": "error",
+            "status": "vor",
+            "version": "1",
+            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
+            "requested_action": "publish",
+            "message": "An error abc has occurred",
+            "update_date": "2012-12-13T00:00:00Z"
+        }


### PR DESCRIPTION
@giorgiosironi - Added where the execution comes from "lax/website" to PostPerfectPublication starter and a unit test. I did PostPerfectPublication_%s.%s.%s % (article_id, process_id, publication_from). Is that what you had in mind?

