### PR TITLE
Create more unique workflow execution ID values in silent correction …

### DIFF
--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -34,8 +34,9 @@ class starter_PostPerfectPublication():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, info, info['article_id'],
-                                                         publication_from)
+        workflow_input = helper.set_workflow_information(
+            self.const_name, "1", None, info, info['article_id'] + "." + str(info['version']),
+            publication_from)
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -35,7 +35,7 @@ class starter_PostPerfectPublication():
         child_policy, \
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(
-            self.const_name, "1", None, info, info['article_id'] + "." + str(info['version']),
+            self.const_name, "1", None, info, "%s.%s" % (info.get('article_id'), info.get('version')),
             publication_from)
 
         # Simple connect

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -47,7 +47,7 @@ class starter_SilentCorrectionsProcess():
         child_policy, \
         execution_start_to_close_timeout, \
         workflow_input = helper.set_workflow_information(self.const_name, "1", None, input,
-                                                         article_id + "." + str(version))
+                                                         "%s.%s" % (article_id, version))
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -46,7 +46,8 @@ class starter_SilentCorrectionsProcess():
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input, article_id)
+        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input,
+                                                         article_id + "." + str(version))
 
         # Simple connect
         conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)

--- a/tests/starter/test_starter_helper.py
+++ b/tests/starter/test_starter_helper.py
@@ -6,7 +6,7 @@ from ddt import ddt, data, unpack
 
 
 example_workflow_name = "PostPerfectPublication"
-example_workflow_id = lambda fe: "PostPerfectPublication_00353." + fe
+example_workflow_id = lambda fe, version: "PostPerfectPublication_00353." + version + "." + fe
 
 
 @ddt
@@ -23,14 +23,15 @@ class TestStarterHelper(unittest.TestCase):
         workflow_version, \
         child_policy, \
         execution_start_to_close_timeout, \
-        workflow_input = starter_helper.set_workflow_information(example_workflow_name,
-                                                                              "1",
-                                                                              None,
-                                                                              data,
-                                                                              data['article_id'],
-                                                                              execution)
+        workflow_input = starter_helper.set_workflow_information(
+            example_workflow_name,
+            "1",
+            None,
+            data,
+            "%s.%s" % (data.get('article_id'), data.get('version')),
+            execution)
 
-        self.assertEqual(example_workflow_id(execution), workflow_id)
+        self.assertEqual(example_workflow_id(execution, data.get('version')), workflow_id)
         self.assertEqual(example_workflow_name, workflow_name)
         self.assertEqual("1", workflow_version)
         self.assertIsNone(child_policy)


### PR DESCRIPTION
…starters.

Small changes as described in https://elifesciences.atlassian.net/browse/ELPP-3460 to make it easier to run concurrent silent corrections of the same article_id, by adding ".[version]" to the workflow execution ID value.