### PR TITLE
Publish digest tweaks

### DIFF
--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -77,11 +77,13 @@ class activity_PublishDigest(Activity):
                 put_response = digest_provider.put_digest_to_endpoint(
                     self.logger, digest_id, self.digest_content, self.settings)
                 self.statuses["put"] = True
-                self.logger.info("Put Digest for %s to the endpoint: " % article_id, put_response)
+                self.logger.info(
+                    "Put Digest for %s to the endpoint, response: %s" %
+                    (article_id, put_response))
             else:
                 self.logger.info(
-                    "Digest is already published, did not put Digest for %s to the endpoint: " %
-                    article_id, put_response)
+                    "Digest is already published, did not put Digest for %s to the endpoint" %
+                    article_id)
 
         except Exception as exception:
             self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -133,9 +133,8 @@ class activity_PublishDigest(Activity):
         "emit the end message to the queue"
         return self.emit_message(
             article_id, version, run, "end",
-            "Finished ingest digest to endpoint for %s. Statuses: %s" % \
-                (article_id, self.statuses)
-        )
+            "Finished ingest digest to endpoint for %s. Statuses: %s" %
+            (article_id, self.statuses))
 
     def emit_error_message(self, article_id, version, run, message):
         "emit an error message to the queue"


### PR DESCRIPTION
I noticed in the `worker.log` when a digest is already published, it has:

```
2018-12-06T23:55:24Z ERROR worker_21422 Exception raised in do_activity. Details: local variable 'put_response' referenced before assignment
```

Here I tweaked that, and included the put response in the log when it is successful.

Linting at L134 was suggested by `proofreader`.