### PR TITLE
Removes GeneratePDFCovers from workflow definition

### DIFF
--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -120,17 +120,6 @@ class workflow_PostPerfectPublication(workflow.workflow):
                         "schedule_to_close_timeout": 60 * 5,
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "GeneratePDFCovers",
-                        "activity_id": "GeneratePDFCovers",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
                     }
                 ],
 


### PR DESCRIPTION
Since GeneratePDFCovers is not production-ready yet we should remove it from the current workflow definition as it will always cause failure of the activity. Once PDF covers is working, we can simply add the activity to this file