### PR TITLE
DepositCrossref python 3 support

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -29,7 +29,8 @@ DepositCrossref activity
 class activity_DepositCrossref(Activity):
 
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
-        Activity.__init__(self, settings, logger, conn, token, activity_task)
+        super(activity_DepositCrossref, self).__init__(
+            settings, logger, conn, token, activity_task)
 
         self.name = "DepositCrossref"
         self.version = "1"

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -8,7 +8,7 @@ import requests
 import glob
 import re
 
-import activity
+from .activity import Activity
 
 import boto.s3
 from boto.s3.connection import S3Connection
@@ -26,10 +26,10 @@ from elifearticle.article import ArticleDate
 DepositCrossref activity
 """
 
-class activity_DepositCrossref(activity.activity):
+class activity_DepositCrossref(Activity):
 
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
-        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+        Activity.__init__(self, settings, logger, conn, token, activity_task)
 
         self.name = "DepositCrossref"
         self.version = "1"
@@ -103,7 +103,7 @@ class activity_DepositCrossref(activity.activity):
 
             if self.publish_status is True:
                 # Clean up outbox
-                print "Moving files from outbox folder to published folder"
+                print("Moving files from outbox folder to published folder")
                 self.clean_outbox()
                 self.upload_crossref_xml_to_s3()
                 self.outbox_status = True

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -52,7 +52,7 @@ def article_next_version(article_id, settings):
 
 def article_version_date_by_version(article_id, version, settings):
     status_code, data = article_versions(article_id, settings)
-    print data
+    print(data)
     if status_code == 200:
         version_data = (vd for vd in data if vd["version"] == int(version)).next()
         return parse(version_data["versionDate"]).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -62,7 +62,7 @@ def article_version_date_by_version(article_id, version, settings):
 def article_publication_date(article_id, settings, logger=None):
     status_code, data = article_versions(article_id, settings)
     if status_code == 200:
-        first_published_version_list = filter(lambda x: int(x["version"]) == 1, data)
+        first_published_version_list = list(filter(lambda x: int(x["version"]) == 1, data))
         if len(first_published_version_list) < 1:
             return None
         first_published_version = first_published_version_list[0]

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -62,7 +62,7 @@ def article_version_date_by_version(article_id, version, settings):
 def article_publication_date(article_id, settings, logger=None):
     status_code, data = article_versions(article_id, settings)
     if status_code == 200:
-        first_published_version_list = list(filter(lambda x: int(x["version"]) == 1, data))
+        first_published_version_list = [x for x in data if int(x['version']) == 1]
         if len(first_published_version_list) < 1:
             return None
         first_published_version = first_published_version_list[0]

--- a/provider/s3lib.py
+++ b/provider/s3lib.py
@@ -88,7 +88,7 @@ def latest_pmc_zip_revision(doi_id, s3_key_names):
         highest_revision = None
         for key_name in name_matches:
 
-            revision_match = re.match(ur'.*r(.*)\.zip$', key_name)
+            revision_match = re.match(r'.*r(.*)\.zip$', key_name)
 
             if revision_match is None:
                 if highest_revision is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyOpenSSL==16.2.0
 newrelic==2.72.0.52
 pylint==1.6.4
 pyGithub==1.27.1
-pyFunctional==1.1.3
+pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
 git+https://github.com/elifesciences/digest-parser.git@55c0e21abccb65fe361f78d9edc28ffb3c8ec708#egg=digestparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.48.0
 Fom==0.9.10
-GitPython==0.3.2.1
+GitPython==2.1.11
 Jinja2==2.7.3
 PyPDF2==1.23
 arrow==0.4.4
@@ -31,7 +31,7 @@ pyOpenSSL==16.2.0
 newrelic==2.72.0.52
 pylint==1.6.4
 pyGithub==1.27.1
-pyFunctional==1.0.0
+pyFunctional==1.1.3
 func_timeout==4.3.0
 python-docx==0.8.6
 git+https://github.com/elifesciences/digest-parser.git@55c0e21abccb65fe361f78d9edc28ffb3c8ec708#egg=digestparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pyOpenSSL==16.2.0
 newrelic==2.72.0.52
 pylint==1.6.4
 pyGithub==1.27.1
+six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -119,7 +119,7 @@ class TestDepositCrossref(unittest.TestCase):
             # Open the first crossref XML and check some of its contents
             crossref_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
             with open(crossref_xml_filename_path, 'rb') as fp:
-                crossref_xml = fp.read()
+                crossref_xml = fp.read().decode('utf8')
                 for expected in test_data.get("expected_crossref_xml_contains"):
                     self.assertTrue(
                         expected in crossref_xml, '{expected} not found in crossref_xml {path}'.format(


### PR DESCRIPTION
Small changes to get the ``DepositCrossref`` activity to be Python 3 compatible - ``print`` with parentheses, cast a filter result as a ``list``, remove the ``'u'`` from regular expression pattern, ``decode()`` some content in tests.

GitPython requirement needs upgrading, and included six 1.10.0 for best compatibility with pyFunctional.