### PR TITLE
Send the digest JATS as a GET request instead of POST.

### DIFF
--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -126,7 +126,7 @@ def post_payload(digest, jats_content, api_key):
 
 def post_jats_to_endpoint(url, payload, logger):
     "issue the POST"
-    resp = post_as_params(url, payload)
+    resp = get_as_params(url, payload)
     # Check for good HTTP status code
     if resp.status_code != 200:
         logger.error(
@@ -139,6 +139,11 @@ def post_jats_to_endpoint(url, payload, logger):
             " \nresponse: %s") %
         (url, payload, resp.status_code, resp.content))
     return True
+
+
+def get_as_params(url, payload):
+    """transmit the payload as a GET with URL parameters"""
+    return requests.get(url, params=payload)
 
 
 def post_as_params(url, payload):

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -34,7 +34,7 @@ class TestPostDigestJats(unittest.TestCase):
         # clean the temporary directory
         self.activity.clean_tmp_dir()
 
-    @patch('requests.post')
+    @patch('requests.get')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @data(
         {
@@ -102,11 +102,11 @@ class TestPostDigestJats(unittest.TestCase):
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999'
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, post_mock):
+    def test_do_activity(self, test_data, fake_storage_context, requests_method_mock):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         # POST response
-        post_mock.return_value = FakeResponse(test_data.get("post_status_code"), None)
+        requests_method_mock.return_value = FakeResponse(test_data.get("post_status_code"), None)
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))
         filename_used = input_data(test_data.get("filename")).get("file_name")


### PR DESCRIPTION
Digest JATS content is not reaching the typesetter yet after the recent addition of `prod` settings. 

The error log has a `404` response. I tested interactively to be sure the endpoint URL is correct (it is), and we can authenticate (we can). 

The 404 response content indicates the method used it wrong, so I tested a `requests.get()` instead of `requests.post()` and it looks like we will get more success with that.

This API call is wrapped in an exception, and this change is low risk of causing havoc, I will merge it if all tests are green.