### PR TITLE
Simplify VerifyPublishResponse, no more publication_authority

### DIFF
--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -1,5 +1,6 @@
 import json
 from provider.execution_context import get_session
+from provider.lax_provider import message_from_lax
 from uuid import UUID
 from activity.objects import Activity
 
@@ -59,7 +60,7 @@ class activity_VerifyLaxResponse(Activity):
 
                 return self.ACTIVITY_SUCCESS
 
-            message = data['message'] if data['message'] is not None else "(empty message)"
+            message = message_from_lax(data)
             self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
                                     "Lax has not ingested article " + article_id +
                                     " result from lax:" + str(data['result']) + '; message from lax: ' + message)

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -33,7 +33,9 @@ class activity_VerifyPublishResponse(Activity):
 
     def get_events(self, data):
         """
-        Do the work
+        Given the data for this activity from Lax and the activity starter,
+        return start and end messages to send to the dashboard queue,
+        also return the status return from Lax, and the return value for this workflow activity
         """
         self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -74,8 +74,7 @@ class activity_VerifyPublishResponse(Activity):
                          self.pretty_name + ": journal", "error",
                          " Lax has not published article " + data['article_id'] +
                          " result from lax:" + str(data['result']) + '; message from lax: ' +
-                         data['message'] if ("message" in data) and
-                         (data['message'] is not None) else "(empty message)"]
+                         message_from_lax(data)]
 
             set_status_property = [
                 self.settings, data['article_id'], "publication-status",
@@ -85,3 +84,8 @@ class activity_VerifyPublishResponse(Activity):
 
         else:
             raise RuntimeError("The publication result isn't a valid one.")
+
+def message_from_lax(data):
+    """format a message from a Lax response"""
+    return data['message'] if (
+        "message" in data and data['message'] is not None) else "(empty message)"

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -1,4 +1,5 @@
 import json
+from provider.lax_provider import message_from_lax
 from activity.objects import Activity
 
 """
@@ -88,8 +89,3 @@ class activity_VerifyPublishResponse(Activity):
 
         else:
             raise RuntimeError("The publication result isn't a valid one.")
-
-def message_from_lax(data):
-    """format a message from a Lax response"""
-    return data['message'] if (
-        "message" in data and data['message'] is not None) else "(empty message)"

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -54,52 +54,7 @@ class activity_VerifyPublishResponse(Activity):
 
     def publication_verification_results(self, data, pub_authority, checking_result_from, success):
 
-        if pub_authority == 'elife-website' and checking_result_from == 'elife-website' and success:
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
-                           self.pretty_name + ": elife-website", "start",
-                           "Starting verification of Publish response " + data['article_id']]
-
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
-                         self.pretty_name + ": elife-website",
-                         "end", "Finished verification of Publish response " + data['article_id']]
-
-            set_status_event = None
-            success = self.ACTIVITY_SUCCESS
-            return start_event, end_event, set_status_event, success
-
-        elif pub_authority == 'elife-website' and checking_result_from == 'journal' and success:
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
-                           self.pretty_name + ": journal", "start",
-                           "Starting verification of Publish response " + data['article_id']]
-
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
-                         self.pretty_name + ": journal", "end",
-                         " Finished Verification. Lax has responded with result: published."
-                         " Authority: elife-website. Exiting."
-                         " Article: " + data['article_id']]
-
-            set_status_property = [self.settings, data['article_id'], "publication-status", "published", "text"]
-            success = self.ACTIVITY_EXIT_WORKFLOW
-            return start_event, end_event, set_status_property, success
-
-        elif pub_authority == 'elife-website' and checking_result_from == 'journal' and success is False:
-
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
-                           self.pretty_name + ": journal", "start",
-                           "Starting verification of Publish response " + data['article_id']]
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
-                         self.pretty_name + ": journal", "error",
-                         " Lax has not published article " + data['article_id'] +
-                         " We will exit this workflow as the publication authority is elife-website."
-                         " result from lax:" + str(data['result']) + '; message from lax: ' +
-                         data['message'] if ("message" in data) and (data['message'] is not None) else "(empty message)"]
-
-            set_status_property = [self.settings, data['article_id'], "publication-status", "publication issues",
-                                "text"]
-            success = self.ACTIVITY_PERMANENT_FAILURE
-            return start_event, end_event, set_status_property, success
-
-        elif pub_authority == 'journal' and checking_result_from == 'journal' and success:
+        if pub_authority == 'journal' and checking_result_from == 'journal' and success:
 
             start_event = [self.settings, data['article_id'], data['version'], data['run'],
                            self.pretty_name + ": journal", "start",
@@ -129,20 +84,6 @@ class activity_VerifyPublishResponse(Activity):
             set_status_property = [self.settings, data['article_id'], "publication-status", "publication issues",
                                 "text"]
             success = self.ACTIVITY_PERMANENT_FAILURE
-            return start_event, end_event, set_status_property, success
-
-        elif pub_authority == 'journal' and checking_result_from == 'elife-website' and success:
-
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
-                           self.pretty_name + ": elife-website", "start",
-                           "Starting verification of Publish response " + data['article_id']]
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
-                         self.pretty_name + ": elife-website", "end",
-                         "Finish verification of Publish response. Authority: journal. Exiting this "
-                         "workflow " + data['article_id']]
-
-            set_status_property = None
-            success = self.ACTIVITY_EXIT_WORKFLOW
             return start_event, end_event, set_status_property, success
 
         else:

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -42,29 +42,8 @@ class activity_VerifyPublishResponse(Activity):
         try:
             run = data['run']
             version = data['version']
-
-            # Verifies authority
-            if pub_authority == 'elife-website':
-
-                if 'requested_action' in data:
-                    # Publication authority is the old site but this call is from new lax.
-                    # Before terminating Workflow gracefully, emit the result of publication to lax on the dashboard
-                    # Terminate Workflow gracefully, log
-                    return self.publication_verification_results(data, pub_authority, 'journal',
-                                                                 success=data['result'] == "published")
-
-                return self.publication_verification_results(data, pub_authority, pub_authority, success=True)
-
-            # Default new site: 2.0
-            if 'requested_action' not in data:
-                # Terminate Workflow gracefully, log - this message didn't come from lax. it was from the old
-                # pipeline, so Ignore it since the new site is the authority
-                return self.publication_verification_results(data, 'journal', 'elife-website', success=True)
-
             return self.publication_verification_results(data, 'journal', 'journal',
                                                          success=data['result'] == "published")
-
-            #########
 
         except Exception:
             self.logger.exception("Exception when Verifying Publish Response")

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -25,7 +25,7 @@ class activity_VerifyPublishResponse(Activity):
         self.logger = logger
 
     def do_activity(self, data=None):
-        (start_msg, end_msg, set_status, result) = self.get_events(data)
+        start_msg, end_msg, set_status, result = self.get_events(data)
         self.emit_monitor_event(*start_msg)
         self.emit_monitor_event(*end_msg)
         if set_status is not None:

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -22,7 +22,6 @@ class activity_VerifyPublishResponse(Activity):
         self.default_task_start_to_close_timeout = 60 * 5
         self.description = ("Verifies data response from Lax in order to decide if we can " +
                             "carry on with workflow")
-        self.logger = logger
 
     def do_activity(self, data=None):
         start_msg, end_msg, set_status, result = self.get_events(data)
@@ -36,8 +35,7 @@ class activity_VerifyPublishResponse(Activity):
         """
         Do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         try:
             return self.publication_verification_results(

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -48,36 +48,40 @@ class activity_VerifyPublishResponse(Activity):
 
     def publication_verification_results(self, data, success):
 
+        article_id = data['article_id']
+        version = data['version']
+        run = data['run']
+
         if success:
 
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
+            start_event = [self.settings, article_id, version, run,
                            self.pretty_name + ": journal", "start",
-                           "Starting verification of Publish response " + data['article_id']]
+                           "Starting verification of Publish response " + article_id]
 
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
+            end_event = [self.settings, article_id, version, run,
                          self.pretty_name + ": journal", "end",
                          " Finished Verification. Lax has responded with result: published."
-                         " Article: " + data['article_id']]
+                         " Article: " + article_id]
 
             set_status_property = [
-                self.settings, data['article_id'], "publication-status", "published", "text"]
+                self.settings, article_id, "publication-status", "published", "text"]
             success = self.ACTIVITY_SUCCESS
             return start_event, end_event, set_status_property, success
 
         elif success is False:
 
-            start_event = [self.settings, data['article_id'], data['version'], data['run'],
+            start_event = [self.settings, article_id, version, run,
                            self.pretty_name + ": journal", "start",
-                           "Starting verification of Publish response " + data['article_id']]
+                           "Starting verification of Publish response " + article_id]
 
-            end_event = [self.settings, data['article_id'], data['version'], data['run'],
+            end_event = [self.settings, article_id, version, run,
                          self.pretty_name + ": journal", "error",
-                         " Lax has not published article " + data['article_id'] +
+                         " Lax has not published article " + article_id +
                          " result from lax:" + str(data['result']) + '; message from lax: ' +
                          message_from_lax(data)]
 
             set_status_property = [
-                self.settings, data['article_id'], "publication-status",
+                self.settings, article_id, "publication-status",
                 "publication issues", "text"]
             success = self.ACTIVITY_PERMANENT_FAILURE
             return start_event, end_event, set_status_property, success

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -19,7 +19,8 @@ class activity_VerifyPublishResponse(Activity):
         self.default_task_schedule_to_close_timeout = 60 * 5
         self.default_task_schedule_to_start_timeout = 30
         self.default_task_start_to_close_timeout = 60 * 5
-        self.description = "Verifies data response from Lax in order to decide if we can carry on with workflow"
+        self.description = ("Verifies data response from Lax in order to decide if we can " +
+                            "carry on with workflow")
         self.logger = logger
 
     def do_activity(self, data=None):
@@ -37,13 +38,9 @@ class activity_VerifyPublishResponse(Activity):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
-        article_id = data['article_id']
-
         try:
-            run = data['run']
-            version = data['version']
-            return self.publication_verification_results(data,
-                                                         success=data['result'] == "published")
+            return self.publication_verification_results(
+                data, success=data['result'] == "published")
 
         except Exception:
             self.logger.exception("Exception when Verifying Publish Response")
@@ -62,7 +59,8 @@ class activity_VerifyPublishResponse(Activity):
                          " Finished Verification. Lax has responded with result: published."
                          " Article: " + data['article_id']]
 
-            set_status_property = [self.settings, data['article_id'], "publication-status", "published", "text"]
+            set_status_property = [
+                self.settings, data['article_id'], "publication-status", "published", "text"]
             success = self.ACTIVITY_SUCCESS
             return start_event, end_event, set_status_property, success
 
@@ -76,10 +74,12 @@ class activity_VerifyPublishResponse(Activity):
                          self.pretty_name + ": journal", "error",
                          " Lax has not published article " + data['article_id'] +
                          " result from lax:" + str(data['result']) + '; message from lax: ' +
-                         data['message'] if ("message" in data) and (data['message'] is not None) else "(empty message)"]
+                         data['message'] if ("message" in data) and
+                         (data['message'] is not None) else "(empty message)"]
 
-            set_status_property = [self.settings, data['article_id'], "publication-status", "publication issues",
-                                "text"]
+            set_status_property = [
+                self.settings, data['article_id'], "publication-status",
+                "publication issues", "text"]
             success = self.ACTIVITY_PERMANENT_FAILURE
             return start_event, end_event, set_status_property, success
 

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -23,14 +23,14 @@ class activity_VerifyPublishResponse(Activity):
         self.logger = logger
 
     def do_activity(self, data=None):
-        (start_msg, end_msg, set_status, result) = self.get_events(data, self.publication_authority(self.settings))
+        (start_msg, end_msg, set_status, result) = self.get_events(data)
         self.emit_monitor_event(*start_msg)
         self.emit_monitor_event(*end_msg)
         if set_status is not None:
             self.set_monitor_property(*set_status, version=data['version'])
         return result
 
-    def get_events(self, data, pub_authority):
+    def get_events(self, data):
         """
         Do the work
         """
@@ -42,19 +42,16 @@ class activity_VerifyPublishResponse(Activity):
         try:
             run = data['run']
             version = data['version']
-            return self.publication_verification_results(data, 'journal', 'journal',
+            return self.publication_verification_results(data,
                                                          success=data['result'] == "published")
 
         except Exception:
             self.logger.exception("Exception when Verifying Publish Response")
             raise
 
-    def publication_authority(self, settings):
-        return settings.publication_authority
+    def publication_verification_results(self, data, success):
 
-    def publication_verification_results(self, data, pub_authority, checking_result_from, success):
-
-        if pub_authority == 'journal' and checking_result_from == 'journal' and success:
+        if success:
 
             start_event = [self.settings, data['article_id'], data['version'], data['run'],
                            self.pretty_name + ": journal", "start",
@@ -69,7 +66,7 @@ class activity_VerifyPublishResponse(Activity):
             success = self.ACTIVITY_SUCCESS
             return start_event, end_event, set_status_property, success
 
-        elif pub_authority == 'journal' and checking_result_from == 'journal' and success is False:
+        elif success is False:
 
             start_event = [self.settings, data['article_id'], data['version'], data['run'],
                            self.pretty_name + ": journal", "start",

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -238,5 +238,4 @@ def message_from_lax(data):
     """
     format a message from a Lax response data
     """
-    return data['message'] if (
-        "message" in data and data['message'] is not None) else "(empty message)"
+    return data.get('message', '(empty message)')

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -238,4 +238,4 @@ def message_from_lax(data):
     """
     format a message from a Lax response data
     """
-    return data.get('message', '(empty message)')
+    return data.get('message') if data.get('message') else '(empty message)'

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -233,3 +233,10 @@ def lax_token(run, version, expanded_folder, status, force=False, run_type=None)
     }
     return base64_encode_string(json.dumps(token))
 
+
+def message_from_lax(data):
+    """
+    format a message from a Lax response data
+    """
+    return data['message'] if (
+        "message" in data and data['message'] is not None) else "(empty message)"

--- a/settings-example.py
+++ b/settings-example.py
@@ -249,8 +249,6 @@ class exp():
     # eLife 2.0 bot lax communication settings
     xml_info_queue = "bot-lax-exp-inc"
     lax_response_queue = "bot-lax-exp-out"
-    # eLife 2.0 transition settings
-    publication_authority = "journal"
     consider_Lax_elife_2_0 = True
 
     # videos
@@ -757,8 +755,6 @@ class live():
     # eLife 2.0 bot lax communication settings
     xml_info_queue = "bot-lax-prod-inc"
     lax_response_queue = "bot-lax-prod-out"
-    # eLife 2.0 transition settings
-    publication_authority = "journal"
     consider_Lax_elife_2_0 = True
 
     # videos

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -72,7 +72,6 @@ journal_preview_base_url = 'https://preview'
 
 features_publication_recipient_email = "features_team@example.org"
 email_video_recipient_email = "features_team@example.org"
-publication_authority = ""
 consider_Lax_elife_2_0 = True
 
 xml_info_queue = 'test-elife-xml-info'

--- a/tests/activity/test_activity_verify_lax_response.py
+++ b/tests/activity/test_activity_verify_lax_response.py
@@ -3,7 +3,7 @@ from ddt import ddt, data
 from mock import patch
 from activity.activity_VerifyLaxResponse import activity_VerifyLaxResponse
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeSession
+from tests.activity.classes_mock import FakeSession, FakeLogger
 
 
 def fake_emit_monitor_event(settings, item_identifier, version, run, event_type, status, message):
@@ -12,7 +12,8 @@ def fake_emit_monitor_event(settings, item_identifier, version, run, event_type,
 @ddt
 class TestVerifyLaxResponse(unittest.TestCase):
     def setUp(self):
-        self.verifylaxresponse = activity_VerifyLaxResponse(settings_mock, None, None, None, None)
+        self.verifylaxresponse = activity_VerifyLaxResponse(settings_mock, FakeLogger(),
+                                                            None, None, None)
 
     @data({
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",

--- a/tests/activity/test_activity_verify_publish_response.py
+++ b/tests/activity/test_activity_verify_publish_response.py
@@ -2,6 +2,7 @@ import unittest
 from ddt import ddt, data
 from mock import patch, MagicMock
 from activity.activity_VerifyPublishResponse import activity_VerifyPublishResponse
+from tests.activity.classes_mock import FakeLogger
 import tests.activity.settings_mock as settings_mock
 
 
@@ -35,7 +36,7 @@ DATA_ERROR_LAX = {
 class TestVerifyPublishResponse(unittest.TestCase):
     def setUp(self):
         self.verifypublishresponse = activity_VerifyPublishResponse(
-            settings_mock, None, None, None, None)
+            settings_mock, FakeLogger(), None, None, None)
 
     @data(DATA_PUBLISHED_LAX)
     def test_get_events_data_published_lax(self, data):

--- a/tests/activity/test_activity_verify_publish_response.py
+++ b/tests/activity/test_activity_verify_publish_response.py
@@ -16,14 +16,7 @@ data_published_lax = {
             "update_date": "2012-12-13T00:00:00Z"
         }
 
-data_published_website = {
-            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
-            "status": "vor",
-            "version": "1",
-            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "update_date": "2012-12-13T00:00:00Z"
-        }
+
 data_error_lax = {
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
             "article_id": "00353",
@@ -94,65 +87,6 @@ class TestVerifyPublishResponse(unittest.TestCase):
                                                      "publication issues", "text",
                                                      version=data["version"])
         self.assertEqual(result, self.verifypublishresponse.ACTIVITY_PERMANENT_FAILURE)
-
-    @data(data_published_website)
-    @patch.object(activity_VerifyPublishResponse, 'publication_authority')
-    @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_published_journal(self, data, fake_emit_monitor, fake_publication_authority):
-        fake_publication_authority.return_value = "elife-website"
-        result = self.verifypublishresponse.do_activity(data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             data["article_id"],
-                                             data["version"],
-                                             data["run"],
-                                             self.verifypublishresponse.pretty_name + ": elife-website",
-                                             "end",
-                                             "Finished verification of Publish response " + data["article_id"])
-        self.assertEqual(result, self.verifypublishresponse.ACTIVITY_SUCCESS)
-
-    @data(data_error_lax)
-    @patch.object(activity_VerifyPublishResponse, 'publication_authority')
-    @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
-    @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_error_published_journal_publ_authority_website(self, data, fake_emit_monitor, fake_set_monitor_property, fake_publication_authority):
-        fake_publication_authority.return_value = "elife-website"
-        result = self.verifypublishresponse.do_activity(data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             data["article_id"],
-                                             data["version"],
-                                             data["run"],
-                                             self.verifypublishresponse.pretty_name + ": journal",
-                                             "error",
-                                             " Lax has not published article " + data["article_id"] +
-                                             " We will exit this workflow as the publication authority is"
-                                             " elife-website."
-                                             " result from lax:" + data['result'] + '; message from lax: ' +
-                                             data['message'])
-        fake_set_monitor_property.assert_called_with(settings_mock, data['article_id'], "publication-status",
-                                                     "publication issues", "text",
-                                                     version=data["version"])
-        self.assertEqual(result, self.verifypublishresponse.ACTIVITY_PERMANENT_FAILURE)
-
-    @data(data_published_lax)
-    @patch.object(activity_VerifyPublishResponse, 'publication_authority')
-    @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
-    @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_published_journal_publ_authority_website(self, data, fake_emit_monitor, fake_set_monitor_property, fake_publication_authority):
-        fake_publication_authority.return_value = "elife-website"
-        result = self.verifypublishresponse.do_activity(data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             data["article_id"],
-                                             data["version"],
-                                             data["run"],
-                                             self.verifypublishresponse.pretty_name + ": journal",
-                                             "end",
-                                             " Finished Verification. Lax has responded with result: published."
-                                             " Authority: elife-website. Exiting."
-                                             " Article: " + data["article_id"])
-        fake_set_monitor_property.assert_called_with(settings_mock, data['article_id'], "publication-status",
-                                                         "published", "text",
-                                                         version=data["version"])
-        self.assertEqual(result, self.verifypublishresponse.ACTIVITY_EXIT_WORKFLOW)
 
     @data(data_error_lax)
     def test_do_activity_key_error(self, data):

--- a/tests/activity/test_activity_verify_publish_response.py
+++ b/tests/activity/test_activity_verify_publish_response.py
@@ -4,87 +4,97 @@ from mock import patch, MagicMock
 from activity.activity_VerifyPublishResponse import activity_VerifyPublishResponse
 import tests.activity.settings_mock as settings_mock
 
-data_published_lax = {
-            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
-            "result": "published",
-            "status": "vor",
-            "version": "1",
-            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "requested_action": "publish",
-            "message": None,
-            "update_date": "2012-12-13T00:00:00Z"
-        }
+
+DATA_PUBLISHED_LAX = {
+    "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+    "article_id": "00353",
+    "result": "published",
+    "status": "vor",
+    "version": "1",
+    "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+    "requested_action": "publish",
+    "message": None,
+    "update_date": "2012-12-13T00:00:00Z"
+}
 
 
-data_error_lax = {
-            "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
-            "result": "error",
-            "status": "vor",
-            "version": "1",
-            "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "requested_action": "publish",
-            "message": "An error abc has occurred",
-            "update_date": "2012-12-13T00:00:00Z"
-        }
+DATA_ERROR_LAX = {
+    "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+    "article_id": "00353",
+    "result": "error",
+    "status": "vor",
+    "version": "1",
+    "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
+    "requested_action": "publish",
+    "message": "An error abc has occurred",
+    "update_date": "2012-12-13T00:00:00Z"
+}
+
 
 @ddt
 class TestVerifyPublishResponse(unittest.TestCase):
     def setUp(self):
-        self.verifypublishresponse = activity_VerifyPublishResponse(settings_mock, None, None, None, None)
+        self.verifypublishresponse = activity_VerifyPublishResponse(
+            settings_mock, None, None, None, None)
 
-    @data(data_published_lax)
+    @data(DATA_PUBLISHED_LAX)
     def test_get_events_data_published_lax(self, data):
-        (exp_start_msg, exp_end_msg, exp_status, exp_result) = self.verifypublishresponse.get_events(data)
-        self.assertEqual(exp_start_msg, [settings_mock, data["article_id"], data["version"],
-                                         data["run"], self.verifypublishresponse.pretty_name + ": journal", "start",
-                                         "Starting verification of Publish response " + data["article_id"]])
-        self.assertEqual(exp_end_msg, [settings_mock, data["article_id"], data["version"],
-                                       data["run"], self.verifypublishresponse.pretty_name + ": journal", "end",
-                                       " Finished Verification. Lax has responded with result: published."
-                                       " Article: " + data["article_id"]])
-        self.assertEqual(exp_status, [settings_mock, data['article_id'], "publication-status","published", "text"])
+        (exp_start_msg, exp_end_msg, exp_status, exp_result) = (
+            self.verifypublishresponse.get_events(data))
+        self.assertEqual(exp_start_msg, [
+            settings_mock, data["article_id"], data["version"],
+            data["run"], self.verifypublishresponse.pretty_name + ": journal", "start",
+            "Starting verification of Publish response " + data["article_id"]])
+        self.assertEqual(exp_end_msg, [
+            settings_mock, data["article_id"], data["version"],
+            data["run"], self.verifypublishresponse.pretty_name + ": journal", "end",
+            " Finished Verification. Lax has responded with result: published."
+            " Article: " + data["article_id"]])
+        self.assertEqual(exp_status, [
+            settings_mock, data['article_id'], "publication-status", "published", "text"])
         self.assertEqual(exp_result, self.verifypublishresponse.ACTIVITY_SUCCESS)
 
-    @data(data_published_lax)
+    @data(DATA_PUBLISHED_LAX)
     @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
     @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_published_lax(self, data, fake_emit_monitor, fake_set_monitor_property):
+    def test_do_activity_data_published_lax(self, data, fake_emit_monitor,
+                                            fake_set_monitor_property):
         result = self.verifypublishresponse.do_activity(data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             data["article_id"],
-                                             data["version"],
-                                             data["run"],
-                                             self.verifypublishresponse.pretty_name + ": journal",
-                                             "end",
-                                             " Finished Verification. Lax has responded with result: published."
-                                             " Article: " + data["article_id"])
-        fake_set_monitor_property.assert_called_with(settings_mock, data['article_id'], "publication-status",
-                                                     "published", "text",
-                                                     version=data["version"])
+        fake_emit_monitor.assert_called_with(
+            settings_mock,
+            data["article_id"],
+            data["version"],
+            data["run"],
+            self.verifypublishresponse.pretty_name + ": journal",
+            "end",
+            " Finished Verification. Lax has responded with result: published."
+            " Article: " + data["article_id"])
+        fake_set_monitor_property.assert_called_with(
+            settings_mock, data['article_id'], "publication-status",
+            "published", "text", version=data["version"])
         self.assertEqual(result, self.verifypublishresponse.ACTIVITY_SUCCESS)
 
-    @data(data_error_lax)
+    @data(DATA_ERROR_LAX)
     @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
     @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
     def test_do_activity_data_error_lax(self, data, fake_emit_monitor, fake_set_monitor_property):
         result = self.verifypublishresponse.do_activity(data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             data["article_id"],
-                                             data["version"],
-                                             data["run"],
-                                             self.verifypublishresponse.pretty_name + ": journal",
-                                             "error",
-                                             " Lax has not published article " + data["article_id"] +
-                                             " result from lax:" + str(data['result']) + '; message from lax: ' +
-                                             data['message'])
-        fake_set_monitor_property.assert_called_with(settings_mock, data['article_id'], "publication-status",
-                                                     "publication issues", "text",
-                                                     version=data["version"])
+        fake_emit_monitor.assert_called_with(
+            settings_mock,
+            data["article_id"],
+            data["version"],
+            data["run"],
+            self.verifypublishresponse.pretty_name + ": journal",
+            "error",
+            " Lax has not published article " + data["article_id"] +
+            " result from lax:" + str(data['result']) + '; message from lax: ' +
+            data['message'])
+        fake_set_monitor_property.assert_called_with(
+            settings_mock, data['article_id'], "publication-status",
+            "publication issues", "text", version=data["version"])
         self.assertEqual(result, self.verifypublishresponse.ACTIVITY_PERMANENT_FAILURE)
 
-    @data(data_error_lax)
+    @data(DATA_ERROR_LAX)
     def test_do_activity_key_error(self, data):
         data_mock = data.copy()
         del data_mock['result']

--- a/tests/activity/test_activity_verify_publish_response.py
+++ b/tests/activity/test_activity_verify_publish_response.py
@@ -36,7 +36,7 @@ class TestVerifyPublishResponse(unittest.TestCase):
 
     @data(data_published_lax)
     def test_get_events_data_published_lax(self, data):
-        (exp_start_msg, exp_end_msg, exp_status, exp_result) = self.verifypublishresponse.get_events(data, "journal")
+        (exp_start_msg, exp_end_msg, exp_status, exp_result) = self.verifypublishresponse.get_events(data)
         self.assertEqual(exp_start_msg, [settings_mock, data["article_id"], data["version"],
                                          data["run"], self.verifypublishresponse.pretty_name + ": journal", "start",
                                          "Starting verification of Publish response " + data["article_id"]])
@@ -48,11 +48,9 @@ class TestVerifyPublishResponse(unittest.TestCase):
         self.assertEqual(exp_result, self.verifypublishresponse.ACTIVITY_SUCCESS)
 
     @data(data_published_lax)
-    @patch.object(activity_VerifyPublishResponse, 'publication_authority')
     @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
     @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_published_lax(self, data, fake_emit_monitor, fake_set_monitor_property, fake_publication_authority):
-        fake_publication_authority.return_value = "journal"
+    def test_do_activity_data_published_lax(self, data, fake_emit_monitor, fake_set_monitor_property):
         result = self.verifypublishresponse.do_activity(data)
         fake_emit_monitor.assert_called_with(settings_mock,
                                              data["article_id"],
@@ -68,11 +66,9 @@ class TestVerifyPublishResponse(unittest.TestCase):
         self.assertEqual(result, self.verifypublishresponse.ACTIVITY_SUCCESS)
 
     @data(data_error_lax)
-    @patch.object(activity_VerifyPublishResponse, 'publication_authority')
     @patch.object(activity_VerifyPublishResponse, 'set_monitor_property')
     @patch.object(activity_VerifyPublishResponse, 'emit_monitor_event')
-    def test_do_activity_data_error_lax(self, data, fake_emit_monitor, fake_set_monitor_property, fake_publication_authority):
-        fake_publication_authority.return_value = "journal"
+    def test_do_activity_data_error_lax(self, data, fake_emit_monitor, fake_set_monitor_property):
         result = self.verifypublishresponse.do_activity(data)
         fake_emit_monitor.assert_called_with(settings_mock,
                                              data["article_id"],


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/710

Lots of code deleted since we do not need to look at whether a publish message comes from `elife-website` or `journal`.

I did some linting too, which hopefully doesn't make the changes too hard to read, if you wish to review.