### PR TITLE
Logging handler compatible with logrotate

### DIFF
--- a/log.py
+++ b/log.py
@@ -1,4 +1,5 @@
 import logging
+from logging import handlers
 import os
 import random
 
@@ -10,7 +11,7 @@ def logger(logFile = None, setLevel = "INFO", identity = ""):
     """
     logger = logging.getLogger('myapp')
     if(logFile):
-        hdlr = logging.FileHandler(os.getcwd() + os.sep + logFile)
+        hdlr = handlers.WatchedFileHandler(os.getcwd() + os.sep + logFile)
     else:
         # No log file provided, use the stream handler
         hdlr = logging.StreamHandler()


### PR DESCRIPTION
logrotate is a Unix daemon that every morning takes the log file, compresses it as worker.log.1.gz, and then creates a new empty one to be written by the application.

The Python code needs to be aware of this to reopen the file after it has been changed, otherwise logs written after the rotation will be lost.