### PR TITLE
Allow alpha characters in article_id of file names in …

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -37,7 +37,7 @@ class ArticleInfo(object):
         (self.filename, self.extension) = full_filename.rsplit('.', 1)
         parts = self.filename.split('-')
 
-        match = re.match('.*?-[0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)?(-([0-9]+))?\.zip', self.full_filename, re.IGNORECASE)
+        match = re.match('.*?-[a-zA-Z0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)?(-([0-9]+))?\.zip', self.full_filename, re.IGNORECASE)
         first_other_index = 2
         if match is not None:
             self.status = match.group(1)

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -1,6 +1,7 @@
 import unittest
 from ddt import ddt, data, unpack
 from mock import patch
+from collections import OrderedDict
 from provider.article_structure import ArticleInfo
 import provider.article_structure as article_structure
 from tests.activity.classes_mock import FakeBucket
@@ -13,6 +14,48 @@ class TestArticleStructure(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+
+    @unpack
+    @data(
+        {
+            'full_filename': 'elife-07702-vor-r4.zip',
+            'attrs': OrderedDict([
+                ('filename', 'elife-07702-vor-r4'),
+                ('extension', 'zip'),
+                ('status', 'vor'),
+                ('is_article_zip', True),
+                ('journal', 'elife'),
+                ('article_id', '07702'),
+                ('versioned', False),
+                ('version', None),
+                ('extra_info', ['r4']),
+                ('file_type', 'ArticleZip')
+            ])
+        },
+        {
+            'full_filename': 'journal-test1-vor-r1.zip',
+            'attrs': OrderedDict([
+                ('filename', 'journal-test1-vor-r1'),
+                ('extension', 'zip'),
+                ('status', 'vor'),
+                ('is_article_zip', True),
+                ('journal', 'journal'),
+                ('article_id', 'test1'),
+                ('versioned', False),
+                ('version', None),
+                ('extra_info', ['r1']),
+                ('file_type', 'ArticleZip')
+            ])
+        },
+    )
+    def test_article_info(self, full_filename, attrs):
+        self.articleinfo = ArticleInfo(full_filename)
+        for attr, value in attrs.items():
+            info_value = getattr(self.articleinfo, attr)
+            self.assertEqual(info_value, value,
+                             '{attr} not equal for {full_filename}: {info_value} != value'.format(
+                                attr=attr, full_filename=full_filename, info_value=info_value,
+                                value=value))
 
     @unpack
     @data({'input': 'elife-07702-vor-r4.zip', 'expected': None},


### PR DESCRIPTION
…article_structure.py

Relaxes the ``article_structure.py`` provider when it is extracting the ``article_id`` value to allow alpha as well as numeric characters, expanding the pattern to ``[a-zA-Z0-9]``.

This was the result of a quick test I tried for a non-eLife sample in the cotinuumtest enviroment which allowed a sample file with a non-numeric article id in the filename to get beyond the ``ExpandArticle`` activity.

I think this is compatible with eLife files and possibly wouldn't hurt to include it for making testing easier with non-eLife files.

I added a test case to compare ``ArticleInfo`` object attributes. More example of files can be added now or in the future.

Including @Jenniferstrej to be aware of this and it might be useful in testing other files.