### PR TITLE
Switch back to python 2 compatible only StringIO.

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from StringIO import StringIO
 
 from wand.image import Image
 
@@ -35,7 +35,7 @@ def resize(format, filep, info, logger):
             if target_height is not image.height or target_width is not image.width:
                 image.resize(width=target_width, height=target_height)
 
-            image_buffer = BytesIO()
+            image_buffer = StringIO()
             image.save(file=image_buffer)
 
     except Exception as e:


### PR DESCRIPTION
The Alfred build is not completing, I don't think this is the issue but I'll give it a try. This is basically reversing the Python 3 compatible attempt where ``StringIO`` was used, back to the original. If it builds we can run with this until there is time to debug the build.