### PR TITLE
Feature digest published value

### DIFF
--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -70,6 +70,10 @@ class activity_PublishDigest(Activity):
             if existing_digest_json.get("stage") != "published":
                 self.digest_content = digest_provider.set_stage(existing_digest_json, 'published')
                 self.logger.info("Set Digest stage value of %s to published" % article_id)
+                # set the published date
+                if not self.digest_content.get("published"):
+                    self.digest_content["published"] = digest_provider.published_date_from_lax(
+                        self.settings, digest_id)
                 put_response = digest_provider.put_digest_to_endpoint(
                     self.logger, digest_id, self.digest_content, self.settings)
                 self.statuses["put"] = True

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -253,6 +253,21 @@ def approve_by_first_vor(settings, logger, article_id, version, status, auth=Tru
     return approve_status
 
 
+def published_date_from_lax(settings, article_id):
+    "published date for a digest is the versionDate of the first VoR in Lax"
+    published = None
+    status_version_map = lax_provider.article_status_version_map(article_id, settings)
+    version = None
+    if status_version_map and status_version_map.get("vor"):
+        # lowest version from the vor version map
+        version = min(status_version_map.get("vor"))
+    if version:
+        snippet = lax_provider.article_snippet(article_id, version, settings)
+        if snippet:
+            published = snippet.get("versionDate")
+    return published
+
+
 def set_stage(json_content, stage="preview"):
     "set the stage attribute"
     json_content["stage"] = stage

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ six==1.10.0
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@88c712a4d4d9c4a45fefbb820859151de49d8cc9#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@92e64a18c0ca5f7581ee6bd5540502bd3f5ee608#egg=digestparser
 psutil==5.4.6

--- a/tests/fixtures/digests/json_content_99999_full.py
+++ b/tests/fixtures/digests/json_content_99999_full.py
@@ -6,7 +6,6 @@ EXPECTED = OrderedDict([
     ('id', u'99999'),
     ('title', u'Fishing for errors in the\xa0tests'),
     ('impactStatement', u'Testing a document which mimics the format of a file we’ve used  before plus CO<sub>2</sub> and Ca<sup>2+</sup>.'),
-    ('published', '2016-06-16T00:00:00Z'),
     ('image', OrderedDict([
         ('thumbnail', OrderedDict([
             ('uri', 'https://iiif.elifesciences.org/digests/99999%2Fdigest-99999.jpg'),

--- a/tests/fixtures/digests/json_content_99999_jats.py
+++ b/tests/fixtures/digests/json_content_99999_jats.py
@@ -6,7 +6,6 @@ EXPECTED = OrderedDict([
     ('id', u'99999'),
     ('title', u'Fishing for errors in the\xa0tests'),
     ('impactStatement', u'Testing a document which mimics the format of a file we’ve used  before plus CO<sub>2</sub> and Ca<sup>2+</sup>.'),
-    ('published', '2016-06-16T00:00:00Z'),
     ('image', OrderedDict([
         ('thumbnail', OrderedDict([
             ('uri', 'https://iiif.elifesciences.org/digests/99999%2Fdigest-99999.jpg'),


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4474

Ready to review, I think it is feature complete.

Newest `digest-parser` library does not automatically set a digest `published` date from the JATS XML file value.

Lax data for the `versionDate` of the first VoR version is used in the `digest_provider` to supply the date we want in `published_date_from_lax()`.

If the digest has no `published` value when it is about to be published in the `PublishDigest` activity, it is set to the value that comes from Lax.