### PR TITLE
Precise email recipients for digest activities.

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -123,7 +123,7 @@ class activity_EmailDigest(Activity):
         sender_email = self.settings.digest_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_recipient_email)
+            self.settings.digest_docx_recipient_email)
 
         connection = email_provider.smtp_connect(self.settings, self.logger)
         # send the emails

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -135,7 +135,7 @@ class activity_PostDigestJATS(Activity):
         sender_email = self.settings.digest_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_recipient_email)
+            self.settings.digest_jats_recipient_email)
 
         messages = email_provider.simple_messages(
             sender_email, recipient_email_list, subject, body, logger=self.logger)
@@ -154,7 +154,7 @@ class activity_PostDigestJATS(Activity):
         sender_email = self.settings.digest_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_error_recipient_email)
+            self.settings.digest_jats_error_recipient_email)
 
         messages = email_provider.simple_messages(
             sender_email, recipient_email_list, subject, body, logger=self.logger)

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -88,7 +88,7 @@ class activity_ValidateDigestInput(Activity):
         sender_email = self.settings.digest_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_error_recipient_email)
+            self.settings.digest_validate_error_recipient_email)
 
         connection = email_provider.smtp_connect(self.settings, self.logger)
         # send the emails

--- a/settings-example.py
+++ b/settings-example.py
@@ -108,8 +108,14 @@ class exp():
     digest_config_file = 'digest.cfg'
     digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
-    digest_recipient_email = ["e@example.org", "life@example.org"]
-    digest_error_recipient_email = "error@example.org"
+    # recipients of digest validation error emails
+    digest_validate_error_recipient_email = "error@example.org"
+    # recipients of digest docx email attachment
+    digest_docx_recipient_email = ["e@example.org", "life@example.org"]
+    # recipients of post digest to endpoint emails and error emails
+    digest_jats_recipient_email = ["e@example.org", "life@example.org"]
+    digest_jats_error_recipient_email = "error@example.org"
+    # recipients of digest medium post created emails
     digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint
@@ -364,8 +370,14 @@ class dev():
     digest_config_file = 'digest.cfg'
     digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
-    digest_recipient_email = ["e@example.org", "life@example.org"]
-    digest_error_recipient_email = "error@example.org"
+    # recipients of digest validation error emails
+    digest_validate_error_recipient_email = "error@example.org"
+    # recipients of digest docx email attachment
+    digest_docx_recipient_email = ["e@example.org", "life@example.org"]
+    # recipients of post digest to endpoint emails and error emails
+    digest_jats_recipient_email = ["e@example.org", "life@example.org"]
+    digest_jats_error_recipient_email = "error@example.org"
+    # recipients of digest medium post created emails
     digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint
@@ -617,8 +629,14 @@ class live():
     digest_config_file = 'digest.cfg'
     digest_config_section = 'elife'
     digest_sender_email = "sender@example.org"
-    digest_recipient_email = ["e@example.org", "life@example.org"]
-    digest_error_recipient_email = "error@example.org"
+    # recipients of digest validation error emails
+    digest_validate_error_recipient_email = "error@example.org"
+    # recipients of digest docx email attachment
+    digest_docx_recipient_email = ["e@example.org", "life@example.org"]
+    # recipients of post digest to endpoint emails and error emails
+    digest_jats_recipient_email = ["e@example.org", "life@example.org"]
+    digest_jats_error_recipient_email = "error@example.org"
+    # recipients of digest medium post created emails
     digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
     # digest endpoint

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -58,8 +58,14 @@ ses_pmc_revision_recipient_email = ["e@example.org", "life@example.org"]
 digest_config_file = 'tests/activity/digest.cfg'
 digest_config_section = 'elife'
 digest_sender_email = "sender@example.org"
-digest_recipient_email = ["e@example.org", "life@example.org"]
-digest_error_recipient_email = "error@example.org"
+# recipients of digest validation error emails
+digest_validate_error_recipient_email = "error@example.org"
+# recipients of digest docx email attachment
+digest_docx_recipient_email = ["e@example.org", "life@example.org"]
+# recipients of post digest to endpoint emails and error emails
+digest_jats_recipient_email = ["e@example.org", "life@example.org"]
+digest_jats_error_recipient_email = "error@example.org"
+# recipients of digest medium post created emails
 digest_medium_recipient_email = ["e@example.org", "life@example.org"]
 
 digest_endpoint = 'https://digests/{digest_id}'


### PR DESCRIPTION
To reach completion of issue https://github.com/elifesciences/issues/issues/4538, recent comments show some people would like to receive certain emails regarding digests and to not receive other emails.

There are four digest related activities that send emails: 

1. when the input zip is validated
2. sending a generated docx file as an email attachment
3. posting digest JATS to an endpoint
4. creating a Medium post for a digest

Some of these send only success emails, and some send success or error emails.

Here I opted to separate each of the currently used email recipient lists into separate variables in the settings. We can then adjust the recipients of each as people prefer.