### PR TITLE
Use BytesIO in the imageresize provider and passing tests for it.

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 
 from wand.image import Image
 
@@ -35,7 +35,7 @@ def resize(format, filep, info, logger):
             if target_height is not image.height or target_width is not image.width:
                 image.resize(width=target_width, height=target_height)
 
-            image_buffer = StringIO.StringIO()
+            image_buffer = BytesIO()
             image.save(file=image_buffer)
 
     except Exception as e:

--- a/tests/provider/test_imageresize.py
+++ b/tests/provider/test_imageresize.py
@@ -1,0 +1,28 @@
+import unittest
+import provider.imageresize as resizer
+import provider.article_structure as article_structure
+from tests.activity.classes_mock import FakeLogger
+
+
+FORMATS = {
+    "Original": {
+        "sources": "tif",
+        "format": "jpg",
+        "download": "yes"
+        }}
+
+
+class TestImageresize(unittest.TestCase):
+
+    def test_resize(self):
+        file_name = 'tests/files_source/elife-00353-fig1-v1.tif'
+        info = article_structure.ArticleInfo(file_name)
+        format_spec = FORMATS.get('Original')
+        new_file_name = None
+        image_buffer = None
+        expected_file_name = 'tests/files_source/elife-00353-fig1-v1.jpg'
+        with open(file_name, 'rb') as open_file:
+            new_file_name, image_buffer = resizer.resize(
+                format_spec, open_file, info, FakeLogger())
+        self.assertEqual(new_file_name, expected_file_name)
+        self.assertIsNotNone(image_buffer)


### PR DESCRIPTION
Should hopefully fix the error reported in end2end tests for merged PR https://github.com/elifesciences/elife-bot/pull/733, this provider was not covered in unit tests.