### PR TITLE
Add VoR XML to the CNPIEC outbox in ScheduleDownstream activity.

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -36,6 +36,7 @@ class activity_ScheduleDownstream(activity.activity):
         self.gooa_outbox_folder = "gooa/outbox/"
         self.wos_outbox_folder = "wos/outbox/"
         self.scopus_outbox_folder = "scopus/outbox/"
+        self.cnpiec_outbox_folder = "cnpiec/outbox/"
 
     def do_activity(self, data=None):
 
@@ -99,6 +100,7 @@ class activity_ScheduleDownstream(activity.activity):
             outbox_list.append(self.gooa_outbox_folder)
             outbox_list.append(self.wos_outbox_folder)
             outbox_list.append(self.scopus_outbox_folder)
+            outbox_list.append(self.cnpiec_outbox_folder)
 
         return outbox_list
 


### PR DESCRIPTION
This simply add the XML file to the new CNPIEC outbox after publication, the same as it does for other pub router recipients.

I will write tests for this activity soon, ticket in https://elifesciences.atlassian.net/browse/ELPP-3220, but I really want to deploy this outbox trigger ASAP and I will skip adding tests as part of this PR.