### PR TITLE
Feature publish digest

### DIFF
--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -125,8 +125,10 @@ class activity_IngestDigestToEndpoint(Activity):
             digest_provider.set_stage(self.digest_content)
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 
-            self.statuses["ingest"] = digest_provider.put_digest_to_endpoint(
+            put_response = digest_provider.put_digest_to_endpoint(
                 self.logger, digest_id, self.digest_content, self.settings)
+            if put_response:
+                self.statuses["ingest"] = True
 
         except Exception as exception:
             self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -122,7 +122,7 @@ class activity_IngestDigestToEndpoint(Activity):
                     str(digest_id))
             self.digest_content = sync_json(self.digest_content, existing_digest_json)
             # set the stage attribute if missing
-            set_stage(self.digest_content)
+            digest_provider.set_stage(self.digest_content)
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 
             self.statuses["ingest"] = self.put_digest_to_endpoint(
@@ -336,9 +336,3 @@ def sync_json(json_content, existing_digest_json):
         if existing_digest_json.get(attr):
             json_content[attr] = existing_digest_json.get(attr)
     return json_content
-
-
-def set_stage(json_content):
-    "set the stage attribute if missing"
-    if "stage" not in json_content:
-        json_content["stage"] = "preview"

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -125,8 +125,8 @@ class activity_IngestDigestToEndpoint(Activity):
             digest_provider.set_stage(self.digest_content)
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 
-            self.statuses["ingest"] = self.put_digest_to_endpoint(
-                digest_id, self.digest_content, self.settings)
+            self.statuses["ingest"] = digest_provider.put_digest_to_endpoint(
+                self.logger, digest_id, self.digest_content, self.settings)
 
         except Exception as exception:
             self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))
@@ -274,18 +274,6 @@ class activity_IngestDigestToEndpoint(Activity):
                 "Exception generating digest json for docx_file %s. Details: %s" %
                 (str(docx_file), str(exception)))
         return json_content
-
-    def put_digest_to_endpoint(self, digest_id, digest_content, settings):
-        "handle issuing the PUT to the digest endpoint"
-        put_status = None
-        try:
-            digest_provider.put_digest(digest_id, digest_content, settings)
-            put_status = True
-        except Exception as exception:
-            self.logger.exception(
-                "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
-                (str(digest_id), str(exception)))
-        return put_status
 
     def create_activity_directories(self):
         """

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -135,7 +135,7 @@ class activity_PublishDigest(Activity):
         approve_status = True
 
         # check by status
-        return_status = approve_by_status(self.logger, article_id, status)
+        return_status = digest_provider.approve_by_status(self.logger, article_id, status)
         if return_status is False:
             approve_status = return_status
 
@@ -152,19 +152,6 @@ class activity_PublishDigest(Activity):
                 "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
                 (str(digest_id), str(exception)))
         return put_status
-
-
-def approve_by_status(logger, article_id, status):
-    "determine approval status by article status value"
-    approve_status = None
-    # PoA do not ingest digests
-    if status == "poa":
-        approve_status = False
-        message = ("\nNot ingesting digest for PoA article {article_id}".format(
-            article_id=article_id
-        ))
-        logger.info(message)
-    return approve_status
 
 
 def set_stage(json_content, stage="preview"):

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -21,7 +21,6 @@ class activity_PublishDigest(Activity):
         # Track the success of some steps
         self.statuses = {
             "approve": None,
-            "stage": None,
             "put": None
         }
 
@@ -71,11 +70,10 @@ class activity_PublishDigest(Activity):
             if existing_digest_json.get("stage") != "published":
                 self.digest_content = digest_provider.set_stage(existing_digest_json, 'published')
                 self.logger.info("Set Digest stage value of %s to published" % article_id)
-                self.statuses["stage"] = True
-            if self.statuses.get("stage"):
-                self.statuses["put"] = digest_provider.put_digest_to_endpoint(
+                put_response = digest_provider.put_digest_to_endpoint(
                     self.logger, digest_id, self.digest_content, self.settings)
-                if self.statuses.get("put"):
+                if put_response:
+                    self.statuses["put"] = True
                     self.logger.info("Put Digest for %s to the endpoint" % article_id)
 
         except Exception as exception:

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -69,7 +69,7 @@ class activity_PublishDigest(Activity):
 
             # set the stage attribute if is not published
             if existing_digest_json.get("stage") != "published":
-                self.digest_content = set_stage(existing_digest_json, 'published')
+                self.digest_content = digest_provider.set_stage(existing_digest_json, 'published')
                 self.logger.info("Set Digest stage value of %s to published" % article_id)
                 self.statuses["stage"] = True
             if self.statuses.get("stage"):
@@ -154,7 +154,3 @@ class activity_PublishDigest(Activity):
         return put_status
 
 
-def set_stage(json_content, stage="preview"):
-    "set the stage attribute if missing"
-    json_content["stage"] = stage
-    return json_content

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -62,7 +62,7 @@ class activity_PublishDigest(Activity):
             existing_digest_json = digest_provider.get_digest(digest_id, self.settings)
             if not existing_digest_json:
                 self.logger.info(
-                    "Did not get existing digest json from the endpoint for digest_id %s" %
+                    "There is no existing digest for digest_id %s" %
                     str(digest_id))
                 self.emit_end_message(article_id, version, run)
                 return self.ACTIVITY_SUCCESS

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -1,0 +1,173 @@
+import json
+import provider.digest_provider as digest_provider
+from .activity import Activity
+
+
+class activity_PublishDigest(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_PublishDigest, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "PublishDigest"
+        self.pretty_name = "Publish the Digest via the API endpoint"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = ("Set digest as published, related to the research article," +
+                            " if the digest not already published.")
+
+        # Track the success of some steps
+        self.statuses = {
+            "approve": None,
+            "stage": None,
+            "put": None
+        }
+
+        # Digest JSON content
+        self.digest_content = None
+
+        # Load the config
+        self.digest_config = digest_provider.digest_config(
+            self.settings.digest_config_section,
+            self.settings.digest_config_file)
+
+    def do_activity(self, data=None):
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        # get data
+        (success, run, article_id, version, status) = self.parse_data(data)
+        if success is not True:
+            self.logger.error("Failed to parse data in %s" % self.pretty_name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+        # emit start message
+        success = self.emit_start_message(article_id, version, run)
+        if success is not True:
+            self.logger.error("Failed to emit a start message in %s" % self.pretty_name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # Wrap in an exception during testing phase
+        try:
+            # Approve for ingestion
+            self.statuses["approve"] = self.approve(article_id, status)
+            if self.statuses.get("approve") is not True:
+                self.logger.info(
+                    "Digest for article %s was not approved for publish" % article_id)
+                self.emit_end_message(article_id, version, run)
+                return self.ACTIVITY_SUCCESS
+
+            # get existing digest data
+            digest_id = article_id
+            existing_digest_json = digest_provider.get_digest(digest_id, self.settings)
+            if not existing_digest_json:
+                self.logger.info(
+                    "Did not get existing digest json from the endpoint for digest_id %s" %
+                    str(digest_id))
+                self.emit_end_message(article_id, version, run)
+                return self.ACTIVITY_SUCCESS
+
+            # set the stage attribute if is not published
+            if existing_digest_json.get("stage") != "published":
+                self.digest_content = set_stage(existing_digest_json, 'published')
+                self.logger.info("Set Digest stage value of %s to published" % article_id)
+                self.statuses["stage"] = True
+            if self.statuses.get("stage"):
+                self.statuses["put"] = self.put_digest_to_endpoint(
+                    digest_id, self.digest_content, self.settings)
+                if self.statuses.get("put"):
+                    self.logger.info("Put Digest for %s to the endpoint" % article_id)
+
+        except Exception as exception:
+            self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))
+
+        self.emit_end_message(article_id, version, run)
+
+        return self.ACTIVITY_SUCCESS
+
+    def parse_data(self, data):
+        "extract individual values from the activity data"
+        run = None
+        article_id = None
+        version = None
+        status = None
+        success = None
+        try:
+            run = data.get("run")
+            article_id = data.get("article_id")
+            version = data.get("version")
+            status = data.get("status")
+            success = True
+        except (TypeError, KeyError) as exception:
+            self.logger.exception("Exception parsing the input data in %s." +
+                                  " Details: %s" % self.pretty_name, str(exception))
+        return success, run, article_id, version, status
+
+    def emit_message(self, article_id, version, run, status, message):
+        "emit message to the queue"
+        try:
+            self.emit_monitor_event(self.settings, article_id, version, run,
+                                    self.pretty_name, status, message)
+            return True
+        except Exception as exception:
+            self.logger.exception("Exception emitting %s message. Details: %s" %
+                                  (str(status), str(exception)))
+
+    def emit_start_message(self, article_id, version, run):
+        "emit the start message to the queue"
+        return self.emit_message(
+            article_id, version, run, "start",
+            "Starting ingest digest to endpoint for " + str(article_id))
+
+    def emit_end_message(self, article_id, version, run):
+        "emit the end message to the queue"
+        return self.emit_message(
+            article_id, version, run, "end",
+            "Finished ingest digest to endpoint for " + str(article_id))
+
+    def emit_error_message(self, article_id, version, run, message):
+        "emit an error message to the queue"
+        return self.emit_message(
+            article_id, version, run, "error", message)
+
+    def approve(self, article_id, status):
+        "should we ingest based on some basic attributes"
+        approve_status = True
+
+        # check by status
+        return_status = approve_by_status(self.logger, article_id, status)
+        if return_status is False:
+            approve_status = return_status
+
+        return approve_status
+
+    def put_digest_to_endpoint(self, digest_id, digest_content, settings):
+        "handle issuing the PUT to the digest endpoint"
+        put_status = None
+        try:
+            digest_provider.put_digest(digest_id, digest_content, settings)
+            put_status = True
+        except Exception as exception:
+            self.logger.exception(
+                "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
+                (str(digest_id), str(exception)))
+        return put_status
+
+
+def approve_by_status(logger, article_id, status):
+    "determine approval status by article status value"
+    approve_status = None
+    # PoA do not ingest digests
+    if status == "poa":
+        approve_status = False
+        message = ("\nNot ingesting digest for PoA article {article_id}".format(
+            article_id=article_id
+        ))
+        logger.info(message)
+    return approve_status
+
+
+def set_stage(json_content, stage="preview"):
+    "set the stage attribute if missing"
+    json_content["stage"] = stage
+    return json_content

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -73,8 +73,8 @@ class activity_PublishDigest(Activity):
                 self.logger.info("Set Digest stage value of %s to published" % article_id)
                 self.statuses["stage"] = True
             if self.statuses.get("stage"):
-                self.statuses["put"] = self.put_digest_to_endpoint(
-                    digest_id, self.digest_content, self.settings)
+                self.statuses["put"] = digest_provider.put_digest_to_endpoint(
+                    self.logger, digest_id, self.digest_content, self.settings)
                 if self.statuses.get("put"):
                     self.logger.info("Put Digest for %s to the endpoint" % article_id)
 
@@ -133,24 +133,8 @@ class activity_PublishDigest(Activity):
     def approve(self, article_id, status):
         "should we ingest based on some basic attributes"
         approve_status = True
-
         # check by status
         return_status = digest_provider.approve_by_status(self.logger, article_id, status)
         if return_status is False:
             approve_status = return_status
-
         return approve_status
-
-    def put_digest_to_endpoint(self, digest_id, digest_content, settings):
-        "handle issuing the PUT to the digest endpoint"
-        put_status = None
-        try:
-            digest_provider.put_digest(digest_id, digest_content, settings)
-            put_status = True
-        except Exception as exception:
-            self.logger.exception(
-                "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
-                (str(digest_id), str(exception)))
-        return put_status
-
-

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -234,3 +234,9 @@ def approve_by_first_vor(settings, logger, article_id, version, status, auth=Tru
     elif first_vor and version and highest_version and int(version) < int(highest_version):
         approve_status = False
     return approve_status
+
+
+def set_stage(json_content, stage="preview"):
+    "set the stage attribute"
+    json_content["stage"] = stage
+    return json_content

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -175,7 +175,7 @@ def digest_put_request(url, verify_ssl, digest_id, data, auth_key=None):
             "Error put digest " + digest_id + " to digest API: %s\n%s" %
             (status_code, response.content))
     else:
-        return response.content
+        return response
 
 
 def put_digest(digest_id, data, settings, auth=True):
@@ -187,15 +187,12 @@ def put_digest(digest_id, data, settings, auth=True):
 
 def put_digest_to_endpoint(logger, digest_id, digest_content, settings):
     "handle issuing the PUT to the digest endpoint"
-    put_status = None
     try:
-        put_digest(digest_id, digest_content, settings)
-        put_status = True
+        return put_digest(digest_id, digest_content, settings)
     except Exception as exception:
         logger.exception(
             "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
             (str(digest_id), str(exception)))
-    return put_status
 
 
 def approve_by_status(logger, article_id, status):

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -8,6 +8,7 @@ from docx.opc.exceptions import PackageNotFoundError
 from digestparser import build, conf
 import provider.utils as utils
 from provider.storage_provider import storage_context
+import provider.lax_provider as lax_provider
 
 
 IDENTITY = "process_%s" % os.getpid()
@@ -182,3 +183,54 @@ def put_digest(digest_id, data, settings, auth=True):
     url = settings.digest_endpoint.replace('{digest_id}', str(digest_id))
     return digest_put_request(url, settings.verify_ssl, digest_id, data,
                               digest_auth_key(settings, auth))
+
+
+def approve_by_status(logger, article_id, status):
+    "determine approval status by article status value"
+    approve_status = None
+    # PoA do not ingest digests
+    if status == "poa":
+        approve_status = False
+        message = ("\nNot ingesting digest for PoA article {article_id}".format(
+            article_id=article_id
+        ))
+        logger.info(message)
+    return approve_status
+
+
+def approve_by_run_type(settings, logger, article_id, run_type, version):
+    "determine ingest approval based on the run_type and version"
+    approve_status = None
+    # VoR and is a silent correction, consult Lax for if it is not the highest version
+    if run_type == "silent-correction":
+        highest_version = lax_provider.article_highest_version(article_id, settings)
+        try:
+            if int(version) < int(highest_version):
+                approve_status = False
+                message = (
+                    "\nNot ingesting digest for silent correction {article_id}" +
+                    " version {version} is less than highest version {highest}").format(
+                        article_id=article_id,
+                        version=version,
+                        highest=highest_version)
+                logger.info(message)
+        except TypeError as exception:
+            approve_status = False
+            message = (
+                "\nException converting version to int for {article_id}, {exc}").format(
+                    article_id=article_id,
+                    exc=str(exception))
+            logger.exception(message.lstrip())
+    return approve_status
+
+
+def approve_by_first_vor(settings, logger, article_id, version, status, auth=True):
+    "check if it is not the first vor or not the highest version"
+    approve_status = None
+    first_vor = lax_provider.article_first_by_status(article_id, version, status, settings, auth)
+    highest_version = lax_provider.article_highest_version(article_id, settings, auth)
+    if not first_vor:
+        approve_status = False
+    elif first_vor and version and highest_version and int(version) < int(highest_version):
+        approve_status = False
+    return approve_status

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -185,6 +185,19 @@ def put_digest(digest_id, data, settings, auth=True):
                               digest_auth_key(settings, auth))
 
 
+def put_digest_to_endpoint(logger, digest_id, digest_content, settings):
+    "handle issuing the PUT to the digest endpoint"
+    put_status = None
+    try:
+        put_digest(digest_id, digest_content, settings)
+        put_status = True
+    except Exception as exception:
+        logger.exception(
+            "Exception issuing PUT to the digest endpoint for digest_id %s. Details: %s" %
+            (str(digest_id), str(exception)))
+    return put_status
+
+
 def approve_by_status(logger, article_id, status):
     "determine approval status by article status value"
     approve_status = None

--- a/register.py
+++ b/register.py
@@ -105,6 +105,7 @@ def start(ENV="dev"):
     activity_names.append("DepositDigestIngestAssets")
     activity_names.append("CopyDigestToOutbox")
     activity_names.append("IngestDigestToEndpoint")
+    activity_names.append("PublishDigest")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -172,7 +172,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         session_test_data = session_data(test_data)
         fake_session.return_value = FakeSession(session_test_data)
         fake_get_digest.return_value = test_data.get('existing_digest_json')
-        fake_put_digest.return_value = None
+        fake_put_digest.return_value = FakeResponse(204, None)
         fake_highest_version.return_value = test_data.get('lax_highest_version')
         fake_article_snippet.return_value = 200, test_data.get('article_snippet')
         fake_provider_storage_context.return_value = FakeStorageContext()

--- a/tests/activity/test_activity_publish_digest.py
+++ b/tests/activity/test_activity_publish_digest.py
@@ -134,7 +134,7 @@ class TestPublishDigest(unittest.TestCase):
                          test_data.get("expected_put_status"),
                          'failed in {comment}'.format(comment=test_data.get("comment")))
         # check stage value in json_content
-        if self.activity.digest_content:
+        if test_data.get("expected_stage"):
             self.assertEqual(self.activity.digest_content.get("stage"),
                              test_data.get("expected_stage"))
 

--- a/tests/activity/test_activity_publish_digest.py
+++ b/tests/activity/test_activity_publish_digest.py
@@ -8,7 +8,7 @@ from ddt import ddt, data
 import provider.digest_provider as digest_provider
 from activity.activity_PublishDigest import activity_PublishDigest as activity_object
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger
+from tests.activity.classes_mock import FakeLogger, FakeResponse
 
 
 ACTIVITY_DATA = {
@@ -68,12 +68,24 @@ class TestPublishDigest(unittest.TestCase):
             "article_id": "99999",
             "status": "vor",
             "existing_digest_json": DIGEST_DATA,
+            "put_response": FakeResponse(204, None),
             "stage": "preview",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_stage": "published",
             "expected_approve_status": True,
-            "expected_stage_status": True,
             "expected_put_status": True
+        },
+        {
+            "comment": "fail to put a digest",
+            "article_id": "99999",
+            "status": "vor",
+            "existing_digest_json": DIGEST_DATA,
+            "put_response": None,
+            "stage": "preview",
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_stage": "published",
+            "expected_approve_status": True,
+            "expected_put_status": None
         },
         {
             "comment": "an already published digest",
@@ -82,7 +94,6 @@ class TestPublishDigest(unittest.TestCase):
             "stage": "published",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_approve_status": True,
-            "expected_stage_status": None,
             "expected_put_status": None
         },
         {
@@ -93,7 +104,6 @@ class TestPublishDigest(unittest.TestCase):
             "stage": "published",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_approve_status": False,
-            "expected_stage_status": None,
             "expected_put_status": None
         },
         {
@@ -103,7 +113,6 @@ class TestPublishDigest(unittest.TestCase):
             "stage": "published",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_approve_status": True,
-            "expected_stage_status": None,
             "expected_put_status": None
         },
     )
@@ -114,7 +123,7 @@ class TestPublishDigest(unittest.TestCase):
             test_data.get("existing_digest_json"),
             test_data.get("stage")
             )
-        fake_put_digest.return_value = None
+        fake_put_digest.return_value = test_data.get("put_response")
         activity_data = digest_activity_data(
             ACTIVITY_DATA,
             test_data.get("status")
@@ -126,9 +135,6 @@ class TestPublishDigest(unittest.TestCase):
                          'failed in {comment}'.format(comment=test_data.get("comment")))
         self.assertEqual(self.activity.statuses.get("approve"),
                          test_data.get("expected_approve_status"),
-                         'failed in {comment}'.format(comment=test_data.get("comment")))
-        self.assertEqual(self.activity.statuses.get("stage"),
-                         test_data.get("expected_stage_status"),
                          'failed in {comment}'.format(comment=test_data.get("comment")))
         self.assertEqual(self.activity.statuses.get("put"),
                          test_data.get("expected_put_status"),

--- a/tests/activity/test_activity_publish_digest.py
+++ b/tests/activity/test_activity_publish_digest.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+
+import unittest
+from collections import OrderedDict
+from mock import patch
+from ddt import ddt, data
+import provider.digest_provider as digest_provider
+from activity.activity_PublishDigest import activity_PublishDigest as activity_object
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+
+
+ACTIVITY_DATA = {
+    "run": "",
+    "article_id": "99999",
+    "version": "1",
+    "status": "vor",
+    "expanded_folder": "",
+}
+
+DIGEST_DATA = OrderedDict([
+    ('id', '99999'),
+    ('title', 'Test'),
+    ('published', '2016-06-16T00:00:00Z'),
+    ('stage', 'preview'),
+    ('relatedContent', [
+        OrderedDict([
+            ('type', 'research-article'),
+            ('status', 'vor'),
+            ('id', '99999'),
+            ])
+        ])
+    ])
+
+
+@ddt
+class TestPublishDigest(unittest.TestCase):
+
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(digest_provider, 'put_digest')
+    @patch.object(digest_provider, 'get_digest')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @data(
+        {
+            "comment": "set a digest as published",
+            "article_id": '99999',
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_stage": "published",
+            "expected_approve_status": True,
+            "expected_stage_status": True,
+            "expected_put_status": True
+        },
+    )
+    def test_do_activity(self, test_data, fake_emit, fake_get_digest, fake_put_digest):
+        # copy files into the input directory using the storage context
+        fake_emit.return_value = None
+        fake_get_digest.return_value = DIGEST_DATA
+        fake_put_digest.return_value = None
+        # do the activity
+        result = self.activity.do_activity(ACTIVITY_DATA)
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.statuses.get("approve"),
+                         test_data.get("expected_approve_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.statuses.get("stage"),
+                         test_data.get("expected_stage_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.statuses.get("put"),
+                         test_data.get("expected_put_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        # check stage value in json_content
+        self.assertEqual(self.activity.digest_content.get("stage"), test_data.get("expected_stage"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -100,6 +100,17 @@ class workflow_PostPerfectPublication(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "PublishDigest",
+                        "activity_id": "PublishDigest",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "GeneratePDFCovers",
                         "activity_id": "GeneratePDFCovers",
                         "version": "1",


### PR DESCRIPTION
Implementing https://github.com/elifesciences/issues/issues/4303.

Started off with the basics of `GET` a digest, if it exists, change to `published` (if applicable) and `PUT` it back.

I refactored by moving some of the functions from the `IngestDigestToEndpoint` activity over to the `digest_provider`.

`PublishDigest` only checks for whether it is a `poa` and does not approve continuing for those. The rest of the logic is based on the `stage` status of the digest JSON. There are a few test scenarios for different type of input.

Exceptions will be caught in `PublishDigest` if anything goes awry.

I added it to the `PostPerfectPublication` workflow before it tries the `GeneratePDFCovers` activity, because `GeneratePDFCovers` still tends to terminate some workflows on a weekly basis, and I don't want it to interfere with digest publishing.