### PR TITLE
Digest unicode bug fix continued

### DIFF
--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -1,6 +1,5 @@
 import os
 import json
-import glob
 from S3utility.s3_notification_info import parse_activity_data
 from provider.storage_provider import storage_context
 from provider.utils import unicode_encode
@@ -85,11 +84,17 @@ class activity_CopyDigestToOutbox(Activity):
 
     def copy_files_to_outbox(self, digest, bucket_name, from_dir):
         "copy all the files from the from_dir to the bucket"
-        folder_path = unicode_encode(from_dir) + "/*"
-        self.logger.info('Checking folder for digest files: %s' % folder_path)
-        file_list = glob.glob(folder_path)
         storage = storage_context(self.settings)
-        for file_path in file_list:
+        self.logger.info('from_dir type: %s' % type(from_dir))
+        encoded_from_dir = unicode_encode(from_dir)
+        self.logger.info('encoded_from_dir type: %s' % type(encoded_from_dir))
+        file_list = os.listdir(from_dir)
+        for file_name in file_list:
+            self.logger.info('file_name type: %s' % type(file_name))
+            encoded_file_name = unicode_encode(file_name)
+            self.logger.info('encoded_file_name type: %s' % type(encoded_file_name))
+            file_path = os.path.join(encoded_from_dir, encoded_file_name)
+            self.logger.info('file_path: %s' % file_path)
             resource_dest = digest_provider.outbox_file_dest_resource(
                 self.settings.storage_provider, digest, bucket_name, file_path)
             self.logger.info("Copying %s to %s", file_path, resource_dest)

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -82,10 +82,10 @@ def base64_decode_string(string):
 
 def unicode_encode(string):
     """safely encode string as utf8 by catching exceptions"""
-    if not string:
+    if string is None or isinstance(string, str):
         return string
     try:
         string = string.encode('utf8')
     except (UnicodeDecodeError, TypeError, AttributeError):
-        pass
-    return unicode_decode(string)
+        string = unicode_decode(string)
+    return string

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -93,12 +93,15 @@ class TestUtils(unittest.TestCase):
 
     @unpack
     @data(
-        (None, None),
-        (u"tmp/foldér", u"tmp/foldér"),
-        (b"tmp/folde\xcc\x81r", u"tmp/foldér")
+        (None, None, type(None)),
+        (u'', '',  str),
+        (u"tmp/foldér", "tmp/foldér", str),
+        (b"tmp/folde\xcc\x81r", "tmp/foldér", str)
         )
-    def test_unicode_encode(self, value, expected):
-        self.assertEqual(utils.unicode_encode(value), expected)
+    def test_unicode_encode(self, value, expected, expected_type):
+        encoded_value = utils.unicode_encode(value)
+        self.assertEqual(encoded_value, expected)
+        self.assertEqual(type(encoded_value), expected_type)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to issue https://github.com/elifesciences/issues/issues/4664 the digest zip unicode files.

Testing the latest code on `continuumtest` was still failing. First problem is `glob.glob()` internally also has an issue getting file names from a folder, so I am switching over to use `os.listdir()` with specific encoding of file name values.

The other is I messed up the return value for the new `unicode_encode()` function. It should always return a `str` if the input is `unicode` or `bytes`, in both Python 2 and 3.

Tests are passing, I will merge to test it out again on `continuumtest`, if it is failing there for regular files, I'll revert this.