### PR TITLE
Original conversion is already happening under ConvertImagesToJPG

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -48,6 +48,8 @@ class activity_ConvertImagesToJPG(activity.activity):
 
             figures = filter(article_structure.article_figure, files_in_bucket)
 
+            # download is not a IIIF asset but is currently kept for compatibility
+            # download may become obsolete in future
             formats = {"Original": {
                             "sources": "tif",
                             "format": "jpg",

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -50,7 +50,8 @@ class activity_ConvertImagesToJPG(activity.activity):
 
             formats = {"Original": {
                             "sources": "tif",
-                            "format": "jpg"
+                            "format": "jpg",
+                            "download": "yes"
                         }}
 
             for file_name in figures:

--- a/formats.yaml
+++ b/formats.yaml
@@ -79,11 +79,12 @@ Figure:
     format: gif
     resolution: 96
 
-  Original:
-    sources: tif
-    format: jpg
-    resolution: 96
-    download: yes
+#  Original images are being converted under ConvertImagesToJPG Activity
+#  Original:
+#    sources: tif
+#    format: jpg
+#    resolution: 96
+#    download: yes
 
 
 Inline:


### PR DESCRIPTION
Last item of the checklist from ELPP-2495: Removes redundant copy of assets to CDN/published buckets from ResizeImages activity

Removes redundancy;
download: yes is being re-added to ConvertImagesToJPG because we don’t have an option to only copy `-download` images excluding the ones without the suffix. It could be added but is this additional complexity worth adding?

