### PR TITLE
Downgrade to Wand==0.4.2 as an experiment, and use BytesIO, …

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+from io import BytesIO
 
 from wand.image import Image
 
@@ -35,7 +35,7 @@ def resize(format, filep, info, logger):
             if target_height is not image.height or target_width is not image.width:
                 image.resize(width=target_width, height=target_height)
 
-            image_buffer = StringIO()
+            image_buffer = BytesIO()
             image.save(file=image_buffer)
 
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 PyYAML==3.11
-Wand==0.4.4
+Wand==0.4.2
 paramiko==2.4.1
 mock==1.3.0
 redis==2.10.5


### PR DESCRIPTION
for Python 3 support.

Due to some memory issues discussed in https://github.com/elifesciences/jira-import/issues/4353, rather than reverting back to Wand 0.4.0 right away, Wand 0.4.2 will install on Python 3, and I will experiment to see if the end2end tests will pass with this particular version.