### PR TITLE
Improvements to tests for efficiency

### DIFF
--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-import os
 import json
 import copy
 import unittest
@@ -218,7 +217,6 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         result = self.activity.do_activity(activity_data)
         self.assertEqual(result, expected_result)
 
-
     @patch.object(digest_provider, 'docx_exists_in_s3')
     @patch.object(lax_provider, 'article_highest_version')
     @patch.object(lax_provider, 'article_first_by_status')
@@ -377,7 +375,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
             "version": 2,
             "run_type": None,
             "highest_version": "2",
-            "version_map": {"poa": [1], "poa": [2]},
+            "version_map": {"poa": [1]},
             "expected": False
         },
         {
@@ -423,6 +421,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         )
         self.assertEqual(status, test_data.get("expected"),
                          "failed in {comment}".format(comment=test_data.get("comment")))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -6,9 +6,7 @@ import copy
 import unittest
 from mock import patch
 from ddt import ddt, data
-import provider.digest_provider as digest_provider
-import provider.article as article
-import provider.lax_provider as lax_provider
+from provider import article, article_processing, digest_provider, lax_provider
 from activity.activity_IngestDigestToEndpoint import (
     activity_IngestDigestToEndpoint as activity_object)
 from tests import read_fixture
@@ -57,6 +55,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
 
     @patch('activity.activity_IngestDigestToEndpoint.json_output.requests.get')
     @patch.object(article, 'storage_context')
+    @patch.object(article_processing, 'storage_context')
     @patch.object(lax_provider, 'article_first_by_status')
     @patch.object(lax_provider, 'article_snippet')
     @patch.object(lax_provider, 'article_highest_version')
@@ -157,7 +156,8 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
                          fake_session, fake_put_digest, fake_get_digest,
                          fake_provider_storage_context,
                          fake_highest_version, fake_article_snippet,
-                         fake_first, fake_article_storage_context, fake_get):
+                         fake_first, fake_processing_storage_context,
+                         fake_article_storage_context, fake_get):
         # copy files into the input directory using the storage context
         named_storage_context = FakeStorageContext()
         if test_data.get('bucket_resources'):
@@ -167,6 +167,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         if test_data.get('bot_bucket_resources'):
             bot_storage_context.resources = test_data.get('bot_bucket_resources')
         fake_provider_storage_context.return_value = bot_storage_context
+        fake_processing_storage_context.return_value = FakeStorageContext()
         fake_first.return_value = test_data.get("first_vor")
         session_test_data = session_data(test_data)
         fake_session.return_value = FakeSession(session_test_data)
@@ -217,17 +218,20 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
         result = self.activity.do_activity(activity_data)
         self.assertEqual(result, expected_result)
 
+
+    @patch.object(digest_provider, 'docx_exists_in_s3')
     @patch.object(lax_provider, 'article_highest_version')
     @patch.object(lax_provider, 'article_first_by_status')
     @patch.object(activity_object, 'emit_monitor_event')
     @patch('activity.activity_IngestDigestToEndpoint.get_session')
     def test_do_activity_docx_exists_exception(self, fake_session, fake_emit, fake_first,
-                                               fake_highest_version):
+                                               fake_highest_version, fake_docx_exists):
         "test and error when checking if a docx exists"
         fake_first.return_value = True
         fake_highest_version.return_value = 1
         session_test_data = session_data({})
         fake_session.return_value = FakeSession(session_test_data)
+        fake_docx_exists.return_value = False
         activity_data = test_activity_data.data_example_before_publish
         expected_result = activity_object.ACTIVITY_SUCCESS
         result = self.activity.do_activity(activity_data)
@@ -239,7 +243,7 @@ class TestIngestDigestToEndpoint(unittest.TestCase):
     @patch.object(digest_provider, 'download_docx_from_s3')
     @patch.object(digest_provider, 'storage_context')
     @patch('activity.activity_IngestDigestToEndpoint.get_session')
-    def test_do_activity_bad_download(self, fake_session, fake_storage_context, fake_download, 
+    def test_do_activity_bad_download(self, fake_session, fake_storage_context, fake_download,
                                       fake_emit, fake_first, fake_highest_version):
         "test unable to download a digest docx file"
         fake_first.return_value = True

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -3,7 +3,8 @@ import os
 import shutil
 from mock import patch
 from ddt import ddt, data, unpack
-import provider.s3lib as s3lib
+from provider import s3lib
+from provider.article import article
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
 import tests.test_data as test_case_data
 import tests.activity.settings_mock as settings_mock
@@ -30,17 +31,22 @@ class TestPubRouterDeposit(unittest.TestCase):
             settings_mock, FakeLogger(), None, None, None)
 
     @patch('provider.lax_provider.article_versions')
+    @patch.object(activity_PubRouterDeposit, 'clean_outbox')
     @patch.object(activity_PubRouterDeposit, 'start_ftp_article_workflow')
     @patch.object(activity_PubRouterDeposit, 'does_source_zip_exist_from_s3')
     @patch.object(activity_PubRouterDeposit, 'download_files_from_s3_outbox')
+    @patch.object(article, 'was_ever_published')
     @patch.object(s3lib, 'get_s3_keys_from_bucket')
-    def test_do_activity(self, fake_get_s3_keys, fake_download, fake_zip_exists,
-                         fake_start, fake_article_versions):
+    def test_do_activity(self, fake_get_s3_keys, fake_was_ever_published, 
+                         fake_download, fake_zip_exists,
+                         fake_start, fake_clean_outbox, fake_article_versions):
         activity_data = {
             "data": {
                 "workflow": "HEFCE"
             }
         }
+        fake_clean_outbox.return_value = None
+        fake_was_ever_published.return_value = None
         fake_download.return_value = download_files(
             ["elife00013.xml", "elife09169.xml"], self.pubrouterdeposit.get_tmp_dir())
         fake_zip_exists.return_value = True

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -179,7 +179,9 @@ class TestPublicationEmail(unittest.TestCase):
     @patch.object(EJP, 'find_latest_s3_file_name')
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
     @patch.object(activity_PublicationEmail, 'clean_tmp_dir')
-    def test_do_activity(self, fake_clean_tmp_dir, fake_elife_add_email_to_email_queue,
+    @patch.object(activity_PublicationEmail, 'clean_outbox')
+    def test_do_activity(self, fake_clean_outbox, fake_clean_tmp_dir,
+                         fake_elife_add_email_to_email_queue,
                          fake_find_latest_s3_file_name,
                          fake_ejp_get_s3key,
                          fake_article_get_folder_names_from_bucket,
@@ -189,6 +191,7 @@ class TestPublicationEmail(unittest.TestCase):
 
         directory = TempDirectory()
         fake_clean_tmp_dir = self.fake_clean_tmp_dir()
+        fake_clean_outbox.return_value = None
 
         # Prime the related article property for when needed
         related_article = article()

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -164,64 +164,6 @@ class TestPublishFinalPOA(unittest.TestCase):
     def tearDown(self):
         self.poa.clean_tmp_dir()
 
-    def count_files_in_dir(self, dir_name):
-        """
-        After do_activity, check the directory contains a zip with ds_zip file name
-        """
-        file_names = glob.glob(dir_name + os.sep + "*")
-        return len(file_names)
-
-    def compare_files_in_dir(self, dir_name, file_list):
-        """
-        Compare the file names in the directroy to the file_list provided
-        """
-        file_names = glob.glob(dir_name + os.sep + "*")
-        # First check the count is the same
-        if len(file_list) != len(file_names):
-            return False
-        # Then can compare file name by file name
-        for file in file_names:
-            file_name = file.split(os.sep)[-1]
-            if file_name not in file_list:
-                return False
-        return True
-
-    def check_xml_contents(self, xml_file, xml_file_values):
-        """
-        Function to compare XML tag value as located by an xpath
-        Can compare one tag only at a time
-        """
-        root = None
-        xml_file_name = xml_file.split(os.sep)[-1]
-        if xml_file_name in xml_file_values:
-            ET.register_namespace("xlink", "http://www.w3.org/1999/xlink")
-            root = ET.parse(xml_file)
-        if root:
-            for (xpath, (attribute, value)) in xml_file_values[xml_file_name].items():
-                matched_tags = root.findall(xpath)
-                if len(matched_tags) != 1:
-                    return False
-                for matched_tag in matched_tags:
-                    if attribute:
-                        if matched_tag.get(attribute) != value:
-                            return False
-                    else:
-                        if matched_tag.text != value:
-                            return False
-
-        return True
-
-    def ds_zip_in_list_of_files(self, xml_file, file_list):
-        """
-        Given an XML file and a list of files
-        check the list of files contains a ds zip file that matches the xml file
-        """
-        doi_id = xml_file.split('-')[-1].split('.')[0]
-        for file in file_list:
-            if str(doi_id) in file and file.endswith('ds.zip'):
-                return True
-        return False
-
     def fake_download_files_from_s3(self, file_list):
         for file in file_list:
             source_doc = "tests/test_data/poa/outbox/" + file
@@ -267,11 +209,11 @@ class TestPublishFinalPOA(unittest.TestCase):
 
             self.assertEqual(self.poa.approve_status, test_data["approve_status"])
             self.assertEqual(self.poa.publish_status, test_data["publish_status"])
-            self.assertEqual(self.count_files_in_dir(self.poa.DONE_DIR),
+            self.assertEqual(count_files_in_dir(self.poa.DONE_DIR),
                              test_data["done_dir_file_count"])
             self.assertEqual(self.poa.activity_status, test_data["activity_status"])
-            self.assertTrue(self.compare_files_in_dir(self.poa.OUTPUT_DIR,
-                                                      test_data["output_dir_files"]))
+            self.assertTrue(compare_files_in_dir(self.poa.OUTPUT_DIR,
+                                                 test_data["output_dir_files"]))
             self.assertEqual(sorted(self.poa.done_xml_files),
                              sorted(test_data["done_xml_files"]))
             self.assertEqual(sorted(self.poa.clean_from_outbox_files),
@@ -287,11 +229,11 @@ class TestPublishFinalPOA(unittest.TestCase):
             if test_data["done_dir_file_count"] > 0:
                 xml_files = glob.glob(self.poa.DONE_DIR + "/*.xml")
                 for xml_file in xml_files:
-                    self.assertTrue(self.check_xml_contents(xml_file, self.xml_file_values))
+                    self.assertTrue(check_xml_contents(xml_file, self.xml_file_values))
 
                     # If a ds zip file for the article, check more XML elements
-                    if self.ds_zip_in_list_of_files(xml_file, self.poa.clean_from_outbox_files):
-                        self.assertTrue(self.check_xml_contents(
+                    if ds_zip_in_list_of_files(xml_file, self.poa.clean_from_outbox_files):
+                        self.assertTrue(check_xml_contents(
                             xml_file, self.xml_file_values_when_ds_zip))
 
             self.assertEqual(True, success)
@@ -306,6 +248,68 @@ class TestPublishFinalPOA(unittest.TestCase):
             self.poa.malformed_ds_file_names = []
             self.poa.empty_ds_file_names = []
             self.poa.unmatched_ds_file_names = []
+
+
+def count_files_in_dir(dir_name):
+    """
+    After do_activity, check the directory contains a zip with ds_zip file name
+    """
+    file_names = glob.glob(dir_name + os.sep + "*")
+    return len(file_names)
+
+
+def compare_files_in_dir(dir_name, file_list):
+    """
+    Compare the file names in the directroy to the file_list provided
+    """
+    file_names = glob.glob(dir_name + os.sep + "*")
+    # First check the count is the same
+    if len(file_list) != len(file_names):
+        return False
+    # Then can compare file name by file name
+    for file in file_names:
+        file_name = file.split(os.sep)[-1]
+        if file_name not in file_list:
+            return False
+    return True
+
+
+def check_xml_contents(xml_file, xml_file_values):
+    """
+    Function to compare XML tag value as located by an xpath
+    Can compare one tag only at a time
+    """
+    root = None
+    xml_file_name = xml_file.split(os.sep)[-1]
+    if xml_file_name in xml_file_values:
+        ET.register_namespace("xlink", "http://www.w3.org/1999/xlink")
+        root = ET.parse(xml_file)
+    if root:
+        for (xpath, (attribute, value)) in xml_file_values[xml_file_name].items():
+            matched_tags = root.findall(xpath)
+            if len(matched_tags) != 1:
+                return False
+            for matched_tag in matched_tags:
+                if attribute:
+                    if matched_tag.get(attribute) != value:
+                        return False
+                else:
+                    if matched_tag.text != value:
+                        return False
+
+    return True
+
+
+def ds_zip_in_list_of_files(xml_file, file_list):
+    """
+    Given an XML file and a list of files
+    check the list of files contains a ds zip file that matches the xml file
+    """
+    doi_id = xml_file.split('-')[-1].split('.')[0]
+    for file in file_list:
+        if str(doi_id) in file and file.endswith('ds.zip'):
+            return True
+    return False
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -252,6 +252,8 @@ class TestPublishFinalPOA(unittest.TestCase):
                 for file in glob.glob(directory_full_path + "/*"):
                     os.remove(file)
 
+
+    @patch.object(activity_PublishFinalPOA, 'clean_outbox')
     @patch.object(activity_PublishFinalPOA, 'get_pub_date_str_from_lax')
     @patch.object(activity_PublishFinalPOA, 'upload_files_to_s3')
     @patch.object(activity_PublishFinalPOA, 'next_revision_number')
@@ -259,9 +261,10 @@ class TestPublishFinalPOA(unittest.TestCase):
     @patch.object(activity_PublishFinalPOA, 'clean_tmp_dir')
     def test_do_activity(self, fake_clean_tmp_dir, fake_download_files_from_s3,
                          fake_next_revision_number, fake_upload_files_to_s3,
-                         fake_get_pub_date_str_from_lax):
+                         fake_get_pub_date_str_from_lax, fake_clean_outbox):
 
         fake_clean_tmp_dir = self.fake_clean_tmp_dir()
+        fake_clean_outbox.return_value = None
         fake_next_revision_number.return_value = 1
         fake_upload_files_to_s3.return_value = True
         fake_get_pub_date_str_from_lax.return_value = "20160704000000"
@@ -281,7 +284,8 @@ class TestPublishFinalPOA(unittest.TestCase):
             self.assertEqual(self.poa.activity_status, test_data["activity_status"])
             self.assertTrue(self.compare_files_in_dir(self.poa.OUTPUT_DIR,
                                                       test_data["output_dir_files"]))
-            self.assertEqual(self.poa.done_xml_files, test_data["done_xml_files"])
+            self.assertEqual(sorted(self.poa.done_xml_files), 
+                             sorted(test_data["done_xml_files"]))
             self.assertEqual(sorted(self.poa.clean_from_outbox_files),
                              sorted(test_data["clean_from_outbox_files"]))
             self.assertEqual(sorted(self.poa.malformed_ds_file_names),


### PR DESCRIPTION
When running tests in Python 3.6 as specified in PR https://github.com/elifesciences/elife-bot/pull/887, some of them were really slow. 

I tracked it down to usually where activities would connect to S3, but the connection wasn't mocked very well in the test logic. It seemed to use more excessive timeouts that testing in Py27 or Py35.

I did some linting and refactoring on the tests that were edited here too.

Changes are limited to tests only, and tests are passing, so I will merge this myself.

