### PR TITLE
Relaxing Glencoe image verification logic

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -79,18 +79,6 @@ class activity_CopyGlencoeStillImages(activity.activity):
                 bad_files = self.validate_jpgs_against_cdn(self.list_files_from_cdn(article_id),
                                                            cdn_still_jpgs,
                                                            article_id)
-            if len(bad_files) > 0:
-                bad_files.sort()
-                dashboard_message = ("Not all still images .jpg have a video with the same name " + \
-                                    "missing videos file names: %s" + \
-                                    " Please check them against CDN files. Article: %s") % \
-                                    (bad_files, article_id)
-                self.logger.error(dashboard_message)
-
-                end_event = [self.settings, article_id, version, run, self.pretty_name, "error",
-                             dashboard_message]
-
-                return start_event, end_event, activity.activity.ACTIVITY_PERMANENT_FAILURE
 
             dashboard_message = ("Finished Copying Glencoe still images to CDN: %s" + \
                                 "Article: %s") % \

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -108,6 +108,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_bad_files(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
                                    fake_store_jpgs, fake_list_files_from_cdn):
+        # updated July 2018: bad files will not cause an error, we do not need to check for these
         # Given
         activity_data = test_activity_data.data_example_before_publish
         fake_storage_context.return_value = FakeStorageContext()
@@ -121,17 +122,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         result = self.copyglencoestillimages.do_activity(activity_data)
 
         # Then
-        self.assertEqual(result, self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE)
-        fake_emit.assert_called_with(settings_mock,
-                                     activity_data["article_id"],
-                                     activity_data["version"],
-                                     activity_data["run"],
-                                     self.copyglencoestillimages.pretty_name,
-                                     "error",
-                                     "Not all still images .jpg have a video with the same name " +
-                                     "missing videos file names: ['elife-12620-media1', 'elife-12620-media2']" +
-                                     " Please check them against CDN files. Article: 00353")
-
+        self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
 
     def test_validate_jpgs_against_cdn(self):
         # Given

--- a/tests/activity/test_activity_verify_image_server.py
+++ b/tests/activity/test_activity_verify_image_server.py
@@ -1,10 +1,11 @@
 import unittest
 import settings_mock
-from activity.activity_VerifyImageServer import activity_VerifyImageServer
-import test_activity_data as test_data
-from mock import patch, MagicMock
-from classes_mock import FakeSession
 from ddt import ddt, data
+from tests.activity.classes_mock import FakeSession
+from activity.activity_VerifyImageServer import activity_VerifyImageServer
+import tests.activity.test_activity_data as test_data
+from mock import patch, MagicMock
+
 
 class FakeStorageContext:
     def list_resources(self, resource):


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/564
Fixes https://github.com/elifesciences/jira-import/issues/4113

As described in the issues, if ``bad_files`` are found by ``CopyGlencoeStillImages`` activity, we do not care. These indicate the CDN bucket has some files that are not found in Glencoe, and these extra files should not cause an activity permanent failures and stop the workflow.

I left in gathering the list of bad files, it will just return success now instead if there are any.