### PR TITLE
Can re-enable Cengage deposits again.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -131,12 +131,12 @@ def run_cron(settings):
                 start_seconds=60 * 31)
 
         # Cengage deposits once per day 22:45 UTC
-        #if current_time.tm_hour == 22:
-        #    workflow_conditional_start(
-        #        settings=settings,
-        #        starter_name="starter_PubRouterDeposit",
-        #        workflow_id="PubRouterDeposit_Cengage",
-        #        start_seconds=60 * 31)
+        if current_time.tm_hour == 22:
+            workflow_conditional_start(
+                settings=settings,
+                starter_name="starter_PubRouterDeposit",
+                workflow_id="PubRouterDeposit_Cengage",
+                start_seconds=60 * 31)
 
         # GoOA / CAS deposits once per day 21:45 UTC
         if current_time.tm_hour == 21:


### PR DESCRIPTION
Reversing the change in PR https://github.com/elifesciences/elife-bot/pull/586 before it had a chance to be deployed anyway, deposits are ok to send again.