### PR TITLE
Continue rather than return when processing unknown S3 notifications

### DIFF
--- a/queue_worker.py
+++ b/queue_worker.py
@@ -81,19 +81,18 @@ class QueueWorker:
                             self.logger.info("S3NotificationInfo: %s", info.to_dict())
                             workflow_name = self.get_starter_name(rules, info)
                             if workflow_name is None:
-                                self.logger.info("Could not handle file %s in bucket %s" % (info.file_name, info.bucket_name))
-                                continue
-
-                            # build message
-                            message = {
-                                'workflow_name': workflow_name,
-                                'workflow_data': info.to_dict()
-                            }
-
-                            # send workflow initiation message
-                            m = Message()
-                            m.set_body(json.dumps(message))
-                            out_queue.write(m)
+                                self.logger.error("Could not handle file %s in bucket %s" % (info.file_name, info.bucket_name))
+                            else:
+                                # build message
+                                message = {
+                                    'workflow_name': workflow_name,
+                                    'workflow_data': info.to_dict()
+                                }
+    
+                                # send workflow initiation message
+                                m = Message()
+                                m.set_body(json.dumps(message))
+                                out_queue.write(m)
 
                             # cancel incoming message
                             self.logger.info("cancelling message")

--- a/queue_worker.py
+++ b/queue_worker.py
@@ -82,7 +82,7 @@ class QueueWorker:
                             workflow_name = self.get_starter_name(rules, info)
                             if workflow_name is None:
                                 self.logger.info("Could not handle file %s in bucket %s" % (info.file_name, info.bucket_name))
-                                return False
+                                continue
 
                             # build message
                             message = {


### PR DESCRIPTION
Continue in ``queue_worker.py`` if an S3 notification cannot be processed rather than returning ``False``. It already writes to the log if the S3 notification cannot be processed. Issuing ``continue`` will send it back to ``while flag.green():`` and continue reading messages from the queue.