### PR TITLE
Override BOTO_CONFIG in travis-ci builds.

### DIFF
--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e # everything must succeed.
+export BOTO_CONFIG=/dev/null
 pip install -r requirements.txt
 git clone https://github.com/elifesciences/elife-poa-xml-generation.git ../elife-poa-xml-generation
 cp ../elife-poa-xml-generation/example-settings.py ../elife-poa-xml-generation/settings.py


### PR DESCRIPTION
A small tweak to travis-ci builds as described on https://github.com/travis-ci/travis-ci/issues/7940. It may help, and the branch build works, so it is probably not causing any side effects. Whether it will fix unpredictable travis-ci build failures I'm not sure about.