### PR TITLE
Removes reference to elife-published bucket by itself

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -63,10 +63,8 @@ class activity_ConvertImagesToJPG(activity.activity):
 
                 cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
                 cdn_resource_path = storage_provider + cdn_bucket_name + "/" + article_id + "/"
-                published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
-                add_resource_path = storage_provider + published_bucket_path + "/" + article_id + "/"
 
-                publish_locations = [cdn_resource_path, add_resource_path]
+                publish_locations = [cdn_resource_path]
 
                 image_conversion.generate_images(self.settings, formats, file_pointer, article_structure.ArticleInfo(file_name),
                                                  publish_locations, self.logger)

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -136,21 +136,16 @@ class activity_CopyGlencoeStillImages(activity.activity):
         cdn = self.settings.storage_provider + "://" + \
                self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
                article_id + "/" + filename
-        published_bucket = self.settings.storage_provider + "://" + \
-               self.settings.publishing_buckets_prefix + self.settings.published_bucket + "/articles/" + \
-               article_id + "/" + filename
-        return cdn, published_bucket
+        return cdn
 
     def store_file(self, path, article_id):
         storage_context = StorageContext(self.settings)
         r = requests.get(path)
         if r.status_code == 200:
-            resource, additional_resource = self.s3_resources(path, article_id)
+            resource = self.s3_resources(path, article_id)
             self.logger.info("S3 resource: " + resource)
             jpg_filename = os.path.split(resource)[-1]
             storage_context.set_resource_from_string(resource, r.content,
-                                                     content_type=r.headers['content-type'])
-            storage_context.set_resource_from_string(additional_resource, r.content,
                                                      content_type=r.headers['content-type'])
             return jpg_filename
         else:

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -54,23 +54,19 @@ class activity_DepositAssets(activity.activity):
             original_figures_and_videos = original_figures + article_structure.get_videos(files_in_bucket)
             other_assets = filter(lambda asset: asset not in original_figures_and_videos, files_in_bucket)
 
-            # assets buckets
+            # assets bucket
             cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
-            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket+'/articles'
 
             no_download_extensions = self.get_no_download_extensions(self.settings.no_download_extensions)
 
             for file_name in other_assets:
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/"
                 dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/"
-                additional_dest_resource = storage_provider + published_bucket_path + "/" + article_id + "/"
 
                 storage_context.copy_resource(orig_resource + file_name, dest_resource + file_name)
-                storage_context.copy_resource(orig_resource + file_name, additional_dest_resource + file_name)
 
                 if self.logger:
-                    self.logger.info("Uploaded file %s to %s and %s" % (file_name, cdn_bucket_name,
-                                                                        published_bucket_path))
+                    self.logger.info("Uploaded file %s to %s" % (file_name, cdn_bucket_name))
 
                 file_name_no_extension, extension = file_name.rsplit('.', 1)
                 if extension not in no_download_extensions:
@@ -84,10 +80,6 @@ class activity_DepositAssets(activity.activity):
                     storage_context.copy_resource(orig_resource + file_name,
                                                   dest_resource + file_download,
                                                   additional_dict_metadata=dict_metadata)
-
-                    # additional metadata is already set in origin resource so it will be copied accross by default
-                    storage_context.copy_resource(dest_resource + file_download,
-                                                  additional_dest_resource + file_download)
 
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "end",

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -317,7 +317,7 @@ class activity_DepositCrossref(activity.activity):
             r = requests.post(url, data=payload, files=files)
 
             # Check for good HTTP status code
-            if r.status_code != requests.codes.ok:
+            if r.status_code != 200:
                 status = False
             #print r.text
             self.http_request_status_text.append("XML file: " + xml_file)

--- a/activity/activity_DepositIIIFAssets.py
+++ b/activity/activity_DepositIIIFAssets.py
@@ -49,19 +49,14 @@ class activity_DepositIIIFAssets(activity.activity):
             original_figures = article_structure.get_figures_for_iiif(files_in_bucket)
             original_figures_and_videos = original_figures + article_structure.get_videos(files_in_bucket)
 
-            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
-
             for file_name in original_figures_and_videos:
 
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/" + file_name
                 dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
-                additional_dest_resource = storage_provider + published_bucket_path + "/" + article_id + "/" + file_name
                 storage_context.copy_resource(orig_resource, dest_resource)
-                storage_context.copy_resource(orig_resource, additional_dest_resource)
 
                 if self.logger:
-                    self.logger.info("Uploaded file %s to %s and %s" % (file_name, cdn_bucket_name,
-                                                                        published_bucket_path))
+                    self.logger.info("Uploaded file %s to %s" % (file_name, cdn_bucket_name))
 
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "end",

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -535,7 +535,7 @@ class activity_PublicationEmail(activity.activity):
         for author in authors:
             # Test sending each type of template
             for email_type in self.email_types:
-                result = self.send_email(email_type, elife_id, author, article)
+                result = self.send_email(email_type, elife_id, author, article, authors)
 
             # For testing set the article as its own related article then send again
 
@@ -548,7 +548,7 @@ class activity_PublicationEmail(activity.activity):
             article.set_related_insight_article(related_article)
             for email_type in ['author_publication_email_VOR_no_POA',
                                'author_publication_email_VOR_after_POA']:
-                result = self.send_email(email_type, elife_id, author, article)
+                result = self.send_email(email_type, elife_id, author, article, authors)
 
     def choose_recipient_authors(self, authors, article_type, feature_article,
                                  related_insight_article):

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -301,7 +301,7 @@ class activity_PublishFinalPOA(activity.activity):
                 subject_tag.text = self.title_case(subject_tag.text)
         return root
 
-    def add_tag_to_xml_before_elocation_id(self, add_tag, root):
+    def add_tag_to_xml_before_elocation_id(self, add_tag, root, doi_id=""):
         # Add the tag to the XML
         for tag in root.findall('./front/article-meta'):
             parent_tag_index = xmlio.get_first_element_index(tag, 'elocation-id')
@@ -331,7 +331,7 @@ class activity_PublishFinalPOA(activity.activity):
     def add_pub_date_to_xml(self, doi_id, date_struct, root):
         # Create the pub-date XML tag
         pub_date_tag = self.pub_date_xml_element(date_struct)
-        root = self.add_tag_to_xml_before_elocation_id(pub_date_tag, root)
+        root = self.add_tag_to_xml_before_elocation_id(pub_date_tag, root, doi_id)
         return root
 
     def pub_date_xml_element(self, pub_date):
@@ -354,7 +354,7 @@ class activity_PublishFinalPOA(activity.activity):
     def add_volume_to_xml(self, doi_id, volume, root):
         # Create the pub-date XML tag
         volume_tag = self.volume_xml_element(volume)
-        root = self.add_tag_to_xml_before_elocation_id(volume_tag, root)
+        root = self.add_tag_to_xml_before_elocation_id(volume_tag, root, doi_id)
         return root
 
     def volume_xml_element(self, volume):

--- a/activity/activity_ResizeImages.py
+++ b/activity/activity_ResizeImages.py
@@ -157,12 +157,6 @@ class activity_ResizeImages(activity.activity):
             storage_context.set_resource_from_file(storage_resource, image,
                                                    metadata={ 'Content-Type': content_type })
 
-            #..
-            published_bucket_path = self.settings.publishing_buckets_prefix + self.settings.published_bucket + '/articles'
-            storage_resource_destination = storage_provider + published_bucket_path + "/" + cdn_path + "/" + filename
-
-            storage_context.copy_resource(storage_resource, storage_resource_destination)
-
             if download:
                 dict_metadata = {'Content-Disposition':
                                      str("Content-Disposition: attachment; filename=" + filename + ";"),
@@ -176,14 +170,6 @@ class activity_ResizeImages(activity.activity):
                 # file is copied with additional metadata
                 storage_context.copy_resource(storage_resource, storage_resource_dest_download_cdn,
                                               additional_dict_metadata=dict_metadata)
-
-                storage_resource_orig_download = storage_resource_dest_download_cdn
-
-                storage_resource_destination_download = storage_provider + \
-                                                        published_bucket_path + "/" + cdn_path + "/" + file_download
-
-                # additional metadata is already set in origin resource so it will be copied accross by default
-                storage_context.copy_resource(storage_resource_orig_download, storage_resource_destination_download)
 
         finally:
             image.close()

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -4,7 +4,7 @@ import tempfile
 from github import Github
 from github import GithubException
 import provider.lax_provider as lax_provider
-from provider.storage_provider import get_storage_context
+from provider.storage_provider import StorageContext
 
 """
 activity_UpdateRepository.py activity
@@ -60,7 +60,7 @@ class activity_UpdateRepository(activity.activity):
 
                 #download xml
                 with tempfile.TemporaryFile(mode='r+') as tmp:
-                    storage_context = get_storage_context(self.settings)
+                    storage_context = StorageContext(self.settings)
                     storage_provider = self.settings.storage_provider + "://"
                     published_path = storage_provider + self.settings.publishing_buckets_prefix + \
                                        self.settings.ppp_cdn_bucket

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -62,10 +62,10 @@ class activity_UpdateRepository(activity.activity):
                 with tempfile.TemporaryFile(mode='r+') as tmp:
                     storage_context = get_storage_context(self.settings)
                     storage_provider = self.settings.storage_provider + "://"
-                    published_bucket = storage_provider + self.settings.publishing_buckets_prefix + \
+                    published_path = storage_provider + self.settings.publishing_buckets_prefix + \
                                        self.settings.ppp_cdn_bucket
 
-                    resource = published_bucket + "/" + s3_file_path
+                    resource = published_path + "/" + s3_file_path
 
                     storage_context.get_resource_to_file(resource, tmp)
 

--- a/lint.sh
+++ b/lint.sh
@@ -6,8 +6,7 @@ source venv/bin/activate
 python -m pylint -E \
     *.py \
     activity/activity.py \
-    activity/activity_Update*.py \
-    activity/activity_Pubmed*.py \
+    activity/activity*.py \
     provider/article_structure.py \
     provider/imageresize.py \
     provider/lax_provider.py \

--- a/provider/execution_context.py
+++ b/provider/execution_context.py
@@ -2,14 +2,22 @@ import redis
 from pydoc import locate
 
 
-class Session(object):
-    def __new__(self, settings):
-        settings_session_class = "RedisSession"  # Default
-        if hasattr(settings, 'session_class'):
-            settings_session_class = settings.session_class
+def Session(settings):
+    settings_session_class = "RedisSession"  # Default
+    if hasattr(settings, 'session_class'):
+        settings_session_class = settings.session_class
 
-        session_class = locate('provider.execution_context.' + settings_session_class)
-        return session_class(settings)
+    session_class = locate('provider.execution_context.' + settings_session_class)
+    return session_class(settings)
+
+# class Session(object):
+#     def __new__(self, settings):
+#         settings_session_class = "RedisSession"  # Default
+#         if hasattr(settings, 'session_class'):
+#             settings_session_class = settings.session_class
+#
+#         session_class = locate('provider.execution_context.' + settings_session_class)
+#         return session_class(settings)
 
 
 class FileSession(object):

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -6,12 +6,12 @@ import re
 import os
 
 
-def get_storage_context(*args):
+def StorageContext(*args):
     return S3StorageContext(args[0])
 
-class StorageContext(object):
-    def __new__(cls, *args):
-        return S3StorageContext(args[0])
+# class StorageContext(object):
+#     def __new__(cls, *args):
+#         return S3StorageContext(args[0])
 
 class S3StorageContext:
 


### PR DESCRIPTION
second step of:
1. change `ppp_cdn_bucket` to the new value. the bot will write twice to the same place
2. change the bot removing every reference to `published_bucket`, which is not necessary anymore
3. rename the setting `ppp_cdn_bucket` to something longer-lasting (we create a new value, leave both old and new key available for a while, eventually removing the old one)