### PR TITLE
only logs at info level when something more relevant has happened

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -52,7 +52,10 @@ def decide(ENV, flag):
 
             token = get_taskToken(decision)
 
-            logger.info('got decision: \n%s' % json.dumps(decision, sort_keys=True, indent=4))
+            if isinstance(decision, dict) and "startedEventId" in decision and decision["startedEventId"] == 0:
+                logger.debug('got decision: \n%s' % json.dumps(decision, sort_keys=True, indent=4))
+            else:
+                logger.info('got decision: \n%s' % json.dumps(decision, sort_keys=True, indent=4))
 
             if token is not None:
                 # Get the workflowType and attempt to do the work


### PR DESCRIPTION
@giorgiosironi - now the logs should appear like this

2016-12-01T12:41:50Z INFO decider_5266 polling for decision...
2016-12-01T12:42:28Z INFO decider_17416 polling for decision...
2016-12-01T12:43:28Z INFO decider_17416 polling for decision...

until an event happens.
