### PR TITLE
Rename the digest image deposited to the CDN bucket.

### DIFF
--- a/activity/activity_DepositDigestIngestAssets.py
+++ b/activity/activity_DepositDigestIngestAssets.py
@@ -78,8 +78,9 @@ class activity_DepositDigestIngestAssets(Activity):
         article_id = utils.pad_msid(msid)
         # file name from the digest image file
         file_name = digest.image.file.split(os.sep)[-1]
+        new_file_name = digest_provider.new_file_name(file_name, msid)
         storage_provider = self.settings.storage_provider + "://"
-        dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
+        dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + new_file_name
         return dest_resource
 
     def deposit_digest_image(self, digest, cdn_bucket_name):

--- a/tests/activity/test_activity_deposit_digest_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_digest_ingest_assets.py
@@ -54,8 +54,8 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
             "expected_digest_image_file": u'IMAGE 99999.jpeg',
-            "expected_dest_resource": 's3://ppd_cdn_bucket/digests/99999/IMAGE 99999.jpeg',
-            "expected_file_list": [u'IMAGE 99999.jpeg']
+            "expected_dest_resource": 's3://ppd_cdn_bucket/digests/99999/digest-99999.jpeg',
+            "expected_file_list": [u'digest-99999.jpeg']
         },
         {
             "comment": 'digest file does not exist example',


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4384

Should support the additional end2end spectrum checks I think. Feel free to merge or edit and merge.