### PR TITLE
Test scenario for S3Monitor activity.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -40,6 +40,9 @@ class FakeS3Connection:
     def get_bucket(self, mock_bucket_name):
         return self.buckets_dict[mock_bucket_name]
 
+    def lookup(self, mock_bucket_name):
+        return self.get_bucket(mock_bucket_name)
+
 
 class FakeSQSMessage:
     def __init__(self, directory):
@@ -210,7 +213,7 @@ class FakeBucket:
     def get_key(self, key): #key will be u'00353.1/7d5fa403-cba9-486c-8273-3078a98a0b98/elife-00353-fig1-v1.tif' for example
         return key
 
-    def list(self, prefix='', delimiter=''):
+    def list(self, prefix='', delimiter='', headers=''):
         "stub for mocking"
         pass
 

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -3,6 +3,8 @@ domain = ""
 default_task_list = ""
 
 bucket = "old_articles_bucket"
+prefix = "a_test_prefix"
+delimiter = "/"
 
 storage_provider = 's3'
 expanded_bucket = 'origin_bucket'

--- a/tests/activity/test_activity_s3_monitor.py
+++ b/tests/activity/test_activity_s3_monitor.py
@@ -1,0 +1,50 @@
+import unittest
+from mock import patch
+from provider.simpleDB import SimpleDB
+import activity.activity_S3Monitor as activity_module
+from activity.activity_S3Monitor import activity_S3Monitor as activity_object
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeS3Connection, FakeBucket
+from boto.s3.prefix import Prefix
+from boto.s3.key import Key
+
+
+BUCKET_NAME = 'origin_bucket'
+
+
+TEST_DATA = {
+    'data': {
+        'bucket': BUCKET_NAME
+    }
+}
+
+
+def bucket_list_data():
+    "some fake S3 Prefix and Key data to look at"
+    bucket_list = []
+    bucket_list.append(Prefix(BUCKET_NAME, '00003/'))
+    fake_key = Key(FakeBucket(), '00003/file.zip')
+    fake_key.last_modified = '2013-01-26T23:48:28.000Z'
+    bucket_list.append(fake_key)
+    return bucket_list
+
+
+class TestS3Monitor(unittest.TestCase):
+
+    def setUp(self):
+        self.activity = activity_object(settings_mock, FakeLogger(), None, None, None)
+
+    @patch.object(FakeBucket, 'list')
+    @patch.object(FakeS3Connection, 'lookup')
+    @patch.object(activity_module, 'S3Connection')
+    @patch.object(SimpleDB, 'get_item')
+    def test_do_activity(self, fake_get_item, fake_s3_mock, fake_lookup, fake_list):
+        fake_s3_mock.return_value = FakeS3Connection()
+        fake_lookup.return_value = FakeBucket()
+        fake_list.return_value = bucket_list_data()
+        result = self.activity.do_activity(TEST_DATA)
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Part of adding test scenarios for activity classes tracking in issue https://github.com/elifesciences/elife-bot/issues/827.

This is only code for test cases, and the real activity code is not altered in any way, so it should be safe. I may merge it without review.

In order to increase test coverage, some fake boto `Prefix` and `Key` objects are created in order to trigger the S3Monitor logic.

I plan to remove this activity entirely in the future after I modernise the PoA bucket file logic, but we still do use this activity right now in a very minimal way.