### PR TITLE
Upgrade paramiko.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc98
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 PyYAML==3.11
 Wand==0.4.4
-paramiko==1.15.2
+paramiko==2.4.1
 mock==1.3.0
 redis==2.10.5
 testfixtures==4.9.1


### PR DESCRIPTION
Fixes https://github.com/elifesciences/jira-import/issues/4320.

There are no tests specifically for the ``sftp.py`` provider, though the tests for the ``FTPArticle`` activity imports the provider. I tested this newer version of ``paramiko`` on my local system with some test settings, and it transferred a file by SFTP correctly.

If we are to have tests for SFTP I think they would fit better as an end2end test (a note to @giorgiosironi, you're probably already aware). Mocking the ``sftp.py`` provider in tests doesn't really test making real connections and what could happen in the wild.

The plan here, as I mentioned in the ticket and on Slack, is we can just merge this (provided unit tests pass), and deploy. Tomorrow I will check whether the downstream recipients who we connect with by SFTP are completed smoothly.