### PR TITLE
Allowing linting on activities that use StorageContext

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -4,7 +4,7 @@ import tempfile
 from github import Github
 from github import GithubException
 import provider.lax_provider as lax_provider
-from provider.storage_provider import StorageContext
+from provider.storage_provider import get_storage_context
 
 """
 activity_UpdateRepository.py activity
@@ -60,7 +60,7 @@ class activity_UpdateRepository(activity.activity):
 
                 #download xml
                 with tempfile.TemporaryFile(mode='r+') as tmp:
-                    storage_context = StorageContext(self.settings)
+                    storage_context = get_storage_context(self.settings)
                     storage_provider = self.settings.storage_provider + "://"
                     published_bucket = storage_provider + self.settings.publishing_buckets_prefix + \
                                        self.settings.ppp_cdn_bucket

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -6,6 +6,9 @@ import re
 import os
 
 
+def get_storage_context(*args):
+    return S3StorageContext(args[0])
+
 class StorageContext(object):
     def __new__(cls, *args):
         return S3StorageContext(args[0])


### PR DESCRIPTION
S3StorageContext is rightly behind an indirection, but client code instantiates StorageContext and gets an instance of another class instead, S3StorageContext itself. This makes the linting go crazy as it sees method of S3StorageContext being called on what it believes is just a StorageContext. The classes have no relation with each other, so we provide a factory function here that does the same job but in a simpler way.