### PR TITLE
Ingest digests in silent corrections

### DIFF
--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -79,6 +79,17 @@ class workflow_SilentCorrectionsProcess(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "IngestDigestToEndpoint",
+                        "activity_id": "IngestDigestToEndpoint",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "PublishToLax",
                         "activity_id": "PublishToLax",
                         "version": "1",


### PR DESCRIPTION
Run the IngestDigestToEndpoint activity as part of the silent corrections workflow.

It should be as simple as adding the activity to the workflow definition to get things going.