### PR TITLE
Digest jats silent logic and email

### DIFF
--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -214,8 +214,7 @@ def success_email_body(current_time, digest_content, jats_content):
     """
     Format the body of the email
     """
-    body = "JATS content for article %s:\n\n%s\n\n" % (
-        str(digest_content.doi), str(jats_content))
+    body = "JATS content for article %s:\n\n%s\n\n" % (digest_content.doi, jats_content)
     date_format = '%Y-%m-%dT%H:%M:%S.000Z'
     datetime_string = time.strftime(date_format, current_time)
     body += "As at " + datetime_string + "\n"

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -62,6 +62,11 @@ class activity_PostDigestJATS(Activity):
         # parse the data with the digest_provider
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
 
+        # check if it is a silent run
+        if digest_provider.silent_digest(real_filename):
+            self.logger.info('PostDigestJATS silent deposit of real_filename: %s', real_filename)
+            return self.ACTIVITY_SUCCESS
+
         # Download from S3
         self.input_file = digest_provider.download_digest_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder, self.input_dir)

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -101,7 +101,7 @@ class activity_PostDigestJATS(Activity):
         return self.ACTIVITY_PERMANENT_FAILURE
 
     def post_jats(self, digest, jats_content):
-        "prepare and POST jats to API endpoint"
+        """prepare and POST jats to API endpoint"""
         url = self.settings.typesetter_digest_endpoint
         payload = post_payload(digest, jats_content, self.settings.typesetter_digest_api_key)
         if payload:
@@ -146,7 +146,7 @@ class activity_PostDigestJATS(Activity):
 
 
 def post_payload(digest, jats_content, api_key):
-    "compile the POST data payload"
+    """compile the POST data payload"""
     if not digest:
         return None
     account_key = 1
@@ -161,7 +161,7 @@ def post_payload(digest, jats_content, api_key):
 
 
 def post_jats_to_endpoint(url, payload, logger):
-    "issue the POST"
+    """issue the POST"""
     resp = get_as_params(url, payload)
     # Check for good HTTP status code
     if resp.status_code != 200:
@@ -172,7 +172,7 @@ def post_jats_to_endpoint(url, payload, logger):
         return False
     logger.info(
         ("Success posting digest JATS to endpoint %s: \npayload: %s \nstatus_code: %s" +
-            " \nresponse: %s") %
+         " \nresponse: %s") %
         (url, payload, resp.status_code, resp.content))
     return True
 
@@ -183,22 +183,22 @@ def get_as_params(url, payload):
 
 
 def post_as_params(url, payload):
-    "post the payload as URL parameters"
+    """post the payload as URL parameters"""
     return requests.post(url, params=payload)
 
 
 def post_as_data(url, payload):
-    "post the payload as form data"
+    """post the payload as form data"""
     return requests.post(url, data=payload)
 
 
 def post_as_json(url, payload):
-    "post the payload as JSON data"
+    """post the payload as JSON data"""
     return requests.post(url, json=payload)
 
 
 def success_email_subject(digest_content):
-    "the email subject"
+    """the email subject"""
     if not digest_content:
         return u''
     try:

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -66,7 +66,9 @@ class activity_PostDigestJATS(Activity):
 
         # check if it is a silent run
         if digest_provider.silent_digest(real_filename):
-            self.logger.info('PostDigestJATS silent deposit of real_filename: %s', real_filename)
+            self.logger.info(
+                'PostDigestJATS is not posting JATS because it is a silent workflow, ' +
+                'real_filename: %s', real_filename)
             return self.ACTIVITY_SUCCESS
 
         # Download from S3

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -240,7 +240,7 @@ def success_email_subject(digest_content):
     if not digest_content:
         return u''
     return u'Digest JATS posted for article {msid:0>5}, author {author}'.format(
-        msid=str(digest_provider.get_digest_msid(digest_content)), 
+        msid=str(digest_provider.get_digest_msid(digest_content)),
         author=digest_utils.unicode_decode(digest_content.author))
 
 
@@ -262,7 +262,7 @@ def error_email_subject(digest_content):
     if not digest_content:
         return u''
     return u'Error in digest JATS post for article {msid:0>5}, author {author}'.format(
-        msid=str(digest_provider.get_digest_msid(digest_content)), 
+        msid=str(digest_provider.get_digest_msid(digest_content)),
         author=digest_utils.unicode_decode(digest_content.author))
 
 

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -352,3 +352,13 @@ def validate_digest(digest_content):
 def silent_digest(filename):
     "check if file name supplied to the bucket is a silent deposit"
     return bool(re.match(".*[- ]silent.(zip|docx)", str(filename).lower()))
+
+
+def get_digest_msid(digest_object):
+    """given a digest object try to get the msid from the doi"""
+    try:
+        doi = getattr(digest_object, 'doi')
+        return doi.split(".")[-1]
+    except AttributeError:
+        return None
+    return None

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -158,14 +158,14 @@ class TestPostDigestJats(unittest.TestCase):
                              'failed in {comment}'.format(comment=test_data.get("comment")))
 
     def test_do_activity_no_endpoint(self):
-        "test returning True if the endpoint is not specified in the settings"
-        del(settings_mock.typesetter_digest_endpoint)
+        """test returning True if the endpoint is not specified in the settings"""
+        del settings_mock.typesetter_digest_endpoint
         activity = activity_object(settings_mock, FakeLogger(), None, None, None)
         result = activity.do_activity()
         self.assertEqual(result, activity_object.ACTIVITY_SUCCESS)
 
     def test_do_activity_blank_endpoint(self):
-        "test returning True if the endpoint is blank"
+        """test returning True if the endpoint is blank"""
         settings_mock.typesetter_digest_endpoint = ""
         activity = activity_object(settings_mock, FakeLogger(), None, None, None)
         result = activity.do_activity()
@@ -185,7 +185,7 @@ class TestPostPayload(unittest.TestCase):
         helpers.delete_files_in_folder('tests/tmp', filter_out=['.keepme'])
 
     def test_post_payload(self):
-        "POST payload for a digest"
+        """POST payload for a digest"""
         api_key = 'api_key'
         filename = os.path.join('tests', 'files_source', 'DIGEST 99999.docx')
         # JATS paragraphs are in an existing fixture file
@@ -207,7 +207,7 @@ class TestPostPayload(unittest.TestCase):
         self.assertEqual(payload, expected)
 
     def test_post_payload_no_digest(self):
-        "POST payload for when there is no digest"
+        """POST payload for when there is no digest"""
         digest = None
         jats_content = '<p>JATS content</p>'
         api_key = 'api_key'
@@ -225,7 +225,7 @@ class TestPost(unittest.TestCase):
 
     @patch('requests.adapters.HTTPAdapter.get_connection')
     def test_post_as_params(self, fake_connection):
-        "test posting data as params only"
+        """"test posting data as params only"""
         url = 'http://localhost/'
         payload = OrderedDict([
             ("type", "digest"),
@@ -241,7 +241,7 @@ class TestPost(unittest.TestCase):
 
     @patch('requests.adapters.HTTPAdapter.get_connection')
     def test_post_as_data(self, fake_connection):
-        "test posting data as data only"
+        """"test posting data as data only"""
         url = 'http://localhost/'
         payload = OrderedDict([
             ("type", "digest"),
@@ -257,7 +257,7 @@ class TestPost(unittest.TestCase):
 
     @patch('requests.adapters.HTTPAdapter.get_connection')
     def test_post_as_json(self, fake_connection):
-        "test posting data as data only"
+        """test posting data as data only"""
         url = 'http://localhost/'
         payload = OrderedDict([
             ("type", "digest"),
@@ -317,7 +317,6 @@ Sincerely
 
 eLife bot'''
         body = activity_module.success_email_body(current_time, digest_content, jats_content)
-        print(body)
         self.assertEqual(body, expected)
 
 

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -110,6 +110,16 @@ class TestPostDigestJats(unittest.TestCase):
             "expected_email_status": None,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999'
         },
+        {
+            "comment": 'digest silent deposit example',
+            "filename": 'DIGEST+99999+SILENT.zip',
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_activity_status": None,
+            "expected_build_status": None,
+            "expected_jats_status": None,
+            "expected_post_status": None,
+            "expected_email_status": None
+        },
     )
     def test_do_activity(self, test_data, fake_storage_context, requests_method_mock,
                          fake_email_smtp_connect):

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -301,7 +301,7 @@ class TestEmailBody(unittest.TestCase):
     def test_success_email_body(self):
         """email body line with correct, unicode data"""
         digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
-        digest_content.text = ['<i>First</i> paragraph.', '<b>First</b> > second, nö?.']
+        digest_content.text = [u'<i>First</i> paragraph.', u'<b>First</b> > second, nö?.']
         jats_content = digest_provider.digest_jats(digest_content)
         current_time = time.gmtime(1)
 

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -407,9 +407,9 @@ As at 1970-01-01T00:00:01.000Z
 Sincerely
 
 eLife bot'''
-        body = activity_module.error_email_body(current_time, digest_content, jats_content, error_message)
+        body = activity_module.error_email_body(
+            current_time, digest_content, jats_content, error_message)
         self.assertEqual(body, expected)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For some remaining tasks in issue https://github.com/elifesciences/issues/issues/4538, eventually instead of sending a digest `.docx` as an email attachment we will only be posting digest JATS to the endpoint.

First logical part is to not post to the endpoint if it is for a silent digest ingestion.

Second part is we want to send an email notification when a successful digest JATS post is completed. This goes to the same recipients as were receiving the email attachment. I added the JATS content to the body of the email which might be useful for debugging purposes.