### PR TITLE
Bug fix, add expanded folder name to old key in ScheduleDownstream.

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -48,8 +48,9 @@ class activity_ScheduleDownstream(Activity):
                                 "Starting scheduling of downstream deposits for " + article_id)
 
         try:
-            xml_key_name = get_xml_file_name(
+            xml_file_name = get_xml_file_name(
                 self.settings, expanded_folder_name, expanded_bucket_name, version)
+            xml_key_name = expanded_folder_name + "/" + xml_file_name
             outbox_list = choose_outboxes(status, outbox_map())
 
             for outbox in outbox_list:


### PR DESCRIPTION
end2end testing is failing on `ScheduleDownstream`, the origin key name is wrong. Adding back the expanded bucket folder name to the origin key so the copy operation will work.