### PR TITLE
Run precise subset of end2end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ elifePipeline {
                     revision: commit,
                     folder: '/opt/elife-bot',
                 ],
-                marker: 'continuum'
+                marker: 'bot'
             )
         }
 


### PR DESCRIPTION
Only the end2end tests that involve the bot are run. See https://github.com/elifesciences/elife-spectrum/commit/e55d6bd6778f0c11df38fd09f71567bad0746c7a where we add the new tag, which was born to mark the pubmed test.

We don't run tests that:
- do not involve the bot
- even if involving the bot, do not add anything new with respect to the core bot tests that publish several articles and versions