### PR TITLE
article_structure provider improvements improved

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -20,10 +20,12 @@ class ArticleInfo(object):
         - Other: file is something else
         (more required!)
     journal: the name of the journal (e.g. elife)
-    article_id: referred to in the naming spec as the file id (f-id) of the article the file is part of (e.g. 00012)
+    article_id: referred to in the naming spec as the file id (f-id) of the
+        article the file is part of (e.g. 00012)
     versioned: boolean representing if the file has a version number
     version: the version of the file (or None if not versioned)
-    extra-info: the parts of the filename between the f-id (or status if present) and the version (if present) or extension
+    extra-info: the parts of the filename between the f-id (or status if present) and
+        the version (if present) or extension
     """
 
     def __init__(self, full_filename):
@@ -31,13 +33,15 @@ class ArticleInfo(object):
 
         # TODO : check full_filename matches basic validation regex for:
         # `elife-<f-id>-<status>(-<asset><a-id>)(-<sub-asset><sa-id>)(-<data><d-id>)(-<code><c-id>)
-        # (-<media><m-id>)(-<reporting standard><repstand-id>)(-<supplementary file><supp-id>)|(-v<version>).<ext>`
+        # (-<media><m-id>)(-<reporting standard><repstand-id>)
+        # (-<supplementary file><supp-id>)|(-v<version>).<ext>`
         # including minimum required info of f-id, status and ext.
 
         (self.filename, self.extension) = full_filename.rsplit('.', 1)
         parts = self.filename.split('-')
 
-        match = re.match('.*?-[a-zA-Z0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)?(-([0-9]+))?\.zip', self.full_filename, re.IGNORECASE)
+        match = re.match(r'.*?-[a-zA-Z0-9]+?-(poa|vor)(-*?(v|r)[0-9]+?)?(-([0-9]+))?\.zip',
+                         self.full_filename, re.IGNORECASE)
         first_other_index = 2
         if match is not None:
             self.status = match.group(1)
@@ -80,27 +84,31 @@ class ArticleInfo(object):
                    or self.extra_info[0].startswith('figsupp'))
               and not self.extra_info[0].startswith('figures')):
             self.file_type = "Figure"
-        elif len(self.extra_info) > 1 and self.extra_info[0].startswith('resp') and self.extra_info[1].startswith('fig'):
+        elif (len(self.extra_info) > 1 and self.extra_info[0].startswith('resp')
+              and self.extra_info[1].startswith('fig')):
             self.file_type = "Figure"
-        elif len(self.extra_info) > 1 and self.extra_info[0].startswith('app') and self.extra_info[1].startswith('fig'):
+        elif (len(self.extra_info) > 1 and self.extra_info[0].startswith('app')
+              and self.extra_info[1].startswith('fig')):
             self.file_type = "Figure"
-        elif len(self.extra_info) > 1 and self.extra_info[0].startswith('box') and self.extra_info[1].startswith('fig'):
+        elif (len(self.extra_info) > 1 and self.extra_info[0].startswith('box')
+              and self.extra_info[1].startswith('fig')):
             self.file_type = "Figure"
         elif len(self.extra_info) > 0 and self.extra_info[0].startswith('inf'):
             self.file_type = "Inline"
-        elif (len(parts) == 2 or len(parts) == 3) and self.extension == 'xml':
+        elif ((len(parts) == 2 or (len(parts) == 3 and not self.extra_info))
+              and self.extension == 'xml'):
             self.file_type = 'ArticleXML'
         else:
             self.file_type = 'Other'
 
     def get_update_date_from_zip_filename(self):
         filename = self.full_filename
-        m = re.search(r'.*?-.*?-.*?-.*?-(.*?)\..*', filename)
-        if m is None:
+        match = re.search(r'.*?-.*?-.*?-.*?-(.*?)\..*', filename)
+        if match is None:
             return None
         else:
             try:
-                raw_update_date = m.group(1)
+                raw_update_date = match.group(1)
                 updated_date = datetime.datetime.strptime(raw_update_date, "%Y%m%d%H%M%S")
                 return updated_date.strftime('%Y-%m-%dT%H:%M:%SZ')
             except:
@@ -108,50 +116,61 @@ class ArticleInfo(object):
 
     def get_version_from_zip_filename(self):
         filename = self.full_filename
-        m = re.search(r'-v([0-9]+?)[\.|-]', filename)
-        if m is None:
+        match = re.search(r'-v([0-9]+?)[\.|-]', filename)
+        if match is None:
             return None
         else:
-            return m.group(1)
+            return match.group(1)
 
-def article_figure(file):
-    article_info = ArticleInfo(file)
+
+def article_figure(filename):
+    article_info = ArticleInfo(filename)
     return article_info.file_type == "Figure"
 
-def figure_pdf(file):
-    article_info = ArticleInfo(file)
+
+def figure_pdf(filename):
+    article_info = ArticleInfo(filename)
     return article_info.file_type == "FigurePDF"
 
-def inline_figure(file):
-    article_info = ArticleInfo(file)
+
+def inline_figure(filename):
+    article_info = ArticleInfo(filename)
     return article_info.file_type == "Inline"
 
-def has_extensions(file, extensions):
-    article_info = ArticleInfo(file)
+
+def has_extensions(filename, extensions):
+    article_info = ArticleInfo(filename)
     return article_info.extension in extensions
 
 
 def get_original_files(files):
     regex = re.compile(r'-v([0-9]+)[\.]')
-    fs = list(filter(regex.search, files))
-    return fs
+    file_list = list(filter(regex.search, files))
+    return file_list
+
 
 def get_figures_for_iiif(files):
     # should only be tif
-    originals_figures_tif = [f for f in get_original_files(files) if (article_figure(f) and has_extensions(f, ['tif']))]
-    fs = originals_figures_tif + get_media_file_images(files)
-    return fs
+    originals_figures_tif = [f for f in get_original_files(files)
+                             if article_figure(f) and has_extensions(f, ['tif'])]
+    file_list = originals_figures_tif + get_media_file_images(files)
+    return file_list
+
 
 def get_inline_figures_for_iiif(files):
     # should only be tif
     "return a list of all inline figure files"
-    return [f for f in get_original_files(files) if (inline_figure(f) and has_extensions(f, ['tif']))]
+    return [f for f in get_original_files(files)
+            if inline_figure(f) and has_extensions(f, ['tif'])]
+
 
 def get_figures_pdfs(files):
-    return [f for f in files if (figure_pdf(f) and has_extensions(f, ['pdf']))]
+    return [f for f in files if figure_pdf(f) and has_extensions(f, ['pdf'])]
+
 
 def get_videos(files):
-    return [f for f in files if (is_video_file(f))]
+    return [f for f in files if is_video_file(f)]
+
 
 def file_parts(filename):
     prefix = filename.split('.')[0]
@@ -160,7 +179,7 @@ def file_parts(filename):
 
 
 def get_media_file_images(files):
-    return list(filter(lambda f: is_video_file(f) and has_extensions(f, ['jpg']), files))
+    return [f for f in files if is_video_file(f) and has_extensions(f, ['jpg'])]
 
 
 def is_video_file(filename):
@@ -171,12 +190,10 @@ def is_video_file(filename):
          match False on elife-00005-media1-code1.wrl
     """
 
-    (file_prefix, file_extension) = file_parts(filename)
+    file_prefix, file_extension = file_parts(filename)
     file_type_plus_index = file_prefix.split('-')[-1]
-    if ("media" in file_type_plus_index) or ("video" in file_type_plus_index):
-        return True
-    else:
-        return False
+    return bool("media" in file_type_plus_index or "video" in file_type_plus_index)
+
 
 def pre_ingest_assets(files):
     original_figures = get_figures_for_iiif(files)
@@ -200,9 +217,10 @@ def get_article_xml_key(bucket, expanded_folder_name):
             return key, filename
     return None, None
 
+
 def main():
-    a = ArticleInfo("elife-00012-fig3-figsupp1-data2.csv")
-    print(a)
+    article = ArticleInfo("elife-00012-fig3-figsupp1-data2.csv")
+    print(article)
 
 
 if __name__ == '__main__':

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -59,7 +59,8 @@ class TestArticleStructure(unittest.TestCase):
 
     @unpack
     @data({'input': 'elife-07702-vor-r4.zip', 'expected': None},
-          {'input': 'elife-00013-vor-v1-20121015000000.zip', 'expected':'2012-10-15T00:00:00Z'})
+          {'input': 'elife-00013-vor-v1-20121015000000.zip', 'expected':'2012-10-15T00:00:00Z'},
+          {'input': 'elife-07702-vor-r4-2012bad_date.zip', 'expected': None})
     def test_get_update_date_from_zip_filename(self, input, expected):
         self.articleinfo = ArticleInfo(input)
         result = self.articleinfo.get_update_date_from_zip_filename()
@@ -107,8 +108,21 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-video1.mp4', 'expected': 'Other'},
         {'input': 'elife-00666-video1-data1-v1.xlsx', 'expected': 'Other'},
         {'input': 'elife-00666.xml', 'expected': 'ArticleXML'},
+        {'input': 'elife-00666.pdf', 'expected': 'Other'},
+        {'input': 'elife-00666-supp99.xml', 'expected': 'Other'},
+        {'input': 'elife-00666-supp99-v1.xml', 'expected': 'Other'},
           )
     def test_get_file_type_from_zip_filename(self, input, expected):
+        self.articleinfo = ArticleInfo(input)
+        result = self.articleinfo.file_type
+        self.assertEqual(result, expected)
+
+    @unpack
+    @data(
+        {'input': 'Video_22.zip', 'expected': None}
+        )
+    def test_get_file_type_edge_case(self, input, expected):
+        "edge case in elife 04493 PoA"
         self.articleinfo = ArticleInfo(input)
         result = self.articleinfo.file_type
         self.assertEqual(result, expected)
@@ -269,7 +283,9 @@ class TestArticleStructure(unittest.TestCase):
 
     @patch.object(FakeBucket, 'list')
     @data(
-        (['test/elife-00666-video2.jpg', 'test/elife-00666-v1.xml'], 'test/elife-00666-v1.xml', 'elife-00666-v1.xml'),
+        (['test/elife-00666-video2.jpg', 'test/elife-00666-v1.xml',
+          'test/elife-00666-supp3-v1.xml'],
+            'test/elife-00666-v1.xml', 'elife-00666-v1.xml'),
         (['test/elife-00666-video2.jpg'], None, None),
     )
     @unpack


### PR DESCRIPTION
Previously reverted article_structure improvements with a bug fix for ArticleXML file detection. All the code changes from PR https://github.com/elifesciences/elife-bot/pull/807  with a fix on the parentheses when looking for ArticleXML:

```
elif ((len(parts) == 2 or (len(parts) == 3 and not self.extra_info))
    and self.extension == 'xml'):
```

Added the test data to cover the scenario that was missed:

```
{'input': 'elife-00666.pdf', 'expected': 'Other'},
```


