### PR TITLE
Transmitting digest JATS to endpoint

### DIFF
--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -126,7 +126,7 @@ def post_payload(digest, jats_content, api_key):
 
 def post_jats_to_endpoint(url, payload, logger):
     "issue the POST"
-    resp = requests.post(url, data=payload)
+    resp = requests.post(url, params=payload)
     # Check for good HTTP status code
     if resp.status_code != 200:
         logger.error(

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -126,7 +126,7 @@ def post_payload(digest, jats_content, api_key):
 
 def post_jats_to_endpoint(url, payload, logger):
     "issue the POST"
-    resp = requests.post(url, params=payload)
+    resp = post_as_params(url, payload)
     # Check for good HTTP status code
     if resp.status_code != 200:
         logger.error(
@@ -139,3 +139,18 @@ def post_jats_to_endpoint(url, payload, logger):
             " \nresponse: %s") %
         (url, payload, resp.status_code, resp.content))
     return True
+
+
+def post_as_params(url, payload):
+    "post the payload as URL parameters"
+    return requests.post(url, params=payload)
+
+
+def post_as_data(url, payload):
+    "post the payload as form data"
+    return requests.post(url, data=payload)
+
+
+def post_as_json(url, payload):
+    "post the payload as JSON data"
+    return requests.post(url, json=payload)

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -206,7 +206,7 @@ class TestPost(unittest.TestCase):
             ("type", "digest"),
             ("content", '<p>"98%"β</p>')
             ])
-        expected_url = 'http://localhost/?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        expected_url = url + '?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
         expected_body = None
         # populate the fake request
         resp = activity_module.post_as_params(url, payload)
@@ -222,7 +222,7 @@ class TestPost(unittest.TestCase):
             ("type", "digest"),
             ("content", '<p>"98%"β</p>')
             ])
-        expected_url = 'http://localhost/'
+        expected_url = url
         expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
         # populate the fake request
         resp = activity_module.post_as_data(url, payload)
@@ -238,7 +238,7 @@ class TestPost(unittest.TestCase):
             ("type", "digest"),
             ("content", '<p>"98%"β</p>')
             ])
-        expected_url = 'http://localhost/'
+        expected_url = url
         expected_body = '{"type": "digest", "content": "<p>\\"98%\\"\\u03b2</p>"}'
         # populate the fake request
         resp = activity_module.post_as_json(url, payload)

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -192,5 +192,60 @@ class TestPostPayload(unittest.TestCase):
         # make assertions
         self.assertEqual(payload, expected)
 
+
+class TestPost(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_params(self, fake_connection):
+        "test posting data as params only"
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = 'http://localhost/?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        expected_body = None
+        # populate the fake request
+        resp = activity_module.post_as_params(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_data(self, fake_connection):
+        "test posting data as data only"
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = 'http://localhost/'
+        expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        # populate the fake request
+        resp = activity_module.post_as_data(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_json(self, fake_connection):
+        "test posting data as data only"
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = 'http://localhost/'
+        expected_body = '{"type": "digest", "content": "<p>\\"98%\\"\\u03b2</p>"}'
+        # populate the fake request
+        resp = activity_module.post_as_json(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This method of sending digest JATS to the endpoint is tested and currently works.

Waiting to see if the method will change after more discussion.