### PR TITLE
Provide an exception message showing the problem when Lax is not available

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -217,7 +217,7 @@ class activity_PubmedArticleDeposit(activity.activity):
         """
         Temporary fix to set the version of the article if available
         """
-        version = lax_provider.article_highest_version(article_id, self.settings, self.logger)
+        version = lax_provider.article_highest_version(article_id, self.settings)
         if version is None:
             return "-1"
         return version

--- a/lint.sh
+++ b/lint.sh
@@ -3,4 +3,4 @@ set -e
 source venv/bin/activate
 
 # intentionally only the script files in the root folder
-pylint -E *.py provider/storage_provider.py activity/activity_Update*.py
+pylint -E *.py provider/storage_provider.py provider/lax_provider.py activity/activity_Update*.py activity/activity_Pubmed*.py

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -14,26 +14,24 @@ def article_versions(article_id, settings):
     url = settings.lax_article_versions.replace('{article_id}', article_id)
     response = requests.get(url, verify=settings.verify_ssl)
     status_code = response.status_code
+    if status_code not in [200, 404]:
+        raise ErrorCallingLaxException("Error looking up article " + article_id + " version in Lax: %s\n%s" % (status_code, response.content))
+
     if status_code == 200:
         data = response.json()
         if "versions" in data:
             return status_code, data["versions"]
+
     return status_code, None
 
 
-def article_highest_version(article_id, settings, logger=None):
+def article_highest_version(article_id, settings):
     status_code, data = article_versions(article_id, settings)
     if status_code == 200:
         high_version = 0 if len(data) < 1 else max(map(lambda x: int(x["version"]), data))
         return high_version
     elif status_code == 404:
         return "1"
-    else:
-        if logger:
-            logger.error("Error obtaining version information from Lax" +
-                         str(status_code))
-        raise ErrorCallingLaxException("Error looking up article " + article_id + " version in Lax. "
-                                                                                  "Please check call to Lax.")
 
 
 def article_next_version(article_id, settings):


### PR DESCRIPTION
Currently `lax_provider` relies on a logger being passed in, but almost no activity actually passes it to `article_highest_version`. Therefore, throw an exception instead as soon as the status code is recognized to be invalid.

The exception is then logged by the appropriate activity.