### PR TITLE
If Pubmed FTP delivery fails, then return a permanent failure.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -119,7 +119,11 @@ class activity_PubmedArticleDeposit(activity.activity):
         if len(self.article_published_file_names) > 0:
             self.add_email_to_queue()
 
-        return self.activity_status
+        # return a value based on the activity_status
+        if self.activity_status is True:
+            return True
+        else:
+            return activity.activity.ACTIVITY_PERMANENT_FAILURE
 
     def set_datestamp(self):
         a = arrow.utcnow()

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -97,7 +97,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             "outbox_filenames": ['elife-15747-v2.xml'],
             "ftp_files_return_value": False,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
-            "expected_result": False,
+            "expected_result": activity_PubmedArticleDeposit.ACTIVITY_PERMANENT_FAILURE,
             "expected_approve_status": True,
             "expected_generate_status": True,
             "expected_publish_status": False,


### PR DESCRIPTION
This should cut down on the repeated attempts of the PubMed deposits if there is an FTP error. Not retrying the FTP transfer if the first attempt fails is probably ok in this case. The files it processed in that case should remain in the outbox, and the deposit will be attempted again in about an hour (since the ``cron.py`` attempts to start a workflow each hour).