### PR TITLE
InvalidateCdn activity to get values from the session instead of data.

### DIFF
--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -1,4 +1,5 @@
 import activity
+from provider.execution_context import get_session
 from provider import fastly_provider
 
 """
@@ -21,9 +22,10 @@ class activity_InvalidateCdn(activity.activity):
 
     def do_activity(self, data):
         try:
-            article_id = data['article_id']
-            version = data['version']
             run = data['run']
+            session = get_session(self.settings, data, run)
+            article_id = session.get_value('article_id')
+            version = session.get_value('version')
         except Exception as e:
             self.logger.error("Error retrieving basic article data. Data: %s, Exception: %s" % (str(data), str(e)))
             return activity.activity.ACTIVITY_PERMANENT_FAILURE

--- a/tests/activity/test_activity_invalidate_cdn.py
+++ b/tests/activity/test_activity_invalidate_cdn.py
@@ -1,7 +1,8 @@
 import unittest
 from activity.activity_InvalidateCdn import activity_InvalidateCdn
 import settings_mock
-from classes_mock import FakeLogger
+from classes_mock import FakeLogger, FakeSession
+import test_activity_data as test_activity_data
 from mock import patch, call
 
 activity_data = {
@@ -16,15 +17,19 @@ class TestInvalidateCdn(unittest.TestCase):
         self.invalidatecdn = activity_InvalidateCdn(settings_mock, None, None, None, None)
         self.invalidatecdn.logger = FakeLogger()
 
+    @patch('activity.activity_InvalidateCdn.get_session')
     @patch('provider.fastly_provider.purge')
     @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
-    def test_invalidation_success(self, fake_emit, purge_mock):
+    def test_invalidation_success(self, fake_emit, purge_mock, fake_session):
+        fake_session.return_value = FakeSession(test_activity_data.session_example)
         result = self.invalidatecdn.do_activity(activity_data)
         self.assertEqual(result, self.invalidatecdn.ACTIVITY_SUCCESS)
 
+    @patch('activity.activity_InvalidateCdn.get_session')
     @patch('provider.fastly_provider.purge')
     @patch.object(activity_InvalidateCdn, 'emit_monitor_event')
-    def test_invalidation_permanent_failure_fastly(self, fake_emit, purge_mock):
+    def test_invalidation_permanent_failure_fastly(self, fake_emit, purge_mock, fake_session):
+        fake_session.return_value = FakeSession(test_activity_data.session_example)
         purge_mock.side_effect = Exception("An error occurred calling the Fastly API")
         result = self.invalidatecdn.do_activity(activity_data)
         self.assertEqual(result, self.invalidatecdn.ACTIVITY_PERMANENT_FAILURE)


### PR DESCRIPTION
Fix for PR https://github.com/elifesciences/elife-bot/pull/805 that failed end2end tests, most likely because `InvalidateCdn` cannot get the values it needs from the workflow data, it needs to get them from the session now it has been moved up to an earlier workflow.