### PR TITLE
Feature: adds python 3.6 to tox environments to test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 PyYAML==4.2b2
-Wand==0.4.2
+Wand==0.5.1
 paramiko==2.4.2
 mock==1.3.0
 redis==2.10.5
@@ -23,7 +23,7 @@ pyOpenSSL==18.0.0
 newrelic==2.72.0.52
 pylint==1.6.4
 pyGithub==1.27.1
-pyFunctional==1.0.0
+pyFunctional==1.2.0
 func_timeout==4.3.0
 python-docx==0.8.6
 git+https://github.com/elifesciences/digest-parser.git@9a33eafcf12b0be4664a4225be9f4925dd75daec#egg=digestparser

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py27,py35,py36
 [testenv]
 passenv = HOME MAGICK_HOME
 deps = -rrequirements.txt


### PR DESCRIPTION
Ubuntu 16.04 LTS uses Python 3.5 (supported)
Ubuntu 18.04 LTS uses Python 3.6

cc @giorgiosironi @gnott 

