### PR TITLE
PDF covers generation, prod url and adapting response

### DIFF
--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -35,8 +35,16 @@ class activity_GeneratePDFCovers(activity.activity):
 
             article = articlelib.article()
 
-            assert hasattr(self.settings, "pdf_cover_generator"), "pdf_cover_generator variable is missing from " \
-                                                                  "settings file!"
+            if not hasattr(self.settings, "pdf_cover_generator") or \
+                    (hasattr(self.settings, "pdf_cover_generator") and self.settings.pdf_cover_generator == None) or \
+                    (hasattr(self.settings, "pdf_cover_generator") and len(self.settings.pdf_cover_generator) < 1):
+
+                self.emit_monitor_event(self.settings, article_id, version, run,
+                                        self.pretty_name, "start", "pdf_cover_generator variable is missing from "
+                                                          "settings file. PDF not generated but flag is set "
+                                                          "for the activity to succeed.")
+                return activity.activity.ACTIVITY_SUCCESS
+
             pdf_cover = article.get_pdf_cover_link(self.settings.pdf_cover_generator, article_id)
 
             assert "a4" in pdf_cover and "letter" in pdf_cover and len(pdf_cover["a4"]) > 1 \

--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -34,13 +34,19 @@ class activity_GeneratePDFCovers(activity.activity):
                                     self.pretty_name, "start", "Starting check for generation of pdf cover.")
 
             article = articlelib.article()
-            pdf_cover_a4 = article.get_pdf_cover_link(self.logger, self.settings, article_id, "a4")
-            pdf_cover_letter = article.get_pdf_cover_link(self.logger, self.settings, article_id, "letter")
+
+            assert hasattr(self.settings, "pdf_cover_generator"), "pdf_cover_generator variable is missing from " \
+                                                                  "settings file!"
+            pdf_cover = article.get_pdf_cover_link(self.settings.pdf_cover_generator, article_id)
+            pdf_cover_a4 = pdf_cover["a4"]
+            pdf_cover_letter = pdf_cover["letter"]
 
             assert len(pdf_cover_a4) > 1 and len(pdf_cover_letter) > 1, "Unexpected result from pdf covers API."
 
+            dashboard_message = ("Finished check for generation of pdf cover. S3 url for a4: %s; "
+                                 "S3 url for letter %s.") % (pdf_cover_a4, pdf_cover_letter)
             self.emit_monitor_event(self.settings, article_id, version, run,
-                                    self.pretty_name, "start", "Finished check for generation of pdf cover.")
+                                    self.pretty_name, "start", dashboard_message)
             return activity.activity.ACTIVITY_SUCCESS
 
         except AssertionError as err:

--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -38,13 +38,12 @@ class activity_GeneratePDFCovers(activity.activity):
             assert hasattr(self.settings, "pdf_cover_generator"), "pdf_cover_generator variable is missing from " \
                                                                   "settings file!"
             pdf_cover = article.get_pdf_cover_link(self.settings.pdf_cover_generator, article_id)
-            pdf_cover_a4 = pdf_cover["a4"]
-            pdf_cover_letter = pdf_cover["letter"]
 
-            assert len(pdf_cover_a4) > 1 and len(pdf_cover_letter) > 1, "Unexpected result from pdf covers API."
+            assert "a4" in pdf_cover and "letter" in pdf_cover and len(pdf_cover["a4"]) > 1 \
+                   and len(pdf_cover["letter"]) > 1, "Unexpected result from pdf covers API."
 
             dashboard_message = ("Finished check for generation of pdf cover. S3 url for a4: %s; "
-                                 "S3 url for letter %s.") % (pdf_cover_a4, pdf_cover_letter)
+                                 "S3 url for letter %s.") % (pdf_cover["a4"], pdf_cover["letter"])
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "start", dashboard_message)
             return activity.activity.ACTIVITY_SUCCESS

--- a/provider/article.py
+++ b/provider/article.py
@@ -233,21 +233,18 @@ class article(object):
         doi_id = x[-1]
         return doi_id
 
-    def get_pdf_cover_link(self, logger, settings, doi_id, format):
+    def get_pdf_cover_link(self, pdf_cover_generator_url ,doi_id):
 
-        url = ""
-        assert hasattr(settings, "pdf_cover_generator"), "pdf_cover_generator variable is missing from settings file!"
+        url = pdf_cover_generator_url + str(doi_id)
+        resp = requests.get(url)
 
-        url = settings.pdf_cover_generator + str(doi_id) + "/" + format
-        urlbot = url + "/bot"
-        resp = requests.get(urlbot)
-
-        assert resp.status_code != 404, "PDF cover not found. Format: %s - url requested: %s" % (format, urlbot)
-        assert resp.status_code == 200, "unhandled status code from PDF cover service: %s . Format: %s - url requested: %s" % \
-                                        (resp.status_code, format, urlbot)
+        assert resp.status_code != 404, "PDF cover not found. Format: %s - url requested: %s" % (format, url)
+        assert resp.status_code == 200, "unhandled status code from PDF cover service: %s . " \
+                                        "Format: %s - url requested: %s" % \
+                                        (resp.status_code, format, url)
 
         data = resp.json()
-        return data['cover']
+        return data['formats']
 
     def get_pub_date_timestamp(self, pub_date):
         """

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -59,7 +59,7 @@ xml_info_queue = 'test-elife-xml-info'
 video_url = ""
 
 # PDF cover
-pdf_cover_generator = ""
+pdf_cover_generator = "url_here"
 
 iiif_resolver = ""
 path_to_iiif_server = ""

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -68,7 +68,11 @@ class TestGeneratePDFCovers(unittest.TestCase):
         data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
                 "article_id": "00353",
                 "version": "1"}
-        fake_request.return_value = FakeResponse(200, {"cover":"https://s3.eu-west-2.amazonaws.com/elifecoversht/09560"})
+        fake_request.return_value = FakeResponse(200, {"formats":
+                                                           {"a4":"https://s3.eu-west-2.amazonaws.com/a4/09560",
+                                                            "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
+                                                           }
+                                                       })
 
         result = self.generatepdfcovers.do_activity(data)
 

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -120,6 +120,17 @@ class workflow_PostPerfectPublication(workflow.workflow):
                         "schedule_to_close_timeout": 60 * 5,
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 5
+                    },
+                    {
+                        "activity_type": "GeneratePDFCovers",
+                        "activity_id": "GeneratePDFCovers",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
                     }
                 ],
 


### PR DESCRIPTION
These changes are assuming that the PDF covers request response is according to @garyttierney 's pointers on https://elifesciences.atlassian.net/browse/ELPP-2047.

If those are ok, we need to add the settings variable pdf_cover_generator before merging (cc @giorgiosironi). 