### PR TITLE
Remove the bucket prefix from the bucket name in PubmedArticleDeposit.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -52,7 +52,7 @@ class activity_PubmedArticleDeposit(activity.activity):
         self.article = articlelib.article(self.settings, self.get_tmp_dir())
 
         # Bucket for outgoing files
-        self.publish_bucket = settings.publishing_buckets_prefix + settings.poa_packaging_bucket
+        self.publish_bucket = settings.poa_packaging_bucket
         self.outbox_folder = "pubmed/outbox"
         self.published_folder = "pubmed/published"
 


### PR DESCRIPTION
In the ``PubmedArticleDeposit`` activity, removing the ``publishing_buckets_prefix`` from the bucket name will have no effect on the ``prod`` environment. All other environments will use the exact bucket name explicitly listed in ``settings.py`` for where it finds input and stores output.