### PR TITLE
Deposit all assets and invalidate the CDN prior to ingesting to Lax.

### DIFF
--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -112,6 +112,28 @@ class workflow_IngestArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "DepositAssets",
+                        "activity_id": "DepositAssets",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
+                        "activity_type": "InvalidateCdn",
+                        "activity_id": "InvalidateCdn",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "VerifyImageServer",
                         "activity_id": "VerifyImageServer",
                         "version": "1",

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -68,28 +68,6 @@ class workflow_ProcessArticleZip(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "DepositAssets",
-                        "activity_id": "DepositAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "InvalidateCdn",
-                        "activity_id": "InvalidateCdn",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -156,6 +156,28 @@ class workflow_SilentCorrectionsIngest(workflow.workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "DepositAssets",
+                        "activity_id": "DepositAssets",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
+                        "activity_type": "InvalidateCdn",
+                        "activity_id": "InvalidateCdn",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "VerifyImageServer",
                         "activity_id": "VerifyImageServer",
                         "version": "1",

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -57,28 +57,6 @@ class workflow_SilentCorrectionsProcess(workflow.workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
-                        "activity_type": "DepositAssets",
-                        "activity_id": "DepositAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "InvalidateCdn",
-                        "activity_id": "InvalidateCdn",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",


### PR DESCRIPTION
Simple re-ordering of some activities in the article ingest workflows, it should hopefully help with refreshing caches before ingest to Lax.

In reference to ticket https://github.com/elifesciences/issues/issues/4458

It may cause some merge conflicts with changes in PR https://github.com/elifesciences/elife-bot/pull/802 if this PR is merged first, since it edits a workflow (`IngestArticleZip`) that will no longer exist if the workflows are unified.