### PR TITLE
“video” or “media” in video files

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -221,7 +221,7 @@ class activity_ApplyVersionNumber(activity.activity):
 
         (file_prefix, file_extension) = self.file_parts(filename)
         file_type_plus_index = file_prefix.split('-')[-1]
-        if "media" in file_type_plus_index:
+        if ("media" in file_type_plus_index) or ("video" in file_type_plus_index):
             return True
         else:
             return False

--- a/tests/activity/test_activity_apply_version_number.py
+++ b/tests/activity/test_activity_apply_version_number.py
@@ -158,7 +158,7 @@ class MyTestCase(unittest.TestCase):
         result = self.applyversionnumber.is_video_file(filename)
         self.assertFalse(result)
 
-    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif')
+    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif', u'elife-11792-video1.mp4')
     def test_is_video_file_true(self,filename):
         result = self.applyversionnumber.is_video_file(filename)
         self.assertTrue(result)


### PR DESCRIPTION
@gnott and @giorgiosironi - I plan to extract this method into article_structure soon, as we will use it for some of the Glencoe stuff. But for now, in order not to cause errors, this change should do.