### PR TITLE
Elpp 2495 - ConvertImagesToJPG extracted from ResizeImages

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -51,8 +51,7 @@ class activity_ConvertImagesToJPG(activity.activity):
             formats = {"Original": {
                             "sources": "tif",
                             "format": "jpg",
-                            "resolution": 96,
-                            "download": "yes"
+                            "resolution": 96
                         }}
 
             for file_name in figures:
@@ -72,7 +71,7 @@ class activity_ConvertImagesToJPG(activity.activity):
 
             self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
                                     "Finished converting images for " + article_id + ": " +
-                                    str(len(files_in_bucket)) + " images processed ")
+                                    str(len(figures)) + " images processed ")
             return activity.activity.ACTIVITY_SUCCESS
 
         except Exception as e:

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -1,0 +1,86 @@
+import activity
+import json
+from provider.execution_context import Session
+from provider.storage_provider import StorageContext
+import provider.article_structure as article_structure
+import provider.image_conversion as image_conversion
+import os
+
+
+
+class activity_ConvertImagesToJPG(activity.activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+
+        self.name = "ConvertImagesToJPG"
+        self.pretty_name = "Convert Images To JPG"
+        self.version = "1"
+
+        # standard bot activity parameters
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Converts article images to JPG"
+        self.logger = logger
+        self.formats = self.load_formats()
+
+    def do_activity(self, data=None):
+        if self.logger:
+            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        run = data['run']
+        session = Session(self.settings)
+        version = session.get_value(run, 'version')
+        article_id = session.get_value(run, 'article_id')
+
+        self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "start",
+                                "Starting submission convert images to jpg for article " + article_id)
+
+        try:
+            expanded_folder_name = session.get_value(run, 'expanded_folder')
+            expanded_folder_bucket = (self.settings.publishing_buckets_prefix +
+                                      self.settings.expanded_bucket)
+            storage_provider = self.settings.storage_provider + "://"
+            orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
+
+            storage_context = StorageContext(self.settings)
+            files_in_bucket = storage_context.list_resources(orig_resource)
+
+            figures = filter(article_structure.article_figure, files_in_bucket)
+
+            formats = [
+                    { "Original": {
+                        "sources": "tif",
+                        "format": "jpg",
+                        "resolution": 96,
+                        "download": "yes"
+                    }}
+                ]
+
+            for file_name in figures:
+                figure_resource = orig_resource + "/" + file_name
+                file_path = self.get_tmp_dir() + os.sep + file_name
+                file_pointer = storage_context.get_resource_to_file_pointer(figure_resource, file_path)
+
+                cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
+                cdn_resource_path = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
+                #addtional cdn
+
+                image_conversion.generate_images(formats, file_pointer, article_structure.ArticleInfo(file_name),
+                                                 cdn_resource_path)
+
+
+
+
+            original_format_filtered = [
+                {"Figure": [
+                    { "Original": {
+                        "sources": "tif",
+                        "format": "jpg",
+                        "resolution": 96,
+                        "download": "yes"
+                    }}
+                ]}]
+
+        except:

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -50,8 +50,7 @@ class activity_ConvertImagesToJPG(activity.activity):
 
             formats = {"Original": {
                             "sources": "tif",
-                            "format": "jpg",
-                            "resolution": 96
+                            "format": "jpg"
                         }}
 
             for file_name in figures:

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -1,0 +1,18 @@
+import provider.imageresize as resizer
+
+def generate_images(formats, fp, info, cdn_path):
+        # delegate this to module
+        try:
+            for format_spec_name in formats:
+                format_spec = formats[format_spec_name]
+                # if sources not present or includes file extension for this image
+                if 'sources' not in format_spec or info.extension in [
+                        x.strip() for x in format_spec['sources'].split(',')]:
+                    download = 'download' in format_spec and format_spec['download']
+                    fp.seek(0)  # rewind the tape
+                    filename, image = resizer.resize(format_spec, fp, info, self.logger)
+                    if filename is not None and image is not None:
+                        self.store_in_cdn(filename, image, cdn_path, download)
+                        self.logger.info("Stored image %s as %s" % (filename, cdn_path))
+        finally:
+            fp.close()

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -16,6 +16,8 @@ def generate_images(settings, formats, fp, info, publish_locations, logger):
                     if filename is not None and image is not None:
                         store_in_publish_locations(settings, filename, image, publish_locations, download)
                         logger.info("Stored image %s as %s" % (filename, str(publish_locations)))
+                    else:
+                        raise RuntimeError("filename or image is None. resizer.resize problem.")
         finally:
             fp.close()
 

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -1,7 +1,9 @@
 import provider.imageresize as resizer
+from provider.storage_provider import StorageContext
+from mimetypes import guess_type
 
-def generate_images(formats, fp, info, cdn_path):
-        # delegate this to module
+
+def generate_images(settings, formats, fp, info, publish_locations, logger):
         try:
             for format_spec_name in formats:
                 format_spec = formats[format_spec_name]
@@ -10,9 +12,31 @@ def generate_images(formats, fp, info, cdn_path):
                         x.strip() for x in format_spec['sources'].split(',')]:
                     download = 'download' in format_spec and format_spec['download']
                     fp.seek(0)  # rewind the tape
-                    filename, image = resizer.resize(format_spec, fp, info, self.logger)
+                    filename, image = resizer.resize(format_spec, fp, info, logger)
                     if filename is not None and image is not None:
-                        self.store_in_cdn(filename, image, cdn_path, download)
-                        self.logger.info("Stored image %s as %s" % (filename, cdn_path))
+                        store_in_publish_locations(settings, filename, image, publish_locations, download)
+                        logger.info("Stored image %s as %s" % (filename, str(publish_locations)))
         finally:
             fp.close()
+
+
+def store_in_publish_locations(settings, filename, image, publish_locations, download):
+        try:
+            storage_context = StorageContext(settings)
+
+            for resource in publish_locations:
+                image.seek(0)
+                content_type, encoding = guess_type(filename)
+                storage_context.set_resource_from_file(resource + filename, image, metadata={'Content-Type': content_type})
+
+                if download:
+                    dict_metadata = {'Content-Disposition':
+                                     str("Content-Disposition: attachment; filename=" + filename + ";"),
+                                     'Content-Type': content_type}
+                    filename_no_extension, extension = filename.rsplit('.', 1)
+                    file_download = filename_no_extension + "-download." + extension
+                    storage_context.copy_resource(resource + filename, resource + file_download,
+                                                  additional_dict_metadata=dict_metadata)
+
+        finally:
+            image.close()

--- a/register.py
+++ b/register.py
@@ -67,6 +67,7 @@ def start(ENV="dev"):
         print 'got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)
 
     activity_names = []
+    activity_names.append("ConvertImagesToJPG")
     activity_names.append("DepositIIIFAssets")
     activity_names.append("CopyGlencoeStillImages")
     activity_names.append("VerifyImageServer")

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -113,6 +113,9 @@ class FakeStorageContext:
     def copy_resource(self, origin, destination):
         pass
 
+    def get_resource_to_file_pointer(self, resource, file_path):
+        return None
+
     # def set_contents_from_filename(self, storage_object, key, path):
     #     copyfile(file, "tests\\" + storage_object + key)
 

--- a/tests/activity/test_activity_convert_images_to_jpg.py
+++ b/tests/activity/test_activity_convert_images_to_jpg.py
@@ -1,0 +1,46 @@
+import unittest
+from activity.activity_ConvertImagesToJPG import activity_ConvertImagesToJPG
+import settings_mock
+from classes_mock import FakeLogger
+from classes_mock import FakeStorageContext
+from classes_mock import FakeSession
+import test_activity_data as test_activity_data
+from mock import patch
+
+
+class TestConvertImagesToJPG(unittest.TestCase):
+    def setUp(self):
+        self.convertimagestojpg = activity_ConvertImagesToJPG(settings_mock, None, None, None, None)
+        self.convertimagestojpg.logger = FakeLogger()
+
+    @patch('provider.image_conversion.generate_images')
+    @patch('activity.activity_ConvertImagesToJPG.Session')
+    @patch('activity.activity_ConvertImagesToJPG.StorageContext')
+    @patch.object(activity_ConvertImagesToJPG, 'emit_monitor_event')
+    def test_activity_success(self, fake_emit, fake_storage_context, fake_session, fake_gen_images):
+
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_session.return_value = FakeSession(test_activity_data.session_example)
+        activity_data = test_activity_data.data_example_before_publish
+
+        result = self.convertimagestojpg.do_activity(activity_data)
+
+        self.assertEqual(self.convertimagestojpg.ACTIVITY_SUCCESS, result)
+
+
+    @patch('activity.activity_ConvertImagesToJPG.Session')
+    @patch('activity.activity_ConvertImagesToJPG.StorageContext')
+    @patch.object(activity_ConvertImagesToJPG, 'emit_monitor_event')
+    def test_activity_failure(self, fake_emit, fake_storage_context, fake_session):
+
+        fake_storage_context.side_effect = Exception("An error occurred")
+        fake_session.return_value = FakeSession(test_activity_data.session_example)
+        activity_data = test_activity_data.data_example_before_publish
+
+        result = self.convertimagestojpg.do_activity(activity_data)
+
+        self.assertEqual(self.convertimagestojpg.ACTIVITY_PERMANENT_FAILURE, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -90,6 +90,17 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "ConvertImagesToJPG",
+                        "activity_id": "ConvertImagesToJPG",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
                         "activity_type": "DepositIIIFAssets",
                         "activity_id": "DepositIIIFAssets",
                         "version": "1",


### PR DESCRIPTION
with content refactored into a provider.
ConvertImagesToJPG uses a provider and more StorageProvider functions. It's basically a refactored ResizeImages and excludes some formats (originally from formats.yaml)