### PR TITLE
Add publishing_buckets_prefix to the bucket names in PoA activities

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -54,7 +54,7 @@ class activity_PackagePOA(activity.activity):
         self.db = dblib.SimpleDB(settings)
 
         # Bucket for outgoing files
-        self.publish_bucket = settings.poa_packaging_bucket
+        self.publish_bucket = settings.publishing_buckets_prefix + settings.poa_packaging_bucket
         self.outbox_folder = "outbox/"
 
         # Some values to set later

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -50,7 +50,7 @@ class activity_PublishFinalPOA(activity.activity):
         self.DONE_DIR = self.get_tmp_dir() + os.sep + "done_dir"
 
         # Bucket for outgoing files
-        self.input_bucket = settings.poa_packaging_bucket
+        self.input_bucket = settings.publishing_buckets_prefix + settings.poa_packaging_bucket
         self.outbox_folder = "outbox/"
         self.published_folder_prefix = "published/"
         self.published_folder_name = None


### PR DESCRIPTION
Add publishing_buckets_prefix to the bucket names in PoA activities for easier end2end testing.

Should have no effect on the ``prod`` environment.