### PR TITLE
Fail if image resizing fails

### DIFF
--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -82,8 +82,8 @@ class activity_ResizeImages(activity.activity):
                                     "Resize Images", "error",
                                     "Error resizing images for article" + article_id +
                                     " message:" + e.message)
-            return False
-        return True
+            return activity.activity.ACTIVITY_PERMANENT_FAILURE
+        return activity.activity.ACTIVITY_SUCCESS
 
     def get_file_infos(self, folder_name):
         # connect to S3 and obtain the expanded article bucket

--- a/lint.sh
+++ b/lint.sh
@@ -3,4 +3,4 @@ set -e
 source venv/bin/activate
 
 # intentionally only the script files in the root folder
-pylint -E *.py provider/storage_provider.py provider/lax_provider.py activity/activity_Update*.py activity/activity_Pubmed*.py
+pylint -E *.py provider/storage_provider.py provider/lax_provider.py provider/imageresize.py activity/activity_Update*.py activity/activity_Pubmed*.py

--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -39,9 +39,9 @@ def resize(format, filep, info, logger):
             image.save(file=image_buffer)
 
     except Exception as e:
-        logger.error("error resizing image %s" % info.filename, exc_info=True)
-        # TODO : raise this error, but only once the decider will terminate the worklfow on hard error
-        # raise e
+        message = "error resizing image %s" % info.filename
+        logger.error(message, exc_info=True)
+        raise RuntimeError("%s (%s)" % (message, e.message))
 
     filename = info.filename
     if format.get('prefix') is not None:

--- a/tests/activity/test_activity_resize_images.py
+++ b/tests/activity/test_activity_resize_images.py
@@ -50,7 +50,7 @@ class TestResizeImages(unittest.TestCase):
         self.resizeimages.logger = mock.MagicMock()
 
         success = self.resizeimages.do_activity(testdata.ResizeImages_data)
-        self.assertEqual(True, success)
+        self.assertEqual('ActivitySuccess', success)
 
         formats = self.resizeimages.get_formats('Figure')
         prefix = self.image_prefix #this is the name of the file (without extension) that is an image inside files_source folder


### PR DESCRIPTION
The activity catches the exception already, and exits by returning False
(not sure what happens after that, is it retried automatically? It should
not)

So today I fed in by error images which were just small text files (long
story). Everything was green on the dashboard, my goal is to fail at the
ImageResize activity; it already logs errors about the images which are not
working.