### PR TITLE
Pubmed bucket change to include the prefix for end2end testing.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -57,7 +57,7 @@ class activity_PubmedArticleDeposit(activity.activity):
         self.article = articlelib.article(self.settings, self.get_tmp_dir())
 
         # Bucket for outgoing files
-        self.publish_bucket = settings.poa_packaging_bucket
+        self.publish_bucket = settings.publishing_buckets_prefix + settings.poa_packaging_bucket
         self.outbox_folder = "pubmed/outbox/"
         self.published_folder = "pubmed/published/"
 


### PR DESCRIPTION
Separate commit mirroring https://github.com/elifesciences/elife-bot/pull/574/commits/11204c0e482f000705e56836955dc64abb000c46 to just allow end2end testing.