### PR TITLE
Retry on SSL timeout from Github

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -4,7 +4,7 @@ from boto.s3.connection import S3Connection
 import tempfile
 from github import Github
 from github import GithubException
-from provider import lax_provider
+import provider
 from provider.storage_provider import StorageContext
 
 """
@@ -52,7 +52,7 @@ class activity_UpdateRepository(activity.activity):
 
             try:
 
-                xml_file = lax_provider.get_xml_file_name(self.settings,
+                xml_file = provider.lax_provider.get_xml_file_name(self.settings,
                                                           data['article_id'],
                                                           self.settings.publishing_buckets_prefix +
                                                           self.settings.ppp_cdn_bucket,
@@ -92,6 +92,7 @@ class activity_UpdateRepository(activity.activity):
                     return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
             except Exception as e:
+                print e
                 self.logger.exception("Exception in do_activity")
                 self.emit_monitor_event(self.settings, data['article_id'], data['version'], data['run'],
                                         self.pretty_name, "error",

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -4,7 +4,7 @@ from boto.s3.connection import S3Connection
 import tempfile
 from github import Github
 from github import GithubException
-import provider.lax_provider as lax_provider
+from provider import lax_provider
 from provider.storage_provider import StorageContext
 
 """
@@ -59,9 +59,9 @@ class activity_UpdateRepository(activity.activity):
                                                           data['version'])
                 s3_file_path = data['article_id'] + "/" + xml_file
 
+                storage_context = StorageContext(self.settings)
                 #download xml
                 with tempfile.TemporaryFile(mode='r+') as tmp:
-                    storage_context = StorageContext(self.settings)
                     storage_provider = self.settings.storage_provider + "://"
                     published_path = storage_provider + self.settings.publishing_buckets_prefix + \
                                        self.settings.ppp_cdn_bucket
@@ -73,7 +73,6 @@ class activity_UpdateRepository(activity.activity):
                     file_content = storage_context.get_resource_as_string(resource)
 
                     message = self.update_github(self.settings.git_repo_path + xml_file, file_content)
-
                     self.logger.info(message)
                     self.emit_monitor_event(self.settings, data['article_id'], data['version'], data['run'],
                                     self.pretty_name, "end",

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -1,3 +1,4 @@
+from ssl import SSLError
 import activity
 from boto.s3.connection import S3Connection
 import tempfile
@@ -82,6 +83,14 @@ class activity_UpdateRepository(activity.activity):
             except RetryException as e:
                 self.logger.info(e.message)
                 return activity.activity.ACTIVITY_TEMPORARY_FAILURE
+
+            except SSLError as e:
+                if e.message == 'The read operation timed out':
+                    self.logger.info(e.message)
+                    return activity.activity.ACTIVITY_TEMPORARY_FAILURE
+                else:
+                    self.logger.exception("Exception in do_activity")
+                    return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
             except Exception as e:
                 self.logger.exception("Exception in do_activity")

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -5,7 +5,7 @@ import tempfile
 from github import Github
 from github import GithubException
 import provider
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 
 """
 activity_UpdateRepository.py activity
@@ -59,7 +59,9 @@ class activity_UpdateRepository(activity.activity):
                                                           data['version'])
                 s3_file_path = data['article_id'] + "/" + xml_file
 
-                storage_context = StorageContext(self.settings)
+                storage_context = storage_context(self.settings)
+                bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
+
                 #download xml
                 with tempfile.TemporaryFile(mode='r+') as tmp:
                     storage_provider = self.settings.storage_provider + "://"
@@ -68,9 +70,9 @@ class activity_UpdateRepository(activity.activity):
 
                     resource = published_path + "/" + s3_file_path
 
-                    storage_context.get_resource_to_file(resource, tmp)
+                    storage.get_resource_to_file(resource, tmp)
 
-                    file_content = storage_context.get_resource_as_string(resource)
+                    file_content = storage.get_resource_as_string(resource)
 
                     message = self.update_github(self.settings.git_repo_path + xml_file, file_content)
                     self.logger.info(message)

--- a/lint.sh
+++ b/lint.sh
@@ -5,7 +5,6 @@ source venv/bin/activate
 # intentionally only an expanding subset of files
 python -m pylint -E \
     *.py \
-    activity/activity.py \
     activity/activity*.py \
     provider/article_structure.py \
     provider/imageresize.py \

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -13,6 +13,9 @@ def StorageContext(*args):
 #     def __new__(cls, *args):
 #         return S3StorageContext(args[0])
 
+def storage_context(*args):
+    return S3StorageContext(*args)
+
 class S3StorageContext:
 
     def __init__(self, settings):

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -5,6 +5,7 @@ from shutil import copy
 import shutil
 import re
 import os
+from mock import MagicMock
 
 
 class FakeSession:
@@ -201,8 +202,9 @@ class FakeLogger:
         self.logerror = msg
 
 
-
-
+FakeLaxProvider = MagicMock()
+FakeLaxProvider.get_xml_file_name = MagicMock()
+FakeLaxProvider.get_xml_file_name.return_value = 'fake.xml'
 
 
 

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -34,6 +34,7 @@ ses_poa_sender_email = ""
 ses_poa_recipient_email = ""
 ses_admin_email = ""
 templates_bucket = ""
+ppp_cdn_bucket = 'ppd_cdn_bucket'
 
 drupal_EIF_endpoint = "https://website/api/article.json"
 drupal_approve_endpoint = "https://website/api/publish/"
@@ -109,3 +110,7 @@ CNPIEC_FTP_URI = "cnpiec.localhost"
 CNPIEC_FTP_USERNAME = ""
 CNPIEC_FTP_PASSWORD = ""
 CNPIEC_FTP_CWD = ""
+
+git_repo_name = 'elife-article-xml-ci'
+git_repo_path = '/articles/'
+github_token = '1234567890abcdef'

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -2,28 +2,23 @@ import unittest
 from ssl import SSLError
 from activity.activity_UpdateRepository import activity_UpdateRepository
 import settings_mock
-from mock import mock, patch, MagicMock
-#from testfixtures import tempdir, compare
-#import os
+from mock import patch, MagicMock
 from activity.activity import activity
-from classes_mock import FakeStorageContext
-#from classes_mock import FakeSession
-#import classes_mock
-#import test_activity_data as testdata
-#from ddt import ddt, data
-#import helpers
+from classes_mock import FakeStorageContext, FakeLogger, FakeLaxProvider
 
+@patch('activity.activity_UpdateRepository.provider')
+@patch('activity.activity_UpdateRepository.StorageContext')
+@patch('dashboard_queue.send_message')
 class TestUpdateRepository(unittest.TestCase):
 
-    @patch('activity.activity_UpdateRepository.lax_provider')
-    @patch('activity.activity_UpdateRepository.StorageContext')
-    @patch('dashboard_queue.send_message')
-    def test_ssl_timeout_error_leads_to_a_retry(self, dashboard_queue, mock_storage_context, mock_lax_provider):
-        a = activity_UpdateRepository(settings_mock, MagicMock())
+    def test_ssl_timeout_error_leads_to_a_retry(self, dashboard_queue, mock_storage_context, provider):
+        a = activity_UpdateRepository(settings_mock, FakeLogger())
         mock_storage_context.return_value = FakeStorageContext()
-        mock_lax_provider.get_xml_file_name = MagicMock()
+        provider.lax_provider = FakeLaxProvider()
         a.update_github = MagicMock()
+
         a.update_github.side_effect = SSLError('The read operation timed out')
+
         result = a.do_activity({
             'article_id': '12345',
             'version': 1,

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -1,0 +1,33 @@
+import unittest
+from ssl import SSLError
+from activity.activity_UpdateRepository import activity_UpdateRepository
+import settings_mock
+from mock import mock, patch, MagicMock
+#from testfixtures import tempdir, compare
+#import os
+from activity.activity import activity
+from classes_mock import FakeStorageContext
+#from classes_mock import FakeSession
+#import classes_mock
+#import test_activity_data as testdata
+#from ddt import ddt, data
+#import helpers
+
+class TestUpdateRepository(unittest.TestCase):
+
+    @patch('activity.activity_UpdateRepository.lax_provider')
+    @patch('activity.activity_UpdateRepository.StorageContext')
+    @patch('dashboard_queue.send_message')
+    def test_ssl_timeout_error_leads_to_a_retry(self, dashboard_queue, mock_storage_context, mock_lax_provider):
+        a = activity_UpdateRepository(settings_mock, MagicMock())
+        mock_storage_context.return_value = FakeStorageContext()
+        mock_lax_provider.get_xml_file_name = MagicMock()
+        a.update_github = MagicMock()
+        a.update_github.side_effect = SSLError('The read operation timed out')
+        result = a.do_activity({
+            'article_id': '12345',
+            'version': 1,
+            'run': '123abc',
+        })
+        self.assertEqual(result, 'ActivityTemporaryFailure')
+

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -7,7 +7,7 @@ from activity.activity import activity
 from classes_mock import FakeStorageContext, FakeLogger, FakeLaxProvider
 
 @patch('activity.activity_UpdateRepository.provider')
-@patch('activity.activity_UpdateRepository.StorageContext')
+@patch('activity.activity_UpdateRepository.storage_context')
 @patch('dashboard_queue.send_message')
 class TestUpdateRepository(unittest.TestCase):
 


### PR DESCRIPTION
Also:
- Using storage_provider for S3 access
- Stop reading the file to a tmp file that is subsequently ignored
- Linter rightly complains that instantiating a class should not return a different class