### PR TITLE
Disable GoOA deposits in the cron temporarily.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -131,12 +131,14 @@ def run_cron(settings):
                 start_seconds=60 * 31)
 
         # GoOA / CAS deposits once per day 21:45 UTC
+        """
         if current_time.tm_hour == 21:
             workflow_conditional_start(
                 settings=settings,
                 starter_name="starter_PubRouterDeposit",
                 workflow_id="PubRouterDeposit_GoOA",
                 start_seconds=60 * 31)
+        """
 
         workflow_conditional_start(
             settings=settings,


### PR DESCRIPTION
GoOA deposits have timed out for four consecutive business days and I am going to temporarily disable the sending until the FTP service is connecting again.