### PR TITLE
Fix for finding digest image name

### DIFF
--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -208,7 +208,7 @@ class activity_IngestDigestToEndpoint(Activity):
     def docx_resource_origin(self, article_id, bucket_name):
         "the resource_origin of the docx file in the storage context"
         resource_path = self.outbox_resource_path(article_id, bucket_name)
-        return resource_path + digest_provider.docx_file_name(article_id)
+        return resource_path + "/" + digest_provider.docx_file_name(article_id)
 
     def docx_exists_in_s3(self, article_id, bucket_name):
         "check if a digest docx exists in the S3 outbox"

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -65,8 +65,8 @@ def digest_resource_origin(storage_provider, filename, bucket_name, bucket_folde
 def outbox_resource_path(storage_provider, msid, bucket_name):
     "the digest outbox bucket folder as a resource"
     article_id = utils.pad_msid(msid)
-    storage_provider = storage_provider + "://"
-    return storage_provider + bucket_name + "/digests/outbox/" + article_id + "/"
+    storage_provider_prefix = storage_provider + "://"
+    return storage_provider_prefix + bucket_name + "/digests/outbox/" + article_id
 
 
 def outbox_dest_resource_path(storage_provider, digest, bucket_name):
@@ -82,7 +82,7 @@ def outbox_file_dest_resource(storage_provider, digest, bucket_name, file_path):
     dest_file_name = new_file_name(
         msid=utils.msid_from_doi(digest.doi),
         file_name=file_name)
-    dest_resource = resource_path + dest_file_name
+    dest_resource = resource_path + "/" + dest_file_name
     return dest_resource
 
 

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -78,6 +78,8 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         {
             "comment": "digest files with version greater than lax highest version",
             "bucket_resources": ["elife-15747-v2.xml"],
+            "bot_bucket_resources": ["digests/outbox/99999/digest-99999.docx",
+                                     "digests/outbox/99999/digest-99999.jpg"],
             "expanded_folder": "digests",
             "article_id": '99999',
             "status": 'vor',
@@ -96,12 +98,15 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
                 "Microbes live in us and on us",
                 u'"relatedContent": [{"type": "research-article"',
                 '"stage": "published"',
-                '"published": "2018-07-06T09:06:01Z"'
+                '"published": "2018-07-06T09:06:01Z"',
+                '"filename": "digest-99999.jpg"}'
                 ]
         },
         {
             "comment": "digest files with no existing digest json ingested",
             "bucket_resources": ["elife-15747-v2.xml"],
+            "bot_bucket_resources": ["digests/outbox/99999/digest-99999.docx",
+                                     "digests/outbox/99999/digest-99999.jpg"],
             "expanded_folder": "digests",
             "article_id": '99999',
             "first_vor": True,
@@ -155,11 +160,14 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
                          fake_highest_version, fake_article_snippet,
                          fake_first, fake_article_storage_context, fake_get):
         # copy files into the input directory using the storage context
-        named_fake_storage_context = FakeStorageContext()
+        named_storage_context = FakeStorageContext()
         if test_data.get('bucket_resources'):
-            named_fake_storage_context.resources = test_data.get('bucket_resources')
-        fake_article_storage_context.return_value = named_fake_storage_context
-        fake_storage_context.return_value = FakeStorageContext()
+            named_storage_context.resources = test_data.get('bucket_resources')
+        fake_article_storage_context.return_value = named_storage_context
+        bot_storage_context = FakeStorageContext()
+        if test_data.get('bot_bucket_resources'):
+            bot_storage_context.resources = test_data.get('bot_bucket_resources')
+        fake_storage_context.return_value = bot_storage_context
         fake_first.return_value = test_data.get("first_vor")
         session_test_data = session_data(test_data)
         fake_session.return_value = FakeSession(session_test_data)

--- a/tests/provider/test_digest_provider.py
+++ b/tests/provider/test_digest_provider.py
@@ -15,7 +15,7 @@ class TestDigestProvider(unittest.TestCase):
         digest = Digest()
         digest.doi = '10.7554/eLife.99999'
         bucket_name = 'elife-bot'
-        expected = 's3://elife-bot/digests/outbox/99999/'
+        expected = 's3://elife-bot/digests/outbox/99999'
         resource_path = digest_provider.outbox_dest_resource_path(
             storage_provider, digest, bucket_name)
         self.assertEqual(resource_path, expected)


### PR DESCRIPTION
Fix for finding digest image name, the bucket resource path should not end in a "/" because the storage context adds the slash. Also populate the image correctly in the JSON output in tests.

Result of testing the workflow so far is the digest JSON `image` attribute is not populated correctly. It looks like getting a list of bucket resources from the digest outbox is failing. The automated unit tests due to how the resources are mocked does not test for this effectively.

If all the tests are green, I will merge this PR and test a workflow again.