### PR TITLE
ELPP-3665 Refine surrogate keys for cache purging

### DIFF
--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -30,11 +30,11 @@ class activity_InvalidateCdn(activity.activity):
 
         try:
             self.emit_monitor_event(self.settings, article_id, version, run, 
-                                    self.pretty_name, "start", "Starting Fastly purge API call.") 
-            fastly_response = fastly_provider.purge(article_id, self.settings)
+                                    self.pretty_name, "start", "Starting Fastly purge API calls.") 
+            fastly_response = fastly_provider.purge(article_id, version, self.settings)
             self.logger.info("Fastly response: %s\n%s", fastly_response.status_code, fastly_response.content)
 
-            dashboard_message = "Fastly purge API call performed for article %s." % str(article_id)
+            dashboard_message = "Fastly purge API calls performed for article %s." % str(article_id)
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "end", dashboard_message)
             return activity.activity.ACTIVITY_SUCCESS

--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -31,8 +31,11 @@ class activity_InvalidateCdn(activity.activity):
         try:
             self.emit_monitor_event(self.settings, article_id, version, run, 
                                     self.pretty_name, "start", "Starting Fastly purge API calls.") 
-            fastly_response = fastly_provider.purge(article_id, version, self.settings)
-            self.logger.info("Fastly response: %s\n%s", fastly_response.status_code, fastly_response.content)
+            fastly_responses = fastly_provider.purge(article_id, version, self.settings)
+            self.logger.info(
+                "Fastly responses: %s",
+                [(r.status_code, r.content) for r in fastly_responses]
+            )
 
             dashboard_message = "Fastly purge API calls performed for article %s." % str(article_id)
             self.emit_monitor_event(self.settings, article_id, version, run,

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,10 +1,10 @@
 import requests
 
-class Purge:
+class FastlyApi:
     def __init__(self, fastly_api_key):
         self._fastly_api_key = fastly_api_key
 
-    def of_key(self, surrogate_key, service_id):
+    def purge(self, surrogate_key, service_id):
         url = "https://api.fastly.com/service/%s/purge/%s" % (service_id, surrogate_key)
 
         response = requests.post(url, headers={
@@ -17,8 +17,11 @@ class Purge:
 KEYS = ['articles/{article_id}v{version}', 'articles/{article_id}/videos']
 
 def purge(article_id, version, settings):
-    p = Purge(settings.fastly_api_key)
+    responses = []
+    api = FastlyApi(settings.fastly_api_key)
     for service_id in settings.fastly_service_ids:
         for key in KEYS:
             surrogate_key = key.format(article_id=article_id.zfill(5), version=version)
-            p.of_key(surrogate_key, service_id)
+            responses.append(api.purge(surrogate_key, service_id))
+
+    return responses

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,12 +1,24 @@
 import requests
 
-def purge(article_id, settings):
-    surrogate_key = 'articles/%s' % article_id.zfill(5)
-    url = "https://api.fastly.com/service/%s/purge/%s" % (settings.fastly_service_id, surrogate_key)
+class Purge:
+    def __init__(self, fastly_api_key):
+        self._fastly_api_key = fastly_api_key
 
-    response = requests.post(url, headers={
-        'Accept': 'application/json',
-        'Fastly-Key': settings.fastly_api_key
-    })
-    response.raise_for_status()
-    return response
+    def of_key(self, surrogate_key, service_id):
+        url = "https://api.fastly.com/service/%s/purge/%s" % (service_id, surrogate_key)
+
+        response = requests.post(url, headers={
+            'Accept': 'application/json',
+            'Fastly-Key': self._fastly_api_key,
+        })
+        response.raise_for_status()
+        return response
+
+KEYS = ['articles/%s']
+
+def purge(article_id, settings):
+    p = Purge(settings.fastly_api_key)
+    for service_id in settings.fastly_service_ids:
+        for key in KEYS:
+            surrogate_key = key % article_id.zfill(5)
+            p.of_key(surrogate_key, service_id)

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -14,11 +14,11 @@ class Purge:
         response.raise_for_status()
         return response
 
-KEYS = ['articles/%s']
+KEYS = ['articles/{article_id}v{version}', 'articles/{article_id}/videos']
 
-def purge(article_id, settings):
+def purge(article_id, version, settings):
     p = Purge(settings.fastly_api_key)
     for service_id in settings.fastly_service_ids:
         for key in KEYS:
-            surrogate_key = key % article_id.zfill(5)
+            surrogate_key = key.format(article_id=article_id.zfill(5), version=version)
             p.of_key(surrogate_key, service_id)

--- a/settings-example.py
+++ b/settings-example.py
@@ -220,7 +220,7 @@ class exp():
     iiif_resolver = "{article_id}/{article_fig}/full/full/0/default.jpg"
 
     # Fastly CDNs
-    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_service_ids = ['3M35rb7puabccOLrFFxy2']
     fastly_api_key = 'fake_fastly_api_key'
 
 
@@ -398,7 +398,7 @@ class dev():
     iiif_resolver = "{article_id}/{article_fig}/full/full/0/default.jpg"
 
     # Fastly CDNs
-    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_service_ids = ['3M35rb7puabccOLrFFxy2']
     fastly_api_key = 'fake_fastly_api_key'
 
 
@@ -576,7 +576,7 @@ class live():
     iiif_resolver = "{article_id}/{article_fig}/full/full/0/default.jpg"
 
     # Fastly CDNs
-    fastly_service_id = '3M35rb7puabccOLrFFxy2'
+    fastly_service_ids = ['3M35rb7puabccOLrFFxy2']
     fastly_api_key = 'fake_fastly_api_key'
 
 

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -8,16 +8,12 @@ from requests.exceptions import HTTPError
 class TestFastlyProvider(unittest.TestCase):
     @patch('requests.post')
     def test_purge(self, post_mock):
-        response = Response()
-        response.status_code = 200
-        post_mock.return_value = response
+        self._allow_call(post_mock)
         fastly_provider.purge('10627', '1', settings_mock)
 
     @patch('requests.post')
     def test_purge_various_keys(self, post_mock):
-        response = Response()
-        response.status_code = 200
-        post_mock.return_value = response
+        self._allow_call(post_mock)
         fastly_provider.purge('10627', '1', settings_mock)
         self.assertEqual(
             [c[1][0] for c in post_mock.mock_calls],
@@ -28,8 +24,19 @@ class TestFastlyProvider(unittest.TestCase):
         )
 
     @patch('requests.post')
+    def test_purge_return_responses(self, post_mock):
+        self._allow_call(post_mock)
+        responses = fastly_provider.purge('10627', '1', settings_mock)
+        self.assertIsInstance(responses[0], Response)
+        self.assertEqual(200, responses[0].status_code)
+
+    @patch('requests.post')
     def test_purge_failure(self, post_mock):
-        response = Response()
-        response.status_code = 500
-        post_mock.return_value = response
+        self._allow_call(post_mock, status_code=500)
         self.assertRaises(HTTPError, lambda: fastly_provider.purge('10627', '1', settings_mock))
+
+    def _allow_call(self, post_mock, status_code=200):
+        response = Response()
+        response.status_code = status_code
+        post_mock.return_value = response
+

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -11,18 +11,19 @@ class TestFastlyProvider(unittest.TestCase):
         response = Response()
         response.status_code = 200
         post_mock.return_value = response
-        fastly_provider.purge('10627', settings_mock)
+        fastly_provider.purge('10627', '1', settings_mock)
 
     @patch('requests.post')
     def test_purge_various_keys(self, post_mock):
         response = Response()
         response.status_code = 200
         post_mock.return_value = response
-        fastly_provider.purge('10627', settings_mock)
+        fastly_provider.purge('10627', '1', settings_mock)
         self.assertEqual(
             [c[1][0] for c in post_mock.mock_calls],
             [
-                'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/articles/10627',
+                'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/articles/10627v1',
+                'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/articles/10627/videos',
             ]
         )
 
@@ -31,4 +32,4 @@ class TestFastlyProvider(unittest.TestCase):
         response = Response()
         response.status_code = 500
         post_mock.return_value = response
-        self.assertRaises(HTTPError, lambda: fastly_provider.purge('10627', settings_mock))
+        self.assertRaises(HTTPError, lambda: fastly_provider.purge('10627', '1', settings_mock))

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -14,6 +14,19 @@ class TestFastlyProvider(unittest.TestCase):
         fastly_provider.purge('10627', settings_mock)
 
     @patch('requests.post')
+    def test_purge_various_keys(self, post_mock):
+        response = Response()
+        response.status_code = 200
+        post_mock.return_value = response
+        fastly_provider.purge('10627', settings_mock)
+        self.assertEqual(
+            [c[1][0] for c in post_mock.mock_calls],
+            [
+                'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/articles/10627',
+            ]
+        )
+
+    @patch('requests.post')
     def test_purge_failure(self, post_mock):
         response = Response()
         response.status_code = 500

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -40,5 +40,5 @@ pdf_cover_generator = "https://localhost/personalised-covers/"
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
 
 # Fastly CDNs
-fastly_service_id = '3M35rb7puabccOLrFFxy2'
+fastly_service_ids = ['3M35rb7puabccOLrFFxy2']
 fastly_api_key = 'fake_fastly_api_key'


### PR DESCRIPTION
Will involves `iiif.elifesciences.org` and `cdn.elifesciences.org`.

In both cases the two cache keys correspond to versioned files and to the unversioned videos (and their stills), see https://github.com/elifesciences/builder/pull/328 for details.