### PR TITLE
UpdateRepository sleep time

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -84,6 +84,7 @@ class activity_UpdateRepository(activity.activity):
 
             except RetryException as e:
                 self.logger.info(e.message)
+                time.sleep(30)
                 return activity.activity.ACTIVITY_TEMPORARY_FAILURE
 
             except Exception as e:

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -1,9 +1,12 @@
 import activity
-from boto.s3.connection import S3Connection
+import provider.lax_provider as lax_provider
+
 import tempfile
+import time
+
+from boto.s3.connection import S3Connection
 from github import Github
 from github import GithubException
-import provider.lax_provider as lax_provider
 
 """
 activity_UpdateRepository.py activity


### PR DESCRIPTION
When there is a temporary failure, do not retry immediately, instead wait for 30 seconds.