### PR TITLE
Media video tweaks

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -134,13 +134,6 @@ def file_parts(filename):
         extension = filename.split('.')[-1]
         return (prefix, extension)
 
-def is_media_file(filename):
-    (file_prefix, file_extension) = file_parts(filename)
-    file_type_plus_index = file_prefix.split('-')[-1]
-    if "media" in file_type_plus_index:
-        return True
-    else:
-        return False
 
 
 def main():

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -1,5 +1,6 @@
 import sys, json
 import requests
+import re
 from functional import seq
 
 '''
@@ -71,7 +72,7 @@ def jpg_href_values(metadata):
 
 
 def has_videos(xml_str):
-    if '<media content-type="glencoe' in xml_str:
+    if re.search(ur'<media.*mimetype="video".*>', xml_str):
         return True
     return False
 

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -72,7 +72,7 @@ def jpg_href_values(metadata):
 
 
 def has_videos(xml_str):
-    if re.search(ur'<media.*mimetype="video".*>', xml_str):
+    if re.search(ur'<media[^>]*mimetype="video".*?>', xml_str):
         return True
     return False
 

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -35,3 +35,15 @@ class TestGlencoeCheck(unittest.TestCase):
         article_id = "7777777701234"
         result  = glencoe_check.extend_article_for_end2end(filename, article_id)
         self.assertEqual("elife-7777777701234-media1-v1.jpg", result)
+
+    def test_has_videos(self):
+        cases = [
+            ('<media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="avi" mimetype="video" xlink:href="elife-00007-media1.avi"></media>', True),
+            ('<media mimetype="video" mime-subtype="mp4" id="fig3video1" xlink:href="elife-00666-fig3-video1.mp4"></media>', True),
+            ('<media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
+            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/><media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
+            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/>', False)
+        ]
+        for xml_str, expected in cases:
+            self.assertEqual(glencoe_check.has_videos(xml_str), expected)
+


### PR DESCRIPTION
To support the new kitchen sink XML, the videos are expressed differently in the XML, with tests to support the check.

Also it looks like is_media_file() is no longer used, and is_video_file() is elsewhere and smarter now.