### PR TITLE
Starter should log an error if PostPerfectPublication workflow cannot start

### DIFF
--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -80,4 +80,4 @@ if __name__ == "__main__":
 
     o = starter_PostPerfectPublication()
 
-    o.start(settings=settings,)
+    o.start(settings=settings,info={})

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -55,7 +55,7 @@ class starter_PostPerfectPublication():
             # There is already a running workflow with that ID, cannot start another
             message = 'SWFWorkflowExecutionAlreadyStartedError: ' \
                       'There is already a running workflow with ID %s' % workflow_id
-            logger.info(message)
+            logger.error(message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 This has happened sometimes in tests that are too eager to publish a new version of an article while the old run has not finished yet.

If this workflow cannot start, it is simply dropped and no error is seen on
the dashboard or on the SWF console, but the end result is updates like the
Github repository are missing.