### PR TITLE
More retries in VerifyImageServer

### DIFF
--- a/provider/iiif.py
+++ b/provider/iiif.py
@@ -12,6 +12,8 @@ def try_endpoint(endpoint, logger):
         response = requests.head(endpoint)
         if response.status_code == 504:
             raise ShortRetryException("Response code was %s" % response.status_code)
+        if response.status_code == 404:
+            raise ShortRetryException("Response code was %s" % response.status_code)
         if response.status_code != 200:
             logger.error("Error status code != 200. Status code: %s for URL %s\nContent:\n%s", response.status_code, endpoint, response.content)
             return False, endpoint

--- a/tests/provider/test_iiif.py
+++ b/tests/provider/test_iiif.py
@@ -24,25 +24,44 @@ class FakeLogger:
 
 class TestIiif(unittest.TestCase):
 
-    @patch('requests.head')
-    def test_try_endpoint_retry(self, request_mock):
-        iterable = (ObjectView({'status_code': 504}), ObjectView({'status_code': 200}))
-        request_mock.side_effect = iterable
-        fake_logger = FakeLogger()
-        success, test_endpoint = iiif.try_endpoint("test_endpoint", fake_logger)
+    def setUp(self):
+        self.fake_logger = FakeLogger()
 
+    @patch('requests.head')
+    def test_try_endpoint_ok(self, request_mock):
+        self._given_responses(request_mock, 200)
+        success, test_endpoint = iiif.try_endpoint("test_endpoint", self.fake_logger)
         self.assertEqual(success, True)
         self.assertEqual(test_endpoint, "test_endpoint")
 
     @patch('requests.head')
     def test_try_endpoint_error(self, request_mock):
-        iterable = (ObjectView({'status_code': 504}), ObjectView({'status_code': 500}))
-        request_mock.side_effect = iterable
-        fake_logger = FakeLogger()
-        success, test_endpoint = iiif.try_endpoint("test_endpoint", fake_logger)
-
+        self._given_responses(request_mock, 500)
+        success, test_endpoint = iiif.try_endpoint("test_endpoint", self.fake_logger)
         self.assertEqual(success, False)
-        self.assertEqual(test_endpoint, "test_endpoint")
+
+    @patch('requests.head')
+    def test_try_endpoint_retry_of_generic_timeout(self, request_mock):
+        self._given_responses(request_mock, 504, 200)
+        success, test_endpoint = iiif.try_endpoint("test_endpoint", self.fake_logger)
+        self.assertEqual(success, True)
+
+    # Loris exposes 404 on unretrievable images, at this time
+    # even if the original error is a 500
+    @patch('requests.head')
+    def test_try_endpoint_retry_of_not_retrievable_image_source(self, request_mock):
+        self._given_responses(request_mock, 404, 200)
+        success, test_endpoint = iiif.try_endpoint("test_endpoint", self.fake_logger)
+        self.assertEqual(success, True)
+
+    @patch('requests.head')
+    def test_try_endpoint_error_on_only_retry(self, request_mock):
+        self._given_responses(request_mock, 504, 500)
+        success, test_endpoint = iiif.try_endpoint("test_endpoint", self.fake_logger)
+        self.assertEqual(success, False)
+
+    def _given_responses(self, request_mock, *status_codes):
+        request_mock.side_effect = [ObjectView({'status_code': code}) for code in status_codes]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This activity sometimes fail because of an image that times out when downloaded from S3 inside the IIIF server. We do our best to detect this and retry once