### PR TITLE
Update digestparser library, the last time for this file name fix  …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@6fc03184b720ba0cd00f44cdbdfc758ddafda12e#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@092b6c65aa1590119b17c5131780797ae25b5f12#egg=digestparser
 psutil==5.4.6


### PR DESCRIPTION
…(I hope).

Was able to recreate the bug on the bot instance using interactive python, if the file name pattern used for string ``format`` is not unicode then the error resembles what is happening in the ``EmailDigest`` activity. It looks like when the builder adds the ``digest.cfg`` file to the instance, it is not giving unicode values, whereas the ``digest.cfg`` file used in all the test cases seems to support unicode by default or is saved correctly in unicode.