### PR TITLE
Bug fix the queue_workflow_starter

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -120,7 +120,7 @@ def process_data_pubmedarticledeposit(workflow_name, workflow_data):
 workflow_data_processors = {
     'IngestArticleZip': process_data_ingestarticlezip,
     'InitialArticleZip': process_data_initialarticlezip,
-    'SilentCorrectionsIngest': process_data_ingestarticlezip,
+    'SilentCorrectionsIngest': process_data_initialarticlezip,
     'PostPerfectPublication': process_data_postperfectpublication,
     'PubmedArticleDeposit': process_data_pubmedarticledeposit
 }


### PR DESCRIPTION
Use the InitialArticleZip style of starter data for SilentCorrectionIngest workflow starts when using the workflow starter queue.

After some analysis of the failures in end2end tests, the failures seem to be related to silent correction tests. Eventually I tracked it down in the ``queue_workflow_starter.log``

```
2018-03-09T23:19:09Z ERROR queue_workflow_starter_10852 Exception while processing message
Traceback (most recent call last):
  File "queue_workflow_starter.py", line 80, in process_message
    start_workflow(name, data)
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/newrelic-2.72.0.52/newrelic/api/background_task.py", line 102, in wrapper
    return wrapped(*args, **kwargs)
  File "queue_workflow_starter.py", line 90, in start_workflow
    workflow_data = data_processor(workflow_name, workflow_data)
  File "queue_workflow_starter.py", line 102, in process_data_ingestarticlezip
    data = {'article_id': workflow_data['article_id'],
KeyError: 'article_id'
```

With the recent introduction of the ``InitialArticleZip`` workflow, that type of starter must also be followed by ``SilentCorrectionIngest``, since both are initiated by an S3Notification message. Leaving ``SilentCorrectionIngest`` to use the altered starter profile ``IngestArticleZip`` is not going to work, since the ``article_id`` is not in the session - no data is available yet.

This is just one line of code, and rather than waiting for a code review, the end2end tests will have a better chance of testing whether this theory is correct, so I will merge immediately.