### PR TITLE
Run type fix part 1

### DIFF
--- a/activity/activity_ReadyToPublish.py
+++ b/activity/activity_ReadyToPublish.py
@@ -36,7 +36,7 @@ class activity_ReadyToPublish(Activity):
             update_date = session.get_value('update_date')
             run_type = session.get_value('run_type')
 
-            article_path = self.preview_path(self.settings.article_path_pattern, article_id, version)
+            article_path = preview_path(self.settings.article_path_pattern, article_id, version)
 
             publication_data_message = starter_message(
                 article_id=article_id,
@@ -65,9 +65,6 @@ class activity_ReadyToPublish(Activity):
 
         return self.ACTIVITY_SUCCESS
 
-    def preview_path(self, article_path_pattern, article_id, version):
-        return article_path_pattern.format(id=article_id, version=version)
-
     def prepare_ready_to_publish_message(self, article_id, version, article_path, publication_data_message):
 
         encoded_message = base64_encode_string(json.dumps(publication_data_message))
@@ -80,3 +77,7 @@ class activity_ReadyToPublish(Activity):
                                   encoded_message, "text", version=version)
         self.set_monitor_property(self.settings, article_id, "publication-status",
                                   "ready to publish", "text", version=version)
+
+
+def preview_path(article_path_pattern, article_id, version):
+    return article_path_pattern.format(id=article_id, version=version)

--- a/activity/activity_ReadyToPublish.py
+++ b/activity/activity_ReadyToPublish.py
@@ -4,6 +4,7 @@ from provider.utils import base64_encode_string
 from provider.token import starter_message
 from activity.objects import Activity
 
+
 class activity_ReadyToPublish(Activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_ReadyToPublish, self).__init__(
@@ -55,17 +56,17 @@ class activity_ReadyToPublish(Activity):
             self.logger.exception("Exception when sending Ready To Publish message")
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "error",
-                                    "Error sending Ready To Publish message for article " + article_id +
-                                    " message:" + str(exception))
+                                    "Error sending Ready To Publish message for article " +
+                                    article_id + " message:" + str(exception))
             return self.ACTIVITY_PERMANENT_FAILURE
 
         self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
-                                    "Sending Ready To Publish message. "
-                                    "Article: " + article_id)
+                                "Sending Ready To Publish message. " + "Article: " + article_id)
 
         return self.ACTIVITY_SUCCESS
 
-    def prepare_ready_to_publish_message(self, article_id, version, article_path, publication_data_message):
+    def prepare_ready_to_publish_message(self, article_id, version, article_path,
+                                         publication_data_message):
 
         encoded_message = base64_encode_string(json.dumps(publication_data_message))
 

--- a/provider/token.py
+++ b/provider/token.py
@@ -1,19 +1,25 @@
 from collections import OrderedDict
 
 
-def build_workflow_data(**kwargs):
+def build_workflow_data(article_id, version, run, expanded_folder, status, update_date, run_type):
     """create a dict of workflow_data from the supplied keyword arguments"""
     workflow_data = OrderedDict()
-    for data_property in ['article_id', 'version', 'run', 'expanded_folder', 'status',
-                          'update_date', 'run_type']:
-        workflow_data[data_property] = kwargs.get(data_property)
+    workflow_data['article_id'] = article_id
+    workflow_data['version'] = version
+    workflow_data['run'] = run
+    workflow_data['expanded_folder'] = expanded_folder
+    workflow_data['status'] = status
+    workflow_data['update_date'] = update_date
+    workflow_data['run_type'] = run_type
     return workflow_data
 
 
-def starter_message(**kwargs):
+def starter_message(article_id, version, run, expanded_folder, status, update_date, run_type, 
+                    workflow_name):
     """create a dict for a workflow starter message"""
     starter_message = OrderedDict()
-    workflow_data = build_workflow_data(**kwargs)
-    starter_message['workflow_name'] = kwargs.get('workflow_name')
+    workflow_data = build_workflow_data(article_id, version, run, expanded_folder, 
+                                        status, update_date, run_type)
+    starter_message['workflow_name'] = workflow_name
     starter_message['workflow_data'] = workflow_data
     return starter_message

--- a/provider/token.py
+++ b/provider/token.py
@@ -1,0 +1,19 @@
+from collections import OrderedDict
+
+
+def build_workflow_data(**kwargs):
+    """create a dict of workflow_data from the supplied keyword arguments"""
+    workflow_data = OrderedDict()
+    for data_property in ['article_id', 'version', 'run', 'expanded_folder', 'status',
+                          'update_date', 'run_type']:
+        workflow_data[data_property] = kwargs.get(data_property)
+    return workflow_data
+
+
+def starter_message(**kwargs):
+    """create a dict for a workflow starter message"""
+    starter_message = OrderedDict()
+    workflow_data = build_workflow_data(**kwargs)
+    starter_message['workflow_name'] = kwargs.get('workflow_name')
+    starter_message['workflow_data'] = workflow_data
+    return starter_message

--- a/tests/activity/test_activity_ready_to_publish.py
+++ b/tests/activity/test_activity_ready_to_publish.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch
 import tests.activity.settings_mock as settings_mock
+import activity.activity_ReadyToPublish as activity_module
 from activity.activity_ReadyToPublish import activity_ReadyToPublish
 from tests.activity.classes_mock import FakeSession, FakeLogger
 
@@ -36,7 +37,7 @@ class TestReadyToPublish(unittest.TestCase):
         self.assertEqual(result, self.readytopublish.ACTIVITY_PERMANENT_FAILURE)
 
     def test_preview_path(self):
-        result = self.readytopublish.preview_path(settings_mock.article_path_pattern, "34427", "1")
+        result = activity_module.preview_path(settings_mock.article_path_pattern, "34427", "1")
         self.assertEqual(result, "/articles/34427v1")
 
 

--- a/tests/provider/test_token.py
+++ b/tests/provider/test_token.py
@@ -31,15 +31,15 @@ class TestTokenProvider(unittest.TestCase):
     def test_build_workflow_data(self):
         """test building workflow data"""
         expected = self.expected_workflow_data()
-        workflow_data = OrderedDict([
-            ('article_id', self.article_id),
-            ('version', self.version),
-            ('run', self.run),
-            ('expanded_folder', self.expanded_folder),
-            ('status', self.status),
-            ('update_date', self.update_date),
-            ('run_type', self.run_type),
-        ])
+        workflow_data = token.build_workflow_data(
+            article_id=self.article_id,
+            version=self.version,
+            run=self.run,
+            expanded_folder=self.expanded_folder,
+            status=self.status,
+            update_date=self.update_date,
+            run_type=self.run_type
+        )
         self.assertEqual(workflow_data, expected)
 
     def test_starter_message(self):

--- a/tests/provider/test_token.py
+++ b/tests/provider/test_token.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+
+import unittest
+from collections import OrderedDict
+import provider.token as token
+
+
+class TestTokenProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.article_id = 'article_id'
+        self.version = 'version'
+        self.run = 'run'
+        self.expanded_folder = 'expanded_folder'
+        self.status = 'status'
+        self.update_date = 'update_date'
+        self.run_type = 'run_type'
+
+    def expected_workflow_data(self):
+        """for reuse in tests some expected workflow data"""
+        return OrderedDict([
+            ('article_id', self.article_id),
+            ('version', self.version),
+            ('run', self.run),
+            ('expanded_folder', self.expanded_folder),
+            ('status', self.status),
+            ('update_date', self.update_date),
+            ('run_type', self.run_type),
+        ])
+
+    def test_build_workflow_data(self):
+        """test building workflow data"""
+        expected = self.expected_workflow_data()
+        workflow_data = OrderedDict([
+            ('article_id', self.article_id),
+            ('version', self.version),
+            ('run', self.run),
+            ('expanded_folder', self.expanded_folder),
+            ('status', self.status),
+            ('update_date', self.update_date),
+            ('run_type', self.run_type),
+        ])
+        self.assertEqual(workflow_data, expected)
+
+    def test_starter_message(self):
+        """test building a starter message with a workflow name and workflow data"""
+        workflow_name = 'workflow_name'
+        expected = OrderedDict([
+            ('workflow_name', workflow_name),
+            ('workflow_data', self.expected_workflow_data())
+        ])
+        starter_message = token.starter_message(
+            article_id=self.article_id,
+            version=self.version,
+            run=self.run,
+            expanded_folder=self.expanded_folder,
+            status=self.status,
+            update_date=self.update_date,
+            run_type=self.run_type,
+            workflow_name=workflow_name
+        )
+        self.assertEqual(starter_message, expected)

--- a/tests/provider/test_token.py
+++ b/tests/provider/test_token.py
@@ -2,7 +2,7 @@
 
 import unittest
 from collections import OrderedDict
-import provider.token as token
+from provider import token
 
 
 class TestTokenProvider(unittest.TestCase):


### PR DESCRIPTION
As described in https://github.com/elifesciences/issues/issues/4777, this is part 1 of 3 in the fix for passing the `run_type` to downstream workflows when a silent correction is run.

Move the logic of building a workflow starter message, which has workflow data in it, over to a new `token.py` provider. Refactor `ReadyToPublish` to create the message from that.

I'll also create some simple tests for the new provider now too.