### PR TITLE
Only send new versions again to PMC in pub router.

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -447,7 +447,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ['GoOA', 'PMC', 'CNKI']:
+        if workflow not in ['PMC']:
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(article.doi, workflow)
                 if was_ever_published is True:


### PR DESCRIPTION
Streamlining the sending in PubRouterDeposit, this is the simplest change to only send new versions and silent corrected packages to PMC.