### PR TITLE
digestparser changed and encoding fixes

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -95,16 +95,23 @@ class activity_EmailDigest(Activity):
             config_section,
             self.settings.digest_config_file))
 
+    def output_path(self, output_dir, file_name):
+        "for python 2 and 3 support, only encode sometimes"
+        try:
+            return os.path.join(output_dir, unicode_value(file_name)).encode('utf8')
+        except AttributeError:
+            return os.path.join(output_dir, unicode_value(file_name))
+
     def generate_output(self, digest_content):
         "From the parsed digest content generate the output"
         if not digest_content:
             return False, None
         file_name = output_file_name(digest_content, self.digest_config)
         self.logger.info('EmailDigest output file_name: %s', file_name)
-        full_file_name = output_file = os.path.join(self.output_dir, unicode_value(file_name))
+        full_file_name = self.output_path(self.output_dir, unicode_value(file_name))
         self.logger.info('EmailDigest output full_file_name: %s', full_file_name)
         try:
-            output_file = output.digest_docx(digest_content, full_file_name, '')
+            output_file = output.digest_docx(digest_content, full_file_name)
         except UnicodeEncodeError as exception:
             self.logger.exception("EmailDigest generate_output exception. Message: %s",
                                   exception.message)

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -6,6 +6,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import boto.ses
+from provider.utils import unicode_decode
 
 
 def ses_connect(settings):
@@ -54,7 +55,8 @@ def attachment(file_name,
     attachment_name = os.path.split(file_name)[-1]
     with open(file_name, 'rb') as open_file:
         email_attachment = MIMEApplication(open_file.read())
-    email_attachment.add_header('Content-Disposition', 'attachment', filename=attachment_name)
+    email_attachment.add_header('Content-Disposition', 'attachment',
+                                filename=unicode_decode(attachment_name))
     email_attachment.add_header('Content-Type', content_type_header)
     return email_attachment
 

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -52,3 +52,12 @@ def unquote_plus(string):
         # python 3
         return urllib.parse.unquote_plus(string)
     return urllib.unquote_plus(string)
+
+
+def unicode_decode(string):
+    "try to decode from utf8"
+    try:
+        string = string.decode('utf8')
+    except (UnicodeEncodeError, AttributeError):
+        pass
+    return string

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@092b6c65aa1590119b17c5131780797ae25b5f12#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@783b2f323379fa73cd6fc4a51901eb0411e95478#egg=digestparser
 psutil==5.4.6


### PR DESCRIPTION
digestparser changed to accept full file name for the output docx file, encode the path and file name in EmailDigest activity propertly for both python 2 and 3 support.

Will hopefully fix the character encoding issues, currently traced to the use of ``os.path.join`` in ``digestparser`` library that should be bypassed now.