### PR TITLE
Missing registration of activity

### DIFF
--- a/register.py
+++ b/register.py
@@ -69,6 +69,7 @@ def start(ENV="dev"):
     activity_names.append("UpdateRepository")
     activity_names.append("SetEIFPublish")
     activity_names.append("VersionLookup")
+    activity_names.append("VersionDateLookup")
     activity_names.append("VerifyPublishResponse")
     activity_names.append("PublishToLax")
     activity_names.append("VerifyLaxResponse")


### PR DESCRIPTION
We got a huge log containing:
```
$ grep DOES_NOT_EXIST decider.log -A 4 -B 4 | grep name | uniq -c
 933661                     "name": "VersionDateLookup",
```
but there are also other error logs elsewhere when we try to test the
silent corrections. The test still do not find out everything has
failed.

Problems should be limited to the \`end2end\` environment.