### PR TITLE
Fix for plus signs in S3 notifications for EmailDigest

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -7,6 +7,7 @@ import activity
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider.storage_provider import storage_context
 import provider.email_provider as email_provider
+import provider.utils as utils
 
 
 class activity_EmailDigest(activity.activity):
@@ -55,9 +56,11 @@ class activity_EmailDigest(activity.activity):
         bucket_folder = None
         if filename:
             bucket_folder = info.file_name.split(filename)[0]
+        # replace + with spaces if present into a real_filename
+        real_filename = utils.unquote_plus(filename)
 
         # Download from S3
-        self.input_file = self.download_digest_from_s3(filename, bucket_name, bucket_folder)
+        self.input_file = self.download_digest_from_s3(real_filename, bucket_name, bucket_folder)
 
         # Parse input and build digest
         self.build_status, self.digest = self.build_digest(self.input_file)

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,4 +1,5 @@
 import re
+import urllib
 
 S3_DATE_FORMAT = '%Y%m%d%H%M%S'
 PUB_DATE_FORMAT = "%Y-%m-%d"
@@ -41,3 +42,13 @@ def volume_from_pub_date(pub_date, start_year=2011):
     except:
         volume = None
     return volume
+
+
+def unquote_plus(string):
+    "unescape plus sign url with python 2 or 3 method"
+    if not string:
+        return string
+    if hasattr(urllib, 'parse'):
+        # python 3
+        return urllib.parse.unquote_plus(string)
+    return urllib.unquote_plus(string)

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -57,7 +57,7 @@ class TestEmailDigest(unittest.TestCase):
         },
         {
             "comment": 'digest zip file example',
-            "filename": 'DIGEST 99999.zip',
+            "filename": 'DIGEST+99999.zip',
             "expected_result": True,
             "expected_activity_status": True,
             "expected_build_status": True,

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -80,6 +80,14 @@ class TestUtils(unittest.TestCase):
         else:
             self.assertEqual(utils.volume_from_pub_date(pub_date), expected)
 
+    @unpack
+    @data(
+        (None, None),
+        ("file_name.jpg", "file_name.jpg"),
+        ("file+name.jpg", "file name.jpg")
+        )
+    def test_unquote_plus(self, value, expected):
+        self.assertEqual(utils.unquote_plus(value), expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -133,7 +133,7 @@ initial_article_zip_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
 ingest_digest_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                       u'event_time': u'2018-06-18T16:14:27.809576Z',
                       u'event_name': u'ObjectCreated:Put',
-                      u'file_name': u'DIGEST 99999.docx',
+                      u'file_name': u'DIGEST+99999.docx',
                       u'file_etag': u'e7f639f63171c097d4761e2d2efe8dc4',
                       u'bucket_name': u'exp-elife-bot-digests-input',
                       u'file_size': 14086}


### PR DESCRIPTION
Fix for how spaces are replaced by plus signs in S3Notification file names.

Test data I'm trying has a space in the file name, and it needs to be unquoted.