### PR TITLE
Deposit inline figure files as part of IIIF assets.

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -142,6 +142,10 @@ def get_figures_for_iiif(files):
     fs = originals_figures_tif + get_media_file_images(files)
     return fs
 
+def get_inline_figures_for_iiif(files):
+    "return a list of all inline figure files"
+    return [f for f in get_original_files(files) if (inline_figure(f))]
+
 def get_figures_pdfs(files):
     return [f for f in files if (figure_pdf(f) and has_extensions(f, ['pdf']))]
 
@@ -175,7 +179,8 @@ def is_video_file(filename):
 
 def pre_ingest_assets(files):
     original_figures = get_figures_for_iiif(files)
-    iiif_assets = original_figures + get_videos(files)
+    inline_figures = get_inline_figures_for_iiif(files)
+    iiif_assets = original_figures + inline_figures + get_videos(files)
     pdf_figures = get_figures_pdfs(files)
     return list(set(iiif_assets + pdf_figures))
 

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -143,8 +143,9 @@ def get_figures_for_iiif(files):
     return fs
 
 def get_inline_figures_for_iiif(files):
+    # should only be tif
     "return a list of all inline figure files"
-    return [f for f in get_original_files(files) if (inline_figure(f))]
+    return [f for f in get_original_files(files) if (inline_figure(f) and has_extensions(f, ['tif']))]
 
 def get_figures_pdfs(files):
     return [f for f in files if (figure_pdf(f) and has_extensions(f, ['pdf']))]

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -160,6 +160,22 @@ class TestArticleStructure(unittest.TestCase):
                     'elife-07398-media1.jpg']
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
+    def test_get_inline_figures_for_iiif(self):
+        "should return all inline figure files"
+        files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
+                 'elife-00666-fig2-figsupp2-v1.tif',
+                 'elife-00666-fig2-figsupp2-v1.jpg',
+                 'elife-00666-inf001-v1.jpg',
+                 'elife-00666-inf001-v1-80w.jpg',
+                 'elife-00666-table3-data1-v1.xlsx',
+                 'elife-07702-vor-r4.zip',
+                 'elife-6148691793723703318-fig10-v1.gif',
+                 'elife-9204580859652100230-fig2-data1-v1.xls',
+                 'elife-00666-video2.jpg',
+                 'elife-07398-media1.jpg']
+        expected = ['elife-00666-inf001-v1.jpg']
+        self.assertListEqual(article_structure.get_inline_figures_for_iiif(files), expected)
+
     # see https://github.com/elifesciences/elife-continuum-documentation/blob/master/file-naming/file_naming_spec.md
     def test_get_figures_pdfs(self):
         files = ['elife-07398-media1.jpg',
@@ -216,6 +232,7 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-13273-media1.mp4']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                     'elife-00666-fig2-figsupp2-v1.tif',
+                    'elife-00666-inf001-v1.jpg',
                     'elife-00666-video2.jpg',
                     'elife-07398-media1.jpg',
                     'elife-13273-media1.mp4',

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -117,22 +117,21 @@ class TestArticleStructure(unittest.TestCase):
     def test_get_original_files(self):
         files = ['elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-fig2-figsupp2-v10.tif',
-                 'elife-00666-inf001-v1.jpg',
-                 'elife-00666-inf001-v1-80w.jpg',
+                 'elife-00666-inf001-v1.tif',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-07398-media1.jpg']
         expected = ['elife-00666-fig2-figsupp2-v1.tif',
                     'elife-00666-fig2-figsupp2-v10.tif',
-                    'elife-00666-inf001-v1.jpg',
+                    'elife-00666-inf001-v1.tif',
                     'elife-00666-table3-data1-v1.xlsx']
 
         self.assertListEqual(article_structure.get_original_files(files), expected)
 
     def test_get_media_file_images(self):
         files = ['elife-00666-fig2-figsupp2-v1.tif',
+                 'elife-00666-inf001-v1.tif',
                  'elife-00666-inf001-v1.jpg',
-                 'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-00666-video2.jpg',
@@ -145,35 +144,24 @@ class TestArticleStructure(unittest.TestCase):
         "Only .tif of original figures"
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
-                 'elife-00666-fig2-figsupp2-v1.jpg',
-                 'elife-00666-inf001-v1.jpg',
-                 'elife-00666-inf001-v1-80w.jpg',
+                 'elife-00666-inf001-v1.tif',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',
-                 'elife-9204580859652100230-fig2-data1-v1.xls',
-                 'elife-00666-video2.jpg',
-                 'elife-07398-media1.jpg']
+                 'elife-9204580859652100230-fig2-data1-v1.xls']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
-                    'elife-00666-fig2-figsupp2-v1.tif',
-                    'elife-00666-video2.jpg',
-                    'elife-07398-media1.jpg']
+                    'elife-00666-fig2-figsupp2-v1.tif']
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
     def test_get_inline_figures_for_iiif(self):
         "should return only .tif of inline figure files"
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
-                 'elife-00666-fig2-figsupp2-v1.jpg',
                  'elife-00666-inf001-v1.tif',
-                 'elife-00666-inf001-v1.jpg',
-                 'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',
-                 'elife-9204580859652100230-fig2-data1-v1.xls',
-                 'elife-00666-video2.jpg',
-                 'elife-07398-media1.jpg']
+                 'elife-9204580859652100230-fig2-data1-v1.xls']
         expected = ['elife-00666-inf001-v1.tif']
         self.assertListEqual(article_structure.get_inline_figures_for_iiif(files), expected)
 
@@ -219,24 +207,17 @@ class TestArticleStructure(unittest.TestCase):
     def test_pre_ingest_assets(self):
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
-                 'elife-00666-fig2-figsupp2-v1.jpg',
                  'elife-00666-inf001-v1.tif',
-                 'elife-00666-inf001-v1.jpg',
-                 'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',
                  'elife-9204580859652100230-fig2-data1-v1.xls',
-                 'elife-00666-video2.jpg',
-                 'elife-07398-media1.jpg',
                  'elife-00666-figures-v1.pdf',
                  'elife-18425-figures-v2.pdf',
                  'elife-13273-media1.mp4']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                     'elife-00666-fig2-figsupp2-v1.tif',
                     'elife-00666-inf001-v1.tif',
-                    'elife-00666-video2.jpg',
-                    'elife-07398-media1.jpg',
                     'elife-13273-media1.mp4',
                     'elife-00666-figures-v1.pdf',
                     'elife-18425-figures-v2.pdf']

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -161,10 +161,11 @@ class TestArticleStructure(unittest.TestCase):
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
     def test_get_inline_figures_for_iiif(self):
-        "should return all inline figure files"
+        "should return only .tif of inline figure files"
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.jpg',
+                 'elife-00666-inf001-v1.tif',
                  'elife-00666-inf001-v1.jpg',
                  'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
@@ -173,7 +174,7 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-9204580859652100230-fig2-data1-v1.xls',
                  'elife-00666-video2.jpg',
                  'elife-07398-media1.jpg']
-        expected = ['elife-00666-inf001-v1.jpg']
+        expected = ['elife-00666-inf001-v1.tif']
         self.assertListEqual(article_structure.get_inline_figures_for_iiif(files), expected)
 
     # see https://github.com/elifesciences/elife-continuum-documentation/blob/master/file-naming/file_naming_spec.md
@@ -219,6 +220,7 @@ class TestArticleStructure(unittest.TestCase):
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.jpg',
+                 'elife-00666-inf001-v1.tif',
                  'elife-00666-inf001-v1.jpg',
                  'elife-00666-inf001-v1-80w.jpg',
                  'elife-00666-table3-data1-v1.xlsx',
@@ -232,7 +234,7 @@ class TestArticleStructure(unittest.TestCase):
                  'elife-13273-media1.mp4']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                     'elife-00666-fig2-figsupp2-v1.tif',
-                    'elife-00666-inf001-v1.jpg',
+                    'elife-00666-inf001-v1.tif',
                     'elife-00666-video2.jpg',
                     'elife-07398-media1.jpg',
                     'elife-13273-media1.mp4',


### PR DESCRIPTION
Should fix the issues with trying to include an inline graphic into a JSON image block, where filling in the image details from the IIIF fails since the inf file has not been copied to the bucket yet prior to ingest to Lax. In reference to https://elifesciences.atlassian.net/browse/ELPP-3312.