### PR TITLE
IngestArticleZip workflow reduce the timeout from 5 hours to 1 hour.

### DIFF
--- a/starter/starter_IngestArticleZip.py
+++ b/starter/starter_IngestArticleZip.py
@@ -40,7 +40,7 @@ class starter_IngestArticleZip():
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(self.const_name, "1", None, input,
                                                          info.file_name.replace('/', '_'),
-                                                         start_to_close_timeout=str(60 * 60 * 5))
+                                                         start_to_close_timeout=str(60 * 60 * 1))
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)


### PR DESCRIPTION
A workflow today when encountering an error in ``SendDashboardProperties`` results in retrying the same activity for 5 hours. The logs would fill up slower if it only retried for 1 hour maximum. If an ``IngestArticleZip`` workflow times out due to too much load, it can be re-run.