### PR TITLE
VerifyImageServer should only check the .tif version of a figure

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -3,4 +3,12 @@ set -e
 source venv/bin/activate
 
 # intentionally only the script files in the root folder
-pylint -E *.py provider/storage_provider.py provider/lax_provider.py provider/imageresize.py activity/activity_Update*.py activity/activity_Pubmed*.py
+python -m pylint -E \
+    *.py \
+    activity/activity_Update*.py \
+    activity/activity_Pubmed*.py \
+    provider/article_structure.py \
+    provider/imageresize.py \
+    provider/lax_provider.py \
+    provider/storage_provider.py \
+    tests/provider/*.py

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -126,7 +126,8 @@ def get_original_files(files):
     return fs
 
 def get_figures_for_iiif(files):
-    fs = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif', 'jpg']))]
+    # should only be tif
+    fs = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
     return fs
 
 def file_parts(filename):

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -106,7 +106,6 @@ class TestArticleStructure(unittest.TestCase):
                     'elife-00666-inf001-v1.jpg',
                     'elife-00666-table3-data1-v1.xlsx']
 
-        self.assertListEqual.__self__.maxDiff = None
         self.assertListEqual(article_structure.get_original_files(files), expected)
 
     def test_get_figures_for_iiif(self):

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -110,8 +110,10 @@ class TestArticleStructure(unittest.TestCase):
         self.assertListEqual(article_structure.get_original_files(files), expected)
 
     def test_get_figures_for_iiif(self):
+        "Only .tif of original figures"
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
+                 'elife-00666-fig2-figsupp2-v1.jpg',
                  'elife-00666-inf001-v1.jpg',
                  'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',


### PR DESCRIPTION
We are falling back to the .jpg version if the .tif doesn't work into the IIIF server, but this is done transparently by the server itself. So I believe we don't need to also check the .jpg, and we can do half the work that this activity is doing for better reliability and speed.