### PR TITLE
security fix, bumps pyyaml to 4.2b

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@32a9a831eca
 git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
-PyYAML==3.11
+PyYAML==4.2b2
 Wand==0.4.2
 paramiko==2.4.2
 mock==1.3.0


### PR DESCRIPTION
unsafe usage of `.load` can be found here:
https://github.com/elifesciences/elife-bot/blob/develop/queue_worker.py#L112

it doesn't look like there is any dependency on loading python code from that file so we should be fine