### PR TITLE
CF Invalidation problem - I believe boto is treating the path as a list

### DIFF
--- a/provider/cloudfront_provider.py
+++ b/provider/cloudfront_provider.py
@@ -7,6 +7,6 @@ from boto.cloudfront.invalidation import InvalidationBatch
 def create_invalidation(article, settings):
     cloudfront = CloudFrontConnection(settings.aws_access_key_id, settings.aws_secret_access_key)
     inval_req = cloudfront.create_invalidation_request(settings.cloudfront_distribution_id_cdn,
-                                                       "/articles/" + article + "/*")
+                                                       ["/articles/" + article + "/*"])
     assert isinstance(inval_req, InvalidationBatch), \
         "Invalidation request did not return expected object."


### PR DESCRIPTION
according to the documentation it says create_invalidation_request(distribution_id, paths, caller_reference=None) Note: paths(plural). It could be splitting the whole string and showing that strange behaviour shown in the ticket ELPP-2963. Worth testing.