### PR TITLE
Digest medium check docx exists

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -71,6 +71,15 @@ class activity_CreateDigestMediumPost(Activity):
 
         # Wrap in an exception during testing phase
         try:
+            # check if there is a digest docx in the bucket for this article
+            docx_file_exists = digest_provider.docx_exists_in_s3(
+                self.settings, article_id, self.settings.bot_bucket, self.logger)
+            if docx_file_exists is not True:
+                self.logger.info(
+                    "Digest docx file does not exist in S3 for article %s" % article_id)
+                self.emit_end_message(article_id, version, run)
+                return self.ACTIVITY_SUCCESS
+
             # Approve for creating a Medium post
             self.statuses["approve"] = self.approve(article_id, status, version, run_type)
             if self.statuses.get("approve") is not True:

--- a/tests/activity/test_activity_create_digest_medium_post.py
+++ b/tests/activity/test_activity_create_digest_medium_post.py
@@ -2,7 +2,6 @@
 
 import unittest
 import copy
-from collections import OrderedDict
 from mock import patch
 from ddt import ddt, data
 import activity.activity_CreateDigestMediumPost as activity_module
@@ -105,6 +104,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
             bot_storage_context.resources = test_data.get('bot_bucket_resources')
         fake_storage_context.return_value = bot_storage_context
         fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_post_content.return_value = None
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
         # lax mocking
         fake_highest_version.return_value = test_data.get('lax_highest_version')
@@ -204,8 +204,9 @@ class TestCreateDigestMediumPost(unittest.TestCase):
         return_value = self.activity.email_notification(99999)
         self.assertTrue(return_value)
         self.assertEqual(
-            self.activity.logger.loginfo, 
+            self.activity.logger.loginfo,
             "Email sending details: OrderedDict([('error', 0), ('success', 2)])")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_create_digest_medium_post.py
+++ b/tests/activity/test_activity_create_digest_medium_post.py
@@ -115,6 +115,19 @@ class TestCreateDigestMediumPost(unittest.TestCase):
         self.assertEqual(result, test_data.get("expected_result"))
         self.assertEqual(self.activity.medium_content, test_data.get("expected_medium_content"))
 
+    @patch.object(digest_provider, 'docx_exists_in_s3')
+    @patch.object(activity_object, 'emit_monitor_event')
+    def test_do_activity_docx_does_not_exist(self, fake_emit, fake_docx_exists):
+        fake_emit.return_value = None
+        fake_docx_exists.return_value = None
+        activity_data = digest_activity_data(
+            ACTIVITY_DATA
+            )
+        # do the activity
+        result = self.activity.do_activity(activity_data)
+        # check assertions
+        self.assertEqual(result, activity_object.ACTIVITY_SUCCESS)
+
     @patch.object(activity_object, 'emit_monitor_event')
     def test_do_activity_missing_credentials(self, fake_emit):
         # copy files into the input directory using the storage context


### PR DESCRIPTION
A small improvement listed on issue https://github.com/elifesciences/issues/issues/4371. 

In the logs there is an ugly exception if an article has no digest, so instead of trying to download the `.docx` file blindly, instead check the `.docx` file exists first. If no `.docx` file exists, log it and return a success for the activity.

The logic checking for if `.docx` files exist is borrowed from its usage in https://github.com/elifesciences/elife-bot/blob/develop/activity/activity_IngestDigestToEndpoint.py.