### PR TITLE
More robust handling of renaming error

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -77,7 +77,7 @@ class activity_ApplyVersionNumber(activity.activity):
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "error",
                                     "Error in applying version number to files for " + article_id +
-                                    " message:" + e.message)
+                                    " message:" + str(e.message))
             return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
         return activity.activity.ACTIVITY_SUCCESS


### PR DESCRIPTION
In a test an XML file was empty, the exception got caught but this handler didn't produce a permanent failure because

```
2017-05-17T09:13:08Z ERROR worker_1791 error executing activity
activity_ApplyVersionNumber
Traceback (most recent call last):
File "worker.py", line 71, in work
    activity_result = activity_object.do_activity(data)
File "/opt/elife-bot/activity/activity_ApplyVersionNumber.py", line 80, in do_activity " message:" + e.message)
    TypeError: cannot concatenate 'str' and 'ExpatError' objects
```