### PR TITLE
More test coverage for starters

### DIFF
--- a/starter/cron_FiveMinute.py
+++ b/starter/cron_FiveMinute.py
@@ -96,7 +96,7 @@ class cron_FiveMinute(object):
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
 
     def get_starter_module(self, starter_name, logger=None):
         """

--- a/starter/cron_FiveMinute.py
+++ b/starter/cron_FiveMinute.py
@@ -4,7 +4,6 @@ parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.sys.path.insert(0, parentdir)
 
 import boto.swf
-import settings as settingsLib
 import log
 import time
 import importlib

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -99,7 +99,7 @@ class cron_NewS3POA(object):
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
 
     def get_starter_module(self, starter_name, logger=None):
         """

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -4,7 +4,6 @@ parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.sys.path.insert(0, parentdir)
 
 import boto.swf
-import settings as settingsLib
 import log
 import time
 import importlib

--- a/starter/starter_AdminEmail.py
+++ b/starter/starter_AdminEmail.py
@@ -43,7 +43,7 @@ class starter_AdminEmail():
                 # There is already a running workflow with that ID, cannot start another
                 message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                            'a running workflow with ID %s' % workflow_id)
-                print message
+                print(message)
                 logger.info(message)
 
     def get_workflow_params(self, workflow):

--- a/starter/starter_DepositCrossref.py
+++ b/starter/starter_DepositCrossref.py
@@ -46,7 +46,7 @@ class starter_DepositCrossref():
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
             logger.info(message)
 
 if __name__ == "__main__":

--- a/starter/starter_FTPArticle.py
+++ b/starter/starter_FTPArticle.py
@@ -46,7 +46,7 @@ class starter_FTPArticle():
                 # There is already a running workflow with that ID, cannot start another
                 message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                            'a running workflow with ID %s' % workflow_id)
-                print message
+                print(message)
                 logger.info(message)
 
     def get_workflow_params(self, workflow, doi_id, settings):

--- a/starter/starter_LensArticlePublish.py
+++ b/starter/starter_LensArticlePublish.py
@@ -63,7 +63,7 @@ class starter_LensArticlePublish():
                     # There is already a running workflow with that ID, cannot start another
                     message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                                'a running workflow with ID %s' % workflow_id)
-                    print message
+                    print(message)
                     logger.info(message)
 
 if __name__ == "__main__":

--- a/starter/starter_PMCDeposit.py
+++ b/starter/starter_PMCDeposit.py
@@ -74,7 +74,7 @@ class starter_PMCDeposit():
                     # There is already a running workflow with that ID, cannot start another
                     message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                                'a running workflow with ID %s' % workflow_id)
-                    print message
+                    print(message)
                     logger.info(message)
 
 

--- a/starter/starter_PackagePOA.py
+++ b/starter/starter_PackagePOA.py
@@ -78,7 +78,7 @@ class starter_PackagePOA():
                     # There is already a running workflow with that ID, cannot start another
                     message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                                'a running workflow with ID %s' % workflow_id)
-                    print message
+                    print(message)
                     logger.info(message)
 
 

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -41,7 +41,7 @@ class starter_Ping():
                 # There is already a running workflow with that ID, cannot start another
                 message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                            'a running workflow with ID %s' % workflow_id)
-                print message
+                print(message)
                 logger.info(message)
 
     def get_workflow_params(self, workflow):

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -43,7 +43,7 @@ class starter_PubRouterDeposit():
                 # There is already a running workflow with that ID, cannot start another
                 message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                            'a running workflow with ID %s' % workflow_id)
-                print message
+                print(message)
                 logger.info(message)
 
     def get_workflow_params(self, workflow, settings):

--- a/starter/starter_PublicationEmail.py
+++ b/starter/starter_PublicationEmail.py
@@ -52,7 +52,7 @@ class starter_PublicationEmail():
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
             logger.info(message)
 
 if __name__ == "__main__":

--- a/starter/starter_PublishPOA.py
+++ b/starter/starter_PublishPOA.py
@@ -44,7 +44,7 @@ class starter_PublishPOA():
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
             logger.info(message)
 
 if __name__ == "__main__":

--- a/starter/starter_PubmedArticleDeposit.py
+++ b/starter/starter_PubmedArticleDeposit.py
@@ -46,7 +46,7 @@ class starter_PubmedArticleDeposit():
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
             logger.info(message)
 
 if __name__ == "__main__":

--- a/starter/starter_S3Monitor.py
+++ b/starter/starter_S3Monitor.py
@@ -41,7 +41,7 @@ class starter_S3Monitor():
                 # There is already a running workflow with that ID, cannot start another
                 message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                            'a running workflow with ID %s' % workflow_id)
-                print message
+                print(message)
                 logger.info(message)
 
     def get_workflow_params(self, workflow, settings):

--- a/starter/starter_SendQueuedEmail.py
+++ b/starter/starter_SendQueuedEmail.py
@@ -32,7 +32,7 @@ class starter_SendQueuedEmail():
         execution_start_to_close_timeout = None
 
         if limit:
-            input = '{"data": {"limit": "' + limit + '"}}'
+            input = '{"data": {"limit": "' + str(limit) + '"}}'
         else:
             input = None
 
@@ -48,7 +48,7 @@ class starter_SendQueuedEmail():
             # There is already a running workflow with that ID, cannot start another
             message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
                        'a running workflow with ID %s' % workflow_id)
-            print message
+            print(message)
             logger.info(message)
 
 if __name__ == "__main__":

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -6,6 +6,16 @@ class FakeBotoConnection:
     def start_workflow_execution(self, *args):
         pass
 
+class FakeLayer1:
+    def respond_decision_task_completed(self, task_token, decisions=None, execution_context=None):
+        pass
+
+    def start_workflow_execution(
+        self, domain, workflow_id, workflow_name, workflow_version, task_list=None, 
+        child_policy=None, execution_start_to_close_timeout=None, input=None, 
+        tag_list=None, task_start_to_close_timeout=None):
+        pass
+
 class FakeFlag():
     "a fake object to return process monitoring status"
     def __init__(self, timeout_seconds=1):

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -16,6 +16,12 @@ class FakeLayer1:
         tag_list=None, task_start_to_close_timeout=None):
         pass
 
+    def list_closed_workflow_executions(
+        self, domain, start_latest_date=None, start_oldest_date=None, close_latest_date=None, 
+        close_oldest_date=None, close_status=None, tag=None, workflow_id=None, workflow_name=None, 
+        workflow_version=None, maximum_page_size=None, next_page_token=None, reverse_order=None):
+        return {'executionInfos': []}
+
 class FakeFlag():
     "a fake object to return process monitoring status"
     def __init__(self, timeout_seconds=1):

--- a/tests/starter/test_cron_five_minute.py
+++ b/tests/starter/test_cron_five_minute.py
@@ -1,0 +1,52 @@
+import unittest
+from provider.simpleDB import SimpleDB
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.cron_FiveMinute import cron_FiveMinute
+from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeLogger
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestCronFiveMinute(unittest.TestCase):
+    def setUp(self):
+        self.starter = cron_FiveMinute()
+
+    @patch.object(SimpleDB, 'elife_get_email_queue_items')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn, fake_get_email):
+        fake_conn.return_value = FakeLayer1()
+        fake_get_email.return_value = []
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(SimpleDB, 'elife_get_email_queue_items')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_email(self, fake_conn, fake_get_email):
+        fake_conn.return_value = FakeLayer1()
+        fake_get_email.return_value = [{'Count': 1}]
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(SimpleDB, 'elife_get_email_queue_items')
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start, fake_get_email):
+        fake_conn.return_value = FakeLayer1()
+        fake_get_email.return_value = []
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    def test_get_starter_module_failure(self):
+        "for coverage test failure"
+        starter_name = 'not_a_starter'
+        module_object = self.starter.get_starter_module(starter_name, FakeLogger())
+        self.assertIsNone(module_object)
+
+    def test_import_starter_module_failure(self):
+        "for coverage test import failure"
+        starter_name = 'not_a_starter'
+        return_value = self.starter.import_starter_module(starter_name, FakeLogger())
+        self.assertFalse(return_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_cron_new_s3_poa.py
+++ b/tests/starter/test_cron_new_s3_poa.py
@@ -1,0 +1,59 @@
+import unittest
+from provider.simpleDB import SimpleDB
+from provider.swfmeta import SWFMeta
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.cron_NewS3POA import cron_NewS3POA
+from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeLogger
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestCronNewS3POA(unittest.TestCase):
+    def setUp(self):
+        self.starter = cron_NewS3POA()
+
+    @patch.object(SimpleDB, 'elife_get_generic_delivery_S3_file_items')
+    @patch.object(SWFMeta, 'get_last_completed_workflow_execution_startTimestamp')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn, fake_timestamp, fake_query):
+        fake_conn.return_value = FakeLayer1()
+        fake_timestamp.return_value = 0
+        fake_query.return_value = []
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(SimpleDB, 'elife_get_generic_delivery_S3_file_items')
+    @patch.object(SWFMeta, 'get_last_completed_workflow_execution_startTimestamp')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_items(self, fake_conn, fake_timestamp, fake_query):
+        fake_conn.return_value = FakeLayer1()
+        fake_timestamp.return_value = 0
+        fake_query.return_value = [1]
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(SimpleDB, 'elife_get_generic_delivery_S3_file_items')
+    @patch.object(SWFMeta, 'get_last_completed_workflow_execution_startTimestamp')
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start, fake_timestamp, fake_query):
+        fake_conn.return_value = FakeLayer1()
+        fake_timestamp.return_value = 0
+        fake_query.return_value = []
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    def test_get_starter_module_failure(self):
+        "for coverage test failure"
+        starter_name = 'not_a_starter'
+        module_object = self.starter.get_starter_module(starter_name, FakeLogger())
+        self.assertIsNone(module_object)
+
+    def test_import_starter_module_failure(self):
+        "for coverage test import failure"
+        starter_name = 'not_a_starter'
+        return_value = self.starter.import_starter_module(starter_name, FakeLogger())
+        self.assertFalse(return_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_admin_email.py
+++ b/tests/starter/test_starter_admin_email.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_AdminEmail import starter_AdminEmail
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterAdminEmail(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_AdminEmail()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_deposit_crossref.py
+++ b/tests/starter/test_starter_deposit_crossref.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_DepositCrossref import starter_DepositCrossref
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterDepositCrossref(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_DepositCrossref()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_ftp_article.py
+++ b/tests/starter/test_starter_ftp_article.py
@@ -1,0 +1,31 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_FTPArticle import starter_FTPArticle
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterFTPArticle(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_FTPArticle()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        workflow = 'HEFCE'
+        doi_id = 3
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, workflow, doi_id))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        workflow = 'HEFCE'
+        doi_id = 3
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock, workflow, doi_id))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_lens_article_publish.py
+++ b/tests/starter/test_starter_lens_article_publish.py
@@ -1,0 +1,31 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_LensArticlePublish import starter_LensArticlePublish
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterLensArticlePublish(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_LensArticlePublish()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        all_doi = None
+        doi_id = 3
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, all_doi, doi_id))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        all_doi = None
+        doi_id = 3
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock, all_doi, doi_id))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_package_poa.py
+++ b/tests/starter/test_starter_package_poa.py
@@ -1,0 +1,44 @@
+import unittest
+from provider.simpleDB import SimpleDB
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PackagePOA import starter_PackagePOA
+from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeLogger
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPackagePOA(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PackagePOA()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        document = 'document'
+        last_updated_since = None
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, document, last_updated_since))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        document = 'document'
+        last_updated_since = None
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock, document, last_updated_since))
+
+    @patch.object(SimpleDB, 'elife_get_POA_delivery_S3_file_items')
+    def test_get_docs_from_simple_db(self, fake_file_items):
+        fake_file_items.return_value = [
+            {
+                'name': 'document'
+            }
+        ]
+        last_updated_since = 'a date'
+        docs = self.starter.get_docs_from_SimpleDB(settings_mock, FakeLogger(), last_updated_since)
+        self.assertEqual(len(docs), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_ping.py
+++ b/tests/starter/test_starter_ping.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_Ping import starter_Ping
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPing(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_Ping()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_pmc_deposit.py
+++ b/tests/starter/test_starter_pmc_deposit.py
@@ -1,0 +1,31 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PMCDeposit import starter_PMCDeposit
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPMCDeposit(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PMCDeposit()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        bucket = None
+        document = 'document'
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, bucket, document))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        bucket = None
+        document = 'document'
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock, bucket, document))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_pub_router_deposit.py
+++ b/tests/starter/test_starter_pub_router_deposit.py
@@ -1,0 +1,29 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PubRouterDeposit import starter_PubRouterDeposit
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPubRouterDeposit(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PubRouterDeposit()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        workflow = 'HEFCE'
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, workflow))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        workflow = 'HEFCE'
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock, workflow))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_publication_email.py
+++ b/tests/starter/test_starter_publication_email.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PublicationEmail import starter_PublicationEmail
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPublicationEmail(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PublicationEmail()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_publish_poa.py
+++ b/tests/starter/test_starter_publish_poa.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PublishPOA import starter_PublishPOA
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPublishPOA(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PublishPOA()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_pubmed_article_deposit.py
+++ b/tests/starter/test_starter_pubmed_article_deposit.py
@@ -1,0 +1,27 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_PubmedArticleDeposit import starter_PubmedArticleDeposit
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterPubmedArticleDeposit(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_PubmedArticleDeposit()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_s3_monitor.py
+++ b/tests/starter/test_starter_s3_monitor.py
@@ -1,0 +1,34 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_S3Monitor import starter_S3Monitor
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterS3Monitor(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_S3Monitor()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        workflow = 'S3Monitor'
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, workflow))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_poa(self, fake_conn):
+        workflow = 'S3Monitor_POA'
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, workflow))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/starter/test_starter_send_queued_email.py
+++ b/tests/starter/test_starter_send_queued_email.py
@@ -1,0 +1,34 @@
+import unittest
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.starter_SendQueuedEmail import starter_SendQueuedEmail
+from tests.classes_mock import FakeLayer1
+import tests.settings_mock as settings_mock
+from mock import patch
+
+
+class TestStarterSendQueuedEmail(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_SendQueuedEmail()
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_conn):
+        limit = None
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, limit))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_limit(self, fake_conn):
+        limit = 5
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock, limit))
+
+    @patch.object(FakeLayer1, 'start_workflow_execution')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        self.assertIsNone(self.starter.start(settings_mock))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Working from a list of files that have no test cases, the starters and cron starters here had no tests at all. The additional motivation for them is to have more confidence in automated testing for Python 3 support.

The parentheses around the `print` statements are duplicated here as is in another PR under review, but it was the easiest way to run the tests in Python 3 without having to wait for the other code to be merged. I expect the two should merge easily enough with no conflicts (if not I'll resolve the conflicts after the first PR is merged).

The other non-test code change is to `str(limit)` in the `SendQueuedEmail` starter, although the activity doesn't do anything with this limit value anyway right now.

