### PR TITLE
Latest elifearticle and elifepubmed adds datasets.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ Jinja2==2.7.3
 arrow==0.4.4
 requests==2.20.0
 git+https://github.com/elifesciences/elife-tools.git@991bd2eed2af68192f5ae36f3c0c00ed8afb07c3#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@bb61d4c0e3742403503efe10852114aeb1e07269#egg=elifearticle
+git+https://github.com/elifesciences/elife-article.git@99710c213cd81fe6fd1e5c150d6e20efe2d1e33b#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@dc9dd335a8d6a3ad58d65c126b884bdca1abed3e#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@32a9a831eca98a03b36b8c9a369c622a34d04a7a#egg=elifepubmed
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@814bcf15dacfbbb0000ba592f7c3b1b047ee99bf#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa


### PR DESCRIPTION
Deployment of datasets to be included in PubMed deposits by updating these two libraries. 

`elifearticle` to include the additional `Dataset` object attributes used in the PubMed logic.

`elifepubmed` has the logic to include additional `<Object>` tags in the deposit XML for the datasets, if they are found (and readable) in the article XML.

All existing tests are passing in this project, and I'm looking forward to releasing this feature.