### PR TITLE
Delete .pyc files from particular folders when install.sh is run.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,12 @@ if [ ! -d venv ]; then
     virtualenv --python=`which python2` venv
 fi
 
+# remove any old compiled python files
+find provider/ -name '*.pyc' -delete
+find activity/ -name '*.pyc' -delete
+find workflow/ -name '*.pyc' -delete
+find starter/ -name '*.pyc' -delete
+
 source venv/bin/activate
 
 if pip list | grep elifetools; then


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4635

I want to refactor some of the workflow objects soon, and in preparation for a module rename, the automatic deletion of `*.pyc` files when `install.sh` is run in the normal deployment process would be a benefit.

Opted for particular folders here that have the most churn of things that are deleted.

Deleting the `*.pyc` files can help guard against a false sense of security that everything runs fine, using the compiled module, but the source code for it has already been removed.