### PR TITLE
If successful, ConvertImagesToJPG to clean its tmp_dir before finishing.

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -72,6 +72,7 @@ class activity_ConvertImagesToJPG(activity.activity):
             self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
                                     "Finished converting images for " + article_id + ": " +
                                     str(len(figures)) + " images processed ")
+            self.clean_tmp_dir()
             return activity.activity.ACTIVITY_SUCCESS
 
         except Exception as e:


### PR DESCRIPTION
ConvertImagesToJPG leaves expanded ``.tif`` files in its activity temp directory after finishing, and these can fill up the disk when many workflows are run. Here, if the activity is successful, then it will remove its tmp dir and the ``.tif`` files inside it.