### PR TITLE
Initializing metadata to empty dict

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -3,4 +3,4 @@ set -e
 source venv/bin/activate
 
 # intentionally only the script files in the root folder
-pylint -E *.py
+pylint -E *.py provider/storage_provider.py

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -70,10 +70,12 @@ class S3StorageContext:
     def copy_resource(self, orig_resource, dest_resource, additional_dict_metadata=None):
         orig_bucket, orig_s3_key = self.s3_storage_objects(orig_resource)
 
-        metadata = {}
         if additional_dict_metadata is not None:
+            metadata = {}
             for mdk in additional_dict_metadata:
                 metadata[mdk] = additional_dict_metadata[mdk]
+        else:
+            metadata = None
 
         dest_bucket, dest_s3_key = self.s3_storage_objects(dest_resource)
 

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -70,7 +70,7 @@ class S3StorageContext:
     def copy_resource(self, orig_resource, dest_resource, additional_dict_metadata=None):
         orig_bucket, orig_s3_key = self.s3_storage_objects(orig_resource)
 
-        metadata = None
+        metadata = {}
         if additional_dict_metadata is not None:
             for mdk in additional_dict_metadata:
                 metadata[mdk] = additional_dict_metadata[mdk]

--- a/tests/provider/test_storage.py
+++ b/tests/provider/test_storage.py
@@ -1,0 +1,15 @@
+import unittest
+from mock import MagicMock
+from provider.storage_provider import S3StorageContext
+
+class TestProviderStorage(unittest.TestCase):
+    def test_copy_without_any_metadata_to_override(self):
+        storage = S3StorageContext({})
+        storage.context['buckets']['a'] = MagicMock()
+        storage.context['buckets']['b'] = MagicMock()
+        storage.context['connection'] = MagicMock()
+        original = "s3://a/1"
+        destination = "s3://b/2"
+        storage.copy_resource(original, destination, None)
+        self.assertIsNone(None, storage.context['buckets']['b'].method_calls[1][2]['metadata'])
+        

--- a/tests/provider/test_storage.py
+++ b/tests/provider/test_storage.py
@@ -1,15 +1,24 @@
 import unittest
-from mock import MagicMock
+from mock import MagicMock, call
 from provider.storage_provider import S3StorageContext
 
 class TestProviderStorage(unittest.TestCase):
+    def setUp(self):
+        self.storage = S3StorageContext({})
+        self.storage.context['buckets']['a'] = MagicMock()
+        self.storage.context['buckets']['b'] = MagicMock()
+        self.storage.context['connection'] = MagicMock()
+
     def test_copy_without_any_metadata_to_override(self):
-        storage = S3StorageContext({})
-        storage.context['buckets']['a'] = MagicMock()
-        storage.context['buckets']['b'] = MagicMock()
-        storage.context['connection'] = MagicMock()
         original = "s3://a/1"
         destination = "s3://b/2"
-        storage.copy_resource(original, destination, None)
-        self.assertIsNone(None, storage.context['buckets']['b'].method_calls[1][2]['metadata'])
+        self.storage.copy_resource(original, destination, None)
+        self.assertEqual({'metadata': None}, self.storage.context['buckets']['b'].copy_key.mock_calls[0][2])
+
+    def test_copy_and_specify_metadata(self):
+        original = "s3://a/1"
+        destination = "s3://b/2"
+        self.storage.copy_resource(original, destination, {'Content-Type': 'application/json'})
+        self.assertEqual({'metadata': {'Content-Type': 'application/json'}}, self.storage.context['buckets']['b'].copy_key.mock_calls[0][2])
+
         


### PR DESCRIPTION
Pylint finds the problem, so adding the file to the list of linted ones:
```
************* Module provider.storage_provider
E: 76,16: Value 'metadata' is unsubscriptable (unsubscriptable-object)
```