### PR TITLE
Renaming to environment-agnostic name

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -114,7 +114,7 @@ class activity_CopyGlencoeStillImages(activity.activity):
 
     def s3_resource(self, path, article_id):
         filename = os.path.split(path)[1]
-        filename = glencoe_check.extend_article_for_end2end(filename, article_id)
+        filename = glencoe_check.force_article_id(filename, article_id)
         return self.settings.storage_provider + "://" + \
                self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
                article_id + "/" + filename

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -85,7 +85,8 @@ def check_msid(msid):
         return pad_msid(msid[-5:])
     return pad_msid(msid)
 
-def extend_article_for_end2end(filename, article_id):
+def force_article_id(filename, article_id):
+    "In case of testing, we have generated article ids pointing to real article ids on Glencoe. This function forces the generated article id on a file coming from outside."
     padded_article_id = check_msid(article_id)
     if padded_article_id == article_id:
         return filename

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -33,5 +33,5 @@ class TestGlencoeCheck(unittest.TestCase):
     def test_extend_article_for_end2end(self):
         filename = "elife-01234-media1-v1.jpg"
         article_id = "7777777701234"
-        result  = glencoe_check.extend_article_for_end2end(filename, article_id)
+        result  = glencoe_check.force_article_id(filename, article_id)
         self.assertEqual("elife-7777777701234-media1-v1.jpg", result)


### PR DESCRIPTION
This method will be used also in continuumtest for example, has to do with testing environment rather than with end2end