### PR TITLE
Form still image path on CDN by using current article id

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -113,10 +113,12 @@ class activity_CopyGlencoeStillImages(activity.activity):
         if r.status_code == 200:
             resource = self.s3_resource(path, article_id)
             self.logger.info("S3 resource: " + resource)
-            jpg_filename = os.path.split(path)[1]
+            jpg_filename = os.path.split(resource)[-1]
             storage_context.set_resource_from_string(resource, r.content,
                                                      content_type=r.headers['content-type'])
             return jpg_filename
+        else:
+            raise RuntimeError("Glencoe returned a %s status code for %s" % (r.status_code, path))
 
 
     def list_files_from_cdn(self, article_id):

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -104,7 +104,7 @@ class FakeStorageContext:
         #bucket_name, s3_key = self.get_bucket_and_key(resource)
         copy(file, data.ExpandArticle_files_dest_folder)
 
-    def set_resource_from_string(self, anyarg1, anyarg2):
+    def set_resource_from_string(self, resource, data, content_type=None):
         pass
 
     # def set_contents_from_filename(self, storage_object, key, path):


### PR DESCRIPTION
No matter if the article id on Glencoe is the original one, Helps in
end2end testing and moves us toward building the filename ourselves as
much as possible.