### PR TITLE
Separating article id from image count

### DIFF
--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -71,7 +71,7 @@ class activity_ResizeImages(activity.activity):
                     # process each key in the folder
                     self.process_key(key, cdn_path)
             self.emit_monitor_event(self.settings, article_id, version, run, "Resize Images", "end",
-                                    "Finished converting images for  " + article_id +
+                                    "Finished converting images for " + article_id + ": " +
                                     str(image_count) + " images processed ")
 
             self.clean_tmp_dir()


### PR DESCRIPTION
On the dashboard, we see
```
Finished converting images for  426183516370560497025 images processed
```
but it should be
```
Finished converting images for 4261835163705604970: 25 images processed
```