### PR TITLE
UpdateRepository retries also on 409 on update

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -3,4 +3,4 @@ set -e
 source venv/bin/activate
 
 # intentionally only the script files in the root folder
-pylint -E *.py provider/storage_provider.py
+pylint -E *.py provider/storage_provider.py activity/activity_Update*.py


### PR DESCRIPTION
Previously https://github.com/elifesciences/elife-bot/pull/365 added a retry of the activity in case Github returns a 409 on create because of a concurrent update to he repository. Now we do the same also on the update of an existing file, to avoid this:
```
2017-01-04T17:12:06Z ERROR worker_1327 Exception in do_activity
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_UpdateRepository.py", line 74, in do_activity
    message = self.update_github(self.settings.git_repo_path + filename, file_content)
  File "/opt/elife-bot/activity/activity_UpdateRepository.py", line 125, in update_github
    response = article_xml_repo.update_file(repo_file , "Updates xml", content, xml_file.sha)
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/github/Repository.py", line 1346, in update_file
    input=put_parameters
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/github/Requester.py", line 172, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/github/Requester.py", line 180, in __check
    raise self.__createException(status, responseHeaders, output)
GithubException: 409 {u'documentation_url': u'https://developer.github.com/v3/repos/contents/', u'message': u'refs/heads/master is at 428c606703c2795141f0e085ba8a0cd0f22b5d20 but expected d161bba578ae62584f37bc6e72d49e675c9c6339'}
```