### PR TITLE
Conflicting logger name

### DIFF
--- a/log.py
+++ b/log.py
@@ -9,7 +9,7 @@ def logger(logFile = None, setLevel = "INFO", identity = ""):
     set the level of logging, and optional identity for what is
     sending logging message, to identify multiple workers
     """
-    logger = logging.getLogger('myapp')
+    logger = logging.getLogger('elife-bot')
     if(logFile):
         hdlr = handlers.WatchedFileHandler(os.getcwd() + os.sep + logFile)
     else:


### PR DESCRIPTION
This logger name conflicts with the `myapp` used in `parseJATS.py` from `elifetools`. Therefor, with this conflict in place all the logs from the bot are also duplicated to the `test.log` file, leading to confusing grep commands.