### PR TITLE
Only set the digest stage to "preview" if stage is missing.

### DIFF
--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -127,7 +127,8 @@ class activity_IngestDigestToEndpoint(Activity):
                     str(digest_id))
             self.digest_content = sync_json(self.digest_content, existing_digest_json)
             # set the stage attribute if missing
-            digest_provider.set_stage(self.digest_content, "preview")
+            if "stage" not in self.digest_content:
+                digest_provider.set_stage(self.digest_content, "preview")
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 
             put_response = digest_provider.put_digest_to_endpoint(

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -127,7 +127,7 @@ class activity_IngestDigestToEndpoint(Activity):
                     str(digest_id))
             self.digest_content = sync_json(self.digest_content, existing_digest_json)
             # set the stage attribute if missing
-            if "stage" not in self.digest_content:
+            if self.digest_content.get("stage") != "published":
                 digest_provider.set_stage(self.digest_content, "preview")
             self.logger.info("Digest stage value %s" % str(self.digest_content.get("stage")))
 

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -74,6 +74,10 @@ class activity_PublishDigest(Activity):
                     self.logger, digest_id, self.digest_content, self.settings)
                 self.statuses["put"] = True
                 self.logger.info("Put Digest for %s to the endpoint: " % article_id, put_response)
+            else:
+                self.logger.info(
+                    "Digest is already published, did not put Digest for %s to the endpoint: " %
+                    article_id, put_response)
 
         except Exception as exception:
             self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))


### PR DESCRIPTION
Fix for bug in comment https://github.com/elifesciences/elife-bot/pull/786#issuecomment-425573237

When I moved `set_stage()` over to the digest_provider and simplified it for `PublishDigest` activity to also used, I removed the logic needed here on ingestion: it should only set `stage` to `preview` if the digest doesn't have a value for it, because if it is a silent correction, the digest will already have a `stage` of `published`, and we do not want to overwrite it with `preview` when the digest is ingested.