### PR TITLE
Comparison fix

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -174,7 +174,7 @@ class activity_CopyGlencoeStillImages(activity.activity):
         self.logger.info("files_in_cdn_no_extention " + str(cdn_all_files_no_extension))
         cdn_still_jpgs_without_video = []
         for still in cdn_still_jpgs_no_extension:
-            if len(list(filter(lambda filename: filename == still, cdn_all_files_no_extension))) != 2:
+            if len(list(filter(lambda filename: filename.lower() == still.lower(), cdn_all_files_no_extension))) != 2:
                 cdn_still_jpgs_without_video.append(still)
 
         self.logger.info("cdn_still_jpgs_without_video " + str(cdn_still_jpgs_without_video))

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -47,7 +47,7 @@ class activity_UpdateRepository(activity.activity):
                                         self.pretty_name, "end",
                                         "UpdateRepository got skipped as there are no Github "
                                         "settings (Test enviroment).")
-                return True
+                return activity.activity.ACTIVITY_SUCCESS
 
             try:
 

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -164,9 +164,10 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Given
         cdn_all_files = ["elife-1234500230-media1-v1.wmv", "elife-1234500230-media2-v1.mp4",
                         "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
-                        "elife-1234500230-fig1-figsupp1-v2-1084w.jpg"]
+                        "elife-1234500230-fig1-figsupp1-v2-1084w.jpg", "eLife-00999-app2-video1.mp4",
+                         "elife-00999-app2-video1.jpg"]
         cdn_still_jpgs = ["elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
-                             "elife-1234500230-media3-v1.jpg"]
+                             "elife-1234500230-media3-v1.jpg", "elife-00999-app2-video1.jpg"]
 
         # When
         result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(cdn_all_files, cdn_still_jpgs,


### PR DESCRIPTION
So I noticed in continuum some files saved in the published/cdn bucket and some had eLife as opposed to elife in the name and it seems to not to be making the comparison properly.
Will this change solve the problems or do you think we should look for a way to always save the file with lower case?