### PR TITLE
copies contents added to elife-publishing-cdn to elife-published/arti…

### DIFF
--- a/activity/activity_ConvertJATS.py
+++ b/activity/activity_ConvertJATS.py
@@ -47,7 +47,6 @@ class activity_ConvertJATS(activity.activity):
             expanded_folder_name = session.get_value(run, 'expanded_folder')
             expanded_folder_bucket = (self.settings.publishing_buckets_prefix
                                       + self.settings.expanded_bucket)
-            print expanded_folder_name
 
             conn = S3Connection(self.settings.aws_access_key_id,
                                 self.settings.aws_secret_access_key)

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -72,13 +72,15 @@ class activity_DepositAssets(activity.activity):
                     dict_metadata = {'Content-Disposition':
                                      str("Content-Disposition: attachment; filename=" + file_name + ";"),
                                      'Content-Type': content_type}
+                    file_download = file_name_no_extension + "-download." + extension
 
-                    dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + \
-                                    file_name_no_extension + "-download." + extension
-                    additional_dest_resource = storage_provider + published_bucket_path + "/" + article_id + "/" + \
-                                               file_name_no_extension + "-download." + extension
-                    storage_context.copy_resource(orig_resource, dest_resource, additional_dict_metadata=dict_metadata)
-                    storage_context.copy_resource(orig_resource, additional_dest_resource)
+                    orig_resource_download = dest_resource
+                    dest_resource_download = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_download
+                    additional_dest_resource_download = storage_provider + published_bucket_path + "/" \
+                                                        + article_id + "/" + file_download
+                    storage_context.copy_resource(orig_resource_download, dest_resource_download,
+                                                  additional_dict_metadata=dict_metadata)
+                    storage_context.copy_resource(dest_resource_download, additional_dest_resource_download)
 
 
 

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -78,8 +78,11 @@ class activity_DepositAssets(activity.activity):
                     dest_resource_download = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_download
                     additional_dest_resource_download = storage_provider + published_bucket_path + "/" \
                                                         + article_id + "/" + file_download
+
+                    # file is copied with additional metadata
                     storage_context.copy_resource(orig_resource_download, dest_resource_download,
                                                   additional_dict_metadata=dict_metadata)
+                    # additional metadata is already set in origin resource so it will be copied accross by default
                     storage_context.copy_resource(dest_resource_download, additional_dest_resource_download)
 
 

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -50,7 +50,7 @@ class activity_DepositAssets(activity.activity):
 
             storage_context = StorageContext(self.settings)
             storage_provider = self.settings.storage_provider + "://"
-            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket_path
+            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
 
             keys = self.get_keys(expanded_bucket, expanded_folder_name)
             for key in keys:

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -101,7 +101,7 @@ class activity_ExpandArticle(activity.activity):
                 dest_path = bucket_folder_name + '/' + filename
                 storage_resource_dest = self.settings.storage_provider + "://" + self.settings.publishing_buckets_prefix + \
                                         self.settings.expanded_bucket + "/" + dest_path
-                storage_context.set_resource_from_file(storage_resource_dest, source_path)
+                storage_context.set_resource_from_filename(storage_resource_dest, source_path)
 
             self.clean_tmp_dir()
 

--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -158,7 +158,7 @@ class activity_ResizeImages(activity.activity):
                                                    metadata={ 'Content-Type': content_type })
 
             #..
-            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket_path
+            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
             storage_resource_destination = storage_provider + published_bucket_path + "/" + cdn_path + "/" + filename
 
             storage_context.copy_resource(storage_resource, storage_resource_destination)
@@ -179,7 +179,6 @@ class activity_ResizeImages(activity.activity):
 
                 storage_resource_orig_download = storage_resource_dest_download_cdn
 
-                published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket_path
                 storage_resource_destination_download = storage_provider + \
                                                         published_bucket_path + "/" + cdn_path + "/" + file_download
 

--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -172,6 +172,8 @@ class activity_ResizeImages(activity.activity):
 
                 storage_resource_dest_download_cdn = storage_provider + cdn_bucket_name + "/" + cdn_path + "/" + \
                                                      file_download
+
+                # file is copied with additional metadata
                 storage_context.copy_resource(storage_resource, storage_resource_dest_download_cdn,
                                               additional_dict_metadata=dict_metadata)
 
@@ -181,6 +183,7 @@ class activity_ResizeImages(activity.activity):
                 storage_resource_destination_download = storage_provider + \
                                                         published_bucket_path + "/" + cdn_path + "/" + file_download
 
+                # additional metadata is already set in origin resource so it will be copied accross by default
                 storage_context.copy_resource(storage_resource_orig_download, storage_resource_destination_download)
 
         finally:

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -44,17 +44,47 @@ class S3StorageContext:
         key.key = s3_key
         return key.get_contents_as_string()
 
-    def set_resource_from_file(self, resource, file):
+    def set_resource_from_filename(self, resource, file):
         bucket, s3_key = self.s3_storage_objects(resource)
         key = Key(bucket)
         key.key = s3_key
         key.set_contents_from_filename(file)
+
+    def set_resource_from_file(self, resource, file, metadata=None):
+        bucket, s3_key = self.s3_storage_objects(resource)
+        key = Key(bucket)
+        key.key = s3_key
+
+        if metadata is not None:
+            for mdk in metadata:
+                key.metadata[mdk] = metadata[mdk]
+
+        key.set_contents_from_file(file)
 
     def set_resource_from_string(self, resource, data):
         bucket, s3_key = self.s3_storage_objects(resource)
         key = Key(bucket)
         key.key = s3_key
         key.set_contents_from_string(data)
+
+    def copy_resource(self, orig_resource, dest_resource, additional_dict_metadata=None):
+        orig_bucket, orig_s3_key = self.s3_storage_objects(orig_resource)
+        orig_key = orig_bucket.get_key(orig_s3_key)
+
+        metadata = None
+        if additional_dict_metadata is not None:
+            metadata = orig_key.metadata.copy()
+            for mdk in additional_dict_metadata:
+                metadata[mdk] = additional_dict_metadata[mdk]
+
+        dest_bucket, dest_s3_key = self.s3_storage_objects(dest_resource)
+
+        dest_key = dest_bucket.get_key(dest_s3_key, validate=True)
+        if dest_key is None:
+            dest_key = dest_bucket.new_key(dest_s3_key)
+            dest_key.set_contents_from_string('')
+
+        dest_bucket.copy_key(dest_key.name[1:], orig_bucket.name, orig_key.name[1:], metadata=metadata)
 
     def get_bucket_from_cache(self, bucket_name):
 

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -69,11 +69,9 @@ class S3StorageContext:
 
     def copy_resource(self, orig_resource, dest_resource, additional_dict_metadata=None):
         orig_bucket, orig_s3_key = self.s3_storage_objects(orig_resource)
-        orig_key = orig_bucket.get_key(orig_s3_key)
 
         metadata = None
         if additional_dict_metadata is not None:
-            metadata = orig_key.metadata.copy()
             for mdk in additional_dict_metadata:
                 metadata[mdk] = additional_dict_metadata[mdk]
 
@@ -84,7 +82,7 @@ class S3StorageContext:
             dest_key = dest_bucket.new_key(dest_s3_key)
             dest_key.set_contents_from_string('')
 
-        dest_bucket.copy_key(dest_key.name[1:], orig_bucket.name, orig_key.name[1:], metadata=metadata)
+        dest_bucket.copy_key(dest_key.name[1:], orig_bucket.name, orig_s3_key[1:], metadata=metadata)
 
     def get_bucket_from_cache(self, bucket_name):
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -44,6 +44,8 @@ class exp():
     archive_bucket = 'elife-publishing-archive'
     xml_bucket = 'elife-publishing-xml'
 
+    published_bucket_path = 'elife-published/articles'
+
     # REST endpoint for drupal node builder
     # drupal_naf_endpoint = 'http://localhost:5000/nodes'
     drupal_EIF_endpoint = 'http://52.4.182.179/api/article.json'

--- a/settings-example.py
+++ b/settings-example.py
@@ -44,7 +44,7 @@ class exp():
     archive_bucket = 'elife-publishing-archive'
     xml_bucket = 'elife-publishing-xml'
 
-    published_bucket_path = 'elife-published/articles'
+    published_bucket = 'elife-published'
 
     # REST endpoint for drupal node builder
     # drupal_naf_endpoint = 'http://localhost:5000/nodes'

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -97,7 +97,7 @@ class FakeStorageContext:
         bucket_name, s3_key = self.get_bucket_and_key(resource)
         copyfile(data.ExpandArticle_files_source_folder + s3_key, file.name)
 
-    def set_resource_from_file(self, resource, file):
+    def set_resource_from_filename(self, resource, file):
         #bucket_name, s3_key = self.get_bucket_and_key(resource)
         copy(file, data.ExpandArticle_files_dest_folder)
 


### PR DESCRIPTION
…cles

plus
Fixes content-type download problem: When loading a key from S3, only a flat copy is made and we don’t have access to the current metadata in this copy, so content-type was being lost. Now I add the content-type when adding content-disposition.

The copy is made in the following pattern

elife-published/articles/[article id]