### PR TITLE
Python 3 support basics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ settings.py
 .boto
 tests/tmp/*
 venv
+.tox/*
 .idea
 workflow-context/*
 !workflow-context/.gitkeep

--- a/activity/activity.py
+++ b/activity/activity.py
@@ -2,9 +2,7 @@ import shutil
 import datetime
 import os
 import re
-# Add parent directory for imports, so activity classes can use elife-poa-xml-generation
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0, parentdir)
+
 import boto.swf
 import dashboard_queue
 
@@ -214,3 +212,5 @@ class activity(object):
                                                          name, value, property_type)
         dashboard_queue.send_message(message, settings)
 
+class Activity(activity):
+    pass

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -1,16 +1,17 @@
-import activity
+import os
+from .activity import Activity
 import json
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 import provider.article_structure as article_structure
 import provider.image_conversion as image_conversion
-import os
 
 
 
-class activity_ConvertImagesToJPG(activity.activity):
+
+class activity_ConvertImagesToJPG(Activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
-        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+        Activity.__init__(self, settings, logger, conn, token, activity_task)
 
         self.name = "ConvertImagesToJPG"
         self.pretty_name = "Convert Images To JPG"
@@ -45,9 +46,11 @@ class activity_ConvertImagesToJPG(activity.activity):
 
             storage = storage_context(self.settings)
             files_in_bucket = storage.list_resources(orig_resource)
-
-            figures = filter(article_structure.article_figure, files_in_bucket) + filter(article_structure.inline_figure, files_in_bucket)
-
+    
+            figures = []
+            figures += filter(article_structure.article_figure, files_in_bucket)
+            figures += filter(article_structure.inline_figure, files_in_bucket)
+    
             # download is not a IIIF asset but is currently kept for compatibility
             # download may become obsolete in future
             formats = {"Original": {
@@ -73,12 +76,12 @@ class activity_ConvertImagesToJPG(activity.activity):
                                     "Finished converting images for " + article_id + ": " +
                                     str(len(figures)) + " images processed ")
             self.clean_tmp_dir()
-            return activity.activity.ACTIVITY_SUCCESS
+            return Activity.ACTIVITY_SUCCESS
 
         except Exception as e:
             self.logger.exception("An error occurred during " + self.pretty_name)
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "error",
                                     "Error converting images to JPG for article" + article_id +
-                                    " message:" + e.message)
-            return activity.activity.ACTIVITY_PERMANENT_FAILURE
+                                    " message:" + str(e))
+            return Activity.ACTIVITY_PERMANENT_FAILURE

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -95,7 +95,7 @@ class ArticleInfo(object):
 
     def get_update_date_from_zip_filename(self):
         filename = self.full_filename
-        m = re.search(ur'.*?-.*?-.*?-.*?-(.*?)\..*', filename)
+        m = re.search(r'.*?-.*?-.*?-.*?-(.*?)\..*', filename)
         if m is None:
             return None
         else:
@@ -108,7 +108,7 @@ class ArticleInfo(object):
 
     def get_version_from_zip_filename(self):
         filename = self.full_filename
-        m = re.search(ur'-v([0-9]+?)[\.|-]', filename)
+        m = re.search(r'-v([0-9]+?)[\.|-]', filename)
         if m is None:
             return None
         else:
@@ -132,7 +132,7 @@ def has_extensions(file, extensions):
 
 
 def get_original_files(files):
-    regex = re.compile(ur'-v([0-9]+)[\.]')
+    regex = re.compile(r'-v([0-9]+)[\.]')
     fs = list(filter(regex.search, files))
     return fs
 
@@ -202,7 +202,7 @@ def get_article_xml_key(bucket, expanded_folder_name):
 
 def main():
     a = ArticleInfo("elife-00012-fig3-figsupp1-data2.csv")
-    print a
+    print(a)
 
 
 if __name__ == '__main__':

--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 
 from wand.image import Image
 

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -26,7 +26,7 @@ class S3StorageContext:
 
     #Resource format expected s3://my-bucket/my/path/abc.zip
     def s3_storage_objects(self, resource):
-        p = re.compile(ur'(.*?)://(.*?)(/.*)')
+        p = re.compile(r'(.*?)://(.*?)(/.*)')
         match = p.match(resource)
         protocol = match.group(1)
         if protocol != 's3':

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ arrow==0.4.4
 beautifulsoup4==4.6.0
 lettuce==0.2.20
 requests==2.11.1
-wsgiref==0.1.2
 lxml==4.1.1
 xlrd==0.9.3
 git+https://github.com/elifesciences/elife-tools.git@df537e13da03accf1f4dee83c6c0892742860b07#egg=elifetools
@@ -18,7 +17,7 @@ git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 PyYAML==3.11
-Wand==0.4.0
+Wand==0.4.4
 paramiko==1.15.2
 mock==1.3.0
 redis==2.10.5

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -1,5 +1,5 @@
 from testfixtures import TempDirectory
-import test_activity_data as data
+import tests.activity.test_activity_data as data
 from shutil import copyfile, copyfileobj
 from shutil import copy
 import shutil
@@ -89,7 +89,7 @@ class FakeStorageContext:
         self.dir = directory
 
     def get_bucket_and_key(self, resource):
-        p = re.compile(ur'(.*?)://(.*?)(/.*)')
+        p = re.compile(r'(.*?)://(.*?)(/.*)')
         match = p.match(resource)
         protocol = match.group(1)
         bucket_name = match.group(2)

--- a/tests/activity/test_activity_convert_images_to_jpg.py
+++ b/tests/activity/test_activity_convert_images_to_jpg.py
@@ -1,10 +1,10 @@
 import unittest
 from activity.activity_ConvertImagesToJPG import activity_ConvertImagesToJPG
-import settings_mock
-from classes_mock import FakeLogger
-from classes_mock import FakeStorageContext
-from classes_mock import FakeSession
-import test_activity_data as test_activity_data
+from tests.activity import settings_mock
+from tests.activity.classes_mock import FakeLogger
+from tests.activity.classes_mock import FakeStorageContext
+from tests.activity.classes_mock import FakeSession
+from tests.activity import test_activity_data
 from mock import patch
 
 

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -1,8 +1,8 @@
 import json
-import classes_mock
+import tests.activity.classes_mock
 import base64
 
-xml_content_for_xml_key = open("tests/test_data/content_for_test_origin.xml", "r").read()
+xml_content_for_xml_key = open("tests/test_data/content_for_test_origin.xml", "rb").read()
 
 bucket_origin_file_name = "test_origin.xml"
 bucket_dest_file_name = "test_dest.json"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = True
+envlist = py27,py35
+[testenv]
+deps = -rrequirements.txt
+commands = coverage run -m pytest


### PR DESCRIPTION
Today I didn't set out to do this, I guess due to recent library changes and features, I explored the scope of the Python 3 upgrade. A very old internal tracking ticket https://github.com/elifesciences/jira-import/issues/4062.

Trying out ``tox``, first of all the changes to ``requirements.txt`` was needed to get a Python 3.5 environment possible to install. I think ``wsgiref`` is not required (after a quick search I don't see it used anywhere). ``Wand`` needed to be upgraded to install on Python 3.

There are numerous errors in the Python 3 side of things right now when trying to run ``tox``. To continue the attempt, I concentrated on the ``ConvertImagesToJPG`` activity, since it is the one that invokes ``Wand``.

Imports of the base ``activity`` object was problematic. What I came up with was first to create a properly named ``Activity`` object (at the bottom of ``activity.py``), and then fixed the import syntax to use the ``.`` relative form of importing, so it is compatible in both Python 2 and 3 without relying on exception handling.

The rest of the changes are mostly import path changes, and also Python 3 didn't like ``'u'`` in the regular expression patterns.

There was also an issue in Python 3 trying to "concatenate" filter results (see https://github.com/elifesciences/elife-bot/blob/3a9faa44c5d836ae9c0f33797ee7eaaf69c68494/activity/activity_ConvertImagesToJPG.py#L51) which I switched over to explicitly list concatenation. Maybe before it was trying to string concatenate when it shouldn't have.

I hope this description is useful in reviewing. For now, I think to reach full Python 3 support, these basics are required (especially the installation requirements changes), and then incrementally work on each failing test case, and merge them in like this if it is compatible with both Python 2 and 3. Then we can do it one bite at a time.
