### PR TITLE
Set default email charset to utf-8

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -71,7 +71,7 @@ def add_attachment(message, file_name,
     message.attach(email_attachment)
 
 
-def add_text(message, text, subtype='plain', charset=None):
+def add_text(message, text, subtype='plain', charset='utf-8'):
     "add text to the message"
     message.attach(MIMEText(text, subtype, charset))
 


### PR DESCRIPTION
Further improvement for issue https://github.com/elifesciences/issues/issues/4733

The email sent by `EmailDigest` is not failing now on continuumtest after merging in PR https://github.com/elifesciences/elife-bot/pull/860. However, in mailtrap.io, the "text" of the email doesn't show. In the "raw" tab, in the email headers it has an empty / blank charset for the text portion. 

Since the default charset on emails is also `None`, change this to `utf-8` as the default, so we can hopefully get some actual email text to appear, instead of just raw email output.