### PR TITLE
Remove Crossref activity reference to bucket prefix

### DIFF
--- a/activity/activity_ScheduleCrossref.py
+++ b/activity/activity_ScheduleCrossref.py
@@ -37,8 +37,7 @@ class activity_ScheduleCrossref(activity.activity):
 
         self.expanded_bucket_name = (self.settings.publishing_buckets_prefix
                                      + self.settings.expanded_bucket)
-        self.crossref_bucket_name = (self.settings.publishing_buckets_prefix
-                                     + self.settings.poa_packaging_bucket)
+        self.crossref_bucket_name = self.settings.poa_packaging_bucket
 
         run = data['run']
         session = get_session(self.settings, data, run)


### PR DESCRIPTION
Yet another place in which the prefix can go. The corresponding `DepositCrossref` activity seems already not to use it.

Spawned by seeing:

```
$ aws s3 ls end2end-elife-poa-packaging-end2end/
PRE crossref/
```

I should be able to delete that bucket after this change, in favor of
`elife-poa-packaging-end2end`.