### PR TITLE
Allow next version to be "1" if the current version is 0 from Lax.

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -31,7 +31,7 @@ def article_highest_version(article_id, settings, logger=None):
 
 def article_next_version(article_id, settings):
     version = article_highest_version(article_id, settings)
-    if isinstance(version, (int,long)) and version >= 1:
+    if isinstance(version, (int,long)) and version >= 0:
         version = str(version + 1)
     if version is None:
         return "-1"

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -35,6 +35,12 @@ class TestLaxProvider(unittest.TestCase):
         self.assertEqual(None, version)
 
     @patch('provider.lax_provider.article_versions')
+    def test_article_highest_version_no_versions(self, mock_lax_provider_article_versions):
+        mock_lax_provider_article_versions.return_value = 200, []
+        version = lax_provider.article_next_version('08411', settings_mock)
+        self.assertEqual("1", version)
+
+    @patch('provider.lax_provider.article_versions')
     def test_article_publication_date_200(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
         date_str = lax_provider.article_publication_date('08411', settings_mock)


### PR DESCRIPTION
Something noticed in production (PI-196) and I think this will fix it. I will merge and deploy if the tests pass, and if it should be otherwise you could review and alter it @Jenniferstrej 