### PR TITLE
Runs only continuum-tagged end2end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,9 @@ elifePipeline {
 
     elifeMainlineOnly {
         stage 'End2end tests'
-        elifeEnd2EndTest {
+        elifeEnd2EndTest({
             builderDeployRevision 'elife-bot--end2end', commit
-        }
+        }, "continuum")
 
         stage 'Approval'
         elifeGitMoveToBranch commit, 'approved'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,28 +1,33 @@
 elifePipeline {
-    stage 'Checkout'
-    checkout scm
-    def commit = elifeGitRevision()
+    def commit
+    stage 'Checkout', {
+        checkout scm
+        commit = elifeGitRevision()
+    }
 
-    stage 'Project tests'
-    lock('elife-bot--ci') {
-        builderDeployRevision 'elife-bot--ci', commit
-        // execute and fail immediately if red, without waiting to download test artifacts
-        builderCmd 'elife-bot--ci', 'cd /opt/elife-bot; ./project_tests.sh'
+    stage 'Project tests', {
+        lock('elife-bot--ci') {
+            builderDeployRevision 'elife-bot--ci', commit
+            // execute and fail immediately if red, without waiting to download test artifacts
+            builderCmd 'elife-bot--ci', 'cd /opt/elife-bot; ./project_tests.sh'
 
-        // part of the bot test suite is a series of lettuce processes which cannot produce a single XML report
-        // until there is a single test suite, we won't have XML test artifacts in the bot
-        //def testArtifact = "${env.BUILD_TAG}.junit.xml"
-        //builderTestArtifact testArtifact, 'elife-bot--ci', '/opt/elife-bot/build/junit.xml'
-        //elifeVerifyJunitXml testArtifact
+            // part of the bot test suite is a series of lettuce processes which cannot produce a single XML report
+            // until there is a single test suite, we won't have XML test artifacts in the bot
+            //def testArtifact = "${env.BUILD_TAG}.junit.xml"
+            //builderTestArtifact testArtifact, 'elife-bot--ci', '/opt/elife-bot/build/junit.xml'
+            //elifeVerifyJunitXml testArtifact
+        }
     }
 
     elifeMainlineOnly {
-        stage 'End2end tests'
-        elifeEnd2EndTest({
-            builderDeployRevision 'elife-bot--end2end', commit
-        }, "continuum")
+        stage 'End2end tests', {
+            elifeEnd2EndTest({
+                builderDeployRevision 'elife-bot--end2end', commit
+            }, "continuum")
+        }
 
-        stage 'Approval'
-        elifeGitMoveToBranch commit, 'approved'
+        stage 'Approval', {
+            elifeGitMoveToBranch commit, 'approved'
+        }
     }
 }


### PR DESCRIPTION
Not useful to run tests that involve, for example, only journal-cms and search and not the bot's code.

Takes the occasion to switch to the new, clearer stages syntax.