### PR TITLE
Finally figured out how to monitor short scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *sublime*
 ftp-credentials.txt
 *.log
+*.log.gz
+/newrelic.ini
 *.pyc
 *.swp
 settings.py
@@ -13,3 +15,4 @@ workflow-context/*
 /tmp
 .cache
 build/
+

--- a/cron.py
+++ b/cron.py
@@ -18,7 +18,6 @@ import newrelic.agent
 SWF cron
 """
 
-@newrelic.agent.background_task(group='cron.py')
 def run_cron(ENV="dev"):
     # Specify run environment settings
     settings = settingsLib.get_settings(ENV)
@@ -267,7 +266,6 @@ def get_s3_key_names_from_bucket(bucket, prefix=None, delimiter='/', headers=Non
     return s3_key_names
 
 if __name__ == "__main__":
-
     # Add options
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string",
@@ -276,4 +274,6 @@ if __name__ == "__main__":
     if options.env:
         ENV = options.env
 
-    run_cron(ENV)
+    application = newrelic.agent.register_application(timeout=10.0)
+    with newrelic.agent.BackgroundTask(application, name='run_cron', group='cron.py'):
+        run_cron(ENV)


### PR DESCRIPTION
The application has to be forced to be started, in order for it to be ready
to collect data when the short task `run_cron` is executed.