### PR TITLE
StorageContext factory cleanup

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -1,7 +1,7 @@
 import activity
 import json
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 import provider.article_structure as article_structure
 import provider.image_conversion as image_conversion
 import os
@@ -43,7 +43,7 @@ class activity_ConvertImagesToJPG(activity.activity):
             storage_provider = self.settings.storage_provider + "://"
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
 
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
             files_in_bucket = storage_context.list_resources(orig_resource)
 
             figures = filter(article_structure.article_figure, files_in_bucket) + filter(article_structure.inline_figure, files_in_bucket)

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -43,8 +43,8 @@ class activity_ConvertImagesToJPG(activity.activity):
             storage_provider = self.settings.storage_provider + "://"
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
 
-            storage_context = storage_context(self.settings)
-            files_in_bucket = storage_context.list_resources(orig_resource)
+            storage = storage_context(self.settings)
+            files_in_bucket = storage.list_resources(orig_resource)
 
             figures = filter(article_structure.article_figure, files_in_bucket) + filter(article_structure.inline_figure, files_in_bucket)
 
@@ -59,7 +59,7 @@ class activity_ConvertImagesToJPG(activity.activity):
             for file_name in figures:
                 figure_resource = orig_resource + "/" + file_name
                 file_path = self.get_tmp_dir() + os.sep + file_name
-                file_pointer = storage_context.get_resource_to_file_pointer(figure_resource, file_path)
+                file_pointer = storage.get_resource_to_file_pointer(figure_resource, file_path)
 
                 cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
                 cdn_resource_path = storage_provider + cdn_bucket_name + "/" + article_id + "/"

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -1,7 +1,7 @@
 import activity
 import json
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 import provider.glencoe_check as glencoe_check
 import os
 import requests
@@ -139,7 +139,7 @@ class activity_CopyGlencoeStillImages(activity.activity):
         return cdn
 
     def store_file(self, path, article_id):
-        storage_context = StorageContext(self.settings)
+        storage_context = storage_context(self.settings)
         r = requests.get(path)
         if r.status_code == 200:
             resource = self.s3_resources(path, article_id)
@@ -153,7 +153,7 @@ class activity_CopyGlencoeStillImages(activity.activity):
 
 
     def list_files_from_cdn(self, article_id):
-        storage_context = StorageContext(self.settings)
+        storage_context = storage_context(self.settings)
         article_path_in_cdn = self.settings.storage_provider + "://" + \
                               self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
                               article_id

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -139,25 +139,28 @@ class activity_CopyGlencoeStillImages(activity.activity):
         return cdn
 
     def store_file(self, path, article_id):
-        storage_context = storage_context(self.settings)
+        storage = storage_context(self.settings)
         r = requests.get(path)
         if r.status_code == 200:
             resource = self.s3_resources(path, article_id)
             self.logger.info("S3 resource: " + resource)
             jpg_filename = os.path.split(resource)[-1]
-            storage_context.set_resource_from_string(resource, r.content,
-                                                     content_type=r.headers['content-type'])
+            storage.set_resource_from_string(
+                resource,
+                r.content,
+                content_type=r.headers['content-type']
+            )
             return jpg_filename
         else:
             raise RuntimeError("Glencoe returned a %s status code for %s" % (r.status_code, path))
 
 
     def list_files_from_cdn(self, article_id):
-        storage_context = storage_context(self.settings)
+        storage = storage_context(self.settings)
         article_path_in_cdn = self.settings.storage_provider + "://" + \
                               self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
                               article_id
-        return storage_context.list_resources(article_path_in_cdn)
+        return storage.list_resources(article_path_in_cdn)
 
     def validate_jpgs_against_cdn(self, cdn_all_files, cdn_still_jpgs, article_id):
         """checks that for each element of cdn_still_jpgs there are two files in the CDN.

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -1,7 +1,7 @@
 import activity
 from boto.s3.connection import S3Connection
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 from mimetypes import guess_type
 from provider import article_structure
 
@@ -43,7 +43,7 @@ class activity_DepositAssets(activity.activity):
             expanded_folder_bucket = (self.settings.publishing_buckets_prefix +
                                       self.settings.expanded_bucket)
 
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
             storage_provider = self.settings.storage_provider + "://"
 
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -43,11 +43,11 @@ class activity_DepositAssets(activity.activity):
             expanded_folder_bucket = (self.settings.publishing_buckets_prefix +
                                       self.settings.expanded_bucket)
 
-            storage_context = storage_context(self.settings)
+            storage = storage_context(self.settings)
             storage_provider = self.settings.storage_provider + "://"
 
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
-            files_in_bucket = storage_context.list_resources(orig_resource)
+            files_in_bucket = storage.list_resources(orig_resource)
 
             # filter figures that have already been copied (see DepositIngestAssets activity)
             pre_ingest_assets = article_structure.pre_ingest_assets(files_in_bucket)
@@ -63,7 +63,7 @@ class activity_DepositAssets(activity.activity):
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/"
                 dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/"
 
-                storage_context.copy_resource(orig_resource + file_name, dest_resource + file_name)
+                storage.copy_resource(orig_resource + file_name, dest_resource + file_name)
 
                 if self.logger:
                     self.logger.info("Uploaded file %s to %s" % (file_name, cdn_bucket_name))
@@ -77,7 +77,7 @@ class activity_DepositAssets(activity.activity):
                     file_download = file_name_no_extension + "-download." + extension
 
                     # file is copied with additional metadata
-                    storage_context.copy_resource(orig_resource + file_name,
+                    storage.copy_resource(orig_resource + file_name,
                                                   dest_resource + file_download,
                                                   additional_dict_metadata=dict_metadata)
 

--- a/activity/activity_DepositIngestAssets.py
+++ b/activity/activity_DepositIngestAssets.py
@@ -41,11 +41,11 @@ class activity_DepositIngestAssets(activity.activity):
 
             cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
 
-            storage_context = storage_context(self.settings)
+            storage = storage_context(self.settings)
             storage_provider = self.settings.storage_provider + "://"
 
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
-            files_in_bucket = storage_context.list_resources(orig_resource)
+            files_in_bucket = storage.list_resources(orig_resource)
 
             pre_ingest_assets = article_structure.pre_ingest_assets(files_in_bucket)
 
@@ -53,7 +53,7 @@ class activity_DepositIngestAssets(activity.activity):
 
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/" + file_name
                 dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
-                storage_context.copy_resource(orig_resource, dest_resource)
+                storage.copy_resource(orig_resource, dest_resource)
 
                 if self.logger:
                     self.logger.info("Uploaded file %s to %s" % (file_name, cdn_bucket_name))

--- a/activity/activity_DepositIngestAssets.py
+++ b/activity/activity_DepositIngestAssets.py
@@ -1,7 +1,7 @@
 import activity
 from boto.s3.connection import S3Connection
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 from provider import article_structure
 
 """
@@ -41,7 +41,7 @@ class activity_DepositIngestAssets(activity.activity):
 
             cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
 
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
             storage_provider = self.settings.storage_provider + "://"
 
             orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -45,7 +45,7 @@ class activity_ExpandArticle(activity.activity):
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
         info = S3NotificationInfo.from_dict(data)
 
-        storage_context = storage_context(self.settings)
+        storage = storage_context(self.settings)
 
         session = Session(self.settings)
 
@@ -80,7 +80,7 @@ class activity_ExpandArticle(activity.activity):
             tmp = self.get_tmp_dir()
             local_zip_file = self.open_file_from_tmp_dir(filename_last_element, mode='wb')
             storage_resource_origin = self.settings.storage_provider + "://" + info.bucket_name + "/" + info.file_name
-            storage_context.get_resource_to_file(storage_resource_origin, local_zip_file)
+            storage.get_resource_to_file(storage_resource_origin, local_zip_file)
             local_zip_file.close()
 
             # extract zip contents
@@ -102,7 +102,7 @@ class activity_ExpandArticle(activity.activity):
                 dest_path = bucket_folder_name + '/' + filename
                 storage_resource_dest = self.settings.storage_provider + "://" + self.settings.publishing_buckets_prefix + \
                                         self.settings.expanded_bucket + "/" + dest_path
-                storage_context.set_resource_from_filename(storage_resource_dest, source_path)
+                storage.set_resource_from_filename(storage_resource_dest, source_path)
 
             self.clean_tmp_dir()
 

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -12,7 +12,7 @@ import datetime
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider.execution_context import Session
 import requests
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 from provider.article_structure import ArticleInfo
 import provider.lax_provider as lax_provider
 
@@ -45,7 +45,7 @@ class activity_ExpandArticle(activity.activity):
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
         info = S3NotificationInfo.from_dict(data)
 
-        storage_context = StorageContext(self.settings)
+        storage_context = storage_context(self.settings)
 
         session = Session(self.settings)
 

--- a/activity/activity_SetEIFPublish.py
+++ b/activity/activity_SetEIFPublish.py
@@ -35,7 +35,7 @@ class activity_SetEIFPublish(activity.activity):
                 self.logger.error(self.pretty_name + " error. eif_location must be string")
                 raise Exception("eif_location not available")
 
-            storage_context = storage_context(self.settings)
+            storage = storage_context(self.settings)
 
             eif_origin = "".join((self.settings.storage_provider,
                                   "://",
@@ -48,7 +48,7 @@ class activity_SetEIFPublish(activity.activity):
             return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
 
-        success, error = self.set_eif_to_publish(storage_context, eif_origin)
+        success, error = self.set_eif_to_publish(storage, eif_origin)
 
         if success:
             self.emit_monitor_event(self.settings, data['article_id'], data['version'], data['run'],
@@ -60,10 +60,10 @@ class activity_SetEIFPublish(activity.activity):
                                 self.pretty_name, "error", error)
         return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
-    def set_eif_to_publish(self, storage_context, eif_origin):
+    def set_eif_to_publish(self, storage, eif_origin):
         try:
 
-            eif_data = self.get_eif(storage_context, eif_origin)
+            eif_data = self.get_eif(storage, eif_origin)
 
         except Exception as e:
 
@@ -72,15 +72,15 @@ class activity_SetEIFPublish(activity.activity):
         try:
 
             eif_data['publish'] = True
-            storage_context.set_resource_from_string(eif_origin, json.dumps(eif_data))
+            storage.set_resource_from_string(eif_origin, json.dumps(eif_data))
             return True, None
 
         except Exception as e:
             return False, "There is something wrong with EIF data and/or we could not upload it. " \
                           "Error details: " + e.message
 
-    def get_eif(self, storage_context, eif_origin):
-        return json.loads(storage_context.get_resource_as_string(eif_origin))
+    def get_eif(self, storage, eif_origin):
+        return json.loads(storage.get_resource_as_string(eif_origin))
 
 
 

--- a/activity/activity_SetEIFPublish.py
+++ b/activity/activity_SetEIFPublish.py
@@ -1,6 +1,6 @@
 import activity
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 import json
 
 """
@@ -35,7 +35,7 @@ class activity_SetEIFPublish(activity.activity):
                 self.logger.error(self.pretty_name + " error. eif_location must be string")
                 raise Exception("eif_location not available")
 
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
 
             eif_origin = "".join((self.settings.storage_provider,
                                   "://",

--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -58,8 +58,8 @@ class activity_VerifyGlencoe(activity.activity):
             xml_origin = "".join((self.settings.storage_provider, "://", expanded_bucket, "/", expanded_folder + '/' +
                                   xml_filename))
 
-            storage_context = storage_context(self.settings)
-            xml_content = storage_context.get_resource_as_string(xml_origin)
+            storage = storage_context(self.settings)
+            xml_content = storage.get_resource_as_string(xml_origin)
 
             if glencoe_check.has_videos(xml_content):
                 glencoe_check.validate_sources(glencoe_check.metadata(glencoe_check.check_msid(article_id), self.settings))

--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -2,7 +2,7 @@ import activity
 import json
 from provider.execution_context import Session
 import provider.lax_provider as lax_provider
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 import time
 import provider.glencoe_check as glencoe_check
 
@@ -58,7 +58,7 @@ class activity_VerifyGlencoe(activity.activity):
             xml_origin = "".join((self.settings.storage_provider, "://", expanded_bucket, "/", expanded_folder + '/' +
                                   xml_filename))
 
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
             xml_content = storage_context.get_resource_as_string(xml_origin)
 
             if glencoe_check.has_videos(xml_content):

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -46,11 +46,11 @@ class activity_VerifyImageServer(activity.activity):
             return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
         try:
-            storage_context = storage_context(self.settings)
+            storage = storage_context(self.settings)
             bucket = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
             images_resource = "".join((self.settings.storage_provider, "://", bucket, "/", article_id))
 
-            files_in_bucket = storage_context.list_resources(images_resource)
+            files_in_bucket = storage.list_resources(images_resource)
             original_figures = article_structure.get_figures_for_iiif(files_in_bucket)
 
             iiif_path_for_article = self.settings.iiif_resolver.replace('{article_id}', article_id)

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -1,7 +1,7 @@
 import activity
 import json
 from provider.execution_context import Session
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 import provider.article_structure as article_structure
 import provider.iiif as iiif
 import requests
@@ -46,7 +46,7 @@ class activity_VerifyImageServer(activity.activity):
             return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
         try:
-            storage_context = StorageContext(self.settings)
+            storage_context = storage_context(self.settings)
             bucket = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
             images_resource = "".join((self.settings.storage_provider, "://", bucket, "/", article_id))
 

--- a/activity/activity_VersionDateLookup.py
+++ b/activity/activity_VersionDateLookup.py
@@ -12,7 +12,7 @@ import datetime
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider.execution_context import Session
 import requests
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 from provider.article_structure import ArticleInfo
 import provider.lax_provider as lax_provider
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -12,7 +12,7 @@ import provider.simpleDB as dblib
 import provider.s3lib as s3lib
 from elifetools import parseJATS as parser
 from provider.article_structure import ArticleInfo
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 
 """
 Article data provider
@@ -712,7 +712,7 @@ class article(object):
 
     @staticmethod
     def _get_bucket_files(settings, expanded_folder_name, xml_bucket):
-        storage_context = StorageContext(settings)
+        storage_context = storage_context(settings)
         resource = settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder_name
         files_in_bucket = storage_context.list_resources(resource)
         return files_in_bucket

--- a/provider/article.py
+++ b/provider/article.py
@@ -712,9 +712,9 @@ class article(object):
 
     @staticmethod
     def _get_bucket_files(settings, expanded_folder_name, xml_bucket):
-        storage_context = storage_context(settings)
+        storage = storage_context(settings)
         resource = settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder_name
-        files_in_bucket = storage_context.list_resources(resource)
+        files_in_bucket = storage.list_resources(resource)
         return files_in_bucket
 
     def get_xml_file_name(self, settings, expanded_folder_name, xml_bucket, version):

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -24,12 +24,12 @@ def generate_images(settings, formats, fp, info, publish_locations, logger):
 
 def store_in_publish_locations(settings, filename, image, publish_locations, download):
         try:
-            storage_context = storage_context(settings)
+            storage = storage_context(settings)
 
             for resource in publish_locations:
                 image.seek(0)
                 content_type, encoding = guess_type(filename)
-                storage_context.set_resource_from_file(resource + filename, image, metadata={'Content-Type': content_type})
+                storage.set_resource_from_file(resource + filename, image, metadata={'Content-Type': content_type})
 
                 if download:
                     dict_metadata = {'Content-Disposition':
@@ -37,7 +37,7 @@ def store_in_publish_locations(settings, filename, image, publish_locations, dow
                                      'Content-Type': content_type}
                     filename_no_extension, extension = filename.rsplit('.', 1)
                     file_download = filename_no_extension + "-download." + extension
-                    storage_context.copy_resource(resource + filename, resource + file_download,
+                    storage.copy_resource(resource + filename, resource + file_download,
                                                   additional_dict_metadata=dict_metadata)
 
         finally:

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -1,5 +1,5 @@
 import provider.imageresize as resizer
-from provider.storage_provider import StorageContext
+from provider.storage_provider import storage_context
 from mimetypes import guess_type
 
 
@@ -24,7 +24,7 @@ def generate_images(settings, formats, fp, info, publish_locations, logger):
 
 def store_in_publish_locations(settings, filename, image, publish_locations, download):
         try:
-            storage_context = StorageContext(settings)
+            storage_context = storage_context(settings)
 
             for resource in publish_locations:
                 image.seek(0)

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -4,9 +4,12 @@ from boto.s3.connection import S3Connection
 from boto.s3.bucket import Bucket
 import re
 import os
+import log
 
 
 def StorageContext(*args):
+    logger = log.logger('deprecated.log', 'INFO', __name__)
+    logger.warning("provider.storage_provider.StorageContext() is deprecated")
     return S3StorageContext(args[0])
 
 def storage_context(*args):

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -9,10 +9,6 @@ import os
 def StorageContext(*args):
     return S3StorageContext(args[0])
 
-# class StorageContext(object):
-#     def __new__(cls, *args):
-#         return S3StorageContext(args[0])
-
 def storage_context(*args):
     return S3StorageContext(*args)
 

--- a/tests/activity/test_activity_convert_images_to_jpg.py
+++ b/tests/activity/test_activity_convert_images_to_jpg.py
@@ -15,7 +15,7 @@ class TestConvertImagesToJPG(unittest.TestCase):
 
     @patch('provider.image_conversion.generate_images')
     @patch('activity.activity_ConvertImagesToJPG.Session')
-    @patch('activity.activity_ConvertImagesToJPG.StorageContext')
+    @patch('activity.activity_ConvertImagesToJPG.storage_context')
     @patch.object(activity_ConvertImagesToJPG, 'emit_monitor_event')
     def test_activity_success(self, fake_emit, fake_storage_context, fake_session, fake_gen_images):
 
@@ -29,7 +29,7 @@ class TestConvertImagesToJPG(unittest.TestCase):
 
 
     @patch('activity.activity_ConvertImagesToJPG.Session')
-    @patch('activity.activity_ConvertImagesToJPG.StorageContext')
+    @patch('activity.activity_ConvertImagesToJPG.storage_context')
     @patch.object(activity_ConvertImagesToJPG, 'emit_monitor_event')
     def test_activity_failure(self, fake_emit, fake_storage_context, fake_session):
 

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -17,7 +17,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
-    @patch('activity.activity_CopyGlencoeStillImages.StorageContext')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.Session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
@@ -40,7 +40,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
-    @patch('activity.activity_CopyGlencoeStillImages.StorageContext')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.Session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_success_no_videos_for_article(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
@@ -74,7 +74,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
 
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
-    @patch('activity.activity_CopyGlencoeStillImages.StorageContext')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.Session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_error(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata, fake_store_jpgs):
@@ -103,7 +103,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
-    @patch('activity.activity_CopyGlencoeStillImages.StorageContext')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.Session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_bad_files(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
@@ -176,7 +176,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         self.assertEqual(1, len(result_bad_files))
 
     @patch('requests.get')
-    @patch('activity.activity_CopyGlencoeStillImages.StorageContext')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     def test_store_file_according_to_the_current_article_id_whatever_is_the_filename_on_glencoe(self, fake_storage_context, fake_requests_get):
         fake_storage_context.return_value = FakeStorageContext()
         fake_requests_get.return_value = MagicMock()

--- a/tests/activity/test_activity_deposit_assets.py
+++ b/tests/activity/test_activity_deposit_assets.py
@@ -48,7 +48,7 @@ class TestDepositAssets(unittest.TestCase):
         self.assertEqual(result, expected)
 
     @patch('activity.activity_DepositAssets.Session')
-    @patch('activity.activity_DepositAssets.StorageContext')
+    @patch('activity.activity_DepositAssets.storage_context')
     @patch.object(activity_DepositAssets, 'emit_monitor_event')
     def test_activity_success(self, fake_emit, fake_storage_context, fake_session):
 
@@ -61,7 +61,7 @@ class TestDepositAssets(unittest.TestCase):
 
 
     @patch('activity.activity_DepositAssets.Session')
-    @patch('activity.activity_DepositAssets.StorageContext')
+    @patch('activity.activity_DepositAssets.storage_context')
     @patch.object(activity_DepositAssets, 'emit_monitor_event')
     def test_activity_permanent_failure(self, fake_emit, fake_storage_context, fake_session):
 

--- a/tests/activity/test_activity_deposit_iiif_assets.py
+++ b/tests/activity/test_activity_deposit_iiif_assets.py
@@ -15,7 +15,7 @@ class TestDepositIngestAssets(unittest.TestCase):
 
 
     @patch('activity.activity_DepositIngestAssets.Session')
-    @patch('activity.activity_DepositIngestAssets.StorageContext')
+    @patch('activity.activity_DepositIngestAssets.storage_context')
     @patch.object(activity_DepositIngestAssets, 'emit_monitor_event')
     def test_activity_success(self, fake_emit, fake_storage_context, fake_session):
 
@@ -29,7 +29,7 @@ class TestDepositIngestAssets(unittest.TestCase):
 
 
     @patch('activity.activity_DepositIngestAssets.Session')
-    @patch('activity.activity_DepositIngestAssets.StorageContext')
+    @patch('activity.activity_DepositIngestAssets.storage_context')
     @patch.object(activity_DepositIngestAssets, 'emit_monitor_event')
     def test_activity_permanent_failure(self, fake_emit, fake_storage_context, fake_session):
 

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -26,7 +26,7 @@ class TestExpandArticle(unittest.TestCase):
 
     @patch.object(activity_ExpandArticle, 'get_tmp_dir')
     @patch('activity.activity_ExpandArticle.Session')
-    @patch('activity.activity_ExpandArticle.StorageContext')
+    @patch('activity.activity_ExpandArticle.storage_context')
     def test_do_activity(self, mock_storage_context, mock_session, mock_get_tmp_dir):
         mock_storage_context.return_value = FakeStorageContext()
         mock_session.return_value = FakeSession(testdata.session_example)
@@ -51,7 +51,7 @@ class TestExpandArticle(unittest.TestCase):
             index += 1
 
     @patch('activity.activity_ExpandArticle.Session')
-    @patch('activity.activity_ExpandArticle.StorageContext')
+    @patch('activity.activity_ExpandArticle.storage_context')
     def test_do_activity_invalid_articleid(self, mock_storage_context, mock_session):
         mock_storage_context.return_value = FakeStorageContext()
         mock_session.return_value = FakeSession(testdata.session_example)
@@ -64,7 +64,7 @@ class TestExpandArticle(unittest.TestCase):
         self.assertEqual(self.expandarticle.ACTIVITY_PERMANENT_FAILURE, success)
 
     @patch('activity.activity_ExpandArticle.Session')
-    @patch('activity.activity_ExpandArticle.StorageContext')
+    @patch('activity.activity_ExpandArticle.storage_context')
     @data(testdata.ExpandArticle_data_invalid_status1_session_example,
           testdata.ExpandArticle_data_invalid_status2_session_example)
     def test_do_activity_invalid_status(self, session_example, mock_storage_context, mock_session):

--- a/tests/activity/test_activity_set_eif_publish.py
+++ b/tests/activity/test_activity_set_eif_publish.py
@@ -14,7 +14,7 @@ class tests_SetEIFPublish(unittest.TestCase):
         self.seteifpublish = activity_SetEIFPublish(settings_mock, None, None, None, None)
 
     @patch.object(activity_SetEIFPublish, 'emit_monitor_event')
-    @patch('activity.activity_SetEIFPublish.StorageContext')
+    @patch('activity.activity_SetEIFPublish.storage_context')
     @patch.object(activity_SetEIFPublish, 'get_eif')
     @patch('activity.activity_SetEIFPublish.Session')
     @data(test_data.data_example_before_publish)
@@ -49,7 +49,7 @@ class tests_SetEIFPublish(unittest.TestCase):
         self.assertEqual(result, self.seteifpublish.ACTIVITY_PERMANENT_FAILURE)
 
     @patch.object(activity_SetEIFPublish, 'emit_monitor_event')
-    @patch('activity.activity_SetEIFPublish.StorageContext')
+    @patch('activity.activity_SetEIFPublish.storage_context')
     @patch.object(activity_SetEIFPublish, 'get_eif')
     @patch('activity.activity_SetEIFPublish.Session')
     @data(test_data.data_example_before_publish)

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -14,7 +14,7 @@ class TestVerifyGlencoe(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('provider.lax_provider.get_xml_file_name')
-    @patch('activity.activity_VerifyGlencoe.StorageContext')
+    @patch('activity.activity_VerifyGlencoe.storage_context')
     @patch('activity.activity_VerifyGlencoe.Session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
     @patch('requests.get')
@@ -48,7 +48,7 @@ class TestVerifyGlencoe(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('provider.lax_provider.get_xml_file_name')
-    @patch('activity.activity_VerifyGlencoe.StorageContext')
+    @patch('activity.activity_VerifyGlencoe.storage_context')
     @patch('activity.activity_VerifyGlencoe.Session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
     @patch('requests.get')
@@ -74,7 +74,7 @@ class TestVerifyGlencoe(unittest.TestCase):
     @patch('provider.glencoe_check.metadata')
     @patch('provider.glencoe_check.validate_sources')
     @patch('provider.lax_provider.get_xml_file_name')
-    @patch('activity.activity_VerifyGlencoe.StorageContext')
+    @patch('activity.activity_VerifyGlencoe.storage_context')
     @patch('activity.activity_VerifyGlencoe.Session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
     def test_do_acitvity_exception(self, fake_emit_monitor, fake_session, fake_storage_context, fake_get_xml_file_name,

--- a/tests/activity/test_activity_verify_image_server.py
+++ b/tests/activity/test_activity_verify_image_server.py
@@ -21,7 +21,7 @@ class TestVerifyImageServer(unittest.TestCase):
     def setUp(self):
         self.verifyimageserver = activity_VerifyImageServer(settings_mock, None, None, None, None)
 
-    @patch('activity.activity_VerifyImageServer.StorageContext')
+    @patch('activity.activity_VerifyImageServer.storage_context')
     @patch('activity.activity_VerifyImageServer.Session')
     @patch.object(activity_VerifyImageServer,'retrieve_endpoints_check')
     def test_do_activity_success(self, fake_retrieve_endpoints_check, fake_session, fake_storage_context):
@@ -37,7 +37,7 @@ class TestVerifyImageServer(unittest.TestCase):
         # Then
         self.assertEqual(result, self.verifyimageserver.ACTIVITY_SUCCESS)
 
-    @patch('activity.activity_VerifyImageServer.StorageContext')
+    @patch('activity.activity_VerifyImageServer.storage_context')
     @patch('activity.activity_VerifyImageServer.Session')
     @patch.object(activity_VerifyImageServer,'retrieve_endpoints_check')
     def test_do_activity_failure(self, fake_retrieve_endpoints_check, fake_session, fake_storage_context):
@@ -53,7 +53,7 @@ class TestVerifyImageServer(unittest.TestCase):
         # Then
         self.assertEqual(result, self.verifyimageserver.ACTIVITY_PERMANENT_FAILURE)
 
-    @patch('activity.activity_VerifyImageServer.StorageContext')
+    @patch('activity.activity_VerifyImageServer.storage_context')
     @patch('activity.activity_VerifyImageServer.Session')
     @patch.object(activity_VerifyImageServer,'retrieve_endpoints_check')
     def test_do_activity_error(self, fake_retrieve_endpoints_check, fake_session, fake_storage_context):


### PR DESCRIPTION
We started switching from
- `StorageContext()`, a function named like a class created for backward compatibility
to
- `storage_context()`, a function properly named and more general

Since you never know if you have found all usages, I inserted a deprecated log file to be written if the old function is still called.