### PR TITLE
PMC fix for file name map

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -348,19 +348,10 @@ class activity_PMCDeposit(activity.activity):
                 self.unzip_or_move_file(file_name, self.TMP_DIR)
 
 
-
-    def rename_files_remove_version_number(self):
-        """
-        Rename files to not include the version number, if present
-        Pre-PPP files will not have a version number, for before PPP is launched
-        """
-
+    def stripped_file_name_map(self, file_names):
+        "from a list of file names, build a map of old to new file name with the version removed"
         file_name_map = {}
-
-        # Get a list of all files
-        dirfiles = self.file_list(self.TMP_DIR)
-
-        for df in dirfiles:
+        for df in file_names:
             filename = df.split(os.sep)[-1]
 
             # Get the new file name
@@ -382,6 +373,21 @@ class activity_PMCDeposit(activity.activity):
             else:
                 if self.logger:
                     self.logger.info('there is no renamed file for ' + filename)
+        return file_name_map
+
+
+    def rename_files_remove_version_number(self):
+        """
+        Rename files to not include the version number, if present
+        Pre-PPP files will not have a version number, for before PPP is launched
+        """
+
+        file_name_map = {}
+
+        # Get a list of all files
+        dirfiles = self.file_list(self.TMP_DIR)
+
+        file_name_map = self.stripped_file_name_map(dirfiles)
 
         for old_name, new_name in file_name_map.iteritems():
             if new_name is not None:

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -1,7 +1,7 @@
 import os
 import boto.swf
 import json
-
+from collections import OrderedDict
 import datetime
 import time
 import zipfile
@@ -350,16 +350,16 @@ class activity_PMCDeposit(activity.activity):
 
     def stripped_file_name_map(self, file_names):
         "from a list of file names, build a map of old to new file name with the version removed"
-        file_name_map = {}
+        file_name_map = OrderedDict()
         for df in file_names:
             filename = df.split(os.sep)[-1]
 
             # Get the new file name
             file_name_map[filename] = None
 
-            # TODO strip the -v1 from it
+            # strip the -v1 from it
             file_extension = filename.split('.')[-1]
-            if '-v' in filename:
+            if '-v' in filename and '-video' not in filename:
                 # Use part before the -v number
                 part_without_version = filename.split('-v')[0]
             else:

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -18,7 +18,7 @@ from boto.s3.connection import S3Connection
 
 import provider.s3lib as s3lib
 import provider.simpleDB as dblib
-
+from provider.article_structure import ArticleInfo, file_parts
 from elifetools import parseJATS as parser
 from elifetools import xmlio
 
@@ -353,26 +353,16 @@ class activity_PMCDeposit(activity.activity):
         file_name_map = OrderedDict()
         for df in file_names:
             filename = df.split(os.sep)[-1]
-
-            # Get the new file name
-            file_name_map[filename] = None
-
-            # strip the -v1 from it
-            file_extension = filename.split('.')[-1]
-            if '-v' in filename and '-video' not in filename:
+            info = ArticleInfo(filename)
+            prefix, extension = file_parts(filename)
+            if info.versioned is True and info.version is not None:
                 # Use part before the -v number
-                part_without_version = filename.split('-v')[0]
+                part_without_version = prefix.split('-v')[0]
             else:
-                # No -v found, use the file name minus the extension
-                part_without_version = ''.join(filename.split('.')[0:-1])
-
-            renamed_filename = part_without_version + '.' + file_extension
-
-            if renamed_filename:
-                file_name_map[filename] = renamed_filename
-            else:
-                if self.logger:
-                    self.logger.info('there is no renamed file for ' + filename)
+                # Not a versioned file, use the whole file prefix
+                part_without_version = prefix
+            renamed_filename = '.'.join([part_without_version, extension])
+            file_name_map[filename] = renamed_filename
         return file_name_map
 
 
@@ -381,9 +371,6 @@ class activity_PMCDeposit(activity.activity):
         Rename files to not include the version number, if present
         Pre-PPP files will not have a version number, for before PPP is launched
         """
-
-        file_name_map = {}
-
         # Get a list of all files
         dirfiles = self.file_list(self.TMP_DIR)
 

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -1,5 +1,6 @@
 import unittest
 from activity.activity_PMCDeposit import activity_PMCDeposit
+from collections import OrderedDict
 import shutil
 import zipfile
 from mock import mock, patch
@@ -112,6 +113,25 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.assertEqual(False, success)
 
+    @data(
+        (
+            ['elife-99999.xml',
+             'elife-99999-fig1-v1.tif',
+             'elife-99999-video1.mp4',
+             'elife-99999-video2.mp4',
+             ],
+            OrderedDict([
+                ('elife-99999.xml', 'elife-99999.xml'),
+                ('elife-99999-fig1-v1.tif', 'elife-99999-fig1.tif'),
+                ('elife-99999-video1.mp4', 'elife-99999-video1.mp4'),
+                ('elife-99999-video2.mp4', 'elife-99999-video2.mp4')
+                ])
+            ),
+    )
+    @unpack
+    def test_stripped_file_name_map(self, file_names, expected_file_name_map):
+        file_name_map = self.activity.stripped_file_name_map(file_names)
+        self.assertEqual(file_name_map, expected_file_name_map)
 
     @data(
         (None, [""]),


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/700

I refactored to allow testing of multiple scenarios from file names to new file names when renaming files in PMC zip packages. When I had the correct output, I refactored it to use the ``article_structure`` provider for hopefully easier adaptability to different versioned or non-versioned files as specified in the rules. For eLife only the video files are non-versioned.