### PR TITLE
Add func_timeout in requirements.txt for support of PoA generation …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ newrelic==2.72.0.52
 pylint==1.6.4
 pyGithub==1.27.1
 pyFunctional==1.0.0
+func_timeout==4.3.0


### PR DESCRIPTION
…library.

May fix the error in building after https://github.com/elifesciences/elife-poa-xml-generation/pull/317 was merged.