### PR TITLE
Bug fix CreateDigestMediumPost sending emails, use default charset.

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -207,7 +207,7 @@ class activity_CreateDigestMediumPost(Activity):
             self.settings.digest_medium_recipient_email)
 
         messages = email_provider.simple_messages(
-            sender_email, recipient_email_list, subject, body, charset=None, logger=self.logger)
+            sender_email, recipient_email_list, subject, body, logger=self.logger)
         self.logger.info('Formatted %d messages in %s' % (len(messages), self.name))
 
         details = email_provider.smtp_send_messages(self.settings, messages, self.logger)


### PR DESCRIPTION
Default charset is 'utf-8` for sending emails with the latest `email_provider.py`. An error in the activity is caught by exception handling right now. This should fix it - simple so I will self-merge.