### PR TITLE
The silent corrections actually wasn’t publishing on the old elife-we…

### DIFF
--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -51,7 +51,7 @@ class activity_VerifyPublishResponse(activity.activity):
 
                     return [start_event
                             , [self.settings, article_id, version, run, self.pretty_name + ": Lax", "end",
-                               "Finish verification of Publish response. Authority: Old Journal. Exiting "
+                               "Finish verification of Publish response. Authority: elife-website. Exiting "
                                 "this workflow " + article_id]
                             , activity.activity.ACTIVITY_EXIT_WORKFLOW]
 

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -123,6 +123,17 @@ class workflow_SilentCorrectionsProcess(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "PreparePostEIF",
+                        "activity_id": "PreparePostEIF",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "PublishToLax",
                         "activity_id": "PublishToLax",
                         "version": "1",


### PR DESCRIPTION
…bsite. That should fix it

After looking well, I had missed the actual publishing of EIF. That should trigger the second PostPerfectPublication workflow and work with either setting (lax/elife-website).

I still need to look on the failure though. I am checking the bot logs now.