### PR TITLE
Use email subtype default of plain instead of None.

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -71,7 +71,7 @@ def add_attachment(message, file_name,
     message.attach(email_attachment)
 
 
-def add_text(message, text, subtype=None, charset=None):
+def add_text(message, text, subtype='plain', charset=None):
     "add text to the message"
     message.attach(MIMEText(text, subtype, charset))
 


### PR DESCRIPTION
Hopefully fixes https://github.com/elifesciences/issues/issues/4733 where plain emails sent by SMTP are not right since the latest code release. I will want to try testing it on continuumtest.