### PR TITLE
Consider non-versioned XML file as an ArticleXML to fix …

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -88,7 +88,7 @@ class ArticleInfo(object):
             self.file_type = "Figure"
         elif len(self.extra_info) > 0 and self.extra_info[0].startswith('inf'):
             self.file_type = "Inline"
-        elif len(parts) == 3 and self.extension == 'xml':
+        elif (len(parts) == 2 or len(parts) == 3) and self.extension == 'xml':
             self.file_type = 'ArticleXML'
         else:
             self.file_type = 'Other'

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -63,6 +63,7 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-table3-data1-v1.xlsx', 'expected': 'Other'},
         {'input': 'elife-00666-video1.mp4', 'expected': 'Other'},
         {'input': 'elife-00666-video1-data1-v1.xlsx', 'expected': 'Other'},
+        {'input': 'elife-00666.xml', 'expected': 'ArticleXML'},
           )
     def test_get_file_type_from_zip_filename(self, input, expected):
         self.articleinfo = ArticleInfo(input)


### PR DESCRIPTION
… SendDashboardProperties.

end2end tests seem to be stopping when reaching SendDashboardProperties. If it looks for the ArticleXML in the expanded bucket before ApplyVersionNumber happens, then it needs to find the non-versioned XML file name and consider that a valid ArticleXML as according to the ``article_structure.py`` provider logic.

I think this doesn't have too many negative consequences.