### PR TITLE
Schedule crossref tests

### DIFF
--- a/activity/activity_ScheduleCrossref.py
+++ b/activity/activity_ScheduleCrossref.py
@@ -5,7 +5,7 @@ import activity
 from boto.s3.connection import S3Connection
 
 from provider.execution_context import Session
-from activity_ConvertJATS import activity_ConvertJATS as ConvertJATS
+from provider.article_structure import get_article_xml_key
 
 """
 ScheduleCrossref.py activity
@@ -57,7 +57,7 @@ class activity_ScheduleCrossref(activity.activity):
                                 "Starting scheduling of crossref deposit for " + article_id)
 
         try:
-            (xml_key, xml_filename) = ConvertJATS.get_article_xml_key(bucket, expanded_folder_name)
+            (xml_key, xml_filename) = get_article_xml_key(bucket, expanded_folder_name)
 
             # Rename the XML file to match what is used already
             new_key_name = self.new_crossref_xml_name(

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -181,7 +181,10 @@ def pre_ingest_assets(files):
 
 
 def get_article_xml_key(bucket, expanded_folder_name):
-    "locate the article XML file in the expanded article bucket on S3"
+    """
+    locate the article XML file in the expanded article bucket on S3
+    and return the S3 key and the filename of the object
+    """
     files = bucket.list(expanded_folder_name + "/", "/")
     for bucket_file in files:
         key = bucket.get_key(bucket_file.key)

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -180,6 +180,17 @@ def pre_ingest_assets(files):
     return list(set(iiif_assets + pdf_figures))
 
 
+def get_article_xml_key(bucket, expanded_folder_name):
+    "locate the article XML file in the expanded article bucket on S3"
+    files = bucket.list(expanded_folder_name + "/", "/")
+    for bucket_file in files:
+        key = bucket.get_key(bucket_file.key)
+        filename = key.name.rsplit('/', 1)[1]
+        info = ArticleInfo(filename)
+        if info.file_type == 'ArticleXML':
+            return key, filename
+    return None, None
+
 def main():
     a = ArticleInfo("elife-00012-fig3-figsupp1-data2.csv")
     print a

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -181,6 +181,10 @@ class FakeBucket:
     def get_key(self, key): #key will be u'00353.1/7d5fa403-cba9-486c-8273-3078a98a0b98/elife-00353-fig1-v1.tif' for example
         return key
 
+    def list(self, prefix='', delimiter=''):
+        "stub for mocking"
+        pass
+
 class FakeLogger:
     def __init__(self):
         self.logdebug = "First logger debug"

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -1,15 +1,17 @@
 import unittest
 from activity.activity_ScheduleCrossref import activity_ScheduleCrossref
-from activity.activity_ConvertJATS import activity_ConvertJATS as ConvertJATS
 from mock import mock, patch
 from tests.activity.classes_mock import FakeSession
-from tests.activity.classes_mock import FakeKey
 from tests.activity.classes_mock import FakeS3Connection
 from tests.activity.classes_mock import FakeLogger
 import tests.activity.settings_mock as settings_mock
 import tests.activity.test_activity_data as testdata
 from ddt import ddt, data, unpack
 
+class FakeKey:
+    "just want a fake key object which can have a property set"
+    def __init__(self):
+        self.name = None
 
 @ddt
 class TestScheduleCrossref(unittest.TestCase):
@@ -21,7 +23,7 @@ class TestScheduleCrossref(unittest.TestCase):
         pass
 
     @patch.object(activity_ScheduleCrossref, 'copy_article_xml_to_crossref_outbox')
-    @patch.object(ConvertJATS, 'get_article_xml_key')
+    @patch('activity.activity_ScheduleCrossref.get_article_xml_key')
     @patch('activity.activity_ScheduleCrossref.S3Connection')
     @patch('activity.activity_ScheduleCrossref.Session')
     @patch.object(activity_ScheduleCrossref, 'emit_monitor_event')
@@ -39,7 +41,7 @@ class TestScheduleCrossref(unittest.TestCase):
         fake_copy_article_xml = mock.MagicMock()
         # create a fake Key if specified
         if xml_key:
-            fake_key = FakeKey
+            fake_key = FakeKey()
             fake_key.name = xml_key
         else:
             fake_key = None

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -1,0 +1,62 @@
+import unittest
+from activity.activity_ScheduleCrossref import activity_ScheduleCrossref
+from activity.activity_ConvertJATS import activity_ConvertJATS as ConvertJATS
+from mock import mock, patch
+from tests.activity.classes_mock import FakeSession
+from tests.activity.classes_mock import FakeKey
+from tests.activity.classes_mock import FakeS3Connection
+from tests.activity.classes_mock import FakeLogger
+import tests.activity.settings_mock as settings_mock
+import tests.activity.test_activity_data as testdata
+from ddt import ddt, data, unpack
+
+
+@ddt
+class TestScheduleCrossref(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_ScheduleCrossref(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        pass
+
+    @patch.object(activity_ScheduleCrossref, 'copy_article_xml_to_crossref_outbox')
+    @patch.object(ConvertJATS, 'get_article_xml_key')
+    @patch('activity.activity_ScheduleCrossref.S3Connection')
+    @patch('activity.activity_ScheduleCrossref.Session')
+    @patch.object(activity_ScheduleCrossref, 'emit_monitor_event')
+    @patch.object(activity_ScheduleCrossref, 'set_monitor_property')
+    @data(
+        ('key_name', 'tests/test_data/elife-00353-v1.xml', True),
+        (None, None, False),
+        )
+    @unpack
+    def test_do_activity(self, xml_key, xml_filename, expected_result,
+                         mock_set_monitor_property, mock_emit_monitor_event, fake_session_mock,
+                         fake_s3_mock, fake_get_article_xml_key, fake_copy_article_xml):
+        fake_session_mock.return_value = FakeSession(testdata.session_example)
+        fake_s3_mock.return_value = FakeS3Connection()
+        fake_copy_article_xml = mock.MagicMock()
+        # create a fake Key if specified
+        if xml_key:
+            fake_key = FakeKey
+            fake_key.name = xml_key
+        else:
+            fake_key = None
+        fake_get_article_xml_key.return_value = (fake_key, xml_filename)
+
+        result = self.activity.do_activity(testdata.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
+
+    @data(
+        ('crossref/outbox/', 'elife', '00353', 'crossref/outbox/elife00353.xml'),
+        ('crossref/outbox/', 'elife', None, None),
+        )
+    @unpack
+    def test_new_crossref_xml_name(self, prefix, journal, article_id, expected_result):
+        self.assertEqual(
+            self.activity.new_crossref_xml_name(prefix, journal, article_id), expected_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As part of integrating the new Crossref generation library, I noticed the ScheduleCrossref activity did not have test cases, and I first added them here.

Reviewing it, I noticed it imported a static method from the ConvertJATS activity in order to find the article XML key from the expanded article bucket. To refactor this to a more logical place, I put the function into the ``article_structure.py`` provider, since it is closely related to knowing what the article XML file name is.

There are at least three other activities that use a ``get_article_xml_key()`` function somewhere, and those can be refactored in the future as part of a new PR, presuming this PR gets merged in.