### PR TITLE
In install.sh uninstall elifearticle and elifecrossref when installing.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,5 +11,11 @@ source venv/bin/activate
 if pip list | grep elifetools; then
     pip uninstall -y elifetools
 fi
+if pip list | grep elifearticle; then
+    pip uninstall -y elifearticle
+fi
+if pip list | grep elifecrossref; then
+    pip uninstall -y elifecrossref
+fi
 pip install -r requirements.txt
 


### PR DESCRIPTION
I tried deploying a bug fix to elifecrossref. After deploying, the bug is still there. I believe the library did not update to the commit as specified in ``requirements.txt``. This addition to ``install.sh`` should follow the similar pattern to what is done with elifetools: to uninstall it first, then it will result in installing the desired commit of each library.