### PR TITLE
VerifyImageServer only needs to run after Copying JPG and DepositIIIF…

### DIFF
--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -112,17 +112,6 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                       "activity_type": "VerifyImageServer",
-                       "activity_id": "VerifyImageServer",
-                       "version": "1",
-                       "input": data,
-                       "control": None,
-                       "heartbeat_timeout": 60 * 5,
-                       "schedule_to_close_timeout": 60 * 5,
-                       "schedule_to_start_timeout": 300,
-                       "start_to_close_timeout": 60 * 5
-                    },
-                    {
                         "activity_type": "PreparePostEIF",
                         "activity_id": "PreparePostEIF",
                         "version": "1",


### PR DESCRIPTION
…Assets

We’ve removed the redundancy, so we don’t need VerifyImageServer twice.