### PR TITLE
Test for register.py

### DIFF
--- a/register.py
+++ b/register.py
@@ -4,7 +4,7 @@ import importlib
 from optparse import OptionParser
 
 import boto.swf
-import settings as settingsLib
+
 import workflow
 import activity
 
@@ -13,9 +13,7 @@ import activity
 Amazon SWF register workflow or activity utility
 """
 
-def start(ENV="dev"):
-    # Specify run environment settings
-    settings = settingsLib.get_settings(ENV)
+def start(settings):
 
     # Simple connect
     conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
@@ -58,7 +56,7 @@ def start(ENV="dev"):
         # Now register it
         response = workflow_object.register()
 
-        print 'got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)
+        print('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
 
     activity_names = []
     activity_names.append("ReadyToPublish")
@@ -121,7 +119,7 @@ def start(ENV="dev"):
         # Now register it
         response = activity_object.register()
 
-        print 'got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)
+        print('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
 
 if __name__ == "__main__":
 
@@ -133,4 +131,7 @@ if __name__ == "__main__":
     if options.env:
         ENV = options.env
 
-    start(ENV)
+    import settings as settings_lib
+    SETTINGS = settings_lib.get_settings(ENV)
+
+    start(SETTINGS)

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -21,10 +21,31 @@ class FakeLayer1:
         pass
 
     def list_closed_workflow_executions(
-        self, domain, start_latest_date=None, start_oldest_date=None, close_latest_date=None, 
-        close_oldest_date=None, close_status=None, tag=None, workflow_id=None, workflow_name=None, 
+        self, domain, start_latest_date=None, start_oldest_date=None, close_latest_date=None,
+        close_oldest_date=None, close_status=None, tag=None, workflow_id=None, workflow_name=None,
         workflow_version=None, maximum_page_size=None, next_page_token=None, reverse_order=None):
         return {'executionInfos': []}
+
+    def describe_workflow_type(self, domain, workflow_name, workflow_version):
+        pass
+
+    def register_workflow_type(
+        self, domain, name, version, task_list=None, default_child_policy=None,
+        default_execution_start_to_close_timeout=None, default_task_start_to_close_timeout=None,
+        description=None):
+        pass
+
+    def describe_activity_type(
+        self, domain, activity_name, activity_version):
+        pass
+
+    def register_activity_type(
+        self, domain, name, version, task_list=None, default_task_heartbeat_timeout=None,
+        default_task_schedule_to_close_timeout=None,
+        default_task_schedule_to_start_timeout=None, default_task_start_to_close_timeout=None,
+        description=None):
+        pass
+
 
 class FakeFlag():
     "a fake object to return process monitoring status"

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -2,6 +2,7 @@ import time
 import os
 from datetime import datetime
 
+
 class FakeBotoConnection:
     def __init__(self):
         self.start_called = None
@@ -15,35 +16,36 @@ class FakeLayer1:
         pass
 
     def start_workflow_execution(
-        self, domain, workflow_id, workflow_name, workflow_version, task_list=None, 
-        child_policy=None, execution_start_to_close_timeout=None, input=None, 
-        tag_list=None, task_start_to_close_timeout=None):
+            self, domain, workflow_id, workflow_name, workflow_version, task_list=None,
+            child_policy=None, execution_start_to_close_timeout=None, input=None,
+            tag_list=None, task_start_to_close_timeout=None):
         pass
 
     def list_closed_workflow_executions(
-        self, domain, start_latest_date=None, start_oldest_date=None, close_latest_date=None,
-        close_oldest_date=None, close_status=None, tag=None, workflow_id=None, workflow_name=None,
-        workflow_version=None, maximum_page_size=None, next_page_token=None, reverse_order=None):
+            self, domain, start_latest_date=None, start_oldest_date=None, close_latest_date=None,
+            close_oldest_date=None, close_status=None, tag=None, workflow_id=None,
+            workflow_name=None, workflow_version=None, maximum_page_size=None,
+            next_page_token=None, reverse_order=None):
         return {'executionInfos': []}
 
     def describe_workflow_type(self, domain, workflow_name, workflow_version):
         pass
 
     def register_workflow_type(
-        self, domain, name, version, task_list=None, default_child_policy=None,
-        default_execution_start_to_close_timeout=None, default_task_start_to_close_timeout=None,
-        description=None):
+            self, domain, name, version, task_list=None, default_child_policy=None,
+            default_execution_start_to_close_timeout=None,
+            default_task_start_to_close_timeout=None, description=None):
         pass
 
     def describe_activity_type(
-        self, domain, activity_name, activity_version):
+            self, domain, activity_name, activity_version):
         pass
 
     def register_activity_type(
-        self, domain, name, version, task_list=None, default_task_heartbeat_timeout=None,
-        default_task_schedule_to_close_timeout=None,
-        default_task_schedule_to_start_timeout=None, default_task_start_to_close_timeout=None,
-        description=None):
+            self, domain, name, version, task_list=None, default_task_heartbeat_timeout=None,
+            default_task_schedule_to_close_timeout=None,
+            default_task_schedule_to_start_timeout=None, default_task_start_to_close_timeout=None,
+            description=None):
         pass
 
 
@@ -62,6 +64,7 @@ class FakeFlag():
             time.sleep(self.timeout_seconds)
         return return_value
 
+
 class FakeS3Event():
     "object to test an S3 notification event from an SQS queue"
     def __init__(self):
@@ -70,20 +73,26 @@ class FakeS3Event():
         # test data below
         self._event_name = u'ObjectCreated:Put'
         self._event_time = u'2016-07-28T16:14:27.809576Z'
-        self._bucket_name =  u'jen-elife-production-final'
-        self._file_name =  u'elife-00353-vor-r1.zip'
+        self._bucket_name = u'jen-elife-production-final'
+        self._file_name = u'elife-00353-vor-r1.zip'
         self._file_etag = u'e7f639f63171c097d4761e2d2efe8dc4'
         self._file_size = 1097506
+
     def event_name(self):
         return self._event_name
+
     def event_time(self):
         return self._event_time
+
     def bucket_name(self):
         return self._bucket_name
+
     def file_name(self):
         return self._file_name
+
     def file_etag(self):
         return self._file_etag
+
     def file_size(self):
         return self._file_size
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -6,6 +6,7 @@ storage_provider = 's3'
 expanded_bucket = 'origin_bucket'
 
 publishing_buckets_prefix = ""
+production_bucket = "production_bucket"
 
 bucket = ""
 
@@ -20,6 +21,8 @@ simpledb_region = ""
 simpledb_domain_postfix = "_test"
 ejp_bucket = 'ejp_bucket'
 templates_bucket = 'templates_bucket'
+ppp_cdn_bucket = 'ppd_cdn_bucket'
+archive_bucket = "archive_bucket"
 bot_bucket = 'bot_bucket'
 lens_bucket = 'dest_bucket'
 poa_packaging_bucket = 'poa_packaging_bucket'
@@ -49,3 +52,6 @@ pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
 # Fastly CDNs
 fastly_service_ids = ['3M35rb7puabccOLrFFxy2']
 fastly_api_key = 'fake_fastly_api_key'
+
+elifepubmed_config_file = 'tests/activity/pubmed.cfg'
+elifepubmed_config_section = 'elife'

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,22 @@
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+import tests.settings_mock as settings_mock
+from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeSQSConn, FakeSQSQueue
+import register
+
+
+class TestRegister(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch('boto.sqs.connection.SQSConnection.get_queue')
+    @patch('boto.sqs.connect_to_region')
+    @patch('boto.swf.layer1.Layer1')
+    def test_start(self, fake_layer, fake_sqs_conn, mock_queue):
+        directory = TempDirectory()
+        fake_sqs_conn.return_value = FakeSQSConn(directory)
+        mock_queue.return_value = FakeSQSQueue(directory)
+        fake_layer.return_value = FakeLayer1()
+        self.assertIsNone(register.start(settings_mock))


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/issues/issues/4062 for Python 3 support.

There were no tests for `register.py` either, which had some `print` statements.

I've continued the method we have right now for importing settings when run as a console app, avoiding settings when running tests (which we've talked about before, could be good to improve the settings handling in future).

Also included some linting of `tests/classes_mock.py`.
