### PR TITLE
Updated elifetools: Cloning into '/tmp/elifetools-shallow-clone'...

### DIFF
--- a/Jenkinsfile.update-elife-tools
+++ b/Jenkinsfile.update-elife-tools
@@ -1,0 +1,15 @@
+def elifeToolsSummary;
+elifeUpdatePipeline(
+    { commit ->
+        lock('elife-bot--ci') {
+            builderDeployRevision 'elife-bot--ci', commit
+            elifeToolsSummary = builderCmd "elife-bot--ci", "source venv/bin/activate && update_python_dependency elifetools https://github.com/elifesciences/elife-tools.git", "/opt/elife-bot", true
+            builderSync "ci--bot.elife.internal", "/opt/elife-bot/"
+            sh "git add requirements.txt"
+        }
+    },
+    {
+        return "Updated elifetools: ${elifeToolsSummary}"
+    },
+    'update_elife_tools/'
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests==2.5.3
 wsgiref==0.1.2
 lxml==3.4.1
 xlrd==0.9.3
-git+https://github.com/elifesciences/elife-tools.git@7fbcef83fbe4ff960a6f44e1d143588b96c79325#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@1e6682548dd41e5168ff886d01163ccb12c78ce3#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@a6d011ec3c3f3803b135fe1c991a187c23e70fbd#egg=elifecrossref
 PyYAML==3.11


### PR DESCRIPTION
remote: Counting objects: 1218, done.[K
remote: Compressing objects:   0% (1/517)   [K
remote: Compressing objects:   1% (6/517)   [K
remote: Compressing objects:   2% (11/517)   [K
remote: Compressing objects:   3% (16/517)   [K
remote: Compressing objects:   4% (21/517)   [K
remote: Compressing objects:   5% (26/517)   [K
remote: Compressing objects:   6% (32/517)   [K
remote: Compressing objects:   7% (37/517)   [K
remote: Compressing objects:   8% (42/517)   [K
remote: Compressing objects:   9% (47/517)   [K
remote: Compressing objects:  10% (52/517)   [K
remote: Compressing objects:  11% (57/517)   [K
remote: Compressing objects:  12% (63/517)   [K
remote: Compressing objects:  13% (68/517)   [K
remote: Compressing objects:  14% (73/517)   [K
remote: Compressing objects:  15% (78/517)   [K
remote: Compressing objects:  16% (83/517)   [K
remote: Compressing objects:  17% (88/517)   [K
remote: Compressing objects:  18% (94/517)   [K
remote: Compressing objects:  19% (99/517)   [K
remote: Compressing objects:  20% (104/517)   [K
remote: Compressing objects:  21% (109/517)   [K
remote: Compressing objects:  22% (114/517)   [K
remote: Compressing objects:  23% (119/517)   [K
remote: Compressing objects:  24% (125/517)   [K
remote: Compressing objects:  25% (130/517)   [K
remote: Compressing objects:  26% (135/517)   [K
remote: Compressing objects:  27% (140/517)   [K
remote: Compressing objects:  28% (145/517)   [K
remote: Compressing objects:  29% (150/517)   [K
remote: Compressing objects:  30% (156/517)   [K
remote: Compressing objects:  31% (161/517)   [K
remote: Compressing objects:  32% (166/517)   [K
remote: Compressing objects:  33% (171/517)   [K
remote: Compressing objects:  34% (176/517)   [K
remote: Compressing objects:  35% (181/517)   [K
remote: Compressing objects:  36% (187/517)   [K
remote: Compressing objects:  37% (192/517)   [K
remote: Compressing objects:  38% (197/517)   [K
remote: Compressing objects:  39% (202/517)   [K
remote: Compressing objects:  40% (207/517)   [K
remote: Compressing objects:  41% (212/517)   [K
remote: Compressing objects:  42% (218/517)   [K
remote: Compressing objects:  43% (223/517)   [K
remote: Compressing objects:  44% (228/517)   [K
remote: Compressing objects:  45% (233/517)   [K
remote: Compressing objects:  46% (238/517)   [K
remote: Compressing objects:  47% (243/517)   [K
remote: Compressing objects:  48% (249/517)   [K
remote: Compressing objects:  49% (254/517)   [K
remote: Compressing objects:  50% (259/517)   [K
remote: Compressing objects:  51% (264/517)   [K
remote: Compressing objects:  52% (269/517)   [K
remote: Compressing objects:  53% (275/517)   [K
remote: Compressing objects:  54% (280/517)   [K
remote: Compressing objects:  55% (285/517)   [K
remote: Compressing objects:  56% (290/517)   [K
remote: Compressing objects:  57% (295/517)   [K
remote: Compressing objects:  58% (300/517)   [K
remote: Compressing objects:  59% (306/517)   [K
remote: Compressing objects:  60% (311/517)   [K
remote: Compressing objects:  61% (316/517)   [K
remote: Compressing objects:  62% (321/517)   [K
remote: Compressing objects:  63% (326/517)   [K
remote: Compressing objects:  64% (331/517)   [K
remote: Compressing objects:  65% (337/517)   [K
remote: Compressing objects:  66% (342/517)   [K
remote: Compressing objects:  67% (347/517)   [K
remote: Compressing objects:  68% (352/517)   [K
remote: Compressing objects:  69% (357/517)   [K
remote: Compressing objects:  70% (362/517)   [K
remote: Compressing objects:  71% (368/517)   [K
remote: Compressing objects:  72% (373/517)   [K
remote: Compressing objects:  73% (378/517)   [K
remote: Compressing objects:  74% (383/517)   [K
remote: Compressing objects:  75% (388/517)   [K
remote: Compressing objects:  76% (393/517)   [K
remote: Compressing objects:  77% (399/517)   [K
remote: Compressing objects:  78% (404/517)   [K
remote: Compressing objects:  79% (409/517)   [K
remote: Compressing objects:  80% (414/517)   [K
remote: Compressing objects:  81% (419/517)   [K
remote: Compressing objects:  82% (424/517)   [K
remote: Compressing objects:  83% (430/517)   [K
remote: Compressing objects:  84% (435/517)   [K
remote: Compressing objects:  85% (440/517)   [K
remote: Compressing objects:  86% (445/517)   [K
remote: Compressing objects:  87% (450/517)   [K
remote: Compressing objects:  88% (455/517)   [K
remote: Compressing objects:  89% (461/517)   [K
remote: Compressing objects:  90% (466/517)   [K
remote: Compressing objects:  91% (471/517)   [K
remote: Compressing objects:  92% (476/517)   [K
remote: Compressing objects:  93% (481/517)   [K
remote: Compressing objects:  94% (486/517)   [K
remote: Compressing objects:  95% (492/517)   [K
remote: Compressing objects:  96% (497/517)   [K
remote: Compressing objects:  97% (502/517)   [K
remote: Compressing objects:  98% (507/517)   [K
remote: Compressing objects:  99% (512/517)   [K
remote: Compressing objects: 100% (517/517)   [K
remote: Compressing objects: 100% (517/517), done.[K
Receiving objects:   0% (1/1218)   
Receiving objects:   1% (13/1218)   
Receiving objects:   2% (25/1218)   
Receiving objects:   3% (37/1218)   
Receiving objects:   4% (49/1218)   
Receiving objects:   5% (61/1218)   
Receiving objects:   6% (74/1218)   
Receiving objects:   7% (86/1218)   
Receiving objects:   8% (98/1218)   
Receiving objects:   9% (110/1218)   
Receiving objects:  10% (122/1218)   
Receiving objects:  11% (134/1218)   
Receiving objects:  12% (147/1218)   
Receiving objects:  13% (159/1218)   
Receiving objects:  14% (171/1218)   
Receiving objects:  15% (183/1218)   
Receiving objects:  16% (195/1218)   
Receiving objects:  17% (208/1218)   
Receiving objects:  18% (220/1218)   
Receiving objects:  19% (232/1218)   
Receiving objects:  20% (244/1218)   
Receiving objects:  21% (256/1218)   
Receiving objects:  22% (268/1218)   
Receiving objects:  23% (281/1218)   
Receiving objects:  24% (293/1218)   
Receiving objects:  25% (305/1218)   
Receiving objects:  26% (317/1218)   
Receiving objects:  27% (329/1218)   
Receiving objects:  28% (342/1218)   
Receiving objects:  29% (354/1218)   
Receiving objects:  30% (366/1218)   
Receiving objects:  31% (378/1218)   
Receiving objects:  32% (390/1218)   
Receiving objects:  33% (402/1218)   
Receiving objects:  34% (415/1218)   
Receiving objects:  35% (427/1218)   
Receiving objects:  36% (439/1218)   
Receiving objects:  37% (451/1218)   
Receiving objects:  38% (463/1218)   
Receiving objects:  39% (476/1218)   
Receiving objects:  40% (488/1218)   
Receiving objects:  41% (500/1218)   
Receiving objects:  42% (512/1218)   
Receiving objects:  43% (524/1218)   
Receiving objects:  44% (536/1218)   
Receiving objects:  45% (549/1218)   
Receiving objects:  46% (561/1218)   
Receiving objects:  47% (573/1218)   
Receiving objects:  48% (585/1218)   
Receiving objects:  49% (597/1218)   
Receiving objects:  50% (609/1218)   
Receiving objects:  51% (622/1218)   
Receiving objects:  52% (634/1218)   
Receiving objects:  53% (646/1218)   
Receiving objects:  54% (658/1218)   
Receiving objects:  55% (670/1218)   
Receiving objects:  56% (683/1218)   
Receiving objects:  57% (695/1218)   
Receiving objects:  58% (707/1218)   
Receiving objects:  59% (719/1218)   
Receiving objects:  60% (731/1218)   
Receiving objects:  61% (743/1218)   
Receiving objects:  62% (756/1218)   
Receiving objects:  63% (768/1218)   
Receiving objects:  64% (780/1218)   
Receiving objects:  65% (792/1218)   
Receiving objects:  66% (804/1218)   
Receiving objects:  67% (817/1218)   
Receiving objects:  68% (829/1218)   
Receiving objects:  69% (841/1218)   
Receiving objects:  70% (853/1218)   
Receiving objects:  71% (865/1218)   
Receiving objects:  72% (877/1218)   
Receiving objects:  73% (890/1218)   
Receiving objects:  74% (902/1218)   
Receiving objects:  75% (914/1218)   
Receiving objects:  76% (926/1218)   
Receiving objects:  77% (938/1218)   
Receiving objects:  78% (951/1218)   
Receiving objects:  79% (963/1218)   
Receiving objects:  80% (975/1218)   
Receiving objects:  81% (987/1218)   
Receiving objects:  82% (999/1218)   
Receiving objects:  83% (1011/1218)   
Receiving objects:  84% (1024/1218)   
Receiving objects:  85% (1036/1218)   
Receiving objects:  86% (1048/1218)   
Receiving objects:  87% (1060/1218)   
Receiving objects:  88% (1072/1218)   
Receiving objects:  89% (1085/1218)   
Receiving objects:  90% (1097/1218)   
Receiving objects:  91% (1109/1218)   
Receiving objects:  92% (1121/1218)   
Receiving objects:  93% (1133/1218)   
Receiving objects:  94% (1145/1218)   
Receiving objects:  95% (1158/1218)   
Receiving objects:  96% (1170/1218)   
Receiving objects:  97% (1182/1218)   
Receiving objects:  98% (1194/1218)   
Receiving objects:  99% (1206/1218)   
remote: Total 1218 (delta 351), reused 1092 (delta 291), pack-reused 0[K
Receiving objects: 100% (1218/1218)   
Receiving objects: 100% (1218/1218), 1.91 MiB | 0 bytes/s, done.
Resolving deltas:   0% (0/351)   
Resolving deltas:   1% (5/351)   
Resolving deltas:  12% (43/351)   
Resolving deltas:  13% (46/351)   
Resolving deltas:  19% (69/351)   
Resolving deltas:  24% (87/351)   
Resolving deltas:  25% (89/351)   
Resolving deltas:  28% (100/351)   
Resolving deltas:  35% (123/351)   
Resolving deltas:  40% (143/351)   
Resolving deltas:  50% (178/351)   
Resolving deltas:  57% (201/351)   
Resolving deltas:  59% (210/351)   
Resolving deltas:  61% (217/351)   
Resolving deltas:  62% (219/351)   
Resolving deltas:  66% (234/351)   
Resolving deltas:  70% (249/351)   
Resolving deltas:  71% (250/351)   
Resolving deltas:  74% (260/351)   
Resolving deltas:  79% (279/351)   
Resolving deltas:  82% (291/351)   
Resolving deltas:  83% (292/351)   
Resolving deltas:  84% (295/351)   
Resolving deltas:  85% (301/351)   
Resolving deltas:  86% (302/351)   
Resolving deltas:  91% (320/351)   
Resolving deltas:  92% (323/351)   
Resolving deltas:  94% (331/351)   
Resolving deltas:  95% (334/351)   
Resolving deltas:  96% (337/351)   
Resolving deltas:  97% (341/351)   
Resolving deltas:  98% (345/351)   
Resolving deltas:  99% (348/351)   
Resolving deltas: 100% (351/351)   
Resolving deltas: 100% (351/351), done.
Checking connectivity... done.
/opt/elife-bot
Uninstalling elifetools-0.1.7:
  Successfully uninstalled elifetools-0.1.7
Requirement already satisfied: boto==2.48.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 1))
Requirement already satisfied: Fom==0.9.10 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 2))
Requirement already satisfied: GitPython==0.3.2.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 3))
Requirement already satisfied: Jinja2==2.7.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 4))
Requirement already satisfied: PyPDF2==1.23 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 5))
Requirement already satisfied: arrow==0.4.4 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 6))
Requirement already satisfied: beautifulsoup4==4.3.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 7))
Requirement already satisfied: lettuce==0.2.20 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 8))
Requirement already satisfied: requests==2.5.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 9))
Requirement already satisfied: wsgiref==0.1.2 in /usr/lib/python2.7 (from -r requirements.txt (line 10))
Requirement already satisfied: lxml==3.4.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 11))
Requirement already satisfied: xlrd==0.9.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 12))
Collecting elifetools from git+https://github.com/elifesciences/elife-tools.git@1e6682548dd41e5168ff886d01163ccb12c78ce3#egg=elifetools (from -r requirements.txt (line 13))
  Cloning https://github.com/elifesciences/elife-tools.git (to 1e6682548dd41e5168ff886d01163ccb12c78ce3) to /tmp/pip-build-9IrSUw/elifetools
[33m  Could not find a tag or branch '1e6682548dd41e5168ff886d01163ccb12c78ce3', assuming commit.[0m
Requirement already satisfied: elifearticle from git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 14))
Requirement already satisfied: elifecrossref from git+https://github.com/elifesciences/elife-crossref-xml-generation.git@a6d011ec3c3f3803b135fe1c991a187c23e70fbd#egg=elifecrossref in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 15))
Requirement already satisfied: PyYAML==3.11 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 16))
Requirement already satisfied: Wand==0.4.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 17))
Requirement already satisfied: paramiko==1.15.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 18))
Requirement already satisfied: mock==1.3.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 19))
Requirement already satisfied: redis==2.10.5 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 20))
Requirement already satisfied: testfixtures==4.9.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 21))
Requirement already satisfied: pytest==2.9.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 22))
Requirement already satisfied: ddt==1.1.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 23))
Requirement already satisfied: Pillow==3.2.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 24))
Obtaining jats-scraper from git+https://github.com/elifesciences/jats-scraper.git#egg=jats-scraper (from -r requirements.txt (line 25))
  Updating ./venv/src/jats-scraper clone
[33m  Running setup.py (path:/opt/elife-bot/venv/src/jats-scraper/setup.py) egg_info for package jats-scraper produced metadata for project name unknown. Fix your #egg=jats-scraper fragments.[0m
Obtaining scraper from hg+https://bitbucket.org/lskibinski/scraper#egg=scraper (from -r requirements.txt (line 26))
  Updating ./venv/src/scraper clone
Requirement already satisfied: ndg-httpsclient==0.4.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 27))
Requirement already satisfied: pyasn1==0.1.9 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 28))
Requirement already satisfied: pyOpenSSL==16.2.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 29))
Requirement already satisfied: newrelic==2.72.0.52 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 30))
Requirement already satisfied: pylint==1.6.4 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 31))
Requirement already satisfied: pyGithub==1.27.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 32))
Requirement already satisfied: pyFunctional==1.0.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 33))
Requirement already satisfied: blinker in ./venv/lib/python2.7/site-packages (from Fom==0.9.10->-r requirements.txt (line 2))
Requirement already satisfied: gitdb>=0.6.0 in ./venv/lib/python2.7/site-packages (from GitPython==0.3.2.1->-r requirements.txt (line 3))
Requirement already satisfied: markupsafe in ./venv/lib/python2.7/site-packages (from Jinja2==2.7.3->-r requirements.txt (line 4))
Requirement already satisfied: python-dateutil in ./venv/lib/python2.7/site-packages (from arrow==0.4.4->-r requirements.txt (line 6))
Requirement already satisfied: python-subunit in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: sure in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: fuzzywuzzy in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: slugify==0.0.1 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: unittest-xml-reporting==1.12.0 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: coverage==3.7.1 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: configparser in ./venv/lib/python2.7/site-packages (from elifecrossref->-r requirements.txt (line 15))
Requirement already satisfied: pycrypto!=2.4,>=2.1 in ./venv/lib/python2.7/site-packages (from paramiko==1.15.2->-r requirements.txt (line 18))
Requirement already satisfied: ecdsa>=0.11 in ./venv/lib/python2.7/site-packages (from paramiko==1.15.2->-r requirements.txt (line 18))
Requirement already satisfied: six>=1.7 in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: funcsigs; python_version < "3.3" in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: pbr>=0.11 in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: py>=1.4.29 in ./venv/lib/python2.7/site-packages (from pytest==2.9.1->-r requirements.txt (line 22))
Requirement already satisfied: pytz==2015.4 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: deepdiff==0.5.9 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: jmespath==0.9.0 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: cryptography>=1.3.4 in ./venv/lib/python2.7/site-packages (from pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: astroid<1.5.0,>=1.4.5 in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: backports.functools-lru-cache; python_version == "2.7" in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: mccabe in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: isort>=4.2.5 in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: dill==0.2.5 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: tabulate==0.7.7 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: future==0.16.0 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: smmap>=0.8.5 in ./venv/lib/python2.7/site-packages (from gitdb>=0.6.0->GitPython==0.3.2.1->-r requirements.txt (line 3))
Requirement already satisfied: extras in ./venv/lib/python2.7/site-packages (from python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: testtools>=0.9.34 in ./venv/lib/python2.7/site-packages (from python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: packaging in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: ipaddress in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: asn1crypto>=0.21.0 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: enum34 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: idna>=2.1 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: cffi>=1.4.1 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: setuptools>=11.3 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: lazy-object-proxy in ./venv/lib/python2.7/site-packages (from astroid<1.5.0,>=1.4.5->pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: wrapt in ./venv/lib/python2.7/site-packages (from astroid<1.5.0,>=1.4.5->pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: traceback2 in ./venv/lib/python2.7/site-packages (from testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: python-mimeparse in ./venv/lib/python2.7/site-packages (from testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: fixtures>=1.3.0 in ./venv/lib/python2.7/site-packages (from testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: unittest2>=1.0.0 in ./venv/lib/python2.7/site-packages (from testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: pyparsing in ./venv/lib/python2.7/site-packages (from packaging->cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: pycparser in ./venv/lib/python2.7/site-packages (from cffi>=1.4.1->cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: appdirs>=1.4.0 in ./venv/lib/python2.7/site-packages (from setuptools>=11.3->cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: linecache2 in ./venv/lib/python2.7/site-packages (from traceback2->testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: argparse in /usr/lib/python2.7 (from unittest2>=1.0.0->testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Installing collected packages: elifetools, unknown, scraper
  Running setup.py install for elifetools ... [?25l- done
[?25h  Found existing installation: UNKNOWN 2015.5.28
    Uninstalling UNKNOWN-2015.5.28:
      Successfully uninstalled UNKNOWN-2015.5.28
  Running setup.py develop for unknown
  Found existing installation: scraper 0.1
    Uninstalling scraper-0.1:
      Successfully uninstalled scraper-0.1
  Running setup.py develop for scraper
Successfully installed elifetools-0.1.7 scraper unknown
pinned elifetools in requirements.txt to 1e6682548dd41e5168ff886d01163ccb12c78ce3


I have run https://alfred.elifesciences.org/job/dependencies-elife-bot-update-elife-tools/2/display/redirect which resulted in this pull request.