### PR TITLE
ELPP-3522 Fix article_id type in invalidation

### DIFF
--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,7 +1,7 @@
 import requests
 
 def purge(article_id, settings):
-    surrogate_key = 'articles/%05d' % article_id
+    surrogate_key = 'articles/%s' % article_id.zfill(5)
     url = "https://api.fastly.com/service/%s/purge/%s" % (settings.fastly_service_id, surrogate_key)
 
     response = requests.post(url, headers={

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -11,11 +11,11 @@ class TestFastlyProvider(unittest.TestCase):
         response = Response()
         response.status_code = 200
         post_mock.return_value = response
-        fastly_provider.purge(10627, settings_mock)
+        fastly_provider.purge('10627', settings_mock)
 
     @patch('requests.post')
     def test_purge_failure(self, post_mock):
         response = Response()
         response.status_code = 500
         post_mock.return_value = response
-        self.assertRaises(HTTPError, lambda: fastly_provider.purge(10627, settings_mock))
+        self.assertRaises(HTTPError, lambda: fastly_provider.purge('10627', settings_mock))


### PR DESCRIPTION
Overlooked that it is a string, not a number