### PR TITLE
Uninstall poa libraries before reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,5 +20,14 @@ fi
 if pip list | grep elifepubmed; then
     pip uninstall -y elifepubmed
 fi
+if pip list | grep ejpcsvparser; then
+    pip uninstall -y ejpcsvparser
+fi
+if pip list | grep jatsgenerator; then
+    pip uninstall -y jatsgenerator
+fi
+if pip list | grep packagepoa; then
+    pip uninstall -y packagepoa
+fi
 pip install -r requirements.txt
 


### PR DESCRIPTION
Uninstall the poa related code libraries then reinstall them in install.sh

The latest library changes did not take effect during deployment, and I remember this is where we have been uninstalling them for certain before reinstalling when a new deployment happens.