### PR TITLE
Load the digest.cfg configuration in EmailDigest activity

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -108,6 +108,8 @@ class exp():
     ses_pmc_revision_recipient_email = "sender@example.com"
 
     # Digest email settings
+    digest_config_file = 'digest.cfg'
+    digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"
@@ -305,6 +307,8 @@ class dev():
     ses_pmc_revision_recipient_email = "sender@example.com"
 
     # Digest email settings
+    digest_config_file = 'digest.cfg'
+    digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"
@@ -502,6 +506,8 @@ class live():
     ses_pmc_revision_recipient_email = "sender@example.com"
 
     # Digest email settings
+    digest_config_file = 'digest.cfg'
+    digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"

--- a/tests/activity/digest.cfg
+++ b/tests/activity/digest.cfg
@@ -1,0 +1,29 @@
+[DEFAULT]
+medium_title_pattern: <h1>{digest_title}</h1>
+medium_summary_pattern: <h2>{digest_summary}</h2>
+medium_paragraph_pattern: <p>{text}</p>
+medium_image_url: {file_name}
+medium_figcaption_pattern: <figcaption>{caption}{credit}{license}</figcaption>
+medium_figure_pattern: <figure><img src="{image_url}" />{figcaption}</figure>
+medium_footer_pattern: 
+medium_content_pattern: {figure}{title}{summary}<hr/>{body}{footer}
+medium_content_format: html
+medium_license: 
+# Medium application settings
+medium_application_client_id:
+medium_application_client_secret:
+# Medium user settings
+medium_access_token:
+# DOCX output
+output_file_name_pattern: {author}_{msid:0>5}.docx
+# IIIF image server settings
+iiif_image_uri:
+iiif_image_source_uri:
+iiif_info_url: 
+
+[elife]
+medium_license: cc-40-by
+medium_image_url: https://iiif.elifesciences.org/digests:{msid:0>5}%2F{file_name}/full/full/0/default.jpg
+iiif_image_uri: https://iiif.elifesciences.org/digests:{msid:0>5}%2F{file_name}
+iiif_image_source_uri: https://iiif.elifesciences.org/digests:{msid:0>5}%2F{file_name}/full/full/0/default.jpg
+iiif_info_url: https://prod--iiif.elifesciences.org/digests:{msid:0>5}%2F{file_name}/info.json

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -46,6 +46,8 @@ ses_pmc_sender_email = ""
 ses_pmc_recipient_email = ""
 ses_pmc_revision_recipient_email = ["e@example.org", "life@example.org"]
 
+digest_config_file = 'tests/activity/digest.cfg'
+digest_config_section = 'elife'
 digest_sender_email = "sender@example.org"
 digest_recipient_email = ["e@example.org", "life@example.org"]
 digest_error_recipient_email = "error@example.org"

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -221,6 +221,17 @@ class TestEmailDigestFileName(unittest.TestCase):
         file_name = activity_module.output_file_name(digest_content)
         self.assertEqual(file_name, expected)
 
+    def test_output_file_name_using_cfg_file(self):
+        "docx output file name with good input"
+        # instantiate an activity object to get its digest_config
+        fake_logger = FakeLogger()
+        activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # continue
+        digest_content = create_digest('Anonymous', '10.7554/eLife.99999')
+        expected = 'Anonymous_99999.docx'
+        file_name = activity_module.output_file_name(digest_content, activity.digest_config)
+        self.assertEqual(file_name, expected)
+
     def test_output_file_name_unicode(self):
         "docx output file name with unicode author name"
         digest_content = create_digest(u'Nö', '10.7554/eLife.99999')


### PR DESCRIPTION
Load the digest.cfg configuration in EmailDigest activity, and tests for the output_file_name.

Should not be merged or deployed before the settings changes of PR https://github.com/elifesciences/builder-private/pull/210 are merged.

Makes it so the ``.docx`` file name is set by the configuration file, in case someone does specify it there. The config file will be more important in other activities than in ``EmailDigest`` particularly.