### PR TITLE
Missing force parameter in starters, read eif_location from session

### DIFF
--- a/activity/activity_RewriteEIF.py
+++ b/activity/activity_RewriteEIF.py
@@ -3,6 +3,7 @@ from boto.s3.key import Key
 from boto.s3.connection import S3Connection
 import requests
 from provider import eif as eif_provider
+from provider.execution_context import get_session
 
 """
 RewriteEIF.py activity
@@ -30,7 +31,8 @@ class activity_RewriteEIF(activity.activity):
         article_id = data['article_id']
         version = data['version']
         run = data['run']
-        eif_location = data['eif_location']
+        session = get_session(self.settings, data, run)
+        eif_location = session.get_value('eif_location')
         update_date = data['update_date']
 
         self.emit_monitor_event(self.settings, article_id, version, run, "Rewrite EIF", "start",

--- a/starter/starter_ProcessArticleZip.py
+++ b/starter/starter_ProcessArticleZip.py
@@ -19,7 +19,7 @@ class starter_ProcessArticleZip():
     def __init__(self):
         self.const_name = "ProcessArticleZip"
 
-    def start(self, settings, article_id, version, requested_action, result, expanded_folder, status, eif_location, run, update_date, message=None):
+    def start(self, settings, article_id, version, requested_action, force, result, expanded_folder, status, eif_location, run, update_date, message=None):
 
         logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
 
@@ -35,6 +35,7 @@ class starter_ProcessArticleZip():
             "expanded_folder": expanded_folder,
             "eif_location": eif_location,
             "requested_action": requested_action,
+            "force": force,
             "message": message,
             "update_date": update_date
         }

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -19,7 +19,7 @@ class starter_SilentCorrectionsProcess():
     def __init__(self):
         self.const_name = "SilentCorrectionsProcess"
 
-    def start(self, settings, article_id, version, requested_action, result, expanded_folder, status, eif_location, run, update_date, message=None):
+    def start(self, settings, article_id, version, requested_action, force, result, expanded_folder, status, eif_location, run, update_date, message=None):
 
         # Log
         logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))

--- a/tests/activity/test_activity_rewrite_eif.py
+++ b/tests/activity/test_activity_rewrite_eif.py
@@ -5,6 +5,7 @@ import test_activity_data as data
 from mock import mock, patch
 from classes_mock import FakeKey
 from classes_mock import FakeS3Connection
+from classes_mock import FakeSession
 import classes_mock
 from testfixtures import TempDirectory
 import json
@@ -20,12 +21,14 @@ class tests_RewriteEIF(unittest.TestCase):
         TempDirectory.cleanup_all()
 
     @patch('activity.activity_RewriteEIF.eif_provider.Key')
+    @patch('activity.activity_RewriteEIF.get_session')
     @patch('activity.activity_RewriteEIF.S3Connection')
     @patch.object(activity_RewriteEIF, 'emit_monitor_event')
     @patch.object(activity_RewriteEIF, 'set_monitor_property')
-    def test_activity(self, mock_set_monitor_property, mock_emit_monitor_event, fake_s3_mock, fake_key_mock):
+    def test_activity(self, mock_set_monitor_property, mock_emit_monitor_event, fake_s3_mock, fake_session, fake_key_mock):
         directory = TempDirectory()
 
+        fake_session.return_value = FakeSession(data.session_example)
         fake_key_mock.return_value = FakeKey(directory, data.bucket_dest_file_name,
                                              data.RewriteEIF_json_input_string)
         fake_s3_mock.return_value = FakeS3Connection()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -69,6 +69,7 @@ data_ingested_lax = {
             "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
             "eif_location": "",
             "requested_action": "ingest",
+            "force": False,
             "message": None,
             "update_date": "2012-12-13T00:00:00Z"
         }
@@ -105,6 +106,7 @@ data_invalid_lax = {
             "expanded_folder": None,
             "eif_location": None,
             "requested_action": "publish",
+            "force": False,
             "message": "An error abc has occurred - everything is invalid",
             "update_date": None
         }


### PR DESCRIPTION
Follow up for https://github.com/elifesciences/elife-bot/pull/595

This is passed in by lax_response_adapter, but was not accepted.

After this, the workflow gets to RewriteEIF but fails there
```
2018-01-12T11:52:48Z INFO worker_11736 got activity: 
{
    "activityId": "RewriteEIF", 
    "activityType": {
        "name": "RewriteEIF", 
        "version": "1"
    }, 
    "input": "{\"status\": \"vor\", \"update_date\": \"2016-03-14T00:00:00Z\", \"force\": false, \"expanded_folder\": \"4527104172759515893
.1/6a4ea19f-73e0-49b7-91b1-6f412bbd3c31\", \"version\": \"1\", \"result\": \"published\", \"run\": \"6a4ea19f-73e0-49b7-91b1-6f412bbd3c31\"
, \"eif_location\": \"\", \"article_id\": \"4527104172759515893\", \"message\": null, \"requested_action\": \"publish\"}", 
    "startedEventId": 18, 
    "taskToken": "AAAAKgAAAAIAAAAAAAAAArQG7SOKA1XY5vTKTuhNXGbdlQ2Ds9HqnduyaHbI51SijLg5GNWixEgBwTyx1KLJSviF1MtGM11G+AM648+oBJ/4GfzuuSjjpa3LW
cTVRgaAer53mh5zIHIox84WylD12d7mGw8m9Ixb3BvmXq9NM9IHau2zauhWs+saF9xiPBFfLGE+/FO3Lfc0gKpp//pogMhJFSJDINF3OeBoZFIUaGvN+nWb+2XiWMNYHWav6kbmxaDN
H49Lgp7FQSzumPtHuLNXzAXudjuxmQAAF7wBYCOPH0Fic4gIYCAjxvYPNT5wRNV3lQ8p6JtnCYtUzCc5VvSCjlXDcsL6udSu53BfNyQ=", 
    "workflowExecution": {
        "runId": "2275lz0e+viVeW659qBqQA3S9ZRHEWEFL044k/Q3xSE1A=", 
        "workflowId": "PostPerfectPublication_4527104172759515893.lax"
    }
}
2018-01-12T11:52:48Z INFO worker_11736 activityType: RewriteEIF
2018-01-12T11:52:48Z ERROR worker_11736 Exception when rewriting EIF
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_RewriteEIF.py", line 45, in
do_activity
    eif_json = eif_provider.read_eif_from_s3(conn, eif_bucket, eif_location)
  File "/opt/elife-bot/provider/eif.py", line 46, in read_eif_from_s3
    data = json.loads(json_input)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```