### PR TITLE
Minimal change for version in silent corrections

### DIFF
--- a/activity/activity_VersionLookup.py
+++ b/activity/activity_VersionLookup.py
@@ -76,7 +76,7 @@ class activity_VersionLookup(activity.activity):
             version = None
             version = article_structure.get_version_from_zip_filename()
             if version is None:
-                version = self.execute_function(lookup_functions[lookup_function], article_structure.article_id, settings)  #lax_provider.article_next_version(article_structure.article_id, self.settings)
+                version = str(self.execute_function(lookup_functions[lookup_function], article_structure.article_id, settings))  #lax_provider.article_next_version(article_structure.article_id, self.settings)
             if version == '-1':
                 return version, "Name '%s' did not match expected pattern for version" % article_structure.full_filename
             return version, None


### PR DESCRIPTION
It appears that `article_highest_version` is returning sometimes a `str`, sometimes an `int`. 

However, I'm not touching that as I see there are conditionals like:
```
if isinstance(version, (int,long)) and version >= 1:
    version = str(version + 1)
```
which rely on the type being an `int` (sometimes).

Therefore, I cast to `str` the version the activity obtains after this call.