### PR TITLE
Add still jpgs to IIIF verification

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -9,6 +9,7 @@ from boto.s3.key import Key
 from boto.s3.connection import S3Connection
 from provider.execution_context import Session
 from provider.article_structure import ArticleInfo
+import provider.article_structure as article_structure
 import provider.s3lib as s3lib
 from elifetools import xmlio
 
@@ -158,7 +159,7 @@ class activity_ApplyVersionNumber(activity.activity):
             # Get the new file name
             file_name_map[filename] = None
 
-            if self.is_video_file(filename) is False:
+            if article_structure.is_video_file(filename) is False:
                 renamed_filename = self.new_filename(filename, version)
             else:
                 # Keep video files named the same
@@ -176,7 +177,7 @@ class activity_ApplyVersionNumber(activity.activity):
         if re.search(ur'-v([0-9])[\.]', old_filename): #is version already in file name?
             new_filename = re.sub(ur'-v([0-9])[\.]', '-v' + str(version) + '.', old_filename)
         else:
-            (file_prefix, file_extension) = self.file_parts(old_filename)
+            (file_prefix, file_extension) = article_structure.file_parts(old_filename)
             new_filename = file_prefix + '-v' + str(version) + '.' + file_extension
         return new_filename
 
@@ -204,27 +205,6 @@ class activity_ApplyVersionNumber(activity.activity):
             if info.file_type == 'ArticleXML':
                 return new_name
 
-
-    def file_parts(self, filename):
-        prefix = filename.split('.')[0]
-        extension = filename.split('.')[-1]
-        return (prefix, extension)
-
-
-    def is_video_file(self, filename):
-        """
-        Simple check for video file names
-        E.g. match True on elife-00005-media1.mov
-             match True on elife-99999-resp-media1.avi
-             match False on elife-00005-media1-code1.wrl
-        """
-
-        (file_prefix, file_extension) = self.file_parts(filename)
-        file_type_plus_index = file_prefix.split('-')[-1]
-        if ("media" in file_type_plus_index) or ("video" in file_type_plus_index):
-            return True
-        else:
-            return False
 
     @staticmethod
     def get_article_xml_key(bucket, expanded_folder_name):

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -139,10 +139,17 @@ def file_parts(filename):
 
 
 def get_media_file_images(files):
-    return list(filter(lambda f: is_media_file(f) and has_extensions(f, ['jpg']), files))
+    return list(filter(lambda f: is_video_file(f) and has_extensions(f, ['jpg']), files))
 
 
-def is_media_file(filename):
+def is_video_file(filename):
+    """
+    Simple check for video file names
+    E.g. match True on elife-00005-media1.mov
+         match True on elife-99999-resp-media1.avi
+         match False on elife-00005-media1-code1.wrl
+    """
+
     (file_prefix, file_extension) = file_parts(filename)
     file_type_plus_index = file_prefix.split('-')[-1]
     if ("media" in file_type_plus_index) or ("video" in file_type_plus_index):

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -128,17 +128,24 @@ def get_original_files(files):
 def get_figures_for_iiif(files):
     # should only be tif
     fs = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
+    fs = originals_and_figures + get_media_files(files)
     return fs
 
+
 def file_parts(filename):
-        prefix = filename.split('.')[0]
-        extension = filename.split('.')[-1]
-        return (prefix, extension)
+    prefix = filename.split('.')[0]
+    extension = filename.split('.')[-1]
+    return prefix, extension
+
+
+def get_media_files(files):
+    return list(filter(is_media_file, files))
+
 
 def is_media_file(filename):
     (file_prefix, file_extension) = file_parts(filename)
     file_type_plus_index = file_prefix.split('-')[-1]
-    if "media" in file_type_plus_index:
+    if ("media" in file_type_plus_index) or ("video" in file_type_plus_index):
         return True
     else:
         return False

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -127,8 +127,8 @@ def get_original_files(files):
 
 def get_figures_for_iiif(files):
     # should only be tif
-    fs = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
-    fs = originals_and_figures + get_media_files(files)
+    originals_figures_tif = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
+    fs = originals_figures_tif + get_media_files(files)
     return fs
 
 

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -128,7 +128,7 @@ def get_original_files(files):
 def get_figures_for_iiif(files):
     # should only be tif
     originals_figures_tif = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
-    fs = originals_figures_tif + get_media_files(files)
+    fs = originals_figures_tif + get_media_file_images(files)
     return fs
 
 
@@ -138,8 +138,8 @@ def file_parts(filename):
     return prefix, extension
 
 
-def get_media_files(files):
-    return list(filter(is_media_file, files))
+def get_media_file_images(files):
+    return list(filter(lambda f: is_media_file(f) and has_extensions(f, ['jpg']), files))
 
 
 def is_media_file(filename):

--- a/tests/activity/test_activity_apply_version_number.py
+++ b/tests/activity/test_activity_apply_version_number.py
@@ -147,22 +147,6 @@ class MyTestCase(unittest.TestCase):
         result = self.applyversionnumber.new_filename(file, version)
         self.assertEqual(result, expected)
 
-    @data(u'elife-15224-fig1-figsupp1.tif')
-    def test_file_parts(self, filename):
-        prefix, extension = self.applyversionnumber.file_parts(filename)
-        self.assertEqual(prefix, u'elife-15224-fig1-figsupp1')
-        self.assertEqual(extension, u'tif')
-
-    @data(u'elife-15224-fig1-figsupp1.tif', u'elife-15224-resp-fig1.tif', u'elife-15224-figures.pdf', u'elife-15802-fig9-data3.docx', u'elife-11792.mp4')
-    def test_is_video_file_false(self, filename):
-        result = self.applyversionnumber.is_video_file(filename)
-        self.assertFalse(result)
-
-    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif', u'elife-11792-video1.mp4')
-    def test_is_video_file_true(self,filename):
-        result = self.applyversionnumber.is_video_file(filename)
-        self.assertTrue(result)
-
     @patch('activity.activity_ApplyVersionNumber.path.join')
     def test_rewrite_xml_file(self, mock_path_join):
         #given

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -119,7 +119,6 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-07398-media1.jpg']
         expected = ['elife-00666-video2.jpg',
                     'elife-07398-media1.jpg']
-        self.assertListEqual.__self__.maxDiff = None
         self.assertListEqual(article_structure.get_media_file_images(files), expected)
 
     def test_get_figures_for_iiif(self):

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -101,12 +101,26 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-00666-inf001-v1.jpg',
                  'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
-                 'elife-07702-vor-r4.zip']
+                 'elife-07702-vor-r4.zip',
+                 'elife-07398-media1.jpg']
         expected = ['elife-00666-fig2-figsupp2-v1.tif',
                     'elife-00666-inf001-v1.jpg',
                     'elife-00666-table3-data1-v1.xlsx']
 
         self.assertListEqual(article_structure.get_original_files(files), expected)
+
+    def test_get_media_files(self):
+        files = ['elife-00666-fig2-figsupp2-v1.tif',
+                 'elife-00666-inf001-v1.jpg',
+                 'elife-00666-inf001-v1-80w.jpg',
+                 'elife-00666-table3-data1-v1.xlsx',
+                 'elife-07702-vor-r4.zip',
+                 'elife-00666-video2.jpg',
+                 'elife-07398-media1.jpg']
+        expected = ['elife-00666-video2.jpg',
+                    'elife-07398-media1.jpg']
+        self.assertListEqual.__self__.maxDiff = None
+        self.assertListEqual(article_structure.get_media_files(files), expected)
 
     def test_get_figures_for_iiif(self):
         "Only .tif of original figures"
@@ -118,9 +132,13 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',
-                 'elife-9204580859652100230-fig2-data1-v1.xls']
+                 'elife-9204580859652100230-fig2-data1-v1.xls',
+                 'elife-00666-video2.jpg',
+                 'elife-07398-media1.jpg']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
-                    'elife-00666-fig2-figsupp2-v1.tif']
+                    'elife-00666-fig2-figsupp2-v1.tif',
+                    'elife-00666-video2.jpg',
+                    'elife-07398-media1.jpg']
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
 

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -155,6 +155,12 @@ class TestArticleStructure(unittest.TestCase):
         result = article_structure.is_video_file(filename)
         self.assertTrue(result)
 
+    @data(u'elife-15224-fig1-figsupp1.tif')
+    def test_file_parts(self, filename):
+        prefix, extension = article_structure.file_parts(filename)
+        self.assertEqual(prefix, u'elife-15224-fig1-figsupp1')
+        self.assertEqual(extension, u'tif')
+
 
 
 if __name__ == '__main__':

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -141,6 +141,20 @@ class TestArticleStructure(unittest.TestCase):
                     'elife-07398-media1.jpg']
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
+    @data(u'elife-15224-fig1-figsupp1.tif',
+          u'elife-15224-resp-fig1.tif', u'elife-15224-figures.pdf',
+          u'elife-15802-fig9-data3.docx', u'elife-11792.mp4',
+          u'elife-00005-media1-code1.wrl')
+    def test_is_video_file_false(self, filename):
+        result = article_structure.is_video_file(filename)
+        self.assertFalse(result)
+
+    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif', u'elife-11792-video1.mp4',
+          u'elife-99999-resp-media1.avi', u'elife-00005-media1.mov')
+    def test_is_video_file_true(self,filename):
+        result = article_structure.is_video_file(filename)
+        self.assertTrue(result)
+
 
 
 if __name__ == '__main__':

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -109,7 +109,7 @@ class TestArticleStructure(unittest.TestCase):
 
         self.assertListEqual(article_structure.get_original_files(files), expected)
 
-    def test_get_media_files(self):
+    def test_get_media_file_images(self):
         files = ['elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-inf001-v1.jpg',
                  'elife-00666-inf001-v1-80w.jpg',
@@ -120,7 +120,7 @@ class TestArticleStructure(unittest.TestCase):
         expected = ['elife-00666-video2.jpg',
                     'elife-07398-media1.jpg']
         self.assertListEqual.__self__.maxDiff = None
-        self.assertListEqual(article_structure.get_media_files(files), expected)
+        self.assertListEqual(article_structure.get_media_file_images(files), expected)
 
     def test_get_figures_for_iiif(self):
         "Only .tif of original figures"


### PR DESCRIPTION
I plan to refactor is_media_file (change its name)
and apply the method in article_structure on ApplyVersionNumber since they do the same thing

These changes should allow still images to be verified with IIIF api.

This could be merged after we make sure everything works with the previous merges for ELPP-2373