### PR TITLE
 PubRouterDeposit tests increased coverage

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -498,20 +498,6 @@ class activity_PubRouterDeposit(Activity):
 
         return approved_articles
 
-    def get_filename_from_path(self, f, extension):
-        """
-        Get a filename minus the supplied file extension
-        and without any folder or path
-        """
-        filename = f.split(extension)[0]
-        # Remove path if present
-        try:
-            filename = filename.split(os.sep)[-1]
-        except:
-            pass
-
-        return filename
-
     def get_to_folder_name(self):
         """
         From the date_stamp

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -98,13 +98,12 @@ HEFCE_FTP_URI = "hefce_ftp.localhost"
 HEFCE_FTP_USERNAME = ""
 HEFCE_FTP_PASSWORD = ""
 HEFCE_FTP_CWD = ""
-HEFCE_EMAIL = ""
+HEFCE_EMAIL = ["", ""]
 
 HEFCE_SFTP_URI = "hefce_sftp.localhost"
 HEFCE_SFTP_USERNAME = ""
 HEFCE_SFTP_PASSWORD = ""
 HEFCE_SFTP_CWD = ""
-HEFCE_EMAIL = ""
 
 CENGAGE_FTP_URI = "cengage.localhost"
 CENGAGE_FTP_USERNAME = ""

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -1,12 +1,53 @@
 import unittest
-from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
-import tests.activity.settings_mock as settings_mock
+import os
+import shutil
+from mock import patch
 from ddt import ddt, data, unpack
+import provider.s3lib as s3lib
+from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
+import tests.test_data as test_case_data
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+
+
+def download_files(filenames, to_dir):
+    copied_filenames = []
+    for filename in filenames:
+        source_doc = "tests/test_data/" + filename
+        dest_doc = os.path.join(to_dir, filename)
+        try:
+            shutil.copy(source_doc, dest_doc)
+            copied_filenames.append(dest_doc)
+        except IOError:
+            pass
+    return copied_filenames
+
 
 @ddt
 class TestPubRouterDeposit(unittest.TestCase):
     def setUp(self):
-        self.pubrouterdeposit = activity_PubRouterDeposit(settings_mock, None, None, None, None)
+        self.pubrouterdeposit = activity_PubRouterDeposit(
+            settings_mock, FakeLogger(), None, None, None)
+
+    @patch('provider.lax_provider.article_versions')
+    @patch.object(activity_PubRouterDeposit, 'start_ftp_article_workflow')
+    @patch.object(activity_PubRouterDeposit, 'does_source_zip_exist_from_s3')
+    @patch.object(activity_PubRouterDeposit, 'download_files_from_s3_outbox')
+    @patch.object(s3lib, 'get_s3_keys_from_bucket')
+    def test_do_activity(self, fake_get_s3_keys, fake_download, fake_zip_exists,
+                         fake_start, fake_article_versions):
+        activity_data = {
+            "data": {
+                "workflow": "HEFCE"
+            }
+        }
+        fake_download.return_value = download_files(
+            ["elife00013.xml", "elife09169.xml"], self.pubrouterdeposit.get_tmp_dir())
+        fake_zip_exists.return_value = True
+        fake_start.return_value = True
+        fake_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
+        result = self.pubrouterdeposit.do_activity(activity_data)
+        self.assertTrue(result)
 
     # input: s3 archive zip file name (name) and date last modified
     # expected output: file name - highest version file (displayed on -v[number]-) then latest last modified date/time

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -89,6 +89,18 @@ class TestPubRouterDeposit(unittest.TestCase):
         output = self.pubrouterdeposit.latest_archive_zip_revision("16747", s3_keys, "elife", "vor")
         self.assertEqual(output, expected)
 
+    @data(
+        "HEFCE",
+        "Cengage",
+        "GoOA",
+        "WoS",
+        "Scopus",
+        "CNPIEC",
+        "CNKI"
+    )
+    def test_get_friendly_email_recipients(self, workflow):
+        self.assertIsNotNone(self.pubrouterdeposit.get_friendly_email_recipients(workflow))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -98,8 +98,11 @@ class TestPubRouterDeposit(unittest.TestCase):
         "CNPIEC",
         "CNKI"
     )
-    def test_get_friendly_email_recipients(self, workflow):
+    def test_workflow_specific_values(self, workflow):
+        "test functions that look at the workflow name"
         self.assertIsNotNone(self.pubrouterdeposit.get_friendly_email_recipients(workflow))
+        self.assertIsNotNone(self.pubrouterdeposit.get_outbox_folder(workflow))
+        self.assertIsNotNone(self.pubrouterdeposit.get_published_folder(workflow))
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -50,18 +50,43 @@ class TestPubRouterDeposit(unittest.TestCase):
         self.assertTrue(result)
 
     # input: s3 archive zip file name (name) and date last modified
-    # expected output: file name - highest version file (displayed on -v[number]-) then latest last modified date/time
+    # expected output: file name - highest version file (displayed on -v[number]-)
+    # then latest last modified date/time
     @unpack
-    @data({"input": [{"name": "elife-16747-vor-v1-20160831000000.zip", "last_modified": "2017-05-18T09:04:11.000Z"},
-                    {"name": "elife-16747-vor-v1-20160831132647.zip", "last_modified": "2016-08-31T06:26:56.000Z"}],
-           "expected": "elife-16747-vor-v1-20160831000000.zip"},
-          {"input": [{"name": "elife-16747-vor-v1-20160831000000.zip", "last_modified": "2017-05-18T09:04:11.000Z"},
-                    {"name": "elife-16747-vor-v1-20160831132647.zip", "last_modified": "2016-08-31T06:26:56.000Z"},
-                    {"name": "elife-16747-vor-v2-20160831000000.zip", "last_modified": "2015-01-05T00:20:50.000Z"}],
-           "expected": "elife-16747-vor-v2-20160831000000.zip"}
-          )
-    def test_latest_archive_zip_revision(self, input, expected):
-        output = self.pubrouterdeposit.latest_archive_zip_revision("16747", input, "elife", "vor")
+    @data(
+        {
+            "s3_keys": [
+                {
+                    "name": "elife-16747-vor-v1-20160831000000.zip",
+                    "last_modified": "2017-05-18T09:04:11.000Z"
+                },
+                {
+                    "name": "elife-16747-vor-v1-20160831132647.zip",
+                    "last_modified": "2016-08-31T06:26:56.000Z"
+                }
+            ],
+            "expected": "elife-16747-vor-v1-20160831000000.zip"
+            },
+        {
+            "s3_keys": [
+                {
+                    "name": "elife-16747-vor-v1-20160831000000.zip",
+                    "last_modified": "2017-05-18T09:04:11.000Z"
+                },
+                {
+                    "name": "elife-16747-vor-v1-20160831132647.zip",
+                    "last_modified": "2016-08-31T06:26:56.000Z"
+                },
+                {
+                    "name": "elife-16747-vor-v2-20160831000000.zip",
+                    "last_modified": "2015-01-05T00:20:50.000Z"
+                }
+            ],
+            "expected": "elife-16747-vor-v2-20160831000000.zip"
+            }
+        )
+    def test_latest_archive_zip_revision(self, s3_keys, expected):
+        output = self.pubrouterdeposit.latest_archive_zip_revision("16747", s3_keys, "elife", "vor")
         self.assertEqual(output, expected)
 
 


### PR DESCRIPTION
Part of activity test coverage issue https://github.com/elifesciences/elife-bot/issues/827

Testing `do_activity()` with some mocking of S3 and Lax data increased the test coverage a fair way. Some additional checks determining the email recipients, outbox and published folder names for each workflow, gets the coverage up to about 70%, up from 20%. 

`get_filename_from_path()` was shown to be unused and is deleted here.