### PR TITLE
Bug fix where article doi_id is not set in PubMedArticleDeposit.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -243,10 +243,12 @@ class activity_PubmedArticleDeposit(activity.activity):
                 # Edge case, ignore this article PoA
                 article.was_ever_poa = False
             elif (article.is_poa is False and
-                  lax_provider.was_ever_poa(article.doi_id, self.settings) is True):
+                  lax_provider.was_ever_poa(self.article.get_doi_id(article.doi),
+                                            self.settings) is True):
                 article.was_ever_poa = True
             elif (article.is_poa is False and
-                  lax_provider.was_ever_poa(article.doi_id, self.settings) is False):
+                  lax_provider.was_ever_poa(self.article.get_doi_id(article.doi),
+                                            self.settings) is False):
                 article.was_ever_poa = False
 
             # Check if each article is published


### PR DESCRIPTION
It turns out PubMedArticleDeposit activity has a different way of parsing the XML (using the elife-poa-xml-generation parser) and as a result the ``doi_id`` doesn't get set. Here is a quick fix to extract the ``doi_id`` from the ``doi`` value.

PubMedArticleDeposit does not have automated tests yet so this was a risk, I had hoped the small change would work, and tested in prod it did not. This should fix it.