### PR TITLE
PI-329 - versionDate field to be used for silent correction Version Date Lookup

### DIFF
--- a/activity/activity_VersionDateLookup.py
+++ b/activity/activity_VersionDateLookup.py
@@ -73,7 +73,7 @@ class activity_VersionDateLookup(activity.activity):
             version_date = article_structure.get_update_date_from_zip_filename()
             if version_date:
                 return version_date, None
-            version_date = lax_provider.article_publication_date_by_version(article_id, version, settings)
+            version_date = lax_provider.article_version_date_by_version(article_id, version, settings)
             return version_date, None
         except Exception as e:
             error_message = "Exception when looking up version Date. Message: " + str(e)

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -50,12 +50,12 @@ def article_next_version(article_id, settings):
     return version
 
 
-def article_publication_date_by_version(article_id, version, settings):
+def article_version_date_by_version(article_id, version, settings):
     status_code, data = article_versions(article_id, settings)
     print data
     if status_code == 200:
         version_data = (vd for vd in data if vd["version"] == int(version)).next()
-        return parse(version_data["published"]).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return parse(version_data["versionDate"]).strftime("%Y-%m-%dT%H:%M:%SZ")
     raise Exception("Error in article_publication_date_by_version: Version date not found. Status: " + str(status_code))
 
 

--- a/tests/activity/test_activity_version_date_lookup.py
+++ b/tests/activity/test_activity_version_date_lookup.py
@@ -11,7 +11,7 @@ class TestVersionDateLookup(unittest.TestCase):
         self.versiondatelookup = activity_VersionDateLookup(settings_mock, None, None, None, None)
 
     @patch('activity.activity_VersionDateLookup.Session')
-    @patch('provider.lax_provider.article_publication_date_by_version')
+    @patch('provider.lax_provider.article_version_date_by_version')
     def test_get_version_date_silent_corrections(self, fake_date_lookup_function, fake_session):
         fake_session_obj = FakeSession(testdata.data_example_before_publish)
         fake_session.return_value = fake_session_obj
@@ -25,7 +25,7 @@ class TestVersionDateLookup(unittest.TestCase):
         self.assertEqual(fake_session_obj.session_dict["update_date"], '2015-11-30T00:00:00Z')
 
     @patch('activity.activity_VersionDateLookup.Session')
-    @patch('provider.lax_provider.article_publication_date_by_version')
+    @patch('provider.lax_provider.article_version_date_by_version')
     def test_get_version_silent_corrections_version_date_in_zip(self, fake_lookup_functions, fake_session):
         data_rep = testdata.data_example_before_publish.copy()
         data_rep['filename_last_element'] = "elife-00353-vor-v1-20121213000000.zip"
@@ -40,7 +40,7 @@ class TestVersionDateLookup(unittest.TestCase):
         self.assertEqual(fake_session_obj.session_dict["update_date"], '2012-12-13T00:00:00Z')
 
     @patch('activity.activity_VersionDateLookup.Session')
-    @patch('provider.lax_provider.article_publication_date_by_version')
+    @patch('provider.lax_provider.article_version_date_by_version')
     def test_get_version_date_silent_corrections_error(self, fake_date_lookup_function, fake_session):
         fake_session_obj = FakeSession(testdata.data_example_before_publish)
         fake_session.return_value = fake_session_obj

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -60,9 +60,9 @@ class TestLaxProvider(unittest.TestCase):
         self.assertEqual(None, date_str)
 
     @patch('provider.lax_provider.article_versions')
-    def test_article_publication_date_by_version(self, mock_lax_provider_article_versions):
+    def test_article_version_date_by_version(self, mock_lax_provider_article_versions):
         mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
-        result = lax_provider.article_publication_date_by_version('08411', "2", settings_mock)
+        result = lax_provider.article_version_date_by_version('08411', "2", settings_mock)
         self.assertEqual("2015-11-30T00:00:00Z", result)
 
     @patch('requests.get')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,17 +5,20 @@ lax_article_versions_response_data = [
                                         {
                                           "status": "poa",
                                           "version": 1,
-                                          "published": "2015-11-26T00:00:00Z"
+                                          "published": "2015-11-26T00:00:00Z",
+                                          "versionDate": "2015-11-26T00:00:00Z"
                                         },
                                         {
                                           "status": "poa",
                                           "version": 2,
-                                          "published": "2015-11-30T00:00:00Z"
+                                          "published": "2015-11-26T00:00:00Z",
+                                          "versionDate": "2015-11-30T00:00:00Z"
                                         },
                                         {
                                           "status": "vor",
                                           "version": 3,
-                                          "published": "2015-12-29T00:00:00Z"
+                                          "published": "2015-11-26T00:00:00Z",
+                                          "versionDate": "2015-12-29T00:00:00Z"
                                         }
                                       ]
 


### PR DESCRIPTION
It was using “publish” field.

This should fix the problem that was was described under PI-329.

@giorgiosironi - I supposed those can be tested on end2end. Calls to lax for version lookup etc.