### PR TITLE
Pass run_type via the lax token

### DIFF
--- a/activity/activity_ReadyToPublish.py
+++ b/activity/activity_ReadyToPublish.py
@@ -33,11 +33,12 @@ class activity_ReadyToPublish(Activity):
             expanded_folder_name = session.get_value('expanded_folder')
             status = session.get_value('status')
             update_date = session.get_value('update_date')
+            run_type = session.get_value('run_type')
 
             article_path = self.preview_path(self.settings.article_path_pattern, article_id, version)
 
             self.prepare_ready_to_publish_message(article_id, version, run, expanded_folder_name, status,
-                                                    update_date, article_path)
+                                                    update_date, article_path, run_type)
 
         except Exception as exception:
             self.logger.exception("Exception when sending Ready To Publish message")
@@ -57,14 +58,15 @@ class activity_ReadyToPublish(Activity):
         return article_path_pattern.format(id=article_id, version=version)
 
     def prepare_ready_to_publish_message(self, article_id, version, run, expanded_folder, status, update_date,
-                                         article_path):
+                                         article_path, run_type):
         workflow_data = {
                 'article_id': article_id,
                 'version': version,
                 'run': run,
                 'expanded_folder': expanded_folder,
                 'status': status,
-                'update_date': update_date
+                'update_date': update_date,
+                'run_type': run_type
             }
 
         message = {

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -1,60 +1,67 @@
 import unittest
+import json
 from lax_response_adapter import LaxResponseAdapter
 from mock import Mock
-import json
 from provider.utils import base64_encode_string
 
-fake_token = json.dumps({u'status': u'vor',
-                         u'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                         u'version': u'1',
-                         u'force': False,
-                         u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
+FAKE_TOKEN = json.dumps({
+    u'status': u'vor',
+    u'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+    u'version': u'1',
+    u'force': False,
+    u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
 
-fake_lax_message = json.dumps({"status": "published",
-                               "requested-action": "publish",
-                               "datetime": "2013-03-26T00:00:00+00:00",
-                               "token": base64_encode_string(fake_token),
-                               "id": "837411455"})
+FAKE_LAX_MESSAGE = json.dumps({
+    "status": "published",
+    "requested-action": "publish",
+    "datetime": "2013-03-26T00:00:00+00:00",
+    "token": base64_encode_string(FAKE_TOKEN),
+    "id": "837411455"})
 
-workflow_message_expected = {'workflow_data':
-                                 {'article_id': u'837411455',
-                                  'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                                  'message': None,
-                                  'requested_action': u'publish',
-                                  'force': False,
-                                  'result': u'published',
-                                  'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                                  'status': u'vor',
-                                  'update_date': '2013-03-26T00:00:00Z',
-                                  'version': u'1',
-                                  'run_type': None},
-                             'workflow_name': 'PostPerfectPublication'}
+WORKFLOW_MESSAGE_EXPECTED = {
+    'workflow_data': {
+        'article_id': u'837411455',
+        'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'message': None,
+        'requested_action': u'publish',
+        'force': False,
+        'result': u'published',
+        'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'status': u'vor',
+        'update_date': '2013-03-26T00:00:00Z',
+        'version': u'1',
+        'run_type': None},
+    'workflow_name': 'PostPerfectPublication'}
 
-fake_token_269 = json.dumps({u'status': u'vor',
-                         u'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                         u'version': u'1',
-                         u'force': False,
-                         u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
+FAKE_TOKEN_269 = json.dumps({
+    u'status': u'vor',
+    u'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+    u'version': u'1',
+    u'force': False,
+    u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
 
-fake_lax_message_269 = json.dumps({"status": "published",
-                               "requested-action": "publish",
-                               "datetime": "2013-03-26T00:00:00+00:00",
-                               "token": base64_encode_string(fake_token_269),
-                               "id": "269"})
+FAKE_LAX_MESSAGE_269 = json.dumps({
+    "status": "published",
+    "requested-action": "publish",
+    "datetime": "2013-03-26T00:00:00+00:00",
+    "token": base64_encode_string(FAKE_TOKEN_269),
+    "id": "269"})
 
-workflow_message_expected_269 = {'workflow_data':
-                                 {'article_id': u'00269',
-                                  'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                                  'message': None,
-                                  'requested_action': u'publish',
-                                  'force': False,
-                                  'result': u'published',
-                                  'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
-                                  'status': u'vor',
-                                  'update_date': '2013-03-26T00:00:00Z',
-                                  'version': u'1',
-                                  'run_type': None},
-                             'workflow_name': 'PostPerfectPublication'}
+WORKFLOW_MESSAGE_EXPECTED_269 = {
+    'workflow_data': {
+        'article_id': u'00269',
+        'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'message': None,
+        'requested_action': u'publish',
+        'force': False,
+        'result': u'published',
+        'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'status': u'vor',
+        'update_date': '2013-03-26T00:00:00Z',
+        'version': u'1',
+        'run_type': None},
+    'workflow_name': 'PostPerfectPublication'}
+
 
 class TestLaxResponseAdapter(unittest.TestCase):
     def setUp(self):
@@ -63,14 +70,17 @@ class TestLaxResponseAdapter(unittest.TestCase):
         self.laxresponseadapter = LaxResponseAdapter(settings, self.logger)
 
     def test_parse_message(self):
-        expected_workflow_starter_message = self.laxresponseadapter.parse_message(fake_lax_message)
+        expected_workflow_starter_message = self.laxresponseadapter.parse_message(
+            FAKE_LAX_MESSAGE)
         self.assertDictEqual.__self__.maxDiff = None
-        self.assertDictEqual(expected_workflow_starter_message, workflow_message_expected)
+        self.assertDictEqual(expected_workflow_starter_message, WORKFLOW_MESSAGE_EXPECTED)
 
     def test_parse_message_269(self):
-        expected_workflow_starter_message = self.laxresponseadapter.parse_message(fake_lax_message_269)
+        expected_workflow_starter_message = self.laxresponseadapter.parse_message(
+            FAKE_LAX_MESSAGE_269)
         self.assertDictEqual.__self__.maxDiff = None
-        self.assertDictEqual(expected_workflow_starter_message, workflow_message_expected_269)
+        self.assertDictEqual(expected_workflow_starter_message, WORKFLOW_MESSAGE_EXPECTED_269)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -62,6 +62,38 @@ WORKFLOW_MESSAGE_EXPECTED_269 = {
         'run_type': None},
     'workflow_name': 'PostPerfectPublication'}
 
+FAKE_SILENT_INGEST_TOKEN = json.dumps({
+    u'status': u'vor',
+    u'run_type': 'silent-correction',
+    u'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+    u'version': u'1',
+    u'force': True,
+    u'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148'})
+
+FAKE_SILENT_INGEST_LAX_MESSAGE = json.dumps({
+    "datetime": "2013-03-26T00:00:00+00:00",
+    "force": True,
+    "status": "ingested",
+    "id": "837411455",
+    "token": base64_encode_string(FAKE_SILENT_INGEST_TOKEN),
+    "validate-only": False,
+    "requested-action": "ingest",
+    })
+
+WORKFLOW_MESSAGE_EXPECTED_SILENT_INGEST = {
+    'workflow_data': {
+        'article_id': u'837411455',
+        'expanded_folder': u'837411455.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'message': None,
+        'requested_action': u'ingest',
+        'force': True,
+        'result': u'ingested',
+        'run': u'a8bb05df-2df9-4fce-8f9f-219aca0b0148',
+        'status': u'vor',
+        'update_date': '2013-03-26T00:00:00Z',
+        'version': u'1',
+        'run_type': 'silent-correction'},
+    'workflow_name': 'SilentCorrectionsProcess'}
 
 class TestLaxResponseAdapter(unittest.TestCase):
     def setUp(self):
@@ -72,14 +104,18 @@ class TestLaxResponseAdapter(unittest.TestCase):
     def test_parse_message(self):
         expected_workflow_starter_message = self.laxresponseadapter.parse_message(
             FAKE_LAX_MESSAGE)
-        self.assertDictEqual.__self__.maxDiff = None
         self.assertDictEqual(expected_workflow_starter_message, WORKFLOW_MESSAGE_EXPECTED)
 
     def test_parse_message_269(self):
         expected_workflow_starter_message = self.laxresponseadapter.parse_message(
             FAKE_LAX_MESSAGE_269)
-        self.assertDictEqual.__self__.maxDiff = None
         self.assertDictEqual(expected_workflow_starter_message, WORKFLOW_MESSAGE_EXPECTED_269)
+
+    def test_parse_message_silent_ingest(self):
+        expected_workflow_starter_message = self.laxresponseadapter.parse_message(
+            FAKE_SILENT_INGEST_LAX_MESSAGE)
+        self.assertDictEqual(
+            expected_workflow_starter_message, WORKFLOW_MESSAGE_EXPECTED_SILENT_INGEST)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As part of issue https://github.com/elifesciences/issues/issues/4777

I started off adding a test for silent correction ingest `workflow_data` in the tests for the `lax_response_adapter`, and linted it as well.

I had a difficult time figuring out where the `run_type` value is dropped as part of silent corrections, so I went to looking at why the `run_type` value of `"initial-article"` was getting lost in normal ingest runs once it reached the post publication workflow.

The `token` value sent back from Lax in an ingest versus a publish action were different. It looks like the token for publish, which is stored in the dashboard, was missing the `run_type` value. I added that here.

I will be continuing to refactor and simplify these in the future. For example, I will probably move the building of the "ready_to_publish" message to a more central place so it can also be used where the silent correction workflow token is made. That is one possibly solution, based on how I think I've figured out why the value is lost.