### PR TITLE
Create digest medium post enable

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -204,7 +204,7 @@ class activity_CreateDigestMediumPost(Activity):
         sender_email = self.settings.digest_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_recipient_email)
+            self.settings.digest_medium_recipient_email)
 
         messages = email_provider.simple_messages(
             sender_email, recipient_email_list, subject, body, logger=self.logger)

--- a/settings-example.py
+++ b/settings-example.py
@@ -110,6 +110,7 @@ class exp():
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"
+    digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint
     digest_endpoint = 'https://digests/{digest_id}'
@@ -365,6 +366,7 @@ class dev():
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"
+    digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint
     digest_endpoint = 'https://digests/{digest_id}'
@@ -614,6 +616,7 @@ class live():
     digest_sender_email = "sender@example.org"
     digest_recipient_email = ["e@example.org", "life@example.org"]
     digest_error_recipient_email = "error@example.org"
+    digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint
     digest_endpoint = 'https://digests/{digest_id}'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -60,6 +60,7 @@ digest_config_section = 'elife'
 digest_sender_email = "sender@example.org"
 digest_recipient_email = ["e@example.org", "life@example.org"]
 digest_error_recipient_email = "error@example.org"
+digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
 digest_endpoint = 'https://digests/{digest_id}'
 digest_auth_key = 'digest_auth_key'

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -112,6 +112,17 @@ class workflow_PostPerfectPublication(Workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "CreateDigestMediumPost",
+                        "activity_id": "CreateDigestMediumPost",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "GeneratePDFCovers",
                         "activity_id": "GeneratePDFCovers",
                         "version": "1",


### PR DESCRIPTION
Two parts to get ready for testing digest Medium posts.

Send to a new list of recipients `digest_medium_recipient_email` in settings so we can send the Medium email to people separately.

Added `CreateDigestMediumPost` to the post publication workflow so it gets invoked. It should be silent if there are no Medium credentials, and not cause failures if there is a runtime error.

Do not merge until builder settings are merged.