### PR TITLE
Refactor to use storage provider and not conn.get_bucket

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -4,6 +4,7 @@ import tempfile
 from github import Github
 from github import GithubException
 import provider.lax_provider as lax_provider
+from provider.storage_provider import StorageContext
 
 """
 activity_UpdateRepository.py activity
@@ -57,21 +58,20 @@ class activity_UpdateRepository(activity.activity):
                                                           data['version'])
                 s3_file_path = data['article_id'] + "/" + xml_file
 
-                #connect to bucket
-                self.conn = S3Connection(self.settings.aws_access_key_id,
-                                     self.settings.aws_secret_access_key,
-                                     host=self.settings.s3_hostname)
-                bucket = self.conn.get_bucket(self.settings.publishing_buckets_prefix +
-                                          self.settings.ppp_cdn_bucket)
-
                 #download xml
                 with tempfile.TemporaryFile(mode='r+') as tmp:
+                    storage_context = StorageContext(self.settings)
+                    storage_provider = self.settings.storage_provider + "://"
+                    published_bucket = storage_context + self.settings.publishing_buckets_prefix + \
+                                       self.settings.ppp_cdn_bucket
 
-                    s3_key = bucket.get_key(s3_file_path)
-                    filename = s3_file_path.split('/')[-1]
-                    s3_key.get_contents_to_file(tmp)
-                    file_content = s3_key.get_contents_as_string()
-                    message = self.update_github(self.settings.git_repo_path + filename, file_content)
+                    resource = published_bucket + "/" + s3_file_path
+
+                    storage_provider.get_resource_to_file(resource, tmp)
+
+                    file_content = storage_provider.get_resource_as_string(resource)
+
+                    message = self.update_github(self.settings.git_repo_path + xml_file, file_content)
 
                     self.logger.info(message)
                     self.emit_monitor_event(self.settings, data['article_id'], data['version'], data['run'],

--- a/provider/article.py
+++ b/provider/article.py
@@ -126,7 +126,7 @@ class article(object):
             self.article_type = parser.article_type(soup)
 
             self.authors = parser.authors(soup)
-            self.authors_string = self.authors_string(self.authors)
+            self.authors_string = self.get_authors_string(self.authors)
 
             self.related_articles = parser.related_article(soup)
 
@@ -174,7 +174,7 @@ class article(object):
         xml_filename = xml_file_url.split('/')[-1]
 
         r = requests.get(xml_file_url)
-        if r.status_code == requests.codes.ok:
+        if r.status_code == 200:
             filename_plus_path = self.get_tmp_dir() + os.sep + xml_filename
             f = open(filename_plus_path, "wb")
             f.write(r.content)
@@ -761,7 +761,7 @@ class article(object):
         #print lookup_url
 
         r = requests.head(lookup_url, allow_redirects=True)
-        if r.status_code == requests.codes.ok:
+        if r.status_code == 200:
             return r.url
         else:
             return None
@@ -774,7 +774,7 @@ class article(object):
         lookup_url = self.lookup_url_prefix + str(doi_id).zfill(5)
         return lookup_url
 
-    def authors_string(self, authors):
+    def get_authors_string(self, authors):
         """
         Given a list of authors return a string for all the article authors
         """

--- a/provider/article.py
+++ b/provider/article.py
@@ -808,14 +808,14 @@ class article(object):
             return False
 
     @staticmethod
-    def get_bucket_files(settings, expanded_folder_name, xml_bucket):
+    def _get_bucket_files(settings, expanded_folder_name, xml_bucket):
         storage_context = StorageContext(settings)
         resource = settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder_name
         files_in_bucket = storage_context.list_resources(resource)
         return files_in_bucket
 
     def get_xml_file_name(self, settings, expanded_folder_name, xml_bucket, version):
-        files = self.get_bucket_files(settings, expanded_folder_name, xml_bucket)
+        files = self._get_bucket_files(settings, expanded_folder_name, xml_bucket)
         for filename in files:
             info = ArticleInfo(filename)
             if info.file_type == 'ArticleXML':

--- a/provider/article.py
+++ b/provider/article.py
@@ -12,6 +12,7 @@ import provider.simpleDB as dblib
 import provider.s3lib as s3lib
 from elifetools import parseJATS as parser
 from provider.article_structure import ArticleInfo
+from provider.storage_provider import StorageContext
 
 """
 Article data provider
@@ -808,17 +809,14 @@ class article(object):
 
     @staticmethod
     def get_bucket_files(settings, expanded_folder_name, xml_bucket):
-        conn = S3Connection(settings.aws_access_key_id,
-                        settings.aws_secret_access_key)
-        bucket = conn.get_bucket(xml_bucket)
-        files = bucket.list(expanded_folder_name + "/", "/")
-        return bucket, files
+        storage_context = StorageContext(settings)
+        resource = settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder_name
+        files_in_bucket = storage_context.list_resources(resource)
+        return files_in_bucket
 
     def get_xml_file_name(self, settings, expanded_folder_name, xml_bucket, version):
-        bucket, files = self.get_bucket_files(settings, expanded_folder_name, xml_bucket)
-        for bucket_file in files:
-            key = bucket.get_key(bucket_file.key)
-            filename = key.name.rsplit('/', 1)[1]
+        files = self.get_bucket_files(settings, expanded_folder_name, xml_bucket)
+        for filename in files:
             info = ArticleInfo(filename)
             if info.file_type == 'ArticleXML':
                 if version is None:

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -14,18 +14,18 @@ class ObjectView(object):
         self.__dict__ = d
 
 
-bucket_files_mock_version = [ObjectView({'key': ObjectView({'name':'06498/elife-06498-fig1-v1.tif'})}),
-                             ObjectView({'key': ObjectView({'name':'06498/elife-06498-resp-fig1-v3-80w.gif'})}),
-                             ObjectView({'key': ObjectView({'name':'06498/elife-06498-v1.xml'})}),
-                             ObjectView({'key': ObjectView({'name':'06498/elife-06498-v2.pdf'})}),
-                             ObjectView({'key': ObjectView({'name':'06498/elife-06498-v2.xml'})}),
-                             ObjectView({'key': ObjectView({'name':'06498/elife-06498-v3-download.xml'})})]
+bucket_files_mock_version = ['elife-06498-fig1-v1.tif',
+                             'elife-06498-resp-fig1-v3-80w.gif',
+                             'elife-06498-v1.xml',
+                             'elife-06498-v2.pdf',
+                             'elife-06498-v2.xml',
+                             'elife-06498-v3-download.xml']
 
-bucket_files_mock = [ObjectView({'key': ObjectView({'name':'06498/elife-06498-fig1-v1.tif'})}),
-                     ObjectView({'key': ObjectView({'name':'06498/elife-06498-resp-fig1-v1-80w.gif'})}),
-                     ObjectView({'key': ObjectView({'name':'06498/elife-06498-v1-download.xml'})}),
-                     ObjectView({'key': ObjectView({'name':'06498/elife-06498-v1.xml'})}),
-                     ObjectView({'key': ObjectView({'name':'06498/elife-06498-v1.pdf'})})]
+bucket_files_mock = ['elife-06498-fig1-v1.tif',
+                     'elife-06498-resp-fig1-v1-80w.gif',
+                     'elife-06498-v1-download.xml',
+                     'elife-06498-v1.xml',
+                     'elife-06498-v1.pdf']
 
 
 
@@ -69,14 +69,14 @@ class TestProviderArticle(unittest.TestCase):
     @patch.object(article, 'get_bucket_files')
     def test_get_xml_file_name_by_version(self, mock_get_bucket_files):
         fake_bucket = FakeBucket()
-        mock_get_bucket_files.return_value = fake_bucket, bucket_files_mock_version
+        mock_get_bucket_files.return_value = bucket_files_mock_version
         result = self.articleprovider.get_xml_file_name(None, None, None, version="2")
         self.assertEqual(result, "elife-06498-v2.xml")
 
     @patch.object(article, 'get_bucket_files')
     def test_get_xml_file_name_no_version(self, mock_get_bucket_files):
         fake_bucket = FakeBucket()
-        mock_get_bucket_files.return_value = fake_bucket, bucket_files_mock
+        mock_get_bucket_files.return_value = bucket_files_mock
         result = self.articleprovider.get_xml_file_name(None, None, None, version=None)
         self.assertEqual(result, "elife-06498-v1.xml")
 

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -66,14 +66,14 @@ class TestProviderArticle(unittest.TestCase):
         result = self.articleprovider.check_is_article_published_by_lax('10.7554/eLife.00013', False, None)
         self.assertEqual(result, False)
 
-    @patch.object(article, 'get_bucket_files')
+    @patch.object(article, '_get_bucket_files')
     def test_get_xml_file_name_by_version(self, mock_get_bucket_files):
         fake_bucket = FakeBucket()
         mock_get_bucket_files.return_value = bucket_files_mock_version
         result = self.articleprovider.get_xml_file_name(None, None, None, version="2")
         self.assertEqual(result, "elife-06498-v2.xml")
 
-    @patch.object(article, 'get_bucket_files')
+    @patch.object(article, '_get_bucket_files')
     def test_get_xml_file_name_no_version(self, mock_get_bucket_files):
         fake_bucket = FakeBucket()
         mock_get_bucket_files.return_value = bucket_files_mock


### PR DESCRIPTION
I would prefer to run a bot article run locally first to see if all these things work, it's difficult to unit test. I will do that on Monday.

I am observing the UpdateRepository temp file loading and I am not sure what it was used for and its use now. Maybe it became redundant. it looks like it's used for nothing.