### PR TITLE
Crossref library using schema 4.4.1 includes elocation_id of citations.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==4.1.1
 xlrd==0.9.3
 git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@bb61d4c0e3742403503efe10852114aeb1e07269#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@078ce423fb17186c5c92967c326119630846252b#egg=elifecrossref
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@dc9dd335a8d6a3ad58d65c126b884bdca1abed3e#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@32a9a831eca98a03b36b8c9a369c622a34d04a7a#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator

--- a/tests/activity/crossref.cfg
+++ b/tests/activity/crossref.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-crossref_schema_version: 4.4.0
+crossref_schema_version: 4.4.1
 generator: elife-crossref-xml-generation
 registrant: 
 depositor_name: 

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -58,7 +58,8 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_crossref_xml_contains": [
                 '<doi>10.7554/eLife.15747</doi>',
                 '<publication_date media_type="online"><month>06</month><day>16</day><year>2016</year></publication_date>',
-                '<item_number item_number_type="article_number">e15747</item_number>'
+                '<item_number item_number_type="article_number">e15747</item_number>',
+                '<citation key="bib13"><journal_title>BMC Biology</journal_title><author>Gilbert</author><volume>12</volume><cYear>2014</cYear><article_title>The Earth Microbiome project: successes and aspirations</article_title><doi>10.1186/s12915-014-0069-1</doi><elocation_id>69</elocation_id></citation>'
                 ]
         },
         {


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/elife-crossref-feed/issues/138, this uses the latest `elife-crossref-xml-generation` commit, ups the Crossref schema version used in tests to 4.4.1, and added another line to check `<elocation_id>` now appears in the Crossref deposit output. 

Note: it still works using 4.4.0 if the `crossref.cfg` file specifies it, so tests should pass and it should be fully compatible with the current configuration.