### PR TITLE
Add pipeline for updating digest-parser

### DIFF
--- a/Jenkinsfile.update-digest-parser
+++ b/Jenkinsfile.update-digest-parser
@@ -1,0 +1,15 @@
+def digestParserSummary;
+elifeUpdatePipeline(
+    { commit ->
+        lock('elife-bot--ci') {
+            builderDeployRevision 'elife-bot--ci', commit
+            elifeToolsSummary = builderCmd "elife-bot--ci", "source venv/bin/activate && update_python_dependency digestparser https://github.com/elifesciences/digest-parser.git 2>/tmp/update-digest-parser.log", "/opt/elife-bot", true
+            builderSync "ci--bot.elife.internal", "/opt/elife-bot/"
+            sh "git add requirements.txt"
+        }
+    },
+    {
+        return "Updated digestparser: ${digestParserSummary}"
+    },
+    'update_digest_parser/'
+)


### PR DESCRIPTION
Identical to https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-elife-tools/ but for `digest-parser`.

Run daily to check if there is a new version not yet updated, opening a PR if that's the case. Can also be run manually.