### PR TITLE
Digest silent documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,19 @@
 elife-bot Overview
 =========
 
-eLife Bot is a set of tools built on top of Amazon's [Simple Work Flow][swf] (SWF) to manage post-publication workflow. After we publish an article within eLife we want a number of processes to happen. eLife Bot mocks an event driven architecture by monitoring an S3 bucket hourly for the arrival of new files. History is stored in an AWS Simple DataBase. When a new or modified file is identified a workflow is trigged in [SWF][swf]. Our workflows have been configured to write logging information back into the Simple DB. 
+eLife Bot is a set of tools built on top of Amazon's [Simple Work Flow][swf] (SWF) to manage publication workflow. The workflows, activities, and libraries change often to support eLife's evolving requirements.
 
+When we publish an article within eLife we want a number of processes to happen. eLife Bot incorporates an event driven architecture from S3 bucket notifications when new files arrive. History is stored in an AWS Simple DataBase, as well as in S3 buckets. When a new or modified file is identified a workflow is trigged in [SWF][swf].
+
+[swf]: https://aws.amazon.com/swf/
 
 ## Installation and tests
 
-eLife bot is currently configured and deployed manually via a custom Ec2 instance. This is partially described in `installation.md`. Tests are provided in `lettuce`.
+eLife bot is currently configured and deployed by eLife builder libraries.
 
 We have added unit tests for the eLife bot activities using Python unittest library. Running on the command line:
 cd to elife-bot and execute:
 python -m pytest --junitxml=build/junit.xml tests/
-
-
-## Existing Workflows
-
-Existing workflows are documentd in `current-workflows.md`.
 
 
 ## Extending eLife bot with a new workflow
@@ -30,7 +28,7 @@ Issues and backlog items are stored in Github on the [project issues page][pip].
 
 Major milestones that we would like to see are:
 
-- setting up deployment via chef
+- setting up deployment
 - making extending the workflow super easy
 - adding a visual reporting strucutre
 - adding a way to poll external endpoints for ALM data (potentially)
@@ -41,7 +39,7 @@ Major milestones that we would like to see are:
 
 ## Contributing to the project
 
-If you have a contribution you wouldl like us to consider, please send a pull request. 
+If you have a contribution you would like us to consider, please send a pull request. 
 
 
 ## Other eLife Resources

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ When we publish an article within eLife we want a number of processes to happen.
 
 [swf]: https://aws.amazon.com/swf/
 
+
+## Digest silent workflow
+
+Digest zip files copied to the digest input bucket (a bucket with a name matching `*-elife-bot-digests-input`) will normally transmit the digest output to a third-party by email or to an API endpoint when a `IngestDigest` workflow is executed.
+
+You can trigger a silent `IngestDigest` workflow, which still validates the input and replaces existing digest data in eLife buckets, but avoids sending a digest to the third-party, by altering the file name of the digest zip file.
+
+To start a silent digest workflow, make sure the zip file name ends with `-silent.zip` or ` silent.zip` (case insensitive, so it can be ` silent.zip` or ` SILENT.zip`), and copy that file to the digest input bucket.
+
+
 ## Installation and tests
 
 eLife bot is currently configured and deployed by eLife builder libraries.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Digest zip files copied to the digest input bucket (a bucket with a name matchin
 
 You can trigger a silent `IngestDigest` workflow, which still validates the input and replaces existing digest data in eLife buckets, but avoids sending a digest to the third-party, by altering the file name of the digest zip file.
 
-To start a silent digest workflow, make sure the zip file name ends with `-silent.zip` or ` silent.zip` (case insensitive, so it can be ` silent.zip` or ` SILENT.zip`), and copy that file to the digest input bucket.
+To start a silent digest workflow, make sure the zip file name ends with `-silent.zip` (with case insensitive matching, so it can be `-silent.zip` or `-SILENT.zip`), and copy that file to the digest input bucket.
 
 
 ## Installation and tests


### PR DESCRIPTION
In reference to https://github.com/elifesciences/issues/issues/4479

Some general clean-up of the readme, and adding a note about how to trigger a silent `IngestDigest` workflow.

I removed the suggestion that zip files names can end in ` silent.zip` because the space character at the start of that format is not really noticeable when the readme is rendered on a web page and it would be confusing (I think).