### PR TITLE
Pubmed library update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ xlrd==0.9.3
 git+https://github.com/elifesciences/elife-tools.git@df537e13da03accf1f4dee83c6c0892742860b07#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@bb61d4c0e3742403503efe10852114aeb1e07269#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@3cf16976fa57e94fd3af45e2162b251674c168d8#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@2b770b5942de763a34b92e378600ed53c175c7e6#egg=elifepubmed
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@32a9a831eca98a03b36b8c9a369c622a34d04a7a#egg=elifepubmed
 PyYAML==3.11
 Wand==0.4.0
 paramiko==1.15.2

--- a/tests/activity/pubmed.cfg
+++ b/tests/activity/pubmed.cfg
@@ -14,12 +14,15 @@ group_author_contrib_types: ["author non-byline", "on-behalf-of"]
 history_date_types: ["received", "accepted"]
 split_article_categories: False
 publication_types: tests/activity/publication_types.yaml
+# abstract paragraphs starting with these terms turn into an AbstractText label value
+abstract_label_types: []
 
 [elife]
 year_of_first_volume: 2012
 batch_file_prefix: elife-pubmed-
 build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
 split_article_categories: True
+abstract_label_types: ["Editorial note:"]
 
 [bmjopen]
 

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -56,7 +56,8 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             "expected_pubmed_xml_contains": [
                 '<ArticleTitle>An evolutionary young defense metabolite influences the root growth of plants via the ancient TOR signaling pathway</ArticleTitle>',
                 '<PubDate PubStatus="aheadofprint"><Year>2017</Year><Month>December</Month><Day>12</Day></PubDate>',
-                '<ELocationID EIdType="doi">10.7554/eLife.29353</ELocationID>'
+                '<ELocationID EIdType="doi">10.7554/eLife.29353</ELocationID>',
+                '<AbstractText Label="">To optimize fitness a plant should monitor its metabolism to appropriately control growth and defense.'
                 ]
         },
         {

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -1,16 +1,14 @@
 import unittest
-from activity.activity_PubmedArticleDeposit import activity_PubmedArticleDeposit
-import shutil
-from mock import patch
-import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger
-from provider.article import article
-from provider.simpleDB import SimpleDB
-from provider import lax_provider
-import tests.test_data as test_case_data
 import os
 from ddt import ddt, data
-from classes_mock import FakeStorageContext
+from mock import patch
+from activity.activity_PubmedArticleDeposit import activity_PubmedArticleDeposit
+from provider.simpleDB import SimpleDB
+from provider import lax_provider
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+from tests.activity.classes_mock import FakeStorageContext
+import tests.test_data as test_case_data
 
 
 @ddt
@@ -20,20 +18,16 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_PubmedArticleDeposit(settings_mock, fake_logger, None, None, None)
 
-
     def tearDown(self):
         self.activity.clean_tmp_dir()
-
 
     def input_dir(self):
         "return the staging dir name for the activity"
         return os.path.join(self.activity.get_tmp_dir(), self.activity.INPUT_DIR)
 
-
     def tmp_dir(self):
         "return the tmp dir name for the activity"
         return os.path.join(self.activity.get_tmp_dir(), self.activity.TMP_DIR)
-
 
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
     @patch.object(lax_provider, 'article_versions')
@@ -54,10 +48,13 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
-                '<ArticleTitle>An evolutionary young defense metabolite influences the root growth of plants via the ancient TOR signaling pathway</ArticleTitle>',
-                '<PubDate PubStatus="aheadofprint"><Year>2017</Year><Month>December</Month><Day>12</Day></PubDate>',
+                ('<ArticleTitle>An evolutionary young defense metabolite influences the root' +
+                 ' growth of plants via the ancient TOR signaling pathway</ArticleTitle>'),
+                ('<PubDate PubStatus="aheadofprint"><Year>2017</Year>' +
+                 '<Month>December</Month><Day>12</Day></PubDate>'),
                 '<ELocationID EIdType="doi">10.7554/eLife.29353</ELocationID>',
-                '<AbstractText Label="">To optimize fitness a plant should monitor its metabolism to appropriately control growth and defense.'
+                ('<AbstractText Label="">To optimize fitness a plant should monitor its' +
+                 ' metabolism to appropriately control growth and defense.')
                 ]
         },
         {
@@ -75,7 +72,8 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             "expected_pubmed_xml_contains": [
                 '<Replaces IdType="doi">10.7554/eLife.15747</Replaces>',
                 '<ArticleTitle>Community-level cohesion without cooperation</ArticleTitle>',
-                '<PubDate PubStatus="epublish"><Year>2016</Year><Month>June</Month><Day>16</Day></PubDate>',
+                ('<PubDate PubStatus="epublish"><Year>2016</Year>' +
+                 '<Month>June</Month><Day>16</Day></PubDate>'),
                 '<ELocationID EIdType="doi">10.7554/eLife.15747</ELocationID>',
                 '<Identifier Source="ORCID">http://orcid.org/0000-0002-9558-1121</Identifier>'
                 ]
@@ -124,13 +122,13 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         },
     )
     def test_do_activity(self, test_data, fake_list_resources, fake_storage_context,
-                         fake_ftp_files_to_endpoint, fake_lax_provider_article_versions,
-                         fake_elife_add_email_to_email_queue):
+                         fake_ftp_files_to_endpoint, fake_article_versions,
+                         fake_email_queue):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = test_data.get("outbox_filenames")
         # lax data overrides
-        fake_lax_provider_article_versions.return_value = 200, test_data.get("article_versions_data")
+        fake_article_versions.return_value = 200, test_data.get("article_versions_data")
         # ftp
         fake_ftp_files_to_endpoint.return_value = test_data.get("ftp_files_return_value")
         # do the activity
@@ -158,8 +156,8 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         if file_count > 0 and test_data.get("expected_pubmed_xml_contains"):
             # Open the first Pubmed XML and check some of its contents
             pubmed_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
-            with open(pubmed_xml_filename_path, 'rb') as fp:
-                pubmed_xml = fp.read()
+            with open(pubmed_xml_filename_path, 'rb') as open_file:
+                pubmed_xml = open_file.read()
                 for expected in test_data.get("expected_pubmed_xml_contains"):
                     self.assertTrue(
                         expected in pubmed_xml,
@@ -190,7 +188,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             self.assertIsNotNone(article, 'failed comparing expected_article')
         if article:
             self.assertEqual(article.doi, test_data.get('expected_doi'),
-                         'failed comparing expected_doi')
+                             'failed comparing expected_doi')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Existing tests pass using the newest PubMed library.

It will now use the ``<AbstractText>`` tag instead of the  ``<Abstract>`` tag in the pubmed deposit. It will also add a label attribute if it matches the config ``abstract_label_types`` list. There is no sample in the tests here that will have a label, and that scenario is tested in the ``elife-pubmed-xml-generation`` library itself.

The rest of the changes are all code linting, and only one test was added to find a partial abstract in the pubmed deposit created.

Expected for all the automated tests to pass, and if so, I will merge and deploy the feature.