### PR TITLE
Use latest commit of elifecrossref project to fix a bug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ lxml==3.4.1
 xlrd==0.9.3
 git+https://github.com/elifesciences/elife-tools.git@1e6682548dd41e5168ff886d01163ccb12c78ce3#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@a6d011ec3c3f3803b135fe1c991a187c23e70fbd#egg=elifecrossref
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@c0af3ba85b244d620dd189175913e964a9e5772a#egg=elifecrossref
 PyYAML==3.11
 Wand==0.4.0
 paramiko==1.15.2


### PR DESCRIPTION
To fix an unusual escape angle brackets situation in DepositCrossref, this latest elifecrossref code should fix it.