### PR TITLE
Padding id value returned by Lax in the lax_response_adapter.py with …

### DIFF
--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -4,6 +4,7 @@ import log
 import json
 from boto.sqs.message import Message
 from provider import process
+from provider import utils
 import base64
 from dateutil.parser import parse
 import newrelic.agent
@@ -70,7 +71,7 @@ class LaxResponseAdapter:
             date_time = parse(message_data['datetime'])
             date_time = date_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-            article_id = message_data["id"]
+            article_id = utils.pad_msid(message_data["id"])
             operation = message_data["requested-action"]
             response_message = None
             if "message" in message_data:

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -29,6 +29,31 @@ workflow_message_expected = {'workflow_data':
                                   'version': u'1'},
                              'workflow_name': 'PostPerfectPublication'}
 
+fake_token_269 = json.dumps({u'status': u'vor',
+                         u'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                         u'eif_location': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-00269-v1.json',
+                         u'version': u'1',
+                         u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
+
+fake_lax_message_269 = json.dumps({"status": "published",
+                               "requested-action": "publish",
+                               "datetime": "2013-03-26T00:00:00+00:00",
+                               "token": base64.encodestring(fake_token_269),
+                               "id": "269"})
+
+workflow_message_expected_269 = {'workflow_data':
+                                 {'article_id': u'00269',
+                                  'eif_location': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-00269-v1.json',
+                                  'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                                  'message': None,
+                                  'requested_action': u'publish',
+                                  'result': u'published',
+                                  'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+                                  'status': u'vor',
+                                  'update_date': '2013-03-26T00:00:00Z',
+                                  'version': u'1'},
+                             'workflow_name': 'PostPerfectPublication'}
+
 class TestLaxResponseAdapter(unittest.TestCase):
     def setUp(self):
         settings = Mock()
@@ -40,6 +65,10 @@ class TestLaxResponseAdapter(unittest.TestCase):
         self.assertDictEqual.__self__.maxDiff = None
         self.assertDictEqual(expected_workflow_starter_message, workflow_message_expected)
 
+    def test_parse_message_269(self):
+        expected_workflow_starter_message = self.laxresponseadapter.parse_message(fake_lax_message_269)
+        self.assertDictEqual.__self__.maxDiff = None
+        self.assertDictEqual(expected_workflow_starter_message, workflow_message_expected_269)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…a test case.

Uses utils.pad_msid() to "zerofill" the id into article_id, and a test case based on the quirky silent correction that failed to complete the PostPerfectPublication workflow, article 00269.