### PR TITLE
Emit end activity event for digest ingestion

### DIFF
--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -90,17 +90,6 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "ReadyToPublish",
-                        "activity_id": "ReadyToPublish",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",
@@ -111,6 +100,17 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "schedule_to_start_timeout": 300,
                         "start_to_close_timeout": 60 * 5
                     },
+                    {
+                        "activity_type": "ReadyToPublish",
+                        "activity_id": "ReadyToPublish",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 300,
+                        "schedule_to_close_timeout": 300,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 300
+                    }
                 ],
 
             "finish":


### PR DESCRIPTION
Found in https://github.com/elifesciences/issues/issues/4326

Avoids this situation on activity failure (which we catch):
<img src="https://screenshotscdn.firefoxusercontent.com/images/886b74f3-f482-4eb2-8588-62476711fb23.png" />

Moreover, the article should be in a `ready to publish` state only if its digest has been processed (whether it has been skipped because it's a PoA, successfully ingested, failed but caught and skipped, etc.). Practically this has little effect for now because we never mark the activity as failed, but long-term it will mean maintaining a clear boundary for when the `Publish` button appears.