### PR TITLE
Wand destroy() to release memory in image resize.

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -37,6 +37,8 @@ def resize(format, filep, info, logger):
 
             image_buffer = BytesIO()
             image.save(file=image_buffer)
+            # destroy the image after saving output to release memory
+            image.destroy()
 
     except Exception as e:
         message = "error resizing image %s" % info.filename


### PR DESCRIPTION
A fix from investigating `Wand` in issue https://github.com/elifesciences/issues/issues/4829, and related to the parent issue https://github.com/elifesciences/issues/issues/4826.

For me, this change to destroy the image object after the output is saved to the image buffer causes the total memory allocated to not grow when resizing multiple images in succession and running `Wand==0.5.1`. The growth in memory doesn't happen in `Wand==0.4.2`.

This might be enough to allow tests to pass without running out of memory.

I'm fairly sure it won't alter the image output, after some cursory testing locally before and after this change, it produces the same JPG output.

If this looks good to test, it probably needs to be merged and then try end2end testing again to see if it passes. You can always revert this PR after merging if it didn't help.