### PR TITLE
ELPP-3150 Inline figures still need to be converted

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -46,7 +46,7 @@ class activity_ConvertImagesToJPG(activity.activity):
             storage_context = StorageContext(self.settings)
             files_in_bucket = storage_context.list_resources(orig_resource)
 
-            figures = filter(article_structure.article_figure, files_in_bucket)
+            figures = filter(article_structure.article_figure, files_in_bucket) + filter(article_structure.inline_figure, files_in_bucket)
 
             # download is not a IIIF asset but is currently kept for compatibility
             # download may become obsolete in future

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -122,6 +122,10 @@ def figure_pdf(file):
     article_info = ArticleInfo(file)
     return article_info.file_type == "FigurePDF"
 
+def inline_figure(file):
+    article_info = ArticleInfo(file)
+    return article_info.file_type == "Inline"
+
 def has_extensions(file, extensions):
     article_info = ArticleInfo(file)
     return article_info.extension in extensions

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -97,6 +97,15 @@ class TestArticleStructure(unittest.TestCase):
     def test_article_figure(self, input, expected):
         self.assertEqual(article_structure.article_figure(input), expected)
 
+    @unpack
+    @data(
+        {'input': 'elife-00666-app1-fig1-v1.tif', 'expected': False},
+        {'input': 'elife-00666-fig1-v1.tif', 'expected': False},
+        {'input': 'elife-00666-inf1-v1.tif', 'expected': True},
+          )
+    def test_inline_figure(self, input, expected):
+        self.assertEqual(article_structure.inline_figure(input), expected, "Case %s" % input)
+
     def test_get_original_files(self):
         files = ['elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-fig2-figsupp2-v10.tif',


### PR DESCRIPTION
These images are not consumed through IIIF, but they are still consumed at original resolution as .jpg

Follow-up to #502