### PR TITLE
PUT /digests/:id Content-Type request header

### DIFF
--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -148,16 +148,23 @@ def digest_auth_key(settings, auth=False):
 
 
 def digest_auth_header(auth_key):
-    "headers for requests to digest API"
+    "headers for edit and view unpublished content on the digest API"
     if auth_key:
         return {'Authorization': auth_key}
     return {}
 
 
+def digest_content_type_header():
+    "headers for describing the digest body"
+    return {'Content-Type': 'application/vnd.elife.digest+json; version=1'}
+
+
 def digest_put_request(url, verify_ssl, digest_id, data, auth_key=None):
     "put request logic to digests API"
+    headers = digest_auth_header(auth_key)
+    headers.update(digest_content_type_header())
     response = requests.put(url, json=data, verify=verify_ssl,
-                            headers=digest_auth_header(auth_key))
+                            headers=headers)
     LOGGER.info("Put to digest API: PUT %s", url)
     LOGGER.info("Response from digest API: %s\n%s", response.status_code, response.content)
     status_code = response.status_code

--- a/tests/provider/test_digest_provider.py
+++ b/tests/provider/test_digest_provider.py
@@ -79,12 +79,12 @@ class TestDigestProvider(unittest.TestCase):
                           '99999', settings_mock)
 
     @patch('requests.put')
-    def test_put_digest_204(self, mock_requests_get):
+    def test_put_digest_204(self, mock_requests_put):
         digest_id = '99999'
         data = {}
         response = MagicMock()
         response.status_code = 204
-        mock_requests_get.return_value = response
+        mock_requests_put.return_value = response
         # cannot depend on a return value, just check there is no exception
         try:
             digest_provider.put_digest(digest_id, data, settings_mock)
@@ -92,21 +92,35 @@ class TestDigestProvider(unittest.TestCase):
             self.assertFalse(True)
 
     @patch('requests.put')
-    def test_put_digest_400(self, mock_requests_get):
+    def test_put_digest_request_headers(self, mock_requests_put):
+        digest_id = '99999'
+        data = {}
+        response = MagicMock()
+        response.status_code = 204
+        mock_requests_put.return_value = response
+        digest_provider.put_digest(digest_id, data, settings_mock)
+        request_named_arguments = mock_requests_put.call_args_list[0][1]
+        headers = request_named_arguments['headers']
+        self.assertIn('Authorization', headers)
+        self.assertIn('Content-Type', headers)
+        self.assertEqual(headers['Content-Type'], 'application/vnd.elife.digest+json; version=1')
+
+    @patch('requests.put')
+    def test_put_digest_400(self, mock_requests_put):
         digest_id = '99999'
         data = {}
         response = MagicMock()
         response.status_code = 400
-        mock_requests_get.return_value = response
+        mock_requests_put.return_value = response
         self.assertRaises(ErrorCallingDigestException, digest_provider.put_digest,
                           digest_id, data, settings_mock)
 
     @patch('requests.put')
-    def test_put_digest_403(self, mock_requests_get):
+    def test_put_digest_403(self, mock_requests_put):
         digest_id = '99999'
         data = {}
         response = MagicMock()
         response.status_code = 403
-        mock_requests_get.return_value = response
+        mock_requests_put.return_value = response
         self.assertRaises(ErrorCallingDigestException, digest_provider.put_digest,
                           digest_id, data, settings_mock)


### PR DESCRIPTION
Header seems mandatory for the time being. We test both `Authorization` and `Content-Type` are passed in.