### PR TITLE
Schedule downstream refactoring and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 dist: trusty
 
 python:

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -3,6 +3,7 @@ import json
 from digestparser import json_output
 from provider.storage_provider import storage_context
 from provider.execution_context import get_session
+from provider.article_processing import download_article_xml
 import provider.digest_provider as digest_provider
 import provider.lax_provider as lax_provider
 from activity.objects import Activity
@@ -306,21 +307,6 @@ class activity_IngestDigestToEndpoint(Activity):
                 os.mkdir(dir_name)
             except OSError:
                 pass
-
-
-def download_article_xml(settings, to_dir, bucket_folder, bucket_name, version=None):
-    xml_file = lax_provider.get_xml_file_name(
-        settings, bucket_folder, bucket_name, version)
-    storage = storage_context(settings)
-    storage_provider = settings.storage_provider + "://"
-    orig_resource = storage_provider + bucket_name + "/" + bucket_folder
-    # download the file
-    article_xml_filename = xml_file.split("/")[-1]
-    filename_plus_path = os.path.join(to_dir, article_xml_filename)
-    with open(filename_plus_path, "wb") as open_file:
-        storage_resource_origin = orig_resource + "/" + article_xml_filename
-        storage.get_resource_to_file(storage_resource_origin, open_file)
-        return filename_plus_path
 
 
 def related_from_lax(article_id, version, settings, logger=None, auth=True):

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import dateutil.parser
 from elifetools import xmlio
-from provider import utils
+from provider import utils, lax_provider
+from provider.storage_provider import storage_context
 
 """
 Functions for processing article zip and XML for reuse by different activities
@@ -135,6 +136,21 @@ def latest_archive_zip_revision(doi_id, s3_keys, journal, status):
                 highest = version_and_date
 
     return s3_key_name
+
+
+def download_article_xml(settings, to_dir, bucket_folder, bucket_name, version=None):
+    xml_file = lax_provider.get_xml_file_name(
+        settings, bucket_folder, bucket_name, version)
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+    orig_resource = storage_provider + bucket_name + "/" + bucket_folder
+    # download the file
+    article_xml_filename = xml_file.split("/")[-1]
+    filename_plus_path = os.path.join(to_dir, article_xml_filename)
+    with open(filename_plus_path, "wb") as open_file:
+        storage_resource_origin = orig_resource + "/" + article_xml_filename
+        storage.get_resource_to_file(storage_resource_origin, open_file)
+        return filename_plus_path
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -1,0 +1,31 @@
+import unittest
+from mock import mock, patch
+import activity.activity_ScheduleDownstream as activity_module
+from activity.activity_ScheduleDownstream import activity_ScheduleDownstream as activity_object
+from provider import article
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+import tests.activity.test_activity_data as activity_test_data
+
+
+class TestScheduleDownstream(unittest.TestCase):
+
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    @patch.object(article, 'storage_context')
+    @patch.object(activity_module, 'storage_context')
+    def test_do_activity(self, fake_activity_storage_context, fake_storage_context):
+        expected_result = True
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_activity_storage_context.return_value = FakeStorageContext()
+        self.activity.emit_monitor_event = mock.MagicMock()
+        # do the activity
+        result = self.activity.do_activity(activity_test_data.data_example_before_publish)
+        # check assertions
+        self.assertEqual(result, expected_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e # everything must succeed.
-export BOTO_CONFIG=/dev/null
 pip install -r requirements.txt

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+export BOTO_CONFIG=/dev/null
 python -m pytest --junitxml=build/junit.xml


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/elife-bot/issues/827 for more tests on bot activities.

Started off with refactoring all the native `S3Connection` usage to use the `storage_context`.

`storage.copy_resource()` is used in other activities to copy objects from one bucket to another, but the mocked `copy_resource()` method doesn't actually copy any data that can be checked in test assertions right now.

Continued to refactor some of the object properties, moved them out to separate functions.

I also included moving `download_article_xml()` to the `article_processing.py` provider, except I didn't need it here since this activity only gets the XML key name and doesn't need to download the XML to copy bucket to bucket.