### PR TITLE
Explicitly do not send the publication email for retraction articles.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -69,6 +69,7 @@ class activity_PublicationEmail(activity.activity):
         self.article_types_do_not_send = []
         self.article_types_do_not_send.append('editorial')
         self.article_types_do_not_send.append('correction')
+        self.article_types_do_not_send.append('retraction')
 
         # Email types, for sending previews of each template
         self.email_types = []

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from provider.article import article
 
 
 def create_folder(folder):
@@ -32,3 +33,14 @@ def delete_directories_in_folder(folder):
 
 def delete_everything_in_folder(self, folder):
     self.delete_files_in_folder(folder)
+
+
+def instantiate_article(article_type, doi, is_poa=None, was_ever_poa=None):
+    "for testing purposes, generate an article object"
+    article_object = article()
+    article_object.article_type = article_type
+    article_object.doi = doi
+    article_object.doi_id = article_object.get_doi_id(doi)
+    article_object.is_poa = is_poa
+    article_object.was_ever_poa = was_ever_poa
+    return article_object

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -18,6 +18,7 @@ from classes_mock import FakeKey
 
 from testfixtures import TempDirectory
 import tests.test_data as test_data
+from tests.activity.helpers import instantiate_article
 
 import os
 # Add parent directory for imports, so activity classes can use elife-poa-xml-generation
@@ -372,25 +373,15 @@ class TestPublicationEmail(unittest.TestCase):
             result = self.activity.send_email(None, None, failed_author, None, None)
             self.assertEqual(result, False)
 
-    def instantiate_article(self, article_type, doi, is_poa=None, was_ever_poa=None):
-        "for testing purposes, generate an article object"
-        article_object = article()
-        article_object.article_type = article_type
-        article_object.doi = doi
-        article_object.doi_id = article_object.get_doi_id(doi)
-        article_object.is_poa = is_poa
-        article_object.was_ever_poa = was_ever_poa
-        return article_object
-
     @patch('provider.lax_provider.article_versions')
     def test_removes_articles_based_on_article_type(self, mock_lax_provider_article_versions):
         "test removing articles based on article type"
         mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
         research_article_doi = '10.7554/eLife.99996'
-        editorial_article = self.instantiate_article('editorial', '10.7554/eLife.99999')
-        correction_article = self.instantiate_article('correction', '10.7554/eLife.99998')
-        retraction_article = self.instantiate_article('retraction', '10.7554/eLife.99997')
-        research_article = self.instantiate_article('research-article', research_article_doi, True, True)
+        editorial_article = instantiate_article('editorial', '10.7554/eLife.99999')
+        correction_article = instantiate_article('correction', '10.7554/eLife.99998')
+        retraction_article = instantiate_article('retraction', '10.7554/eLife.99997')
+        research_article = instantiate_article('research-article', research_article_doi, True, True)
         articles = [editorial_article, correction_article, retraction_article, research_article]
         approved_articles = self.activity.approve_articles(articles)
         # one article will remain, the research-article

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -372,6 +372,31 @@ class TestPublicationEmail(unittest.TestCase):
             result = self.activity.send_email(None, None, failed_author, None, None)
             self.assertEqual(result, False)
 
+    def instantiate_article(self, article_type, doi, is_poa=None, was_ever_poa=None):
+        "for testing purposes, generate an article object"
+        article_object = article()
+        article_object.article_type = article_type
+        article_object.doi = doi
+        article_object.doi_id = article_object.get_doi_id(doi)
+        article_object.is_poa = is_poa
+        article_object.was_ever_poa = was_ever_poa
+        return article_object
+
+    @patch('provider.lax_provider.article_versions')
+    def test_approve_articles(self, mock_lax_provider_article_versions):
+        "test removing articles based on article type"
+        mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
+        research_article_doi = '10.7554/eLife.99996'
+        editorial_article = self.instantiate_article('editorial', '10.7554/eLife.99999')
+        correction_article = self.instantiate_article('correction', '10.7554/eLife.99998')
+        retraction_article = self.instantiate_article('retraction', '10.7554/eLife.99997')
+        research_article = self.instantiate_article('research-article', research_article_doi, True, True)
+        articles = [editorial_article, correction_article, retraction_article, research_article]
+        approved_articles = self.activity.approve_articles(articles)
+        # one article will remain, the research-article
+        self.assertEqual(len(approved_articles), 1)
+        self.assertEqual(approved_articles[0].doi, research_article_doi)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -383,7 +383,7 @@ class TestPublicationEmail(unittest.TestCase):
         return article_object
 
     @patch('provider.lax_provider.article_versions')
-    def test_approve_articles(self, mock_lax_provider_article_versions):
+    def test_removes_articles_based_on_article_type(self, mock_lax_provider_article_versions):
         "test removing articles based on article type"
         mock_lax_provider_article_versions.return_value = 200, test_data.lax_article_versions_response_data
         research_article_doi = '10.7554/eLife.99996'


### PR DESCRIPTION
Production asked whether authors would be emailed upon the publication of a retraction article. 

Logs show for a retraction the ``PublicationEmail`` activity was unable to find any authors from its data sources, and wouldn't send it. As the code is written, I'm fairly certain the logic would be unable to find which email template to use and would not send emails for retractions anyway.

That said, here is a more explicit block to not email authors about retraction articles by adding it to the other types we do not send for (``editorial`` and ``correction``).

I added a test specifically for the ``approve_articles()`` function which processes some basic article objects to test the logic.

I will be creating a new issue to describe a more elaborate refactoring for the types of articles and possibly the template types to be moved to a configuration file rather than having it in code, which should make it easier for other users to adapt it to their own preferences for email communication.