### PR TITLE
Work in progress for comment - Simple cut contact with elife-website.

### DIFF
--- a/workflow/workflow_ApproveArticlePublication.py
+++ b/workflow/workflow_ApproveArticlePublication.py
@@ -56,19 +56,6 @@ class workflow_ApproveArticlePublication(workflow.workflow):
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 5
                     },
-                    {
-                        "activity_type": "ApprovePublication",
-                        "activity_id": "ApprovePublication",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-
-
                 ],
 
             "finish":

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -112,15 +112,15 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "PreparePostEIF",
-                        "activity_id": "PreparePostEIF",
+                        "activity_type": "PostEIFBridge",
+                        "activity_id": "PostEIFBridge",
                         "version": "1",
                         "input": data,
                         "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
                         "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
+                        "start_to_close_timeout": 300
                     },
 
                 ],

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -112,15 +112,15 @@ class workflow_SilentCorrectionsProcess(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "PreparePostEIF",
-                        "activity_id": "PreparePostEIF",
+                        "activity_type": "PostEIFBridge",
+                        "activity_id": "PostEIFBridge",
                         "version": "1",
                         "input": data,
                         "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
                         "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
+                        "start_to_close_timeout": 300
                     },
                     {
                         "activity_type": "PublishToLax",


### PR DESCRIPTION
The first commit here may be a simplistic start, but hopefully it is enough to illustrate an idea and attract some comments please.

The motivation is: if elife-website is turned off, to have no adverse effects on the bot, and to allow publication of articles to happen normally.

In looking at the ``PreparePostEIF`` activity, ``shimmy.py``, ``ArticleInformationSupplier`` workflow, and ``PostEIFBridge`` activity and how they interconnect, it could be simply to substitute ``PreparePostEIF`` activity with the ``PostEIFBridge`` activity.

``PostEIFBridge`` seems to load variables from the data passed to it. The data doesn't include too many items that elife-website would have provided, other than an ``updated`` date (which is probably not used, or taken from Lax), and a ``published`` value, where we prefer the value Lax gives the bot.

Open for comment!

It would also be interesting to see if this variation were run on and end2end workflow whether everything would work as expected. That could be a quick way to determine the blind spots.

Ideally something like this needs to be merged and deployed before elife-website is turned off.