### PR TITLE
ELPP-3522 Add Fastly to InvalidateCdn activity

### DIFF
--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -58,7 +58,8 @@ class activity_InvalidateCdn(activity.activity):
                     return activity.activity.ACTIVITY_TEMPORARY_FAILURE
                 raise
 
-            fastly_provider.purge(article_id, self.settings)
+            fastly_response = fastly_provider.purge(article_id, self.settings)
+            self.logger.info("Fastly response: %s\n%s", fastly_response.status_code, fastly_response.content)
 
             dashboard_message = "CloudFront Invalidation command sent for article %s." % str(article_id)
             self.emit_monitor_event(self.settings, article_id, version, run,

--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -1,5 +1,5 @@
 import activity
-from provider import cloudfront_provider
+from provider import cloudfront_provider, fastly_provider
 from boto.cloudfront.exception import CloudFrontServerError
 
 """
@@ -57,6 +57,8 @@ class activity_InvalidateCdn(activity.activity):
                     )
                     return activity.activity.ACTIVITY_TEMPORARY_FAILURE
                 raise
+
+            fastly_provider.purge(article_id, self.settings)
 
             dashboard_message = "CloudFront Invalidation command sent for article %s." % str(article_id)
             self.emit_monitor_event(self.settings, article_id, version, run,

--- a/lint.sh
+++ b/lint.sh
@@ -8,7 +8,6 @@ python -m pylint -E \
     activity/activity*.py \
     provider/article_structure.py \
     provider/imageresize.py \
-    provider/lax_provider.py \
-    provider/storage_provider.py \
+    provider/*_provider.py \
     tests/activity/*.py \
     tests/provider/*.py

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,7 +1,6 @@
 import requests
 
 def purge(article_id, settings):
-    api = fastly.API()
     surrogate_key = 'articles/%05d' % article_id
     url = "https://api.fastly.com/service/%s/purge/%s" % (settings.fastly_service_id, surrogate_key)
 

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,0 +1,3 @@
+
+def purge(*args):
+    pass

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,3 +1,13 @@
+import requests
 
-def purge(*args):
-    pass
+def purge(article_id, settings):
+    api = fastly.API()
+    surrogate_key = 'articles/%05d' % article_id
+    url = "https://api.fastly.com/service/%s/purge/%s" % (settings.fastly_service_id, surrogate_key)
+
+    response = requests.post(url, headers={
+        'Accept': 'application/json',
+        'Fastly-Key': settings.fastly_api_key
+    })
+    response.raise_for_status()
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ pylint==1.6.4
 pyGithub==1.27.1
 pyFunctional==1.0.0
 func_timeout==4.3.0
+fastly==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,3 @@ pylint==1.6.4
 pyGithub==1.27.1
 pyFunctional==1.0.0
 func_timeout==4.3.0
-fastly==0.1.3

--- a/settings-example.py
+++ b/settings-example.py
@@ -228,6 +228,10 @@ class exp():
 
     cloudfront_distribution_id_cdn = "DISTRIBUTIONID"
 
+    # Fastly CDNs
+    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_api_key = 'fake_fastly_api_key'
+
 
 class dev():
 
@@ -412,6 +416,11 @@ class dev():
     # CloudFront
     cloudfront_distribution_id_cdn = "DISTRIBUTIONID"
 
+    # Fastly CDNs
+    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_api_key = 'fake_fastly_api_key'
+
+
 
 class live():
     # AWS settings
@@ -594,6 +603,11 @@ class live():
 
     # CloudFront
     cloudfront_distribution_id_cdn = "DISTRIBUTIONID"
+
+    # Fastly CDNs
+    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_api_key = 'fake_fastly_api_key'
+
 
 def get_settings(ENV="dev"):
     """

--- a/tests/activity/test_activity_invalidate_cdn.py
+++ b/tests/activity/test_activity_invalidate_cdn.py
@@ -18,21 +18,30 @@ class TestInvalidateCdn(unittest.TestCase):
         self.invalidatecdn.logger = FakeLogger()
 
     @patch('provider.cloudfront_provider.create_invalidation')
+    @patch('provider.fastly_provider.purge')
     @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
-    def test_invalidation_success(self, fake_emit, invalidation_mock):
+    def test_invalidation_success(self, fake_emit, purge_mock, invalidation_mock):
         result = self.invalidatecdn.do_activity(activity_data)
         self.assertEqual(result, self.invalidatecdn.ACTIVITY_SUCCESS)
 
     @patch('provider.cloudfront_provider.create_invalidation')
     @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
-    def test_invalidation_permanent_failure(self, fake_emit, invalidation_mock):
-        invalidation_mock.side_effect = Exception("An error occurred")
+    def test_invalidation_permanent_failure_cloudfront(self, fake_emit, invalidation_mock):
+        invalidation_mock.side_effect = Exception("An error occurred calling the CloudFront API")
+        result = self.invalidatecdn.do_activity(activity_data)
+        self.assertEqual(result, self.invalidatecdn.ACTIVITY_PERMANENT_FAILURE)
+
+    @patch('provider.cloudfront_provider.create_invalidation')
+    @patch('provider.fastly_provider.purge')
+    @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
+    def test_invalidation_permanent_failure_fastly(self, fake_emit, purge_mock, invalidation_mock):
+        purge_mock.side_effect = Exception("An error occurred calling the Fastly API")
         result = self.invalidatecdn.do_activity(activity_data)
         self.assertEqual(result, self.invalidatecdn.ACTIVITY_PERMANENT_FAILURE)
 
     @patch('provider.cloudfront_provider.create_invalidation')
     @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
-    def test_invalidation_temporary_failure_due_to_rate_limiting(self, fake_emit, invalidation_mock):
+    def test_invalidation_temporary_failure_cloudfront_due_to_rate_limiting(self, fake_emit, invalidation_mock):
         invalidation_mock.side_effect = CloudFrontServerError(400, 'Bad Request', '<ErrorResponse xmlns="http://cloudfront.amazonaws.com/doc/2010-11-01/"><Error><Type>Sender</Type><Code>TooManyInvalidationsInProgress</Code><Message>Processing your request will cause you to exceed the maximum number of in-progress wildcard invalidations.</Message></Error><RequestId>b47186e6-b7d7-11e7-bd6c-d7fe045b879d</RequestId></ErrorResponse>')
         result = self.invalidatecdn.do_activity(activity_data)
         self.assertEqual(result, self.invalidatecdn.ACTIVITY_TEMPORARY_FAILURE)

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -1,0 +1,21 @@
+import unittest
+from mock import mock, patch
+from provider import fastly_provider
+from tests import settings_mock
+from requests.models import Response
+from requests.exceptions import HTTPError
+
+class TestFastlyProvider(unittest.TestCase):
+    @patch('requests.post')
+    def test_purge(self, post_mock):
+        response = Response()
+        response.status_code = 200
+        post_mock.return_value = response
+        fastly_provider.purge(10627, settings_mock)
+
+    @patch('requests.post')
+    def test_purge_failure(self, post_mock):
+        response = Response()
+        response.status_code = 500
+        post_mock.return_value = response
+        self.assertRaises(HTTPError, lambda: fastly_provider.purge(10627, settings_mock))

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -38,3 +38,7 @@ setLevel = "INFO"
 # PDF cover
 pdf_cover_generator = "https://localhost/personalised-covers/"
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
+
+# Fastly CDNs
+fastly_service_id = '3M35rb7puabccOLrFFxy2'
+fastly_api_key = 'fake_fastly_api_key'


### PR DESCRIPTION
Eventually, Fastly will replace CloudFront and invalidation times should go down from "let's wait 10 minutes because there are too many wildcard invalidations running" to milliseconds.

Will add formula configuration shortly to put it into the provided `settings.py`.

The CDNs already exist so there is no blocker for this bar the linked builder-private configuration. They have a separate DNS entry not to conflict with CloudFront until ready for the switch. Example:
```
curl -v https://prod-fastly.elifesciences.org/favicon.ico -o /dev/null
curl -v https://prod-fastly.elifesciences.org/articles/00666/elife-00666-fig4-v1.jpg -o /dev/null
```
Their configuration is in https://github.com/elifesciences/builder/pull/321