### PR TITLE
Starters and python 3

### DIFF
--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,5 +1,6 @@
 import re
 import urllib
+import base64
 
 S3_DATE_FORMAT = '%Y%m%d%H%M%S'
 PUB_DATE_FORMAT = "%Y-%m-%d"
@@ -61,3 +62,11 @@ def unicode_decode(string):
     except (UnicodeEncodeError, AttributeError):
         pass
     return string
+
+
+def base64_encode_string(string):
+    "base64 endcode string for python 2 or 3"
+    if hasattr(base64, 'encodebytes'):
+        # python 3
+        return base64.encodebytes(bytes(string, 'utf8'))
+    return base64.encodestring(string)

--- a/starter/starter_ApproveArticlePublication.py
+++ b/starter/starter_ApproveArticlePublication.py
@@ -11,8 +11,8 @@ import json
 import random
 from optparse import OptionParser
 
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF PublishArticle starter, for API and Lens publishing etc.

--- a/starter/starter_CopyGlencoeStillImages.py
+++ b/starter/starter_CopyGlencoeStillImages.py
@@ -9,8 +9,8 @@ import boto.swf
 import json
 from argparse import ArgumentParser
 
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF CopyGlencoeStillImages starter, for copying Glencoe still images to IIIF bucket.

--- a/starter/starter_IngestArticleZip.py
+++ b/starter/starter_IngestArticleZip.py
@@ -9,8 +9,8 @@ import json
 import random
 from optparse import OptionParser
 from S3utility.s3_notification_info import S3NotificationInfo
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF IngestArticleZip starter, preparing article xml for lax.

--- a/starter/starter_InitialArticleZip.py
+++ b/starter/starter_InitialArticleZip.py
@@ -9,8 +9,8 @@ import json
 import random
 from optparse import OptionParser
 from S3utility.s3_notification_info import S3NotificationInfo
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF InitialArticleZip starter

--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -7,8 +7,8 @@ import boto.swf
 import log
 import json
 from optparse import OptionParser
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF PostPerfectPublication starter, for API and Lens publishing etc.

--- a/starter/starter_ProcessArticleZip.py
+++ b/starter/starter_ProcessArticleZip.py
@@ -8,8 +8,8 @@ import log
 import json
 import random
 from optparse import OptionParser
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF ProcessArticleZip starter, preparing article xml for lax.

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -7,8 +7,8 @@ import boto.swf
 import json
 from optparse import OptionParser
 from S3utility.s3_notification_info import S3NotificationInfo
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF SilentCorrectionsIngest starter, preparing article xml for lax.

--- a/starter/starter_SilentCorrectionsProcess.py
+++ b/starter/starter_SilentCorrectionsProcess.py
@@ -8,8 +8,8 @@ import log
 import json
 import random
 from optparse import OptionParser
-import starter_helper as helper
-from starter_helper import NullRequiredDataException
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
 
 """
 Amazon SWF SilentCorrectionsProcess starter, preparing article xml for lax.

--- a/starter/starter_helper.py
+++ b/starter/starter_helper.py
@@ -23,7 +23,7 @@ def set_workflow_information(name, workflow_version, child_policy, data, workflo
         workflow_version = workflow_version
         child_policy = child_policy
         execution_start_to_close_timeout = start_to_close_timeout
-        workflow_input = json.dumps(data, default=lambda ob: ob.__dict__)
+        workflow_input = json.dumps(data, default=lambda ob: None)
 
         return workflow_id, \
                workflow_name, \

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 import json
 import base64
+from provider.utils import base64_encode_string
 
 lax_article_versions_response_data = [
                                         {
@@ -142,17 +143,17 @@ ingest_digest_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
 queue_worker_rules = {
     'ArticleZip': {
         'bucket_name_pattern': '.*elife-production-final$',
-        'file_name_pattern': '.*\.zip',
+        'file_name_pattern': r'.*\.zip',
         'starter_name': 'InitialArticleZip'
         },
     'SilentCorrectionsArticleZip': {
        'bucket_name_pattern': '.*elife-silent-corrections$',
-       'file_name_pattern': '.*\.zip',
+       'file_name_pattern': r'.*\.zip',
        'starter_name': 'SilentCorrectionsIngest'
        },
     'DigestInputFile': {
        'bucket_name_pattern': '.*elife-bot-digests-input$',
-       'file_name_pattern': '.*\.(docx|zip)',
+       'file_name_pattern': r'.*\.(docx|zip)',
        'starter_name': 'IngestDigest'
        },
     }
@@ -181,7 +182,7 @@ def ApprovePublication_data(update_date="2012-12-13T00:00:00Z"):
             "article_id": "00353",
             "version": "1",
             "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-            "publication_data": base64.encodestring(json.dumps(ApprovePublication_publication_data(update_date)))
+            "publication_data": base64_encode_string(json.dumps(ApprovePublication_publication_data(update_date)))
             }
 
 def ApprovePublication_json_output_return_example(update_date):


### PR DESCRIPTION
Continuation of improving Python 3 support, I looked at getting the tests for the starters to pass.

The imports for `starter_helper` are improved with a full path used.

`base64` uses `encodebytes` since `encodestring` is deprecated, which is handled here by a new `base64_encode_string()` function.

`bytes` has no `__dict__` so when json dumping to string, the default function would now return `None` instead of (presumably) a dict. It should have no effect how it is used normally, as long as the activity `data` is checked to be non-None before trying to get values from it.