### PR TITLE
Write to un-prefixed pubmed outbox

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -25,7 +25,7 @@ class activity_ScheduleDownstream(activity.activity):
         self.logger = logger
 
         # Bucket for outgoing files
-        self.publish_bucket = (settings.publishing_buckets_prefix + settings.poa_packaging_bucket)
+        self.publish_bucket = settings.poa_packaging_bucket
 
         # Outbox folders on S3
         self.pubmed_outbox_folder = "pubmed/outbox/"


### PR DESCRIPTION
Follow-up to #722. Only affects `end2end` as an environment, but we have
to write the file where it is read by the other activity.

I've seen also `ScheduleCrossref` and we should discuss in general the
removal of the prefix, but this seems the minimal change to make the
test suite green.