### PR TITLE
Simple cut contact with elife-website, 2nd attempt

### DIFF
--- a/activity/activity_PostEIFBridge.py
+++ b/activity/activity_PostEIFBridge.py
@@ -43,7 +43,7 @@ class activity_PostEIFBridge(activity.activity):
             self.emit_monitor_event(self.settings, article_id, version, run, "Post EIF Bridge", "start",
                                 "Starting " + article_id)
 
-            published = data['published']
+            published = session.get_value('published')
 
             # assemble data to start post-publication workflow
             expanded_folder = data['expanded_folder']

--- a/activity/activity_PostEIFBridge.py
+++ b/activity/activity_PostEIFBridge.py
@@ -31,10 +31,11 @@ class activity_PostEIFBridge(activity.activity):
     def do_activity(self, data=None):
         try:
 
-            article_path = data['article_path']
             article_id = data['article_id']
             version = data['version']
             run = data['run']
+            session = get_session(self.settings, data, run)
+            article_path = session.get_value('article_path')
             self.set_monitor_property(self.settings, article_id, 'path',
                                   article_path, 'text', version=version)
 

--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -40,13 +40,18 @@ class activity_VerifyLaxResponse(activity.activity):
         article_id = data['article_id']
         run = data['run']
         version = data['version']
+        force = data['force']
+        session = get_session(self.settings, data, run)
 
         self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "start",
                                 "Starting verification of Lax response " + article_id)
 
         try:
             if data['result'] == "ingested":
-
+                if force is True:
+                    session.store_value('published', True)
+                else:
+                    session.store_value('published', False)
                 self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
                                         " Finished Verification. Lax has responded with result: ingested."
                                         " Article: " + article_id)

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -83,6 +83,7 @@ class LaxResponseAdapter:
             expanded_folder = token['expanded_folder']
             status = token['status']
             eif_location = token['eif_location'] #support for old journal
+            force = token['force']
 
             workflow_data = {
                 "run": run,
@@ -94,7 +95,8 @@ class LaxResponseAdapter:
                 "result": result,
                 "message": response_message,
                 "update_date": date_time,
-                "requested_action": operation
+                "requested_action": operation,
+                "force": force
             }
 
             if operation == "ingest":

--- a/tests/activity/test_activity_post_eif_bridge.py
+++ b/tests/activity/test_activity_post_eif_bridge.py
@@ -8,6 +8,7 @@ from classes_mock import FakeSQSConn
 from classes_mock import FakeSQSMessage
 from classes_mock import FakeSQSQueue
 from classes_mock import FakeLogger
+from classes_mock import FakeSession
 from testfixtures import TempDirectory
 import json
 import base64
@@ -32,15 +33,23 @@ class tests_PostEIFBridge(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
 
+    @patch('activity.activity_PostEIFBridge.get_session')
     @patch.object(activity_PostEIFBridge, 'emit_monitor_event')
     @patch.object(activity_PostEIFBridge, 'set_monitor_property')
     @patch('boto.sqs.connect_to_region')
     @patch('activity.activity_PostEIFBridge.Message')
-    def test_activity_published_article(self, mock_sqs_message, mock_sqs_connect, mock_set_monitor_property, mock_emit_monitor_event):
+    def test_activity_published_article(self, mock_sqs_message, mock_sqs_connect,
+                                        mock_set_monitor_property, mock_emit_monitor_event,
+                                        fake_get_session):
 
         directory = TempDirectory()
         mock_sqs_connect.return_value = FakeSQSConn(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
+
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
+        # prime the session with data that would be set by an earlier activity
+        fake_session.store_value('article_path', 'content/1/e00353v1')
 
         data = test_data.PostEIFBridge_data(True, u'2012-12-13T00:00:00Z')
 
@@ -64,9 +73,14 @@ class tests_PostEIFBridge(unittest.TestCase):
                                                    "Finished Post EIF Bridge " + data["article_id"])
 
     @data(test_publication_data)
+    @patch('activity.activity_PostEIFBridge.get_session')
     @patch.object(activity_PostEIFBridge, 'emit_monitor_event')
     @patch.object(activity_PostEIFBridge, 'set_monitor_property')
-    def test_activity_unpublished_article(self, expected_publication_data, mock_set_monitor_property, mock_emit_monitor_event):
+    def test_activity_unpublished_article(self, expected_publication_data, mock_set_monitor_property,
+                                          mock_emit_monitor_event, fake_get_session):
+
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
 
         #Given
         data = test_data.PostEIFBridge_data(False, u'2012-12-13T00:00:00Z')
@@ -88,12 +102,16 @@ class tests_PostEIFBridge(unittest.TestCase):
                                                    "Post EIF Bridge", "end",
                                                    "Finished Post EIF Bridge " + data["article_id"])
 
+    @patch('activity.activity_PostEIFBridge.get_session')
     @patch('boto.sqs.connect_to_region')
     @patch('activity.activity_PostEIFBridge.Message')
-    def test_activity_published_article_no_update_date(self, mock_sqs_message, mock_sqs_connect):
+    def test_activity_published_article_no_update_date(self, mock_sqs_message, mock_sqs_connect,
+                                                       fake_get_session):
         directory = TempDirectory()
         mock_sqs_connect.return_value = FakeSQSConn(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
         self.activity_PostEIFBridge.set_monitor_property = mock.MagicMock()
         self.activity_PostEIFBridge.emit_monitor_event = mock.MagicMock()
         success = self.activity_PostEIFBridge.do_activity(test_data.PostEIFBridge_data(True, None))
@@ -102,10 +120,13 @@ class tests_PostEIFBridge(unittest.TestCase):
         self.assertEqual(True, success)
         self.assertEqual(json.dumps(test_data.PostEIFBridge_message_no_update_date), data_written_in_test_queue)
 
+    @patch('activity.activity_PostEIFBridge.get_session')
     @patch.object(activity_PostEIFBridge, 'emit_monitor_event')
-    def test_activity_exception(self, mock_emit_monitor_event):
+    def test_activity_exception(self, mock_emit_monitor_event, fake_get_session):
 
         fake_logger = FakeLogger()
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
         self.activity_PostEIFBridge_with_log = activity_PostEIFBridge(settings_mock, fake_logger, None, None, None)
 
         data = test_data.PostEIFBridge_data(False, u'2012-12-13T00:00:00Z')

--- a/tests/activity/test_activity_post_eif_bridge.py
+++ b/tests/activity/test_activity_post_eif_bridge.py
@@ -46,7 +46,7 @@ class tests_PostEIFBridge(unittest.TestCase):
         mock_sqs_connect.return_value = FakeSQSConn(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
 
-        fake_session = FakeSession({})
+        fake_session = FakeSession({'published': True})
         fake_get_session.return_value = fake_session
         # prime the session with data that would be set by an earlier activity
         fake_session.store_value('article_path', 'content/1/e00353v1')
@@ -79,7 +79,7 @@ class tests_PostEIFBridge(unittest.TestCase):
     def test_activity_unpublished_article(self, expected_publication_data, mock_set_monitor_property,
                                           mock_emit_monitor_event, fake_get_session):
 
-        fake_session = FakeSession({})
+        fake_session = FakeSession({'published': False})
         fake_get_session.return_value = fake_session
 
         #Given
@@ -110,7 +110,7 @@ class tests_PostEIFBridge(unittest.TestCase):
         directory = TempDirectory()
         mock_sqs_connect.return_value = FakeSQSConn(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
-        fake_session = FakeSession({})
+        fake_session = FakeSession({'published': True})
         fake_get_session.return_value = fake_session
         self.activity_PostEIFBridge.set_monitor_property = mock.MagicMock()
         self.activity_PostEIFBridge.emit_monitor_event = mock.MagicMock()
@@ -125,7 +125,7 @@ class tests_PostEIFBridge(unittest.TestCase):
     def test_activity_exception(self, mock_emit_monitor_event, fake_get_session):
 
         fake_logger = FakeLogger()
-        fake_session = FakeSession({})
+        fake_session = FakeSession({'published': False})
         fake_get_session.return_value = fake_session
         self.activity_PostEIFBridge_with_log = activity_PostEIFBridge(settings_mock, fake_logger, None, None, None)
 

--- a/tests/activity/test_activity_verify_lax_response.py
+++ b/tests/activity/test_activity_verify_lax_response.py
@@ -2,6 +2,7 @@ import unittest
 from activity.activity_VerifyLaxResponse import activity_VerifyLaxResponse
 import activity
 import settings_mock
+from classes_mock import FakeSession
 from ddt import ddt, data
 from mock import patch
 
@@ -23,12 +24,16 @@ class TestVerifyLaxResponse(unittest.TestCase):
             "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
             "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
             "requested_action": "ingest",
+            "force": False,
             "message": None,
             "update_date": "2012-12-13T00:00:00Z"
         })
+    @patch('activity.activity_VerifyLaxResponse.get_session')
     @patch.object(activity_VerifyLaxResponse, 'emit_monitor_event')
-    def test_do_activity(self, data, fake_emit_monitor):
+    def test_do_activity(self, data, fake_emit_monitor, fake_get_session):
         fake_emit_monitor.side_effect = fake_emit_monitor_event
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
         result = self.verifylaxresponse.do_activity(data)
         fake_emit_monitor.assert_called_with(settings_mock,
                                              data["article_id"],
@@ -39,7 +44,39 @@ class TestVerifyLaxResponse(unittest.TestCase):
                                              " Finished Verification. Lax has responded with result: ingested."
                                              " Article: " + data["article_id"])
         self.assertEqual(result, self.verifylaxresponse.ACTIVITY_SUCCESS)
+        self.assertEqual(fake_session.get_value('published'), False)
 
+
+    @data({
+            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "article_id": "00353",
+            "result": "ingested",
+            "status": "vor",
+            "version": "1",
+            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+            "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
+            "requested_action": "ingest",
+            "force": True,
+            "message": None,
+            "update_date": "2012-12-13T00:00:00Z"
+        })
+    @patch('activity.activity_VerifyLaxResponse.get_session')
+    @patch.object(activity_VerifyLaxResponse, 'emit_monitor_event')
+    def test_do_activity_force_true(self, data, fake_emit_monitor, fake_get_session):
+        fake_emit_monitor.side_effect = fake_emit_monitor_event
+        fake_session = FakeSession({})
+        fake_get_session.return_value = fake_session
+        result = self.verifylaxresponse.do_activity(data)
+        fake_emit_monitor.assert_called_with(settings_mock,
+                                             data["article_id"],
+                                             data["version"],
+                                             data["run"],
+                                             "Verify Lax Response",
+                                             "end",
+                                             " Finished Verification. Lax has responded with result: ingested."
+                                             " Article: " + data["article_id"])
+        self.assertEqual(result, self.verifylaxresponse.ACTIVITY_SUCCESS)
+        self.assertEqual(fake_session.get_value('published'), True)
 
 
     @data({
@@ -51,12 +88,15 @@ class TestVerifyLaxResponse(unittest.TestCase):
             "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
             "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
             "requested_action": "ingest",
+            "force": False,
             "message": None,
             "update_date": "2012-12-13T00:00:00Z"
         })
+    @patch('activity.activity_VerifyLaxResponse.get_session')
     @patch.object(activity_VerifyLaxResponse, 'emit_monitor_event')
-    def test_do_activity_error_no_message(self, data, fake_emit_monitor):
+    def test_do_activity_error_no_message(self, data, fake_emit_monitor, fake_session):
         fake_emit_monitor.side_effect = fake_emit_monitor_event
+        fake_session.return_value = FakeSession({})
         result = self.verifylaxresponse.do_activity(data)
         fake_emit_monitor.assert_called_with(settings_mock,
                                              data["article_id"],
@@ -77,12 +117,15 @@ class TestVerifyLaxResponse(unittest.TestCase):
             "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
             "eif_location": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff/elife-00353-v1.json",
             "requested_action": "ingest",
+            "force": False,
             "message": "An error has occurred",
             "update_date": "2012-12-13T00:00:00Z"
         })
+    @patch('activity.activity_VerifyLaxResponse.get_session')
     @patch.object(activity_VerifyLaxResponse, 'emit_monitor_event')
-    def test_do_activity_error(self, data, fake_emit_monitor):
+    def test_do_activity_error(self, data, fake_emit_monitor, fake_session):
         fake_emit_monitor.side_effect = fake_emit_monitor_event
+        fake_session.return_value = FakeSession({})
         result = self.verifylaxresponse.do_activity(data)
         fake_emit_monitor.assert_called_with(settings_mock,
                                              data["article_id"],

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -8,6 +8,7 @@ fake_token = json.dumps({u'status': u'vor',
                          u'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                          u'eif_location': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-837411455-v1.json',
                          u'version': u'1',
+                         u'force': False,
                          u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
 
 fake_lax_message = json.dumps({"status": "published",
@@ -22,6 +23,7 @@ workflow_message_expected = {'workflow_data':
                                   'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'message': None,
                                   'requested_action': u'publish',
+                                  'force': False,
                                   'result': u'published',
                                   'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'status': u'vor',
@@ -33,6 +35,7 @@ fake_token_269 = json.dumps({u'status': u'vor',
                          u'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                          u'eif_location': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148/elife-00269-v1.json',
                          u'version': u'1',
+                         u'force': False,
                          u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
 
 fake_lax_message_269 = json.dumps({"status": "published",
@@ -47,6 +50,7 @@ workflow_message_expected_269 = {'workflow_data':
                                   'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'message': None,
                                   'requested_action': u'publish',
+                                  'force': False,
                                   'result': u'published',
                                   'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'status': u'vor',

--- a/workflow/workflow_ApproveArticlePublication.py
+++ b/workflow/workflow_ApproveArticlePublication.py
@@ -56,19 +56,6 @@ class workflow_ApproveArticlePublication(workflow.workflow):
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 5
                     },
-                    {
-                        "activity_type": "ApprovePublication",
-                        "activity_id": "ApprovePublication",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-
-
                 ],
 
             "finish":

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -112,15 +112,15 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "PreparePostEIF",
-                        "activity_id": "PreparePostEIF",
+                        "activity_type": "PostEIFBridge",
+                        "activity_id": "PostEIFBridge",
                         "version": "1",
                         "input": data,
                         "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
                         "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
+                        "start_to_close_timeout": 300
                     },
 
                 ],

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -112,15 +112,15 @@ class workflow_SilentCorrectionsProcess(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "PreparePostEIF",
-                        "activity_id": "PreparePostEIF",
+                        "activity_type": "PostEIFBridge",
+                        "activity_id": "PostEIFBridge",
                         "version": "1",
                         "input": data,
                         "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
                         "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
+                        "start_to_close_timeout": 300
                     },
                     {
                         "activity_type": "PublishToLax",


### PR DESCRIPTION
Trying again https://github.com/elifesciences/elife-bot/pull/553/commits

Problem encountered on end2end:

```
2018-01-11T11:19:21Z INFO worker_10673 activityType: PostEIFBridge
2018-01-11T11:19:21Z ERROR worker_10673 Exception after submitting article EIF
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_PostEIFBridge.py", line 34, in do_activity
    article_path = data['article_path']
KeyError: 'article_path'
```
Input to the activity/workflow:
```
2018-01-11T11:19:12Z INFO worker_10656 got activity: 
{
    "activityId": "PostEIFBridge", 
    "activityType": {
        "name": "PostEIFBridge", 
        "version": "1"
    }, 
    "input": "{\"status\": \"vor\", \"update_date\": \"2018-01-11T11:18:05Z\", \"run\": \"f10d37bf-4807-4dca-a95d-6f1c3ebe33d0\", \"expanded_folder\": \"1157624208528401239.1/f10d37bf-4807-4dca-a95d-6f1c3ebe33d0\", \"version\": \"1\", \"result\": \"ingested\", \"eif_location\": \"\", \"article_id\": \"1157624208528401239\", \"message\": null, \"requested_action\": \"ingest\"}", 
    "startedEventId": 84, 
    "taskToken": "AAAAKgAAAAIAAAAAAAAAAlGShZjxVfwsDplkbt9csxmyO6oE6Doou8AEMYa8w4HrhnrV1kYwh5bw41iw8NPpdatWmKtNDYXmiVdql3V2QQY3jlJicYhYJDmSWOMDiPGXRpQtTJJXIRDX1gQ/RrVpF/B/DN2mFjIoWfBlMk4+4xAFik+Ld39mNBg3ty9tNkHg0EsNR0gdjRk7gjOB5tC6+C0InV0cz9/rYWNfKLagSMhlG0MEP7GMbH+XAHojlaU3ckfHDphduHMVLCptxhYC3lsG0CodUXUJq0+S1mGc/IKP2aPsjsF23pSUf1fcXgzfpkN4GonFdlPK2+ebz+PUZ6+ZdHK+la22mQacl/GexV4=", 
    "workflowExecution": {
        "runId": "226EEXuLGKK9+iIl5yL9THvtOzN47jgUGa5uCFoBD05do=", 
        "workflowId": "ProcessArticleZip_1157624208528401239"
    }
}
```
Not only `article_path` but also `published` is missing. Both were provided by the shimmy, which we are skipping now https://github.com/elifesciences/elife-bot/blob/develop/shimmy.py#L91-L102

Are there defaults we can use?
- `article_path` is a value similar to `content/4/e822311538705904637v1` so it can probably be changed to `/articles/...` to work as the preview link?
- `published` is a boolean, can we deduce if it's false or true?

Alternatively, we can still go through the shimmy, and make up some values. I'll evaluate that option too.