### PR TITLE
Uninstall elifepubmed before installing requirements.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,5 +17,8 @@ fi
 if pip list | grep elifecrossref; then
     pip uninstall -y elifecrossref
 fi
+if pip list | grep elifepubmed; then
+    pip uninstall -y elifepubmed
+fi
 pip install -r requirements.txt
 


### PR DESCRIPTION
After reviewing the PubMed deposit generated from a retraction article (https://github.com/elifesciences/elife-pubmed-feed/issues/40) it did not include the ``<Object Type="Retraction">`` as expected.

I think even though we have the correct git commit for the ``elifepubmed`` library in ``requirements.txt`` here, it is not reinstalling it on the instance properly.

This is to uninstall it first (as we do with other libraries) when running ``install.sh`` so we have the desired library commit.