### PR TITLE
Incremental change - Deposit IIIF assets activity transfering only IIIF related files

### DIFF
--- a/activity/activity_DepositIIIFAssets.py
+++ b/activity/activity_DepositIIIFAssets.py
@@ -9,7 +9,7 @@ DepositIIIFAssets.py activity
 """
 
 
-class activity_DepositAssets(activity.activity):
+class activity_DepositIIIFAssets(activity.activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         activity.activity.__init__(self, settings, logger, conn, token, activity_task)
 

--- a/activity/activity_DepositIIIFAssets.py
+++ b/activity/activity_DepositIIIFAssets.py
@@ -1,0 +1,80 @@
+import activity
+from boto.s3.connection import S3Connection
+from provider.execution_context import Session
+from provider.storage_provider import StorageContext
+from provider import article_structure
+
+"""
+DepositIIIFAssets.py activity
+"""
+
+
+class activity_DepositAssets(activity.activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+
+        self.name = "DepositIIIFAssets"
+        self.pretty_name = "Deposit IIIF Assets"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Deposit IIIF assets"
+        self.logger = logger
+
+    def do_activity(self, data=None):
+
+        run = data['run']
+        session = Session(self.settings)
+        version = session.get_value(run, 'version')
+        article_id = session.get_value(run, 'article_id')
+
+        self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "start",
+                                "Depositing IIIF assets for " + article_id)
+
+        try:
+
+            expanded_folder_name = session.get_value(run, 'expanded_folder')
+            expanded_folder_bucket = (self.settings.publishing_buckets_prefix +
+                                      self.settings.expanded_bucket)
+
+            cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
+
+            storage_context = StorageContext(self.settings)
+            storage_provider = self.settings.storage_provider + "://"
+
+            orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
+            files_in_bucket = storage_context.list_resources(orig_resource)
+            original_figures = article_structure.get_figures_for_iiif(files_in_bucket)
+
+            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
+
+            for file_name in original_figures:
+
+                orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/" + file_name
+                dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
+                additional_dest_resource = storage_provider + published_bucket_path + "/" + article_id + "/" + file_name
+                storage_context.copy_resource(orig_resource, dest_resource)
+                storage_context.copy_resource(orig_resource, additional_dest_resource)
+
+                if self.logger:
+                    self.logger.info("Uploaded file %s to %s and %s" % (file_name, cdn_bucket_name,
+                                                                        published_bucket_path))
+
+            self.emit_monitor_event(self.settings, article_id, version, run,
+                                    self.pretty_name, "end",
+                                    "Deposited IIIF assets for article " + article_id)
+            return activity.activity.ACTIVITY_SUCCESS
+
+        except Exception as e:
+            self.logger.exception("Exception when Depositing IIIF assets")
+            self.emit_monitor_event(self.settings, article_id, version, run,
+                                    self.pretty_name, "error",
+                                    "Error depositing IIIF assets for article " + article_id +
+                                    " message:" + e.message)
+            return activity.activity.ACTIVITY_PERMANENT_FAILURE
+
+
+
+

--- a/register.py
+++ b/register.py
@@ -67,6 +67,7 @@ def start(ENV="dev"):
         print 'got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)
 
     activity_names = []
+    activity_names.append("DepositIIIFAssets")
     activity_names.append("CopyGlencoeStillImages")
     activity_names.append("VerifyImageServer")
     activity_names.append("GeneratePDFCovers")

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -90,6 +90,39 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "DepositIIIFAssets",
+                        "activity_id": "DepositIIIFAssets",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
+                        "activity_type": "CopyGlencoeStillImages",
+                        "activity_id": "CopyGlencoeStillImages",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
+                        "activity_type": "VerifyImageServer",
+                        "activity_id": "VerifyImageServer",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
                         "activity_type": "IngestToLax",
                         "activity_id": "IngestToLax",
                         "version": "1",

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -112,17 +112,6 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "CopyGlencoeStillImages",
-                        "activity_id": "CopyGlencoeStillImages",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
                        "activity_type": "VerifyImageServer",
                        "activity_id": "VerifyImageServer",
                        "version": "1",


### PR DESCRIPTION
I will be issuing incremental PRs for this task. This is the creation of DepositIIIFAssets which will copy all the IIIF related files (tiff figures in this case). Later on I will do the change that will remove a duplicate copy/paste in DepositAssets, but for now this would do what we need and we will get the desired effect quicker.
I am not sure what I can unit test on this activity though, any suggestions are welcome. (It basically constructs the S3 resource paths and the storage provider reads/writes to it)
Obs: I am also repeating VerifyImageServer for now as since we are currently overriding everything on DepositAssets it's a bit safer to have the verification again. The redundancy will be removed as soon as we see that this works.