### PR TITLE
Integrating build to propose updates of elife-poa-xml-generation

### DIFF
--- a/Jenkinsfile.update-elife-poa-xml-generation
+++ b/Jenkinsfile.update-elife-poa-xml-generation
@@ -4,13 +4,13 @@ elifeUpdatePipeline(
         lock('elife-bot--ci') {
             builderDeployRevision 'elife-bot--ci', commit
             builderCmd "elife-bot--ci", "./update-elife-poa-xml-generation.sh", "/opt/elife-bot"
-            builderSync "ci--elife-bot.elife.internal", "/opt/elife-bot/"
+            builderSync "ci--bot.elife.internal", "/opt/elife-bot/"
             sh "git add elife-poa-xml-generation.sha1"
             elifePoaXmlGenerationSummary = builderCmd "elife-bot--ci", "git log -1 --pretty=\"%B\" | head -n 1", "/opt/elife-poa-xml-generation", true
         }
     },
     {
-        return "Updated bot-lax-adaptor to: ${elifePoaXmlGenerationSummary}"
+        return "Updated elife-poa-xml-generation to: ${elifePoaXmlGenerationSummary}"
     },
-    'update_bot_lax_adaptor_'
+    'update_elife_poa_xml_generation/'
 )


### PR DESCRIPTION
This Jenkinsfile was broken from the start, but it's now fixed. It will run at https://alfred.elifesciences.org/job/dependencies-elife-bot-update-elife-poa-xml-generation/ as often as we like (weekly, or daily), and open a PR if there is a new `master` of `elife-poa-xml-generation` to use.

This is quite similar to https://github.com/elifesciences/lax/pull/310 for `bot-lax-adaptor`, only it's probably not worth it (nor particularly easy) to run it at every new commit on `master`.

This is also not massively useful for `elife-poa-xml-generation`, but it's a standard practice we do on dependencies and it's here so that the process can be easily extended to the other libraries the bot depends on; it could also be performed on new versions of those, rather than periodically, becoming more sophisticated.