### PR TITLE
removes published_bucket references

### DIFF
--- a/provider/article.py
+++ b/provider/article.py
@@ -168,8 +168,8 @@ class article(object):
             return False
 
         # Download XML file via HTTP for now
-        bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
-        xml_file_url = ('http://s3-external-1.amazonaws.com/' + bucket_name + '/'
+        bucket_path = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
+        xml_file_url = ('http://s3-external-1.amazonaws.com/' + bucket_path + '/'
                         + doi_id + '/' + 'elife-' + doi_id + '-v' + str(version) + '.xml')
         xml_filename = xml_file_url.split('/')[-1]
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -168,8 +168,8 @@ class article(object):
             return False
 
         # Download XML file via HTTP for now
-        published_bucket_name = self.settings.publishing_buckets_prefix + self.settings.published_bucket
-        xml_file_url = ('http://s3-external-1.amazonaws.com/' + published_bucket_name + '/articles/'
+        bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
+        xml_file_url = ('http://s3-external-1.amazonaws.com/' + bucket_name + '/'
                         + doi_id + '/' + 'elife-' + doi_id + '-v' + str(version) + '.xml')
         xml_filename = xml_file_url.split('/')[-1]
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -44,8 +44,6 @@ class exp():
     archive_bucket = 'elife-publishing-archive'
     xml_bucket = 'elife-publishing-xml'
 
-    published_bucket = 'elife-published'
-
     # REST endpoint for drupal node builder
     # drupal_naf_endpoint = 'http://localhost:5000/nodes'
     drupal_EIF_endpoint = 'http://52.4.182.179/api/article.json'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -11,7 +11,6 @@ expanded_bucket = 'origin_bucket'
 publishing_buckets_prefix = ""
 production_bucket = "production_bucket"
 ppp_cdn_bucket = ""
-published_bucket = ""
 
 archive_bucket = "archive_bucket"
 


### PR DESCRIPTION
@gnott  - FYI, I am undoing what you did under article.py because we did the change the other way around, we changed the value of ppp_cdn_bucket to elife-published/articles so we are removing all references to the single bucket name value "elife-published".