### PR TITLE
Tox environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 skipsdist = True
 envlist = py27,py35
 [testenv]
+passenv = HOME MAGICK_HOME
 deps = -rrequirements.txt
 commands = coverage run -m pytest


### PR DESCRIPTION
Pass environment variables to tox, fixes GitPython and image resize. 

When trying to run `tox` tests, there were some tests not passing when running in python 2 that I expected to pass.

One failing was `test_activity_convert_images_to_jpg`, where it was unable to import imagemagick libraries. Passing tox the `MAGICK_HOME` value solves it for me.

The other failing tests were to generate Crossref deposits, Pubmed deposits, and some others, tracking it down to the usage of `GitPython` to get the most recent git commit sha for inclusion in XML output files. By passing `HOME` to tox, it seems to avoid the `ValueError`, where `GitPython` was returning `''` as the sha value.

This PR should have no impact, I think, but if someone wants to look at it. 

Maybe in future the automated tests can be switched over to run `tox` when it is running correctly.