### PR TITLE
Pass run_type as workflow data

### DIFF
--- a/activity/activity_IngestToLax.py
+++ b/activity/activity_IngestToLax.py
@@ -42,6 +42,7 @@ class activity_IngestToLax(activity.activity):
         data['status'] = session.get_value('status')
         data['expanded_folder'] = session.get_value('expanded_folder')
         data['update_date'] = session.get_value('update_date')
+        data['run_type'] = session.get_value('run_type')
 
         queue_connection_settings = {"sqs_region": self.settings.sqs_region,
                                      "aws_access_key_id":self.settings.aws_access_key_id,
@@ -76,6 +77,7 @@ class activity_IngestToLax(activity.activity):
 
         try:
             expanded_folder = data['expanded_folder']
+            run_type = data.get('run_type')
 
             ##########
             if not consider_elife_20:
@@ -95,7 +97,8 @@ class activity_IngestToLax(activity.activity):
                                 "expanded_folder": expanded_folder,
                                 "requested_action": "",
                                 "message": "",
-                                "update_date": data['update_date']
+                                "update_date": data['update_date'],
+                                "run_type": run_type
                             }
                         }
 
@@ -117,8 +120,9 @@ class activity_IngestToLax(activity.activity):
 
             force = True if ("force" in data and data["force"] == True) else False
 
-            message = lax_provider.prepare_action_message(self.settings,
-                                                          article_id, run, expanded_folder, version, status, 'ingest', force)
+            message = lax_provider.prepare_action_message(
+                self.settings, article_id, run, expanded_folder,
+                version, status, 'ingest', force, run_type)
 
             return (message, self.settings.xml_info_queue, start_event, "end",
                     [self.settings, article_id, version, run, self.pretty_name, "end",

--- a/activity/activity_PublishToLax.py
+++ b/activity/activity_PublishToLax.py
@@ -47,14 +47,16 @@ class activity_PublishToLax(activity.activity):
 
         status = workflow_data['status']
         expanded_folder = workflow_data['expanded_folder']
+        run_type = workflow_data.get('run_type')
 
         self.emit_monitor_event(self.settings, article_id, version, run, "Publish To Lax", "start",
                                 "Starting preparation of article for Lax " + article_id)
 
         try:
             force = True if ("force" in data and data["force"] == True) else False
-            message = lax_provider.prepare_action_message(self.settings,
-                                                          article_id, run, expanded_folder, version, status, 'publish', force)
+            message = lax_provider.prepare_action_message(
+                self.settings, article_id, run, expanded_folder, version,
+                status, 'publish', force, run_type)
             message_body = json.dumps(message)
             self.logger.info("Sending message to lax: %s", message_body)
             sqs_conn = boto.sqs.connect_to_region(

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -56,7 +56,8 @@ class LaxResponseAdapter:
                 "run": None,
                 "version": None,
                 "expanded_folder": None,
-                "status": None
+                "status": None,
+                "run_type": None
             }
 
     def parse_message(self, message):
@@ -82,6 +83,7 @@ class LaxResponseAdapter:
             expanded_folder = token['expanded_folder']
             status = token['status']
             force = token['force']
+            run_type = token.get('run_type')
 
             workflow_data = {
                 "run": run,
@@ -93,7 +95,8 @@ class LaxResponseAdapter:
                 "message": response_message,
                 "update_date": date_time,
                 "requested_action": operation,
-                "force": force
+                "force": force,
+                "run_type": run_type
             }
 
             if operation == "ingest":

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -198,7 +198,8 @@ def published_considering_poa_status(article_id, settings, is_poa, was_ever_poa)
     return False
 
 
-def prepare_action_message(settings, article_id, run, expanded_folder, version, status, action, force=False):
+def prepare_action_message(settings, article_id, run, expanded_folder, version,
+                           status, action, force=False, run_type=None):
         xml_bucket = settings.publishing_buckets_prefix + settings.expanded_bucket
         xml_file_name = get_xml_file_name(settings, expanded_folder, xml_bucket)
         xml_path = 'https://s3-external-1.amazonaws.com/' + xml_bucket + '/' + expanded_folder + '/' + xml_file_name
@@ -208,7 +209,7 @@ def prepare_action_message(settings, article_id, run, expanded_folder, version, 
             'id': article_id,
             'version': int(version),
             'force': force,
-            'token': lax_token(run, version, expanded_folder, status, force)
+            'token': lax_token(run, version, expanded_folder, status, force, run_type)
         }
         message = carry_over_data
         return message
@@ -220,13 +221,14 @@ def get_xml_file_name(settings, expanded_folder, xml_bucket, version=None):
     return xml_file_name
 
 
-def lax_token(run, version, expanded_folder, status, force=False):
+def lax_token(run, version, expanded_folder, status, force=False, run_type=None):
     token = {
         'run': run, 
         'version': version,
         'expanded_folder': expanded_folder,
         'status': status,
-        'force': force
+        'force': force,
+        'run_type': run_type
     }
     return base64.encodestring(json.dumps(token))
 

--- a/starter/starter_ProcessArticleZip.py
+++ b/starter/starter_ProcessArticleZip.py
@@ -19,7 +19,8 @@ class starter_ProcessArticleZip():
     def __init__(self):
         self.const_name = "ProcessArticleZip"
 
-    def start(self, settings, article_id, version, requested_action, force, result, expanded_folder, status, run, update_date, message=None):
+    def start(self, settings, article_id, version, requested_action, force, result,
+              expanded_folder, status, run, update_date, message=None, run_type=None):
 
         logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
 
@@ -36,7 +37,8 @@ class starter_ProcessArticleZip():
             "requested_action": requested_action,
             "force": force,
             "message": message,
-            "update_date": update_date
+            "update_date": update_date,
+            "run_type": run_type
         }
 
         workflow_id, \

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -19,7 +19,8 @@ class starter_SilentCorrectionsProcess():
     def __init__(self):
         self.const_name = "SilentCorrectionsProcess"
 
-    def start(self, settings, article_id, version, requested_action, force, result, expanded_folder, status, run, update_date, message=None):
+    def start(self, settings, article_id, version, requested_action, force, result,
+              expanded_folder, status, run, update_date, message=None, run_type=None):
 
         # Log
         logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
@@ -38,7 +39,8 @@ class starter_SilentCorrectionsProcess():
             "requested_action": requested_action,
             "message": message,
             "update_date": update_date,
-            "force": True
+            "force": True,
+            "run_type": run_type
         }
 
         workflow_id, \

--- a/tests/activity/test_activity_ingest_to_lax.py
+++ b/tests/activity/test_activity_ingest_to_lax.py
@@ -68,7 +68,8 @@ class TestIngestToLax(unittest.TestCase):
                                     "expanded_folder": data['expanded_folder'],
                                     "requested_action": "",
                                     "message": "",
-                                    "update_date": data['update_date']
+                                    "update_date": data['update_date'],
+                                    "run_type": data.get('run_type')
                                 }
                             })
         self.assertEqual(queue, settings_mock.workflow_starter_queue)

--- a/tests/activity/test_activity_publish_to_lax.py
+++ b/tests/activity/test_activity_publish_to_lax.py
@@ -1,0 +1,134 @@
+import unittest
+import copy
+import base64
+import json
+from ddt import ddt, data
+from mock import patch
+from activity.activity_PublishToLax import activity_PublishToLax as activity_object
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeSQSConn, FakeSQSQueue, FakeSQSMessage
+from testfixtures import TempDirectory
+
+
+ACTIVITY_DATA = {
+    "article_id": "00353",
+    "version": "1",
+    "run": "bb2d37b8-e73c-43b3-a092-d555753316af",
+    "status": "vor",
+    "expanded_folder": "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
+}
+
+
+WORKFLOW_DATA = {
+    "workflow_data": {
+        "article_id": u"00353",
+        "expanded_folder": u"00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
+        "message": None,
+        "requested_action": u"publish",
+        "force": False,
+        "result": u"published",
+        "run": u"bb2d37b8-e73c-43b3-a092-d555753316af",
+        "status": u"vor",
+        "update_date": "2013-03-26T00:00:00Z",
+        "version": u"1",
+        "run_type": None
+    }
+}
+
+
+def workflow_data(data, run_type=None):
+    "format workflow data for different test scenarios"
+    workflow_data = copy.copy(data)
+    if run_type:
+        workflow_data["run_type"] = run_type
+    return workflow_data
+
+
+def activity_data(data, force=None, workflow_data=None):
+    "format activity data for different test scenarios"
+    activity_data = copy.copy(data)
+    if force:
+        activity_data["force"] = force
+    if workflow_data:
+        activity_data["publication_data"] = base64.encodestring(json.dumps(workflow_data))
+    return activity_data
+
+
+@ddt
+class TestPublishToLax(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch('activity.activity_PublishToLax.RawMessage')
+    @patch('boto.sqs.connection.SQSConnection.get_queue')
+    @patch('boto.sqs.connect_to_region')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @data(
+        {
+            "comment": "default activity input data",
+            "expected_force": False
+        },
+        {
+            "comment": "test force is True",
+            "force": True,
+            "expected_force": True
+        },
+        {
+            "comment": "test with default workflow data",
+            "set_workflow_data": True,
+            "expected_force": False
+        },
+        {
+            "comment": "test workflow data with run_type",
+            "set_workflow_data": True,
+            "run_type": "silent-correction",
+            "expected_force": False
+        }
+        )
+    def test_do_activity_success(self, test_data, fake_emit, fake_file_name,
+                                 fake_sqs_conn, fake_sqs_queue, fake_sqs_message):
+        directory = TempDirectory()
+        fake_sqs_conn.return_value = FakeSQSConn(directory)
+        fake_sqs_queue.return_value = FakeSQSQueue(directory)
+        fake_sqs_message.return_value = FakeSQSMessage(directory)
+        fake_file_name.return_value = "elife-00353-v1.xml"
+        # format the activity data
+        workflow_test_data = None
+        if test_data.get("set_workflow_data"):
+            workflow_test_data = workflow_data(WORKFLOW_DATA, test_data.get("run_type"))
+        activity_test_data = activity_data(
+            ACTIVITY_DATA, test_data.get("force"), workflow_test_data)
+        # run do_activity
+        result = self.activity.do_activity(activity_test_data)
+        # make assertions
+        self.assertEqual(result, True)
+        # read in the message body from the TempDirectory()
+        message_body = json.loads(directory.read("fake_sqs_body"))
+        self.assertEqual(message_body.get("force"), test_data.get("expected_force"))
+        self.assertEqual(message_body.get("action"), "publish")
+        self.assertEqual(message_body.get("id"), activity_test_data.get("article_id"))
+        self.assertIsNotNone(message_body.get("location"))
+        # parse the token
+        token = json.loads(base64.decodestring(message_body.get("token")))
+        self.assertEqual(token.get("status"), activity_test_data.get("status"))
+        self.assertEqual(token.get("run_type"), activity_test_data.get("run_type"))
+        self.assertEqual(token.get("force"), test_data.get("expected_force"))
+        self.assertEqual(token.get("expanded_folder"), activity_test_data.get("expanded_folder"))
+        self.assertEqual(token.get("version"), activity_test_data.get("version"))
+        self.assertEqual(token.get("run"), activity_test_data.get("run"))
+
+    @patch("provider.lax_provider.prepare_action_message")
+    @patch.object(activity_object, 'emit_monitor_event')
+    def test_do_activity_error(self, fake_emit, fake_lax_provider):
+        fake_lax_provider.side_effect = Exception("Access Denied")
+        result = self.activity.do_activity(activity_data(ACTIVITY_DATA))
+        self.assertEqual(result, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -183,7 +183,8 @@ class TestLaxProvider(unittest.TestCase):
                                                                   "version": "1",
                                                                   "expanded_folder": "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
                                                                   "status": "vor",
-                                                                  "force": False})
+                                                                  "force": False,
+                                                                  "run_type": None})
 
     @patch('provider.lax_provider.article_versions')
     def test_was_ever_poa_was_poa(self, mock_lax_provider_article_versions):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -69,7 +69,8 @@ data_ingested_lax = {
             "requested_action": "ingest",
             "force": False,
             "message": None,
-            "update_date": "2012-12-13T00:00:00Z"
+            "update_date": "2012-12-13T00:00:00Z",
+            "run_type": None
         }
 
 data_published_website = {

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -26,7 +26,8 @@ workflow_message_expected = {'workflow_data':
                                   'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'status': u'vor',
                                   'update_date': '2013-03-26T00:00:00Z',
-                                  'version': u'1'},
+                                  'version': u'1',
+                                  'run_type': None},
                              'workflow_name': 'PostPerfectPublication'}
 
 fake_token_269 = json.dumps({u'status': u'vor',
@@ -51,7 +52,8 @@ workflow_message_expected_269 = {'workflow_data':
                                   'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
                                   'status': u'vor',
                                   'update_date': '2013-03-26T00:00:00Z',
-                                  'version': u'1'},
+                                  'version': u'1',
+                                  'run_type': None},
                              'workflow_name': 'PostPerfectPublication'}
 
 class TestLaxResponseAdapter(unittest.TestCase):


### PR DESCRIPTION
The `PostPerfectPublication` workflow is the last one to run in a chain of workflows in the article publication process. The earlier workflows read data from the `session`. Once it gets to `PostPerfectPublication` it relies on the data passed to the workflow when the workflow is started.

The data used in the workflow start comes from a `token` - a base64 encoded dict of values - that is returned by Lax when a publication messages is received by the bot's `lax_response_adapter`.

In order for Lax to return the token containing the `run_type` value (added here) we also need to add it to the `token` the `PublishToLax` activity sends to the queue for Lax to read.

`IngestToLax` is also updated, because it can bypass issuing the publish message to Lax in the case of a silent correction.

The starters of some of the workflows also need to be aware of the `run_type` attribute so they can start their workflows and make the value available to the activities within them.

`PublishToLax` activity had no tests, so I spent some time creating some with good coverage.