### PR TITLE
Use MIMEApplication to set email Content-Type header.

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -73,23 +73,20 @@ def encode_filename(file_name):
 
 def attachment(file_name,
                media_type='vnd.openxmlformats-officedocument.wordprocessingml.document',
-               charset='UTF-8'):
+               charset='utf-8'):
     "create an attachment from the file"
-    content_type_header = '{media_type}; charset={charset}'.format(
-        media_type=media_type, charset=charset)
     attachment_name = encode_filename(os.path.split(file_name)[-1])
     with open(file_name, 'rb') as open_file:
-        email_attachment = MIMEApplication(open_file.read())
+        email_attachment = MIMEApplication(open_file.read(), media_type)
     email_attachment.add_header(
         'Content-Disposition', 'attachment',
-        filename=('utf-8', '', attachment_name))
-    email_attachment.add_header('Content-Type', content_type_header)
+        filename=(charset, '', attachment_name))
     return email_attachment
 
 
 def add_attachment(message, file_name,
                    media_type='vnd.openxmlformats-officedocument.wordprocessingml.document',
-                   charset='UTF-8'):
+                   charset='utf-8'):
     "add an attachment to the message"
     email_attachment = attachment(file_name, media_type, charset)
     message.attach(email_attachment)


### PR DESCRIPTION
A bug reported in issue https://github.com/elifesciences/issues/issues/4795, appeared after the deploy of email attachment changes yesterday, where in gmail the attachment file name is not appearing.

The code here was resulting in two `Content-Type` headers in the email attachment. By giving `MIMEApplication` the media type, it sets the one good header rather than it adding the second header of `Content-Type: application/octet-stream` I want to avoid.

There still may be an issue with attachment file name and its encoding which doesn't work in gmail, which can be diagnosed later after another real test.