### PR TITLE
Fixes XML that wasn’t being found by Article class

### DIFF
--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -50,7 +50,7 @@ class activity_VerifyGlencoe(activity.activity):
             expanded_bucket = self.settings.publishing_buckets_prefix + self.settings.expanded_bucket
             self.logger.info("expanded_bucket: " + expanded_bucket)
 
-            xml_filename = lax_provider.get_xml_file_name(self.settings, expanded_folder, expanded_bucket)
+            xml_filename = lax_provider.get_xml_file_name(self.settings, expanded_folder, expanded_bucket, version)
             if xml_filename is None:
                 raise RuntimeError("No xml_filename found.")
 

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -68,17 +68,6 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
-                        "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoe",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
                         "activity_type": "ApplyVersionNumber",
                         "activity_id": "ApplyVersionNumber",
                         "version": "1",
@@ -88,6 +77,17 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "schedule_to_close_timeout": 60 * 10,
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 10
+                    },
+                    {
+                        "activity_type": "VerifyGlencoe",
+                        "activity_id": "VerifyGlencoe",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
                     },
                     {
                         "activity_type": "IngestToLax",


### PR DESCRIPTION
It was necessary to put VerifyGlencoe happening after ApplyVersionNumber since the checks in Article class are made on an assumption that -v[number] has been added to the file, which only occurs on ApplyVersionNumber activity.