### PR TITLE
Remove consider Lax two point oh

### DIFF
--- a/activity/activity_IngestToLax.py
+++ b/activity/activity_IngestToLax.py
@@ -51,7 +51,7 @@ class activity_IngestToLax(Activity):
                                      "aws_secret_access_key": self.settings.aws_secret_access_key}
 
         (message, queue, start_event,
-         end_event, end_event_details, exception) = self.get_message_queue(data, self.settings.consider_Lax_elife_2_0)
+         end_event, end_event_details, exception) = self.get_message_queue(data)
 
         self.emit_monitor_event(*start_event)
         if end_event == "error":
@@ -65,7 +65,7 @@ class activity_IngestToLax(Activity):
 
 
 
-    def get_message_queue(self, data=None, consider_elife_20=True):
+    def get_message_queue(self, data=None):
         """
         Do the work
         """
@@ -81,42 +81,6 @@ class activity_IngestToLax(Activity):
         try:
             expanded_folder = data['expanded_folder']
             run_type = data['run_type']
-
-            ##########
-            if not consider_elife_20:
-
-                start_event = [self.settings, article_id, version, run, self.pretty_name + " (Skipping)", "start",
-                               "Starting preparation of article " + article_id]
-
-                try:
-                    workflow_starter_message = {
-                            "workflow_name": "ProcessArticleZip",
-                            "workflow_data": {
-                                "run":run ,
-                                "article_id": article_id,
-                                "result": "",
-                                "status": status,
-                                "version": version,
-                                "expanded_folder": expanded_folder,
-                                "requested_action": "",
-                                "message": "",
-                                "update_date": data['update_date'],
-                                "run_type": run_type
-                            }
-                        }
-
-                    return (workflow_starter_message, self.settings.workflow_starter_queue,start_event,
-                            "end", [self.settings, article_id, version, run, self.pretty_name + " (Skipping)", "end",
-                                    "Lax is not being considered, this activity just triggered next "
-                                    "workflow without influence from Lax."], None)
-
-                except Exception as exception:
-                    return (None, None, start_event, "error",
-                            [self.settings, article_id, version, run, self.pretty_name + " (Skipping)", "error",
-                             "An error has occurred. Details: %s", str(exception)],
-                            str(exception))
-
-            ##########
 
             start_event = [self.settings, article_id, version, run, self.pretty_name, "start",
                            "Starting preparation of article for Lax " + article_id]

--- a/activity/activity_IngestToLax.py
+++ b/activity/activity_IngestToLax.py
@@ -67,7 +67,8 @@ class activity_IngestToLax(Activity):
 
     def get_message_queue(self, data=None):
         """
-        Do the work
+        Given data from an article workflow, return a message to add to the Lax queue,
+        and also return values to be sent to the dashboard
         """
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))

--- a/activity/activity_IngestToLax.py
+++ b/activity/activity_IngestToLax.py
@@ -34,8 +34,7 @@ class activity_IngestToLax(Activity):
 
     def do_activity(self, data=None):
 
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         run = data["run"]
         session = get_session(self.settings, data, run)
@@ -70,8 +69,6 @@ class activity_IngestToLax(Activity):
         Given data from an article workflow, return a message to add to the Lax queue,
         and also return values to be sent to the dashboard
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         run = data['run']
         version = data['version']

--- a/activity/activity_PublishToLax.py
+++ b/activity/activity_PublishToLax.py
@@ -32,14 +32,6 @@ class activity_PublishToLax(Activity):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
-        ###########
-        if not self.settings.consider_Lax_elife_2_0:
-            if self.logger:
-                self.logger.info('PublishToLax. Lax is not being considered. Skipping activity.')
-            return True
-
-        ###########
-
         article_id = data['article_id']
         version = data['version']
         run = data['run']

--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -33,11 +33,6 @@ class activity_VerifyLaxResponse(Activity):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
-        ########
-        if not self.settings.consider_Lax_elife_2_0:
-            return self.ACTIVITY_SUCCESS
-        #######
-
         article_id = data['article_id']
         run = data['run']
         version = data['version']
@@ -64,8 +59,6 @@ class activity_VerifyLaxResponse(Activity):
                                     "Lax has not ingested article " + article_id +
                                     " result from lax:" + str(data['result']) + '; message from lax: ' + message)
             return self.ACTIVITY_PERMANENT_FAILURE
-
-        #########
 
         except Exception as e:
             self.logger.exception("Exception when Verifying Lax Response")

--- a/settings-example.py
+++ b/settings-example.py
@@ -251,7 +251,6 @@ class exp():
     lax_response_queue = "bot-lax-exp-out"
     # eLife 2.0 transition settings
     publication_authority = "journal"
-    consider_Lax_elife_2_0 = True
 
     # videos
     video_url = "https://video.url.here/"
@@ -759,7 +758,6 @@ class live():
     lax_response_queue = "bot-lax-prod-out"
     # eLife 2.0 transition settings
     publication_authority = "journal"
-    consider_Lax_elife_2_0 = True
 
     # videos
     video_url = "https://video.url.here/"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -73,7 +73,6 @@ journal_preview_base_url = 'https://preview'
 features_publication_recipient_email = "features_team@example.org"
 email_video_recipient_email = "features_team@example.org"
 publication_authority = ""
-consider_Lax_elife_2_0 = True
 
 xml_info_queue = 'test-elife-xml-info'
 

--- a/tests/activity/test_activity_ingest_to_lax.py
+++ b/tests/activity/test_activity_ingest_to_lax.py
@@ -79,35 +79,5 @@ class TestIngestToLax(unittest.TestCase):
                                                  " message: Access Denied"])
 
 
-    @data(data_example)
-    def test_get_message_queue_not_consider_lax(self, data):
-
-        message, queue, start_event, end_event, end_event_details, exception = self.ingesttolax.get_message_queue(data, False)
-        self.assertDictEqual(message, {
-                                "workflow_name": "ProcessArticleZip",
-                                "workflow_data": {
-                                    "run":data['run'] ,
-                                    "article_id": data['article_id'],
-                                    "result": "",
-                                    "status": data['status'],
-                                    "version": data['version'],
-                                    "expanded_folder": data['expanded_folder'],
-                                    "requested_action": "",
-                                    "message": "",
-                                    "update_date": data['update_date'],
-                                    "run_type": data['run_type']
-                                }
-                            })
-        self.assertEqual(queue, settings_mock.workflow_starter_queue)
-        self.assertEqual(start_event, [settings_mock, data['article_id'], data['version'], data['run'],
-                                       self.ingesttolax.pretty_name + " (Skipping)", "start",
-                                       "Starting preparation of article " + data['article_id']])
-        self.assertEqual(end_event, "end")
-        self.assertEqual(end_event_details, [settings_mock, data['article_id'], data['version'], data['run'],
-                                             self.ingesttolax.pretty_name + " (Skipping)", "end",
-                                             "Lax is not being considered, this activity just triggered next "
-                                             "workflow without influence from Lax."])
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_ingest_to_lax.py
+++ b/tests/activity/test_activity_ingest_to_lax.py
@@ -25,7 +25,7 @@ class TestIngestToLax(unittest.TestCase):
 
     @data(data_example)
     @patch('provider.lax_provider.prepare_action_message')
-    def test_do_activity_success(self, data, fake_action_message):
+    def test_get_message_queue_success(self, data, fake_action_message):
         fake_action_message.return_value = {"example_message": True}
 
         message, queue, start_event, end_event, end_event_details, exception = self.ingesttolax.get_message_queue(data)
@@ -42,7 +42,7 @@ class TestIngestToLax(unittest.TestCase):
 
     @data(data_example)
     @patch("provider.lax_provider.prepare_action_message")
-    def test_do_activity_error(self, data, fake_lax_provider):
+    def test_get_message_queue_error(self, data, fake_lax_provider):
         fake_lax_provider.side_effect = Exception("Access Denied")
         message, queue, start_event, end_event, end_event_details, exception = self.ingesttolax.get_message_queue(data)
         self.assertEqual(end_event, "error")
@@ -54,7 +54,7 @@ class TestIngestToLax(unittest.TestCase):
 
 
     @data(data_example)
-    def test_do_activity_not_consider_lax(self, data):
+    def test_get_message_queue_not_consider_lax(self, data):
 
         message, queue, start_event, end_event, end_event_details, exception = self.ingesttolax.get_message_queue(data, False)
         self.assertDictEqual(message, {

--- a/tests/activity/test_activity_ingest_to_lax.py
+++ b/tests/activity/test_activity_ingest_to_lax.py
@@ -49,6 +49,18 @@ class TestIngestToLax(unittest.TestCase):
         return_value = self.ingesttolax.do_activity(data)
         self.assertEqual(return_value, activity_IngestToLax.ACTIVITY_SUCCESS)
 
+    @patch.object(activity_IngestToLax, 'get_message_queue')
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_IngestToLax, 'emit_monitor_event')
+    def test_do_activity_error(self, fake_emit_monitor, fake_session, fake_message_queue):
+        """test for when the end_event is error"""
+        fake_data = {'run': ''}
+        start_event = []
+        end_event = "error"
+        fake_message_queue.return_value = None, None, start_event, end_event, None, None
+        return_value = self.ingesttolax.do_activity(fake_data)
+        self.assertEqual(return_value, activity_IngestToLax.ACTIVITY_PERMANENT_FAILURE)
+
     @data(data_example)
     @patch('provider.lax_provider.prepare_action_message')
     def test_get_message_queue_success(self, data, fake_action_message):


### PR DESCRIPTION
As part of the workflow data clean up in issue https://github.com/elifesciences/issues/issues/4777, the `settings.consider_Lax_elife_2_0` is old and we do not need it anymore.

I started out by adding more tests for `IngestToLax` for better coverage before I refactored.

All the blocks that considered `consider_Lax_elife_2_0` are no longer considering.