### PR TITLE
Digest unicode fixes

### DIFF
--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -3,6 +3,7 @@ import json
 import glob
 from S3utility.s3_notification_info import parse_activity_data
 from provider.storage_provider import storage_context
+from provider.utils import unicode_encode
 import provider.digest_provider as digest_provider
 from activity.objects import Activity
 
@@ -84,7 +85,9 @@ class activity_CopyDigestToOutbox(Activity):
 
     def copy_files_to_outbox(self, digest, bucket_name, from_dir):
         "copy all the files from the from_dir to the bucket"
-        file_list = glob.glob(from_dir + "/*")
+        folder_path = unicode_encode(from_dir) + "/*"
+        self.logger.info('Checking folder for digest files: %s' % folder_path)
+        file_list = glob.glob(folder_path)
         storage = storage_context(self.settings)
         for file_path in file_list:
             resource_dest = digest_provider.outbox_file_dest_resource(

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -78,3 +78,14 @@ def base64_decode_string(string):
         # python 3
         return base64.decodebytes(bytes(string, 'utf8')).decode()
     return base64.decodestring(string)
+
+
+def unicode_encode(string):
+    """safely encode string as utf8 by catching exceptions"""
+    if not string:
+        return string
+    try:
+        string = string.encode('utf8')
+    except (UnicodeDecodeError, TypeError, AttributeError):
+        pass
+    return unicode_decode(string)

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import unittest
 import time
 from ddt import ddt, data, unpack
@@ -88,6 +90,15 @@ class TestUtils(unittest.TestCase):
         )
     def test_unquote_plus(self, value, expected):
         self.assertEqual(utils.unquote_plus(value), expected)
+
+    @unpack
+    @data(
+        (None, None),
+        (u"tmp/foldér", u"tmp/foldér"),
+        (b"tmp/folde\xcc\x81r", u"tmp/foldér")
+        )
+    def test_unicode_encode(self, value, expected):
+        self.assertEqual(utils.unicode_encode(value), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I continued troubleshooting the digest unicode character bug again today, continuing from last week, issue https://github.com/elifesciences/issues/issues/4664.

Trying to hunt down exactly why this is happening, and putting together an overall solution for it, I haven't been able to do yet. This is one part of a plan B, a working solution, which is what works when I tested on a bot instance.

The automated tests will not, on any OS we are testing on, exhibit the same error. As such, I think it has something to do with how `worker.py` calls the activity, or in how the `process` provider calls `worker.py`. We could possibly recreate this error with `DIGEST 35774.zip` in an end2end testing situation, because it cannot be reproduced otherwise (so far), an idea for coverage @giorgiosironi ?

Here, the fix is basically: if a digest zip contains a `.docx` file with a unicode character in it, after unzipping the file using the `digestparser` library, the activity `self.temp_dir` ends up being `unicode`, instead of normally a `str`, and this causes an exception when using it in `os.path.join`.

I think this bug is only on Python 2.7, and may not be on Python 3.5, but I'm not complete sure.

If this little fix is acceptable, it will manage to finish an `IngestDigest` workflow, except the digest email attachment file name will not be right. I can do that on a new PR. I'd like to get this part merged to test it again on `continuumtest` to confirm my troubleshooting did address the issue.