### PR TITLE
Copy digest to outbox

### DIFF
--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -28,10 +28,6 @@ class activity_CopyDigestToOutbox(Activity):
         self.description = ("Copies the Digest files to a bucket folder for later use" +
                             " in article ingestion")
 
-        # Track some values
-        self.input_file = None
-        self.digest = None
-
         # Local directory settings
         self.temp_dir = os.path.join(self.get_tmp_dir(), "tmp_dir")
         self.input_dir = os.path.join(self.get_tmp_dir(), "input_dir")
@@ -39,22 +35,19 @@ class activity_CopyDigestToOutbox(Activity):
         # Create output directories
         self.create_activity_directories()
 
-        # Track the success of some steps
-        self.build_status = None
-
     def do_activity(self, data=None):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
         # parse the data with the digest_provider
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
         # Download from S3
-        self.input_file = digest_provider.download_digest_from_s3(
+        input_file = digest_provider.download_digest_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder, self.input_dir)
         # Parse input and build digest
-        self.build_status, self.digest = digest_provider.build_digest(
-            self.input_file, self.temp_dir, self.logger)
+        build_status, digest = digest_provider.build_digest(
+            input_file, self.temp_dir, self.logger)
 
-        if not self.build_status:
+        if not build_status:
             self.logger.info("Failed to build the Digest in Copy Digest To Outbox for %s",
                              real_filename)
             return self.ACTIVITY_PERMANENT_FAILURE
@@ -65,14 +58,14 @@ class activity_CopyDigestToOutbox(Activity):
         bucket_name = self.settings.bot_bucket
 
         # clean out the outbox if not empty
-        self.clean_outbox(self.digest, bucket_name)
+        self.clean_outbox(digest, bucket_name)
 
         # copy the files to S3
         # if it is zip file take the files from the temp_dir, otherwise from the input_dir
         from_dir = self.input_dir
-        if self.input_file.endswith('.zip'):
+        if input_file.endswith('.zip'):
             from_dir = self.temp_dir
-        self.copy_files_to_outbox(self.digest, bucket_name, from_dir)
+        self.copy_files_to_outbox(digest, bucket_name, from_dir)
 
         return self.ACTIVITY_SUCCESS
 

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -54,9 +54,27 @@ class activity_CopyDigestToOutbox(Activity):
                              real_filename)
             return self.ACTIVITY_PERMANENT_FAILURE
 
-        # todo!!  the rest of the logic
+        # continue with copying files now
+
+        # bucket name
+        bucket_name = self.settings.bot_bucket
+
 
         return self.ACTIVITY_SUCCESS
+
+    def dest_resource_path(self, digest, bucket_name):
+        "the bucket folder where files will be saved"
+        msid = utils.msid_from_doi(digest.doi)
+        article_id = utils.pad_msid(msid)
+        storage_provider = self.settings.storage_provider + "://"
+        return storage_provider + bucket_name + "/digests/outbox/" + article_id + "/"
+
+    def file_dest_resource(self, digest, bucket_name, file_path):
+        "concatenate the S3 bucket object path we copy the file to"
+        resource_path = self.dest_resource_path(digest, bucket_name)
+        file_name = file_path.split(os.sep)[-1]
+        dest_resource = resource_path + file_name
+        return dest_resource
 
     def create_activity_directories(self):
         """

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -86,7 +86,10 @@ class activity_CopyDigestToOutbox(Activity):
         "concatenate the S3 bucket object path we copy the file to"
         resource_path = self.dest_resource_path(digest, bucket_name)
         file_name = file_path.split(os.sep)[-1]
-        dest_resource = resource_path + file_name
+        new_file_name = digest_provider.new_file_name(
+            msid=utils.msid_from_doi(digest.doi),
+            file_name=file_name)
+        dest_resource = resource_path + new_file_name
         return dest_resource
 
     def clean_outbox(self, digest, bucket_name):

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -101,8 +101,8 @@ class activity_CopyDigestToOutbox(Activity):
         storage = storage_context(self.settings)
         for file_path in file_list:
             resource_dest = self.file_dest_resource(digest, bucket_name, file_path)
+            self.logger.info("Copying %s to %s", file_path, resource_dest)
             storage.set_resource_from_filename(resource_dest, file_path)
-            self.logger.info("Copied %s to %s", file_path, resource_dest)
 
     def create_activity_directories(self):
         """

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -64,7 +64,7 @@ class activity_CopyDigestToOutbox(Activity):
         bucket_name = self.settings.bot_bucket
 
         # clean out the outbox if not empty
-        # todo!!!
+        self.clean_outbox(self.digest, bucket_name)
 
         # copy the files to S3
         # if it is zip file take the files from the temp_dir, otherwise from the input_dir
@@ -88,6 +88,15 @@ class activity_CopyDigestToOutbox(Activity):
         file_name = file_path.split(os.sep)[-1]
         dest_resource = resource_path + file_name
         return dest_resource
+
+    def clean_outbox(self, digest, bucket_name):
+        "remove files from the outbox folder"
+        resource_path = self.dest_resource_path(digest, bucket_name)
+        storage = storage_context(self.settings)
+        files_in_bucket = storage.list_resources(resource_path)
+        for resource in files_in_bucket:
+            self.logger.info("Deleting %s from the outbox", resource)
+            storage.delete_resource(resource)
 
     def copy_files_to_outbox(self, digest, bucket_name, from_dir):
         "copy all the files from the from_dir to the bucket"

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -37,6 +37,9 @@ class activity_CopyDigestToOutbox(Activity):
         # Create output directories
         self.create_activity_directories()
 
+        # Track the success of some steps
+        self.build_status = None
+
     def do_activity(self, data=None):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
@@ -58,7 +61,6 @@ class activity_CopyDigestToOutbox(Activity):
 
         # bucket name
         bucket_name = self.settings.bot_bucket
-
 
         return self.ACTIVITY_SUCCESS
 

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -1,0 +1,69 @@
+import os
+import json
+from S3utility.s3_notification_info import parse_activity_data
+from provider.storage_provider import storage_context
+import provider.digest_provider as digest_provider
+import provider.utils as utils
+from .activity import Activity
+
+
+"""
+activity_CopyDigestToOutbox.py activity
+"""
+
+
+class activity_CopyDigestToOutbox(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_CopyDigestToOutbox, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "CopyDigestToOutbox"
+        self.pretty_name = "Copy Digest files to an outbox"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Copies the Digest files to a bucket folder for later use"
+
+        # Track some values
+        self.input_file = None
+        self.digest = None
+
+        # Local directory settings
+        self.temp_dir = os.path.join(self.get_tmp_dir(), "tmp_dir")
+        self.input_dir = os.path.join(self.get_tmp_dir(), "input_dir")
+
+        # Create output directories
+        self.create_activity_directories()
+
+    def do_activity(self, data=None):
+        if self.logger:
+            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        # parse the data with the digest_provider
+        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+        # Download from S3
+        self.input_file = digest_provider.download_digest_from_s3(
+            self.settings, real_filename, bucket_name, bucket_folder, self.input_dir)
+        # Parse input and build digest
+        self.build_status, self.digest = digest_provider.build_digest(
+            self.input_file, self.temp_dir, self.logger)
+
+        if not self.build_status:
+            self.logger.info("Failed to build the Digest in Copy Digest To Outbox for %s",
+                             real_filename)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # todo!!  the rest of the logic
+
+        return self.ACTIVITY_SUCCESS
+
+    def create_activity_directories(self):
+        """
+        Create the directories in the activity tmp_dir
+        """
+        for dir_name in [self.temp_dir, self.input_dir]:
+            try:
+                os.mkdir(dir_name)
+            except OSError:
+                pass

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -25,7 +25,8 @@ class activity_CopyDigestToOutbox(Activity):
         self.default_task_schedule_to_close_timeout = 60 * 5
         self.default_task_schedule_to_start_timeout = 30
         self.default_task_start_to_close_timeout = 60 * 5
-        self.description = "Copies the Digest files to a bucket folder for later use"
+        self.description = ("Copies the Digest files to a bucket folder for later use" +
+                            " in article ingestion")
 
         # Track some values
         self.input_file = None

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -21,6 +21,13 @@ def build_digest(input_file, temp_dir, logger=None):
     return True, digest
 
 
+def new_file_name(file_name, msid):
+    "new name for the files stored for internal use"
+    if file_name and file_name.endswith('.docx'):
+        return 'digest-{msid:0>5}.docx'.format(msid=msid)
+    return file_name
+
+
 def digest_resource_origin(storage_provider, filename, bucket_name, bucket_folder):
     "concatenate the origin of a digest file for the storage provider"
     if not filename or not bucket_name or bucket_folder is None:

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -25,7 +25,10 @@ def new_file_name(file_name, msid):
     "new name for the files stored for internal use"
     if file_name and file_name.endswith('.docx'):
         return 'digest-{msid:0>5}.docx'.format(msid=msid)
-    return file_name
+    else:
+        # current only one optional image will be in a package, rename it too
+        extension = file_name.split('.')[-1]
+        return 'digest-{msid:0>5}.{extension}'.format(msid=msid, extension=extension)
 
 
 def digest_resource_origin(storage_provider, filename, bucket_name, bucket_folder):

--- a/register.py
+++ b/register.py
@@ -103,6 +103,7 @@ def start(ENV="dev"):
     activity_names.append("ModifyArticleSubjects")
     activity_names.append("EmailDigest")
     activity_names.append("DepositDigestIngestAssets")
+    activity_names.append("CopyDigestToOutbox")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -112,9 +112,11 @@ class FakeStorageContext:
     def get_resource_as_string(self, origin):
         return '<mock><media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="wmv" mimetype="video" xlink:href="elife-00569-media1.wmv"></media></mock>'
 
-    def set_resource_from_filename(self, resource, file):
-        #bucket_name, s3_key = self.get_bucket_and_key(resource)
-        copy(file, data.ExpandArticle_files_dest_folder)
+    def set_resource_from_filename(self, resource, file_name):
+        "resource name can be different than the file name"
+        to_file_name = resource.split('/')[-1]
+        dest = data.ExpandArticle_files_dest_folder + '/' + to_file_name
+        copy(file_name, dest)
 
     def set_resource_from_string(self, resource, data, content_type=None):
         pass

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -87,6 +87,7 @@ class FakeStorageContext:
     def __init__(self, directory=data.ExpandArticle_files_source_folder):
         "can instantiate specifying a data directory or use the default"
         self.dir = directory
+        self.resources = ["elife-00353-fig1-v1.tif", "elife-00353-v1.pdf", "elife-00353-v1.xml"]
 
     def get_bucket_and_key(self, resource):
         p = re.compile(r'(.*?)://(.*?)(/.*)')
@@ -119,13 +120,17 @@ class FakeStorageContext:
         pass
 
     def list_resources(self, resource):
-        return ["elife-00353-fig1-v1.tif", "elife-00353-v1.pdf", "elife-00353-v1.xml"]
+        return self.resources
 
     def copy_resource(self, origin, destination, additional_dict_metadata=None):
         pass
 
     def delete_resource(self, resource):
-        pass
+        # delete from the destination folder
+        bucket, s3_key = self.get_bucket_and_key(resource)
+        src = data.ExpandArticle_files_dest_folder + s3_key
+        if os.path.exists(src):
+            os.remove(src)
 
     def get_resource_to_file_pointer(self, resource, file_path):
         return None

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from ddt import ddt, data
+import provider.digest_provider as digest_provider
+from activity.activity_CopyDigestToOutbox import activity_CopyDigestToOutbox as activity_object
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeStorageContext
+import tests.activity.test_activity_data as testdata
+import tests.activity.helpers as helpers
+
+
+def input_data(file_name_to_change=None):
+    activity_data = test_case_data.ingest_digest_data
+    if file_name_to_change is not None:
+        activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestCopyDigestToOutbox(unittest.TestCase):
+
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+        # clean out the bucket destination folder
+        helpers.delete_files_in_folder(testdata.ExpandArticle_files_dest_folder,
+                                       filter_out=['.gitkeep'])
+
+    @patch.object(digest_provider, 'storage_context')
+    @patch('activity.activity_CopyDigestToOutbox.storage_context')
+    @data(
+        {
+            "comment": 'digest docx file example',
+            "filename": None,
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
+            "expected_digest_image_file": None,
+            "expected_dest_resource": None,
+            "expected_file_list": []
+        },
+        {
+            "comment": 'digest zip file example',
+            "filename": 'DIGEST+99999.zip',
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
+            "expected_digest_image_file": u'IMAGE 99999.jpeg',
+            "expected_dest_resource": 's3://ppd_cdn_bucket/digests/99999/IMAGE 99999.jpeg',
+            "expected_file_list": [u'IMAGE 99999.jpeg']
+        },
+        {
+            "comment": 'digest file does not exist example',
+            "filename": '',
+            "expected_digest_doi": None,
+            "expected_digest_image_file": None,
+            "expected_dest_resource": None,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+            "expected_file_list": []
+        },
+        {
+            "comment": 'bad digest docx file example',
+            "filename": 'DIGEST+99998.docx',
+            "expected_digest_doi": None,
+            "expected_digest_image_file": None,
+            "expected_dest_resource": None,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+            "expected_file_list": []
+        },
+    )
+    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context):
+        # copy XML files into the input directory using the storage context
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_provider_storage_context.return_value = FakeStorageContext()
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -41,28 +41,22 @@ class TestCopyDigestToOutbox(unittest.TestCase):
     @data(
         {
             "comment": 'digest docx file example',
-            "filename": None,
+            "filename": 'DIGEST+99999.docx',
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
-            "expected_digest_image_file": None,
-            "expected_dest_resource": None,
-            "expected_file_list": []
+            "expected_file_list": ['DIGEST 99999.docx']
         },
         {
             "comment": 'digest zip file example',
             "filename": 'DIGEST+99999.zip',
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
-            "expected_digest_image_file": u'IMAGE 99999.jpeg',
-            "expected_dest_resource": 's3://ppd_cdn_bucket/digests/99999/IMAGE 99999.jpeg',
-            "expected_file_list": [u'IMAGE 99999.jpeg']
+            "expected_file_list": ['DIGEST 99999.docx', 'IMAGE 99999.jpeg']
         },
         {
             "comment": 'digest file does not exist example',
             "filename": '',
             "expected_digest_doi": None,
-            "expected_digest_image_file": None,
-            "expected_dest_resource": None,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
             "expected_file_list": []
         },
@@ -70,8 +64,6 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "comment": 'bad digest docx file example',
             "filename": 'DIGEST+99998.docx',
             "expected_digest_doi": None,
-            "expected_digest_image_file": None,
-            "expected_dest_resource": None,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
             "expected_file_list": []
         },
@@ -85,6 +77,11 @@ class TestCopyDigestToOutbox(unittest.TestCase):
 
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        # Check destination folder as a list
+        files = sorted(os.listdir(testdata.ExpandArticle_files_dest_folder))
+        compare_files = [file_name for file_name in files if file_name != '.gitkeep']
+        self.assertEqual(compare_files, test_data.get("expected_file_list"),
                          'failed in {comment}'.format(comment=test_data.get("comment")))
 
     def test_dest_resource_path(self):

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -4,6 +4,7 @@ import os
 import unittest
 from mock import patch
 from ddt import ddt, data
+from digestparser.objects import Digest
 import provider.digest_provider as digest_provider
 from activity.activity_CopyDigestToOutbox import activity_CopyDigestToOutbox as activity_object
 import tests.activity.settings_mock as settings_mock
@@ -85,6 +86,26 @@ class TestCopyDigestToOutbox(unittest.TestCase):
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"),
                          'failed in {comment}'.format(comment=test_data.get("comment")))
+
+    def test_dest_resource_path(self):
+        "test building the path to the bucket folder"
+        digest = Digest()
+        digest.doi = '10.7554/eLife.99999'
+        bucket_name = 'elife-bot'
+        expected = 's3://elife-bot/digests/outbox/99999/'
+        resource_path = self.activity.dest_resource_path(digest, bucket_name)
+        self.assertEqual(resource_path, expected)
+
+    def test_file_dest_resource(self):
+        "test the bucket destination resource path for a file"
+        digest = Digest()
+        digest.doi = '10.7554/eLife.99999'
+        bucket_name = 'elife-bot'
+        # create a full path to test stripping out folder names
+        file_path = os.getcwd() + os.sep + 'DIGEST 99999.docx'
+        expected = 's3://elife-bot/digests/outbox/99999/DIGEST 99999.docx'
+        dest_resource = self.activity.file_dest_resource(digest, bucket_name, file_path)
+        self.assertEqual(dest_resource, expected)
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -53,7 +53,7 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "bucket_resources": ['s3://bucket/DIGEST 99999_alternate.docx'],
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
-            "expected_file_list": ['DIGEST 99999.docx']
+            "expected_file_list": ['digest-99999.docx']
         },
         {
             "comment": 'digest zip file example',
@@ -62,7 +62,7 @@ class TestCopyDigestToOutbox(unittest.TestCase):
                                  's3://bucket/DIGEST 99999_old.docx'],
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
-            "expected_file_list": ['DIGEST 99999.docx', 'IMAGE 99999.jpeg']
+            "expected_file_list": ['IMAGE 99999.jpeg', 'digest-99999.docx']
         },
         {
             "comment": 'digest file does not exist example',
@@ -116,7 +116,7 @@ class TestCopyDigestToOutbox(unittest.TestCase):
         bucket_name = 'elife-bot'
         # create a full path to test stripping out folder names
         file_path = os.getcwd() + os.sep + 'DIGEST 99999.docx'
-        expected = 's3://elife-bot/digests/outbox/99999/DIGEST 99999.docx'
+        expected = 's3://elife-bot/digests/outbox/99999/digest-99999.docx'
         dest_resource = self.activity.file_dest_resource(digest, bucket_name, file_path)
         self.assertEqual(dest_resource, expected)
 

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -52,7 +52,6 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "filename": 'DIGEST+99999.docx',
             "bucket_resources": ['s3://bucket/DIGEST 99999_alternate.docx'],
             "expected_result": activity_object.ACTIVITY_SUCCESS,
-            "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
             "expected_file_list": ['digest-99999.docx']
         },
         {
@@ -61,14 +60,12 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "bucket_resources": ['s3://bucket/IMAGE 99999.jpg',
                                  's3://bucket/DIGEST 99999_old.docx'],
             "expected_result": activity_object.ACTIVITY_SUCCESS,
-            "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
             "expected_file_list": ['IMAGE 99999.jpeg', 'digest-99999.docx']
         },
         {
             "comment": 'digest file does not exist example',
             "filename": '',
             "bucket_resources": [],
-            "expected_digest_doi": None,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
             "expected_file_list": []
         },
@@ -76,7 +73,6 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "comment": 'bad digest docx file example',
             "filename": 'DIGEST+99998.docx',
             "bucket_resources": [],
-            "expected_digest_doi": None,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
             "expected_file_list": []
         },

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -60,7 +60,7 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "bucket_resources": ['s3://bucket/IMAGE 99999.jpg',
                                  's3://bucket/DIGEST 99999_old.docx'],
             "expected_result": activity_object.ACTIVITY_SUCCESS,
-            "expected_file_list": ['IMAGE 99999.jpeg', 'digest-99999.docx']
+            "expected_file_list": [ 'digest-99999.docx', 'digest-99999.jpeg']
         },
         {
             "comment": 'digest file does not exist example',

--- a/tests/activity/test_activity_deposit_digest_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_digest_ingest_assets.py
@@ -41,7 +41,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
     @data(
         {
             "comment": 'digest docx file example',
-            "filename": None,
+            "filename": 'DIGEST+99999.docx',
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
             "expected_digest_image_file": None,

--- a/workflow/workflow_IngestDigest.py
+++ b/workflow/workflow_IngestDigest.py
@@ -67,6 +67,17 @@ class workflow_IngestDigest(workflow.workflow):
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 300
                     },
+                    {
+                        "activity_type": "CopyDigestToOutbox",
+                        "activity_id": "CopyDigestToOutbox",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 300
+                    },
                 ],
 
             "finish":


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4300
Fixes https://github.com/elifesciences/issues/issues/4302

A new ``CopyDigestToOutbox`` activity, complets the ``IngestDigest`` workflow.

Hopefully the time spent trying to read from the bucket, delete files, and upload files, all mocked using the test objects, will be useful because it was not pleasant to figure it all out. Not tested for real yet either, so hopefully the tests represent the real state of the buckets.

The ``.docx`` file is renamed as suggested in issue https://github.com/elifesciences/issues/issues/4300. The particular issue can probably be closed, since all the unknowns about file locations are filled in, though it is providing some details for later activities to be built that will read from the bucket the files kept in stasis.

Feedback and edits are welcome - thanks!