### PR TITLE
Prevent multiple workflows running concurrently

### DIFF
--- a/starter/starter_ApproveArticlePublication.py
+++ b/starter/starter_ApproveArticlePublication.py
@@ -46,8 +46,7 @@ class starter_ApproveArticlePublication():
         child_policy, \
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(self.const_name, "1", None, info,
-                                                         article_id + "." + str(version),
-                                                         os.getpid())
+                                                         article_id + "." + str(version))
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_ArticleInformationSupplier.py
+++ b/starter/starter_ArticleInformationSupplier.py
@@ -48,7 +48,7 @@ class starter_ArticleInformationSupplier():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id, os.getpid())
+        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id)
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_IngestArticleZip.py
+++ b/starter/starter_IngestArticleZip.py
@@ -39,7 +39,7 @@ class starter_IngestArticleZip():
         child_policy, \
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(self.const_name, "1", None, input,
-                                                         info.file_name.replace('/', '_'), os.getpid(),
+                                                         info.file_name.replace('/', '_'),
                                                          start_to_close_timeout=str(60 * 60 * 5))
 
         # Simple connect

--- a/starter/starter_ProcessArticleZip.py
+++ b/starter/starter_ProcessArticleZip.py
@@ -44,7 +44,7 @@ class starter_ProcessArticleZip():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id, os.getpid())
+        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id)
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -38,7 +38,7 @@ class starter_SilentCorrectionsIngest():
         child_policy, \
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(self.const_name, "1", None, input,
-                                                         info.file_name.replace('/', '_'), os.getpid())
+                                                         info.file_name.replace('/', '_'))
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -47,7 +47,7 @@ class starter_SilentCorrectionsProcess():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id, os.getpid())
+        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id)
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_helper.py
+++ b/starter/starter_helper.py
@@ -15,7 +15,9 @@ def get_starter_logger(set_level, identity, log_file="starter.log"):
 
 def set_workflow_information(name, workflow_version, child_policy, data, workflow_id_part,
                              extra="", start_to_close_timeout=str(60 * 30)):
-        workflow_id = "%s_%s.%s" % (name, workflow_id_part, extra)
+        workflow_id = "%s_%s" % (name, workflow_id_part)
+        if extra:
+            workflow_id = workflow_id + (".%s" % extra)
         workflow_name = name
         workflow_version = workflow_version
         child_policy = child_policy


### PR DESCRIPTION
AFAIK, two workflows with the same id will be stopped from running (the
second one will be dropped). For these workflows it seems safe to say we
don't want more than one copy running at a given time.

The pid remains useful for the identity of processes (like worker.py),
which will continue to log it. It's also logged as the `Identity` field
of all the activities on the SWF console, as different activities are
performed by different workers (e.g. `worker_31510`)