### PR TITLE
Stop altering the title case of subject values in PublishFinalPOA.

### DIFF
--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -233,9 +233,6 @@ class activity_PublishFinalPOA(activity.activity):
         soup = self.article_soup(xml_file)
 
         if parser.is_poa(soup):
-            # Capitalise subject group values in article categories
-            root = self.subject_group_convert_in_xml(root)
-
             pub_date = None
             if parser.pub_date(soup) is None:
                 # add the published date to the XML
@@ -280,26 +277,6 @@ class activity_PublishFinalPOA(activity.activity):
 
     def article_soup(self, xml_file):
         return parser.parse_document(xml_file)
-
-    def title_case(self, string):
-        ignore_words = ['and']
-        word_list = string.split(' ')
-        for i, word in enumerate(word_list):
-            # Skip if the word if the first letter is a capital
-            if word and word[0] == word[0].upper():
-                continue
-            if word.lower() not in ignore_words:
-                word_list[i] = word.capitalize()
-        return ' '.join(word_list)
-
-    def subject_group_convert_in_xml(self, root):
-        """
-        Convert capitalisation of <subject> tags in article categories
-        """
-        for tag in root.findall('./front/article-meta/article-categories/subj-group'):
-            for subject_tag in tag.findall('./subject'):
-                subject_tag.text = self.title_case(subject_tag.text)
-        return root
 
     def add_tag_to_xml_before_elocation_id(self, add_tag, root, doi_id=""):
         # Add the tag to the XML


### PR DESCRIPTION
Now we are using the latest elife-poa-xml-generation code, we can turn off the title case alteration of PoA XML when it goes through PublishFinalPOA.