### PR TITLE
Update digestparser library again for a simplified image credit parsing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@95377b5e374a1b0a6487e67284cd45a1ef51e6ca#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@bd6a52744c213a4dfb7e4f6677643f2d0a8c20c0#egg=digestparser
 psutil==5.4.6


### PR DESCRIPTION
Deploying the library changes merged as part of PR https://github.com/elifesciences/digest-parser/pull/47.