### PR TITLE
Update Crossref library and test for elocation_id

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -19,7 +19,7 @@ import provider.s3lib as s3lib
 from provider import lax_provider
 from provider import utils
 from elifecrossref import generate
-from elifecrossref.conf import config, parse_raw_config
+from elifecrossref.conf import raw_config, parse_raw_config
 from elifearticle.article import ArticleDate
 
 """
@@ -167,9 +167,9 @@ class activity_DepositCrossref(activity.activity):
 
     def elifecrossref_config(self, config_section):
         "parse the config values from the elifecrossref config"
-        config.read(self.settings.elifecrossref_config_file)
-        raw_config = config[config_section]
-        return parse_raw_config(raw_config)
+        return parse_raw_config(raw_config(
+            config_section,
+            self.settings.elifecrossref_config_file))
 
     def article_first_pub_date(self, article):
         "find the first article pub date from the list of crossref config pub_date_types"
@@ -247,10 +247,11 @@ class activity_DepositCrossref(activity.activity):
             if self.approve_to_generate(article) is not True:
                 generate_status = False
             else:
+                crossref_config = self.elifecrossref_config(
+                    self.settings.elifecrossref_config_section)
                 try:
                     # Will write the XML to the TMP_DIR
-                    generate.crossref_xml_to_disk(
-                        article_list, config_section=self.settings.elifecrossref_config_section)
+                    generate.crossref_xml_to_disk(article_list, crossref_config)
                 except:
                     generate_status = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ requests==2.11.1
 wsgiref==0.1.2
 lxml==4.1.1
 xlrd==0.9.3
-git+https://github.com/elifesciences/elife-tools.git@34a6cf5ad878571e1229b9b31dc50880a05d73c9#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@368688609c1f398fe1a34498dd66c777a0f8f12e#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@0eb54174f6c87821ead5661fc25797d3482b74c3#egg=elifecrossref
+git+https://github.com/elifesciences/elife-tools.git@26c59bfbbd95a793f03c9041c614635e180a551d#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@bb61d4c0e3742403503efe10852114aeb1e07269#egg=elifearticle
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@3cf16976fa57e94fd3af45e2162b251674c168d8#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@2b770b5942de763a34b92e378600ed53c175c7e6#egg=elifepubmed
 PyYAML==3.11
 Wand==0.4.0

--- a/tests/activity/crossref.cfg
+++ b/tests/activity/crossref.cfg
@@ -1,6 +1,9 @@
 [DEFAULT]
 crossref_schema_version: 4.4.0
 generator: elife-crossref-xml-generation
+registrant: 
+depositor_name: 
+email_address: 
 contrib_types: ["author", "on-behalf-of"]
 jats_abstract: false
 face_markup: false
@@ -8,13 +11,14 @@ crossmark: true
 crossmark_policy:
 crossmark_domain:
 batch_file_prefix: crossref-
-doi_pattern: {doi}
-component_doi_pattern: {doi}
+doi_pattern: 
+component_doi_pattern: 
+component_license_ref:
 elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
 elocation_id: true
-access_indicators_applies_to: ["vor", "am", "tdm"]
-pub_date_types: ["pub", "publication", "epub"]
+access_indicators_applies_to: ["vor"]
+pub_date_types: ["pub", "publication", "epub", "epub-ppub"]
 reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
@@ -27,9 +31,11 @@ crossmark: false
 batch_file_prefix: elife-crossref-
 doi_pattern: https://elifesciences.org/articles/{manuscript}
 component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}
+component_license_ref: https://submit.elifesciences.org/html/elife_author_instructions.html#policies
 elife_style_component_doi: true
 year_of_first_volume: 2012
-elocation_id: false
+elocation_id: true
+access_indicators_applies_to: ["vor", "am", "tdm"]
 reference_distribution_opts: any
 text_mining_xml_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.xml
 text_mining_pdf_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -58,7 +58,8 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
                 '<doi>10.7554/eLife.15747</doi>',
-                '<publication_date media_type="online"><month>06</month><day>16</day><year>2016</year></publication_date>'
+                '<publication_date media_type="online"><month>06</month><day>16</day><year>2016</year></publication_date>',
+                '<item_number item_number_type="article_number">e15747</item_number>'
                 ]
         },
         {


### PR DESCRIPTION
Started off to include the ``elocation_id`` in Crossref deposits for eLife. 

I also wanted to update the ``crossref.cfg`` file in the test cases to be the latest one, and in doing so I uncovered to override the config file loaded was too difficult. So I went back to refactor how the Crossref config is loaded, merged in PR https://github.com/elifesciences/elife-crossref-xml-generation/pull/67.

Changes here will make the ``elife-bot`` project compatible with using the latest revision of the ``elife-crossref-xml-generation`` library.

There is also a test looking for ``'<item_number item_number_type="article_number">e15747</item_number>'`` in the test scenario output, which is the new value added in the deposit.