### PR TITLE
Fix for clean_outbox in CopyDigestToOutbox

### DIFF
--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -78,8 +78,9 @@ class activity_CopyDigestToOutbox(Activity):
         storage = storage_context(self.settings)
         files_in_bucket = storage.list_resources(resource_path)
         for resource in files_in_bucket:
-            self.logger.info("Deleting %s from the outbox", resource)
-            storage.delete_resource(resource)
+            orig_resource = resource_path + "/" + resource
+            self.logger.info("Deleting %s from the outbox", orig_resource)
+            storage.delete_resource(orig_resource)
 
     def copy_files_to_outbox(self, digest, bucket_name, from_dir):
         "copy all the files from the from_dir to the bucket"

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -129,10 +129,9 @@ class FakeStorageContext:
 
     def delete_resource(self, resource):
         # delete from the destination folder
-        bucket, s3_key = self.get_bucket_and_key(resource)
-        src = data.ExpandArticle_files_dest_folder + s3_key
-        if os.path.exists(src):
-            os.remove(src)
+        file_name = data.ExpandArticle_files_dest_folder + '/' + resource.split('/')[-1]
+        if os.path.exists(file_name):
+            os.remove(file_name)
 
     def get_resource_to_file_pointer(self, resource, file_path):
         return None

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -25,7 +25,7 @@ def populate_outbox(resources):
     "populate the bucket with outbox files to later be deleted"
     for resource in resources:
         file_name = resource.split('/')[-1]
-        file_path = os.path.join(testdata.ExpandArticle_files_dest_folder, file_name)
+        file_path = testdata.ExpandArticle_files_dest_folder + '/' + file_name
         with open(file_path, 'a'):
             os.utime(file_path, None)
 


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4490

When deleting files from S3, the path must be added back to the file name first to get the full path.  