### PR TITLE
Accept 202 from personalised-covers

### DIFF
--- a/provider/article.py
+++ b/provider/article.py
@@ -241,7 +241,7 @@ class article(object):
         resp = requests.post(url)
         logger.info("Response code for PDF Generator %s", str(resp.status_code))
         assert resp.status_code != 404, "PDF cover not found. Format: %s - url requested: %s" % (format, url)
-        assert (resp.status_code == 200), "unhandled status code from PDF cover service: %s . " \
+        assert (resp.status_code in [200, 202]), "unhandled status code from PDF cover service: %s . " \
                                           "Format: %s - url requested: %s" % \
                                           (resp.status_code, format, url)
         data = resp.json()

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -64,7 +64,23 @@ class TestGeneratePDFCovers(unittest.TestCase):
 
     @patch('requests.post')
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
-    def test_do_activity_success(self, fake_monitor_event, fake_request):
+    def test_do_activity_success_first_generation(self, fake_monitor_event, fake_request):
+        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
+                "article_id": "00353",
+                "version": "1"}
+        fake_request.return_value = FakeResponse(202, {"formats":
+                                                           {"a4":"https://s3.eu-west-2.amazonaws.com/a4/09560",
+                                                            "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
+                                                           }
+                                                       })
+
+        result = self.generatepdfcovers.do_activity(data)
+
+        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
+
+    @patch('requests.post')
+    @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
+    def test_do_activity_success_already_existing(self, fake_monitor_event, fake_request):
         data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
                 "article_id": "00353",
                 "version": "1"}
@@ -77,7 +93,6 @@ class TestGeneratePDFCovers(unittest.TestCase):
         result = self.generatepdfcovers.do_activity(data)
 
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Spawned from a randomly failing end2end test.

https://github.com/elifesciences/personalised-covers/blob/cceb10b59caf19218dcfac59a3da9abe9ec3da8e/src/App/DefaultController.php#L127 shows either 200 or 202 can be returned, both are successes for the activity.