### PR TITLE
Related the problem on PI-206

### DIFF
--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -73,10 +73,7 @@ class activity_ExpandArticle(activity.activity):
         session.store_value(run, 'status', status)
         self.emit_monitor_event(self.settings, article_id, version, run, "Expand Article", "start",
                                 "Starting expansion of article " + article_id)
-        self.set_monitor_property(self.settings, article_id, "article-id", article_id, "text")
-        self.set_monitor_property(self.settings, article_id, "publication-status",
-                                  "publication in progress", "text",
-                                  version=version)
+
 
         try:
             # download zip to temp folder

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -5,6 +5,11 @@ import base64
 import json
 from dateutil.parser import parse
 
+
+class ErrorCallingLaxException(Exception):
+    pass
+
+
 def article_versions(article_id, settings):
     url = settings.lax_article_versions.replace('{article_id}', article_id)
     response = requests.get(url, verify=settings.verify_ssl)
@@ -27,7 +32,8 @@ def article_highest_version(article_id, settings, logger=None):
         if logger:
             logger.error("Error obtaining version information from Lax" +
                          str(status_code))
-        return None
+        raise ErrorCallingLaxException("Error looking up article " + article_id + " version in Lax. "
+                                                                                  "Please check call to Lax.")
 
 
 def article_next_version(article_id, settings):
@@ -35,7 +41,7 @@ def article_next_version(article_id, settings):
     if isinstance(version, (int,long)) and version >= 0:
         version = str(version + 1)
     if version is None:
-        return "-1"
+        raise RuntimeError("Error looking up article next version. Version is Null. Check call to Lax.")
     return version
 
 
@@ -101,10 +107,12 @@ def prepare_action_message(settings, article_id, run, expanded_folder, version, 
         message = carry_over_data
         return message
 
+
 def get_xml_file_name(settings, expanded_folder, xml_bucket, version=None):
     Article = article.article()
     xml_file_name = Article.get_xml_file_name(settings, expanded_folder, xml_bucket, version)
     return xml_file_name
+
 
 def lax_token(run, version, expanded_folder, status, eif_location, force=False):
     token = {

--- a/tests/activity/test_activity_version_lookup.py
+++ b/tests/activity/test_activity_version_lookup.py
@@ -21,6 +21,8 @@ class TestVersionLookup(unittest.TestCase):
 
     def setUp(self):
         self.versionlookup = activity_VersionLookup(settings_mock, None, None, None, None)
+        self.versionlookup.logger = MagicMock()
+        self.versionlookup.set_monitor_property = MagicMock()
 
     @patch('activity.activity_VersionLookup.Session')
     @patch.object(activity_VersionLookup, 'execute_function')
@@ -78,14 +80,8 @@ class TestVersionLookup(unittest.TestCase):
 
         result = self.versionlookup.do_activity(test_data)
 
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             "00353",
-                                             None,
-                                             test_data["run"],
-                                             self.versionlookup.pretty_name,
-                                             "error",
-                                             "Error Looking up version article 00353 message: "
-                                             "Exception when looking up version. Message: Time out.")
+        fake_emit_monitor.assert_not_called()
+        self.assertEqual(self.versionlookup.ACTIVITY_PERMANENT_FAILURE, result)
 
 
     @patch('activity.activity_VersionLookup.Session')
@@ -98,14 +94,8 @@ class TestVersionLookup(unittest.TestCase):
 
         result = self.versionlookup.do_activity(test_data)
 
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             "00353",
-                                             None,
-                                             test_data["run"],
-                                             self.versionlookup.pretty_name,
-                                             "error",
-                                             "Error Looking up version article 00353 message: "
-                                             "Exception when looking up version. Message: Protocol Error message.")
+        fake_emit_monitor.assert_not_called()
+        self.assertEqual(self.versionlookup.ACTIVITY_PERMANENT_FAILURE, result)
 
 
 if __name__ == '__main__':

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -4,6 +4,7 @@ import tests.settings_mock as settings_mock
 import base64
 import json
 import tests.test_data as test_data
+from provider.lax_provider import ErrorCallingLaxException
 
 from mock import mock, patch
 
@@ -11,10 +12,10 @@ from mock import mock, patch
 class TestLaxProvider(unittest.TestCase):
 
     @patch('provider.lax_provider.article_versions')
-    def test_article_highest_version(self, mock_lax_provider_article_versions):
+    def test_article_highest_version_200(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
         version = lax_provider.article_highest_version('08411', settings_mock)
-        self.assertEqual(2, version)
+        self.assertEqual(3, version)
 
     @patch('provider.lax_provider.article_versions')
     def test_article_highest_version_no_versions(self, mock_lax_provider_article_versions):
@@ -23,19 +24,18 @@ class TestLaxProvider(unittest.TestCase):
         self.assertEqual(0, version)
 
     @patch('provider.lax_provider.article_versions')
-    def test_article_highest_version(self, mock_lax_provider_article_versions):
+    def test_article_highest_version_404(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 404, None
         version = lax_provider.article_highest_version('08411', settings_mock)
         self.assertEqual("1", version)
 
     @patch('provider.lax_provider.article_versions')
-    def test_article_highest_version(self, mock_lax_provider_article_versions):
+    def test_article_highest_version_500(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 500, None
-        version = lax_provider.article_highest_version('08411', settings_mock)
-        self.assertEqual(None, version)
+        self.assertRaises(ErrorCallingLaxException, lax_provider.article_highest_version, '08411', settings_mock)
 
     @patch('provider.lax_provider.article_versions')
-    def test_article_highest_version_no_versions(self, mock_lax_provider_article_versions):
+    def test_article_next_version_no_versions(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 200, []
         version = lax_provider.article_next_version('08411', settings_mock)
         self.assertEqual("1", version)


### PR DESCRIPTION
There is no point in having an error event on Version Lookup. If there is an error here, we will have no version to log it against, so it’s better to throw an exception.
plus fixed tests

@gnott @jhroot - This is the bot part of dealing with errors in the call for version from Lax. There are some fixes in the tests too.
