### PR TITLE
PoA author aff tag fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ git+https://github.com/elifesciences/elife-tools.git@df537e13da03accf1f4dee83c6c
 git+https://github.com/elifesciences/elife-article.git@bb61d4c0e3742403503efe10852114aeb1e07269#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@3cf16976fa57e94fd3af45e2162b251674c168d8#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@32a9a831eca98a03b36b8c9a369c622a34d04a7a#egg=elifepubmed
-git+https://github.com/elifesciences/ejp-csv-parser.git@2d584ff98810d2f2dbf61a85b6711bc8a19e2ff4#egg=ejpcsvparser
-git+https://github.com/elifesciences/jats-generator.git@7e106d80836e0249686adbf204e95fcc420f7a21#egg=jatsgenerator
+git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
+git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 PyYAML==3.11
 Wand==0.4.0


### PR DESCRIPTION
Update the ejpcsvparser library, and jatsgenerator too, the former in particular will fix duplicate PoA XML aff tags from being added.