### PR TITLE
Add name header to email attachment too.

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -77,7 +77,8 @@ def attachment(file_name,
     "create an attachment from the file"
     attachment_name = encode_filename(os.path.split(file_name)[-1])
     with open(file_name, 'rb') as open_file:
-        email_attachment = MIMEApplication(open_file.read(), media_type)
+        email_attachment = MIMEApplication(
+            open_file.read(), media_type, name=(charset, '', attachment_name))
     email_attachment.add_header(
         'Content-Disposition', 'attachment',
         filename=(charset, '', attachment_name))


### PR DESCRIPTION
Part of trying to solve utf-8 attachment file but in issue https://github.com/elifesciences/issues/issues/4795.

After continued searches, although adding  `name=` to the `Content-type` header is possibly discouraged, I can find no other better suggestion to make Gmail to possibly accept the utf-8 file name instead of showing it as `"noname"`.

It's possible quotation marks around the value when running it in Python 2.7 is a cause of the problem. It is also possible it might be solved by adding a custom header adding a fully encoded file name instead of relying on the python module to do it.

Going to try this first and hope it solves it.

I tested on `continuumtest` environment first briefly and I don't think this is any worse than what we do now.