### PR TITLE
Use the latest digestparser library with a small fix to path encoding.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ pyGithub==1.27.1
 pyFunctional==1.0.0
 func_timeout==4.3.0
 python-docx==0.8.6
-git+https://github.com/elifesciences/digest-parser.git@d01754229075f38d20edca736b1aa5a5f1571d4f#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@0525de3e558f2db81b18fb08292b658c9611fde1#egg=digestparser
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium
 psutil==5.4.6


### PR DESCRIPTION
One step forward in troubleshooting unicode file names in digest zip input, in issue https://github.com/elifesciences/issues/issues/4664, this should allow the workflow to progress past the `ValidateDigestInput` activity step in `continuumtest` testing.