### PR TITLE
Improving error message on bad file structure

### DIFF
--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -94,6 +94,7 @@ class activity_ExpandArticle(activity.activity):
             for f in listdir(content_folder):
                 if isfile(join(content_folder, f)) and f[0] != '.' and not f[0] == '_':
                     upload_filenames.append(f)
+            self.check_filenames(upload_filenames)
 
             bucket_folder_name = article_version_id + '/' + run
             for filename in upload_filenames:
@@ -126,3 +127,11 @@ class activity_ExpandArticle(activity.activity):
         if version is None:
             return "-1"
         return version
+
+    def check_filenames(self, filenames):
+        xml_found = False
+        for filename in filenames:
+            if filename.endswith(".xml"):
+                xml_found = True
+        if not xml_found:
+            raise RuntimeError("No .xml file found. List of files found is %s" % filenames)

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -76,6 +76,12 @@ class TestExpandArticle(unittest.TestCase):
         success = self.expandarticle.do_activity(testdata.ExpandArticle_data_invalid_status)
         self.assertEqual(self.expandarticle.ACTIVITY_PERMANENT_FAILURE, success)
 
+    def test_check_filenames(self):
+        self.expandarticle.check_filenames(['elife-12345-vor.xml'])
+        self.expandarticle.check_filenames(['elife-12345-vor.xml', 'elife-12345-vor.pdf'])
+        with self.assertRaises(RuntimeError):
+            self.expandarticle.check_filenames(['elife-12345'])
+
     def create_temp_folder(self, plus=None):
         if not os.path.exists('tests/tmp'):
             os.makedirs('tests/tmp')


### PR DESCRIPTION
When files inside the zip are put in a subfolder, a cryptic error message results from the ApplyVersionNumber about concatenating a string with a None. This should provide a nicer error message, and earlier in the flow.