### PR TITLE
Improvements to EmailDigest activity

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -75,15 +75,14 @@ class activity_EmailDigest(Activity):
             self.activity_status = True
 
         # Approve files for emailing
-        # todo!!!
-        self.approve_status = True
+        self.approve_status, error_message = approve_sending(self.digest)
 
-        if self.approve_status is True:
-            # Email files
-            if self.generate_status is True:
-                self.email_status = self.email_digest(self.digest, output_file)
-            else:
-                self.email_status = self.email_error_report(real_filename)
+        if self.approve_status is True and self.generate_status is True:
+            # Email file
+            self.email_status = self.email_digest(self.digest, output_file)
+        else:
+            # Send error email
+            self.email_status = self.email_error_report(real_filename, error_message)
 
         # return a value based on the activity_status
         if self.activity_status is True:
@@ -154,10 +153,10 @@ class activity_EmailDigest(Activity):
                 success = False
         return success
 
-    def email_error_report(self, filename):
+    def email_error_report(self, filename, error_message=None):
         "send an email on error"
         current_time = time.gmtime()
-        body = error_email_body(current_time)
+        body = error_email_body(current_time, error_message)
         subject = error_email_subject(filename)
         sender_email = self.settings.digest_sender_email
 
@@ -185,6 +184,23 @@ class activity_EmailDigest(Activity):
             except OSError:
                 pass
 
+
+def approve_sending(digest_content):
+    "validate the data for whether it is suitable to email"
+    approve_status = True
+    error_message = ''
+
+    if not digest_content:
+        approve_status = False
+        error_message += '\nDigest was empty'
+    if digest_content and not digest_content.author:
+        approve_status = False
+        error_message += '\nDigest author is missing'
+    if digest_content and not digest_content.doi:
+        approve_status = False
+        error_message += '\nDigest DOI is missing'
+
+    return approve_status, error_message
 
 def output_file_name(digest_content):
     "from the digest content return the file name for the DOCX output"
@@ -224,12 +240,14 @@ def error_email_subject(filename):
     return u'Error processing digest file: {filename}'.format(filename=filename)
 
 
-def error_email_body(current_time):
+def error_email_body(current_time, error_message=None):
     "body of an error email"
     body = ""
+    if error_message:
+        body += str(error_message)
     date_format = '%Y-%m-%dT%H:%M:%S.000Z'
     datetime_string = time.strftime(date_format, current_time)
-    body += "As at " + datetime_string + "\n"
+    body += "\nAs at " + datetime_string + "\n"
     body += "\n"
     body += "\n\nSincerely\n\neLife bot"
     return body

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -202,7 +202,7 @@ def success_email_subject(digest_content):
         msid = doi.split(".")[-1]
     except AttributeError:
         msid = None
-    return 'Digest: {author}_{msid}'.format(author=digest_content.author, msid=msid)
+    return u'Digest: {author}_{msid}'.format(author=digest_content.author, msid=msid)
 
 
 def success_email_body(current_time):

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -189,12 +189,8 @@ def output_file_name(digest_content):
     "from the digest content return the file name for the DOCX output"
     if not digest_content:
         return
-    try:
-        doi = getattr(digest_content, 'doi')
-        msid = doi.split(".")[-1]
-    except AttributeError:
-        msid = None
-    return '{author}_{msid:0>5}.docx'.format(author=digest_content.author, msid=msid)
+    # use the digestparser library to generate the output docx file name
+    return output.docx_file_name(digest_content)
 
 
 def success_email_subject(digest_content):

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -202,7 +202,7 @@ def success_email_subject(digest_content):
         msid = doi.split(".")[-1]
     except AttributeError:
         msid = None
-    return u'Digest: {author}_{msid}'.format(author=digest_content.author, msid=msid)
+    return u'Digest: {author}_{msid:0>5}'.format(author=digest_content.author, msid=msid)
 
 
 def success_email_body(current_time):
@@ -220,7 +220,7 @@ def success_email_body(current_time):
 
 def error_email_subject(filename):
     "email subject for an error email"
-    return 'Error processing digest file: {filename}'.format(filename=filename)
+    return u'Error processing digest file: {filename}'.format(filename=filename)
 
 
 def error_email_body(current_time):

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -5,17 +5,18 @@ import traceback
 import boto.swf
 from digestparser import build, output
 from docx.opc.exceptions import PackageNotFoundError
-import activity
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider.storage_provider import storage_context
 import provider.email_provider as email_provider
 import provider.utils as utils
+from .activity import Activity
 
 
-class activity_EmailDigest(activity.activity):
+class activity_EmailDigest(Activity):
     "EmailDigest activity"
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
-        activity.activity.__init__(self, settings, logger, conn, token, activity_task)
+        super(activity_EmailDigest, self).__init__(
+            settings, logger, conn, token, activity_task)
 
         self.name = "EmailDigest"
         self.version = "1"
@@ -88,7 +89,7 @@ class activity_EmailDigest(activity.activity):
         if self.activity_status is True:
             return True
 
-        return activity.activity.ACTIVITY_PERMANENT_FAILURE
+        return self.ACTIVITY_PERMANENT_FAILURE
 
     def download_digest_from_s3(self, filename, bucket_name, bucket_folder):
         "Connect to the S3 bucket and download the input"
@@ -202,7 +203,7 @@ def success_email_subject(digest_content):
         msid = doi.split(".")[-1]
     except AttributeError:
         msid = None
-    return u'Digest: {author}_{msid:0>5}'.format(author=digest_content.author, msid=msid)
+    return u'Digest: {author}_{msid:0>5}'.format(author=digest_content.author, msid=str(msid))
 
 
 def success_email_body(current_time):

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -82,7 +82,7 @@ class activity_EmailDigest(activity.activity):
             if self.generate_status is True:
                 self.email_status = self.email_digest(self.digest, output_file)
             else:
-                self.email_status = self.email_error_report(filename)
+                self.email_status = self.email_error_report(real_filename)
 
         # return a value based on the activity_status
         if self.activity_status is True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@55c0e21abccb65fe361f78d9edc28ffb3c8ec708#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@1915547a103331ca5f1de127dfe4a6b29f774263#egg=digestparser

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -187,5 +187,24 @@ class TestEmailDigestFileName(unittest.TestCase):
         self.assertEqual(file_name, expected)
 
 
+class TestEmailSubject(unittest.TestCase):
+
+    def test_success_email_subject(self):
+        "email subject line with correct, unicode data"
+        digest_content = Digest()
+        digest_content.author = u'Nö'
+        digest_content.doi = '10.7554/eLife.99999'
+        expected = u'Digest: Nö_99999'
+        subject = activity_module.success_email_subject(digest_content)
+        self.assertEqual(subject, expected)
+
+    def test_success_email_subject_bad_object(self):
+        "email subject line when digest is None"
+        digest_content = None
+        expected = None
+        subject = activity_module.success_email_subject(digest_content)
+        self.assertEqual(subject, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -198,11 +198,25 @@ class TestEmailSubject(unittest.TestCase):
         subject = activity_module.success_email_subject(digest_content)
         self.assertEqual(subject, expected)
 
+    def test_success_email_subject_no_doi(self):
+        "email subject line when no doi attribute"
+        digest_content = Digest()
+        expected = u'Digest: None_0None'
+        file_name = activity_module.success_email_subject(digest_content)
+        self.assertEqual(file_name, expected)
+
     def test_success_email_subject_bad_object(self):
         "email subject line when digest is None"
         digest_content = None
         expected = None
         subject = activity_module.success_email_subject(digest_content)
+        self.assertEqual(subject, expected)
+
+    def test_error_email_subject(self):
+        "email subject for error emails with a unicode filename"
+        filename = u'DIGESTö 99999.zip'
+        expected = u'Error processing digest file: DIGESTö 99999.zip'
+        subject = activity_module.error_email_subject(filename)
         self.assertEqual(subject, expected)
 
 

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import os
 import glob
 import unittest
@@ -158,6 +160,15 @@ class TestEmailDigestFileName(unittest.TestCase):
         digest_content.author = 'Anonymous'
         digest_content.doi = '10.7554/eLife.99999'
         expected = 'Anonymous_99999.docx'
+        file_name = activity_module.output_file_name(digest_content)
+        self.assertEqual(file_name, expected)
+
+    def test_output_file_name_unicode(self):
+        "docx output file name with unicode author name"
+        digest_content = Digest()
+        digest_content.author = u'Nö'
+        digest_content.doi = '10.7554/eLife.99999'
+        expected = u'Nö_99999.docx'
         file_name = activity_module.output_file_name(digest_content)
         self.assertEqual(file_name, expected)
 

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -143,7 +143,7 @@ class TestEmailDigest(unittest.TestCase):
             self.assertEqual(len(email_files), test_data.get("expected_email_count"))
             # can look at the first email for the subject and sender
             first_email_content = None
-            with open(email_files[0], 'rb') as open_file:
+            with open(email_files[0]) as open_file:
                 first_email_content = open_file.read()
             if first_email_content:
                 if test_data.get("expected_email_subject"):


### PR DESCRIPTION
Includes deploying a newer ``digest-parser`` library, with the fix for issue https://github.com/elifesciences/digest-parser/issues/30 regarding unicode author names.

Added ``approve_sending()`` too, to require the author and DOI to be specified, otherwise send the error email.

Also some changes to make the activity and test Python 3 compatible.