### PR TITLE
Isolate providers logs

### DIFF
--- a/activity/activity_ArchiveArticle.py
+++ b/activity/activity_ArchiveArticle.py
@@ -99,30 +99,3 @@ class activity_ArchiveArticle(activity.activity):
                                 "end", "Finished archiving article " + data['article_id'] +
                                 " for version " + version + " run " + data["run"])
         return activity.activity.ACTIVITY_SUCCESS
-
-def main(args):
-
-    """
-    This sets up dummy SWF activity data, creates an instance of this activity and runs it only for
-    testing and debugging. This activity would usually be executed by worker.py
-    """
-
-    data = {
-        'id': '00353',
-        'expanded_folder': '00353.1/9a0f0b0d-1f0b-47c8-88ef-050bd9cdff92',
-        'version': '1',
-        'status': 'VOR',
-        'updated_date': datetime.strftime(datetime.utcnow(), "%Y-%m-%dT%H:%M:%S")
-    }
-
-    settings = settings_lib.get_settings('exp')
-    identity = "resize_%s" % int(random.random() * 1000)
-    log_file = "worker.log"
-    logger = log.logger(log_file, settings.setLevel, identity)
-    conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
-    act = activity_ArchiveArticle(settings, logger, conn=conn)
-    act.do_activity(data)
-
-if __name__ == '__main__':
-    import sys
-    main(sys.argv[1:])

--- a/log.py
+++ b/log.py
@@ -5,13 +5,13 @@ import random
 import sys
 import newrelic.agent
 
-def logger(logFile = None, setLevel = "INFO", identity = ""):
+def logger(logFile = None, setLevel = "INFO", identity = "", loggerName = 'elife-bot'):
     """
     Create a logger, by specifying a unique (or same) logFile,
     set the level of logging, and optional identity for what is
     sending logging message, to identify multiple workers
     """
-    logger = logging.getLogger('elife-bot')
+    logger = logging.getLogger(loggerName)
     if(logFile):
         hdlr = handlers.WatchedFileHandler(os.getcwd() + os.sep + logFile)
     else:

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -12,7 +12,7 @@ import provider.lax_provider as lax_provider
 
 
 IDENTITY = "process_%s" % os.getpid()
-LOGGER = log.logger("digest_provider.log", 'INFO', IDENTITY)
+LOGGER = log.logger("digest_provider.log", 'INFO', IDENTITY, loggerName=__name__)
 
 
 class ErrorCallingDigestException(Exception):

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -8,7 +8,7 @@ import log
 import os
 
 identity = "process_%s" % os.getpid()
-logger = log.logger("lax_provider.log", 'INFO', identity)
+logger = log.logger("lax_provider.log", 'INFO', identity, loggerName=__name__)
 
 
 class ErrorCallingLaxException(Exception):

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -8,7 +8,7 @@ import log
 
 
 def StorageContext(*args):
-    logger = log.logger('deprecated.log', 'INFO', __name__)
+    logger = log.logger('deprecated.log', 'INFO', __name__, loggerName=__name__)
     logger.warning("provider.storage_provider.StorageContext() is deprecated")
     return S3StorageContext(args[0])
 


### PR DESCRIPTION
Fixes an issue where all providers end up using the same logger as the main process, meaning they duplicate into their own file the whole output of `worker.log` or whatever is using them:

```
elife@end2end--bot:/opt/elife-bot$ grep activityType: digest_provider.log | head
2018-09-20T13:15:45Z INFO process_4086 activityType: VerifyGlencoe
2018-09-20T13:15:48Z INFO process_4086 activityType: PingWorker
2018-09-20T13:15:48Z INFO process_4092 activityType: VersionLookup
2018-09-20T13:15:49Z INFO process_4086 activityType: PingWorker
2018-09-20T13:15:49Z INFO process_4092 activityType: VerifyPublishResponse
2018-09-20T13:15:49Z INFO process_4086 activityType: VersionReasonDecider
2018-09-20T13:15:50Z INFO process_4092 activityType: CopyGlencoeStillImages
2018-09-20T13:15:51Z INFO process_4086 activityType: ApplyVersionNumber
2018-09-20T13:15:52Z INFO process_4092 activityType: VersionReasonDecider
2018-09-20T13:15:54Z INFO process_4092 activityType: PingWorker
```

After this, only the calls inside the specific `provider.something._provider` should go to its own file, with no mixing.