### PR TITLE
Introduce get_digest_preview for PublishDigest

### DIFF
--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -115,6 +115,11 @@ class activity_IngestDigestToEndpoint(Activity):
 
             # get existing digest data
             digest_id = self.digest_content.get("id")
+            # TODO: what are we doing this for?
+            # assumption: we are ingesting the digest multiple times on the first VoR version
+            # assumption: we are not ingesting the digest on any other version
+            # only possible case is silent correction?
+            # but then, only do it on silent correction?
             existing_digest_json = digest_provider.get_digest(digest_id, self.settings)
             if not existing_digest_json:
                 self.logger.info(
@@ -122,7 +127,7 @@ class activity_IngestDigestToEndpoint(Activity):
                     str(digest_id))
             self.digest_content = sync_json(self.digest_content, existing_digest_json)
             # set the stage attribute if missing
-            digest_provider.set_stage(self.digest_content)
+            digest_provider.set_stage(self.digest_content, "preview")
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 
             put_response = digest_provider.put_digest_to_endpoint(

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -58,7 +58,7 @@ class activity_PublishDigest(Activity):
 
             # get existing digest data
             digest_id = article_id
-            existing_digest_json = digest_provider.get_digest(digest_id, self.settings)
+            existing_digest_json = digest_provider.get_digest_preview(digest_id, self.settings)
             if not existing_digest_json:
                 self.logger.info(
                     "There is no existing digest for digest_id %s" %

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -122,9 +122,10 @@ def has_image(digest_content):
     return True
 
 
-def digest_get_request(url, verify_ssl, digest_id):
+def digest_get_request(url, verify_ssl, digest_id, auth_key=None):
     "common get request logic to digests API"
-    response = requests.get(url, verify=verify_ssl)
+    headers = digest_auth_header(auth_key)
+    response = requests.get(url, verify=verify_ssl, headers=headers)
     LOGGER.info("Request to digest API: GET %s", url)
     LOGGER.info("Response from digest API: %s\n%s", response.status_code, response.content)
     status_code = response.status_code
@@ -141,6 +142,11 @@ def get_digest(digest_id, settings):
     "get digest from the endpoint"
     url = settings.digest_endpoint.replace('{digest_id}', str(digest_id))
     return digest_get_request(url, settings.verify_ssl, digest_id)
+
+def get_digest_preview(digest_id, settings):
+    "get digest from the endpoint, including digests in preview"
+    url = settings.digest_endpoint.replace('{digest_id}', str(digest_id))
+    return digest_get_request(url, settings.verify_ssl, digest_id, digest_auth_key(settings, auth=True))
 
 
 def digest_auth_key(settings, auth=False):

--- a/tests/activity/test_activity_publish_digest.py
+++ b/tests/activity/test_activity_publish_digest.py
@@ -60,7 +60,7 @@ class TestPublishDigest(unittest.TestCase):
         self.activity.clean_tmp_dir()
 
     @patch.object(digest_provider, 'put_digest')
-    @patch.object(digest_provider, 'get_digest')
+    @patch.object(digest_provider, 'get_digest_preview')
     @patch.object(activity_object, 'emit_monitor_event')
     @data(
         {

--- a/tests/provider/test_digest_provider.py
+++ b/tests/provider/test_digest_provider.py
@@ -78,6 +78,18 @@ class TestDigestProvider(unittest.TestCase):
         self.assertRaises(ErrorCallingDigestException, digest_provider.get_digest,
                           '99999', settings_mock)
 
+    @patch('requests.get')
+    def test_get_digest_preview(self, mock_requests_get):
+        expected_data = {'id': u'99999'}
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {'id': u'99999'}
+        mock_requests_get.return_value = response
+        data = digest_provider.get_digest_preview('99999', settings_mock)
+        request_named_arguments = mock_requests_get.call_args_list[0][1]
+        headers = request_named_arguments['headers']
+        self.assertIn('Authorization', headers)
+
     @patch('requests.put')
     def test_put_digest_204(self, mock_requests_put):
         digest_id = '99999'


### PR DESCRIPTION
The last `PublishDigest` error was

```
2018-09-27T08:37:56Z INFO worker_5920 Request to digest API: GET http://end2end--gateway.elife.internal/digests/6955600639083406847
2018-09-27T08:37:56Z INFO worker_5920 Response from digest API: 404
```

It likely has to check for preview digests too.

Note on multiple versions: I think `PublishDigest` will always re-publish the digest, even in a v3 VoR after a v2 VoR that already published it. Seems harmless but if we have a way to avoid it, one fewer thing that can go wrong.

Note on `IngestDigestToEndpoint`: I cannot guess the case for which we read back the digest. It currently can only read a published digest, so it should be for silent corrections. However the activity is not in silent corrections workflow, could we start out by not doing this at all? My comments are in the activity.