### PR TITLE
Queue workflow starter tests

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -73,11 +73,6 @@ def start_workflow(settings, workflow_name, workflow_data):
         workflow_data = data_processor(workflow_name, workflow_data)
     module_name = "starter." + workflow_name
     module = importlib.import_module(module_name)
-    # TODO: deprecate reloading a module, this should not be needed as every deploy restarts all long-running processes?
-    try:
-        reload(eval(module))
-    except:
-        pass
     full_path = "starter." + workflow_name + "." + workflow_name + "()"
     s = eval(full_path)
     s.start(settings=settings, **workflow_data)

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -27,23 +27,13 @@ Example message:
 }
 """
 
-settings = None
-logger = None
 
-
-def main(settings_input, env_input, flag):
-    global settings
-    global env
-    settings = settings_input
-    env = env_input
-
+def main(settings, flag):
     log_file = "queue_workflow_starter.log"
-    global logger
     identity = "queue_workflow_starter_%s" % os.getpid()
     logger = log.logger(log_file, settings.setLevel, identity=identity)
-
     # Simple connect
-    queue = get_queue()
+    queue = get_queue(settings)
 
     while flag.green():
         messages = queue.get_messages(1, visibility_timeout=60,
@@ -51,13 +41,13 @@ def main(settings_input, env_input, flag):
         if messages:
             logger.info(str(len(messages)) + " message received")
             logger.info('message contents: %s', messages[0].get_body())
-            process_message(messages[0])
+            process_message(settings, logger, messages[0])
         else:
             logger.debug("No messages received")
 
     logger.info("graceful shutdown")
 
-def get_queue():
+def get_queue(settings):
     conn = boto.sqs.connect_to_region(settings.sqs_region,
                                       aws_access_key_id=settings.aws_access_key_id,
                                       aws_secret_access_key=settings.aws_secret_access_key)
@@ -65,18 +55,18 @@ def get_queue():
     return queue
 
 
-def process_message(message):
+def process_message(settings, logger, message):
     try:
         message_payload = json.loads(str(unicode_decode(message.get_body())))
         name = message_payload.get('workflow_name')
         data = message_payload.get('workflow_data')
-        start_workflow(name, data)
+        start_workflow(settings, name, data)
     except Exception:
         logger.exception("Exception while processing %s", message.get_body())
     message.delete()
 
 @newrelic.agent.background_task(group='queue_workflow_starter.py')
-def start_workflow(workflow_name, workflow_data):
+def start_workflow(settings, workflow_name, workflow_data):
     data_processor = workflow_data_processors.get(workflow_name)
     workflow_name = 'starter_' + workflow_name
     if data_processor is not None:
@@ -128,14 +118,13 @@ workflow_data_processors = {
 }
 
 
-def load_settings(env):
-    "get settings for the environment"
+def get_settings(env):
     import settings as settings_lib
     return settings_lib.get_settings(env)
 
 
 def console_start():
-    "capture options when running standalone"
+    """capture options when running standalone"""
     parser = OptionParser()
     parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
                       help="set the environment to run, either dev or live")
@@ -146,6 +135,6 @@ def console_start():
 
 
 if __name__ == "__main__":
-    ENV_INPUT = console_start()
-    SETTINGS_INPUT = load_settings(env)
-    process.monitor_interrupt(lambda flag: main(SETTINGS_INPUT, ENV_INPUT, flag))
+    ENV = console_start()
+    SETTINGS = get_settings(ENV)
+    process.monitor_interrupt(lambda flag: main(SETTINGS, flag))

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -47,6 +47,7 @@ def main(settings, flag):
 
     logger.info("graceful shutdown")
 
+
 def get_queue(settings):
     conn = boto.sqs.connect_to_region(settings.sqs_region,
                                       aws_access_key_id=settings.aws_access_key_id,
@@ -65,6 +66,7 @@ def process_message(settings, logger, message):
         logger.exception("Exception while processing %s", message.get_body())
     message.delete()
 
+
 @newrelic.agent.background_task(group='queue_workflow_starter.py')
 def start_workflow(settings, workflow_name, workflow_data):
     data_processor = workflow_data_processors.get(workflow_name)
@@ -72,10 +74,11 @@ def start_workflow(settings, workflow_name, workflow_data):
     if data_processor is not None:
         workflow_data = data_processor(workflow_name, workflow_data)
     module_name = "starter." + workflow_name
-    module = importlib.import_module(module_name)
+    importlib.import_module(module_name)
     full_path = "starter." + workflow_name + "." + workflow_name + "()"
-    s = eval(full_path)
-    s.start(settings=settings, **workflow_data)
+    starter_object = eval(full_path)
+    starter_object.start(settings=settings, **workflow_data)
+
 
 def process_data_ingestarticlezip(workflow_name, workflow_data):
     data = {'article_id': workflow_data['article_id'],
@@ -83,14 +86,17 @@ def process_data_ingestarticlezip(workflow_name, workflow_data):
             'scheduled_publication_date': workflow_data.get('scheduled_publication_date')}
     return data
 
+
 def process_data_initialarticlezip(workflow_name, workflow_data):
     data = {'info': S3NotificationInfo.from_dict(workflow_data),
             'run': str(uuid.uuid4())}
     return data
 
+
 def process_data_postperfectpublication(workflow_name, workflow_data):
     data = {'info': workflow_data}
     return data
+
 
 def process_data_pubmedarticledeposit(workflow_name, workflow_data):
     data = {}

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -1,18 +1,17 @@
 """
 Process SQS message from queue and start required workflow
 """
-from S3utility.s3_notification_info import S3NotificationInfo
+import os
+import uuid
+import json
+import importlib
 from optparse import OptionParser
 import log
 import boto.sqs
+import newrelic.agent
+from S3utility.s3_notification_info import S3NotificationInfo
 from provider import process
 from provider.utils import unicode_decode
-import json
-import importlib
-import os
-import uuid
-import newrelic.agent
-
 # this is not an unused import, it is used dynamically
 import starter
 

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -71,7 +71,7 @@ def start_workflow(settings, workflow_name, workflow_data):
     data_processor = workflow_data_processors.get(workflow_name)
     workflow_name = 'starter_' + workflow_name
     if data_processor is not None:
-        workflow_data = data_processor(workflow_name, workflow_data)
+        workflow_data = data_processor(workflow_data)
     module_name = "starter." + workflow_name
     importlib.import_module(module_name)
     full_path = "starter." + workflow_name + "." + workflow_name + "()"
@@ -79,30 +79,30 @@ def start_workflow(settings, workflow_name, workflow_data):
     starter_object.start(settings=settings, **workflow_data)
 
 
-def process_data_ingestarticlezip(workflow_name, workflow_data):
+def process_data_ingestarticlezip(workflow_data):
     data = {'article_id': workflow_data['article_id'],
             'run': workflow_data['run'], 'version_reason': workflow_data.get('version_reason'),
             'scheduled_publication_date': workflow_data.get('scheduled_publication_date')}
     return data
 
 
-def process_data_initialarticlezip(workflow_name, workflow_data):
+def process_data_initialarticlezip(workflow_data):
     data = {'info': S3NotificationInfo.from_dict(workflow_data),
             'run': str(uuid.uuid4())}
     return data
 
 
-def process_data_postperfectpublication(workflow_name, workflow_data):
+def process_data_postperfectpublication(workflow_data):
     data = {'info': workflow_data}
     return data
 
 
-def process_data_pubmedarticledeposit(workflow_name, workflow_data):
+def process_data_pubmedarticledeposit(workflow_data):
     data = {}
     return data
 
 
-def process_data_ingestdigest(workflow_name, workflow_data):
+def process_data_ingestdigest(workflow_data):
     data = {'info': S3NotificationInfo.from_dict(workflow_data),
             'run': str(uuid.uuid4())}
     return data

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -55,6 +55,13 @@ class FakeSQSMessage:
             # python 3, write bytes
             self.dir.write("fake_sqs_body", bytes(body, 'utf-8'))
 
+    def get_body(self):
+        return self.dir.read("fake_sqs_body")
+
+    def delete(self):
+        pass
+
+
 class FakeSQSConn:
     def __init__(self, directory):
         self.dir = directory
@@ -74,6 +81,10 @@ class FakeSQSQueue:
 
     def read(self, dir_name):
         return self.dir.read(dir_name)
+
+    def get_messages(self):
+        "for mocking return a list of messages"
+        return []
 
     def delete_message(self, message):
         pass

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -3,8 +3,12 @@ import os
 from datetime import datetime
 
 class FakeBotoConnection:
+    def __init__(self):
+        self.start_called = None
+
     def start_workflow_execution(self, *args):
-        pass
+        self.start_called = True
+
 
 class FakeFlag():
     "a fake object to return process monitoring status"

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -1,0 +1,44 @@
+import unittest
+import json
+import boto.swf.layer1
+from mock import patch
+from testfixtures import TempDirectory
+import tests.settings_mock as settings_mock
+from tests.classes_mock import FakeFlag, FakeBotoConnection
+from tests.activity.classes_mock import FakeSQSMessage, FakeSQSQueue
+import queue_workflow_starter
+
+
+class TestQueueWorkflowStarter(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch('tests.activity.classes_mock.FakeSQSQueue.get_messages')
+    @patch('queue_workflow_starter.get_queue')
+    @patch.object(boto.swf.layer1, 'Layer1')
+    def test_main(self, fake_boto_conn, mock_queue, mock_queue_read):
+        directory = TempDirectory()
+        env = 'dev'
+        message_body = json.dumps(
+            {
+                'workflow_name': 'Ping',
+                'workflow_data': {}
+            }
+        )
+        mock_boto_connection = FakeBotoConnection()
+        fake_boto_conn.return_value = mock_boto_connection
+        mock_queue.return_value = FakeSQSQueue(directory)
+        fake_message = FakeSQSMessage(directory)
+        fake_message.set_body(message_body)
+        mock_queue_read.return_value = [fake_message]
+        # create a fake green flag
+        flag = FakeFlag()
+        queue_workflow_starter.main(settings_mock, env, flag)
+        self.assertEqual(mock_boto_connection.start_called, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -21,7 +21,6 @@ class TestQueueWorkflowStarter(unittest.TestCase):
     @patch.object(boto.swf.layer1, 'Layer1')
     def test_main(self, fake_boto_conn, mock_queue, mock_queue_read):
         directory = TempDirectory()
-        env = 'dev'
         message_body = json.dumps(
             {
                 'workflow_name': 'Ping',
@@ -34,10 +33,106 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         mock_queue_read.return_value = [fake_message]
-        # create a fake green flag
-        flag = FakeFlag()
-        queue_workflow_starter.main(settings_mock, env, flag)
+        queue_workflow_starter.main(settings_mock, 'dev', FakeFlag())
         self.assertEqual(mock_boto_connection.start_called, True)
+
+    @patch.object(boto.swf.layer1, 'Layer1')
+    def test_process_message(self, fake_boto_conn):
+        directory = TempDirectory()
+        message_body = json.dumps(
+            {
+                'workflow_name': 'PubmedArticleDeposit',
+                'workflow_data': {}
+            }
+        )
+        mock_boto_connection = FakeBotoConnection()
+        fake_boto_conn.return_value = mock_boto_connection
+        fake_message = FakeSQSMessage(directory)
+        fake_message.set_body(message_body)
+        queue_workflow_starter.process_message(fake_message)
+        self.assertEqual(mock_boto_connection.start_called, True)
+
+    @patch.object(boto.swf.layer1, 'Layer1')
+    def test_process_message_no_data_processor(self, fake_boto_conn):
+        directory = TempDirectory()
+        message_body = json.dumps(
+            {
+                'workflow_name': 'Ping',
+                'workflow_data': {}
+            }
+        )
+        mock_boto_connection = FakeBotoConnection()
+        fake_boto_conn.return_value = mock_boto_connection
+        fake_message = FakeSQSMessage(directory)
+        fake_message.set_body(message_body)
+        queue_workflow_starter.process_message(fake_message)
+        self.assertEqual(mock_boto_connection.start_called, True)
+
+    @patch.object(boto.swf.layer1, 'Layer1')
+    def test_process_message_fail_to_start_workflow(self, fake_boto_conn):
+        directory = TempDirectory()
+        message_body = json.dumps(
+            {
+                'workflow_name': 'not_a_real_workflow',
+                'workflow_data': {}
+            }
+        )
+        mock_boto_connection = FakeBotoConnection()
+        fake_boto_conn.return_value = mock_boto_connection
+        fake_message = FakeSQSMessage(directory)
+        fake_message.set_body(message_body)
+        queue_workflow_starter.process_message(fake_message)
+        self.assertEqual(mock_boto_connection.start_called, None)
+
+    def test_process_data_ingestarticlezip(self):
+        workflow_name = ''
+        workflow_data = {
+            'article_id': '',
+            'run': '',
+            'version_reason': '',
+            'scheduled_publication_date': '',
+        }
+        data = queue_workflow_starter.process_data_ingestarticlezip(workflow_name, workflow_data)
+        self.assertEqual(sorted(data), sorted(workflow_data))
+
+    def test_process_data_initialarticlezip(self):
+        workflow_name = ''
+        workflow_data = {
+            'event_name': '',
+            'event_time': '',
+            'bucket_name': '',
+            'file_name': '',
+            'file_etag': '',
+            'file_size': '',
+        }
+        data = queue_workflow_starter.process_data_initialarticlezip(workflow_name, workflow_data)
+        s3_notification_dict = data.get("info").to_dict()
+        self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
+        self.assertIsNotNone(data.get('run'))
+
+    def test_process_data_postperfectpublication(self):
+        workflow_name = ''
+        workflow_data = {
+            'some': 'data'
+        }
+        data = queue_workflow_starter.process_data_postperfectpublication(
+            workflow_name, workflow_data)
+        self.assertEqual(sorted(data.get('info')), sorted(workflow_data))
+
+    def test_process_data_ingestdigest(self):
+        workflow_name = ''
+        workflow_data = {
+            'event_name': '',
+            'event_time': '',
+            'bucket_name': '',
+            'file_name': '',
+            'file_etag': '',
+            'file_size': '',
+        }
+        data = queue_workflow_starter.process_data_ingestdigest(workflow_name, workflow_data)
+        s3_notification_dict = data.get("info").to_dict()
+        self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
+        self.assertIsNotNone(data.get('run'))
 
 
 if __name__ == '__main__':

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -5,7 +5,7 @@ from mock import patch
 from testfixtures import TempDirectory
 import tests.settings_mock as settings_mock
 from tests.classes_mock import FakeFlag, FakeBotoConnection
-from tests.activity.classes_mock import FakeSQSMessage, FakeSQSQueue
+from tests.activity.classes_mock import FakeSQSMessage, FakeSQSQueue, FakeLogger
 import queue_workflow_starter
 
 
@@ -33,7 +33,7 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         mock_queue_read.return_value = [fake_message]
-        queue_workflow_starter.main(settings_mock, 'dev', FakeFlag())
+        queue_workflow_starter.main(settings_mock, FakeFlag())
         self.assertEqual(mock_boto_connection.start_called, True)
 
     @patch.object(boto.swf.layer1, 'Layer1')
@@ -49,7 +49,7 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         fake_boto_conn.return_value = mock_boto_connection
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
-        queue_workflow_starter.process_message(fake_message)
+        queue_workflow_starter.process_message(settings_mock, FakeLogger(), fake_message)
         self.assertEqual(mock_boto_connection.start_called, True)
 
     @patch.object(boto.swf.layer1, 'Layer1')
@@ -65,7 +65,7 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         fake_boto_conn.return_value = mock_boto_connection
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
-        queue_workflow_starter.process_message(fake_message)
+        queue_workflow_starter.process_message(settings_mock, FakeLogger(), fake_message)
         self.assertEqual(mock_boto_connection.start_called, True)
 
     @patch.object(boto.swf.layer1, 'Layer1')
@@ -81,7 +81,7 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         fake_boto_conn.return_value = mock_boto_connection
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
-        queue_workflow_starter.process_message(fake_message)
+        queue_workflow_starter.process_message(settings_mock, FakeLogger(), fake_message)
         self.assertEqual(mock_boto_connection.start_called, None)
 
     def test_process_data_ingestarticlezip(self):

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -85,18 +85,16 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         self.assertEqual(mock_boto_connection.start_called, None)
 
     def test_process_data_ingestarticlezip(self):
-        workflow_name = ''
         workflow_data = {
             'article_id': '',
             'run': '',
             'version_reason': '',
             'scheduled_publication_date': '',
         }
-        data = queue_workflow_starter.process_data_ingestarticlezip(workflow_name, workflow_data)
+        data = queue_workflow_starter.process_data_ingestarticlezip(workflow_data)
         self.assertEqual(sorted(data), sorted(workflow_data))
 
     def test_process_data_initialarticlezip(self):
-        workflow_name = ''
         workflow_data = {
             'event_name': '',
             'event_time': '',
@@ -105,22 +103,19 @@ class TestQueueWorkflowStarter(unittest.TestCase):
             'file_etag': '',
             'file_size': '',
         }
-        data = queue_workflow_starter.process_data_initialarticlezip(workflow_name, workflow_data)
+        data = queue_workflow_starter.process_data_initialarticlezip(workflow_data)
         s3_notification_dict = data.get("info").to_dict()
         self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
         self.assertIsNotNone(data.get('run'))
 
     def test_process_data_postperfectpublication(self):
-        workflow_name = ''
         workflow_data = {
             'some': 'data'
         }
-        data = queue_workflow_starter.process_data_postperfectpublication(
-            workflow_name, workflow_data)
+        data = queue_workflow_starter.process_data_postperfectpublication(workflow_data)
         self.assertEqual(sorted(data.get('info')), sorted(workflow_data))
 
     def test_process_data_ingestdigest(self):
-        workflow_name = ''
         workflow_data = {
             'event_name': '',
             'event_time': '',
@@ -129,7 +124,7 @@ class TestQueueWorkflowStarter(unittest.TestCase):
             'file_etag': '',
             'file_size': '',
         }
-        data = queue_workflow_starter.process_data_ingestdigest(workflow_name, workflow_data)
+        data = queue_workflow_starter.process_data_ingestdigest(workflow_data)
         s3_notification_dict = data.get("info").to_dict()
         self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
         self.assertIsNotNone(data.get('run'))


### PR DESCRIPTION
One of the last remaining parts with no test in the `elife-bot` project is `queue_workflow_starter.py`.

I moved the importing and loading of the `settings` module for easier testing, as is done on many of the parts that are run like console apps.

`json.loads()` didn't work too well in Python 3 until the bytes string was decoded.