### PR TITLE
Video email in html format

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -207,7 +207,7 @@ class activity_CreateDigestMediumPost(Activity):
             self.settings.digest_medium_recipient_email)
 
         messages = email_provider.simple_messages(
-            sender_email, recipient_email_list, subject, body, logger=self.logger)
+            sender_email, recipient_email_list, subject, body, charset=None, logger=self.logger)
         self.logger.info('Formatted %d messages in %s' % (len(messages), self.name))
 
         details = email_provider.smtp_send_messages(self.settings, messages, self.logger)

--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -172,7 +172,7 @@ class activity_EmailVideoArticlePublished(Activity):
             # create the message
             message = email_provider.simple_message(
                 headers["sender_email"], recipient.get("e_mail"),
-                headers["subject"], body, logger=self.logger)
+                headers["subject"], body, subtype=headers.get("format"), logger=self.logger)
         except Exception as exception:
             self.logger.exception(
                 "Failed to build the email message in send_email: %s" % str(exception))

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -71,9 +71,9 @@ def add_attachment(message, file_name,
     message.attach(email_attachment)
 
 
-def add_text(message, text):
+def add_text(message, text, subtype, charset):
     "add text to the message"
-    message.attach(MIMEText(text))
+    message.attach(MIMEText(text, subtype, charset))
 
 
 def message(subject, sender, recipient):
@@ -121,19 +121,21 @@ def smtp_send_messages(settings, messages, logger=None):
     return details
 
 
-def simple_message(sender, recipient, subject, body, attachments=None, logger=None):
+def simple_message(sender, recipient, subject, body, subtype='plain',
+                   attachments=None, logger=None):
     """set values of a message
 
     :param sender: email address of the sender
     :param recipient: email address of the recipient
     :param subject: email subject
     :param body: email body
+    :param subtype: body text subtype, typically plain or html
     :param attachments: optional list of email attachments, each a file system path to the file
     :param logger: optional log.logger object
     :returns: MIMEMultipart email message object
     """
     email_message = message(subject, sender, recipient)
-    add_text(email_message, body)
+    add_text(email_message, body, subtype, 'utf-8')
     if attachments:
         for attachment in attachments:
             add_attachment(email_message, attachment)

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -71,7 +71,7 @@ def add_attachment(message, file_name,
     message.attach(email_attachment)
 
 
-def add_text(message, text, subtype, charset):
+def add_text(message, text, subtype=None, charset=None):
     "add text to the message"
     message.attach(MIMEText(text, subtype, charset))
 
@@ -122,7 +122,7 @@ def smtp_send_messages(settings, messages, logger=None):
 
 
 def simple_message(sender, recipient, subject, body, subtype='plain',
-                   attachments=None, logger=None):
+                   charset='utf-8', attachments=None, logger=None):
     """set values of a message
 
     :param sender: email address of the sender
@@ -130,32 +130,38 @@ def simple_message(sender, recipient, subject, body, subtype='plain',
     :param subject: email subject
     :param body: email body
     :param subtype: body text subtype, typically plain or html
+    :param charset: charset for the body text
     :param attachments: optional list of email attachments, each a file system path to the file
     :param logger: optional log.logger object
     :returns: MIMEMultipart email message object
     """
     email_message = message(subject, sender, recipient)
-    add_text(email_message, body, subtype, 'utf-8')
+    add_text(email_message, body, subtype, charset)
     if attachments:
         for attachment in attachments:
             add_attachment(email_message, attachment)
     return email_message
 
 
-def simple_messages(sender, recipients, subject, body, attachments=None, logger=None):
+def simple_messages(sender, recipients, subject, body, subtype='plain',
+                   charset='utf-8', attachments=None, logger=None):
     """list of simple messages for a list of recipients
 
     :param sender: email address of the sender
     :param recipients: list of recipient email addresses
     :param subject: email subject
     :param body: email body
+    :param subtype: body text subtype, typically plain or html
+    :param charset: charset for the body text
     :param attachments: optional list of email attachments, each a file system path to the file
     :param logger: optional log.logger object
     :returns: list of MIMEMultipart email message objects
     """
     messages = []
     for recipient in recipients:
-        messages.append(simple_message(sender, recipient, subject, body, attachments, logger))
+        messages.append(simple_message(
+            sender, recipient, subject, body, subtype=subtype, 
+            charset=charset, attachments=attachments, logger=logger))
     return messages
 
 

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -1,5 +1,6 @@
 import unittest
 from ddt import ddt, data, unpack
+from provider.utils import base64_encode_string
 import provider.email_provider as email_provider
 
 
@@ -58,3 +59,32 @@ class TestListEmailRecipients(unittest.TestCase):
         recipient = Recipient()
         setattr(recipient, "e_mail", e_mail)
         self.assertEqual(email_provider.valid_recipient_object(recipient), expected)
+
+    @data(
+        ('plain', 'Content-Type: text/plain; charset="utf-8"'),
+        ('html', 'Content-Type: text/html; charset="utf-8"'),
+    )
+    @unpack
+    def test_simple_message(self, subtype, expected_content_type):
+        sender = 'sender@example.org'
+        recipient = 'recipient@example.org'
+        subject = 'Email subject'
+        body = '<p>Email body</p>'
+        expected_fragments = []
+        # note: boundary value is not constant so cannot compare with a fixture easily
+        expected_fragments.append('Content-Type: multipart/mixed; boundary=')
+        expected_fragments.append('Subject: %s' % subject)
+        expected_fragments.append('From: %s' % sender)
+        expected_fragments.append('To: %s' % recipient)
+        expected_fragments.append(expected_content_type)
+        expected_fragments.append('MIME-Version: 1.0')
+        expected_fragments.append('Content-Transfer-Encoding: base64')
+        # body is base64 encoded
+        expected_fragments.append(base64_encode_string(body))
+        # create the message
+        email_message = email_provider.simple_message(
+            sender, recipient, subject, body, subtype=subtype)
+        for expected in expected_fragments:
+            self.assertTrue(
+                expected in str(email_message),
+                'Fragment %s not found in email %s' % (expected, str(email_message)))


### PR DESCRIPTION
There were some video emails coming from the workflows today, good! The bad is the HTML content was all in plain text. 

Here is a little tweak to support `text/plain` and `text/html` emails sent from the email provider. I also added in the `charset` option. If the `charset` is `utf-8` then the email body is base64 encoded. I don't know if we always want that, so there are some options to leave the charset as `None` for sending really simple emails.

Hopefully sending in multipart emails using this provider will work for all the current situations. If it can send simple plain messages, HTML emails, and emails with attachments, I think it will cover all the uses we have.