### PR TITLE
PMC no more sending emails

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -1,9 +1,6 @@
 import os
-import boto.swf
 import json
 from collections import OrderedDict
-import datetime
-import time
 import zipfile
 import shutil
 import re
@@ -11,6 +8,7 @@ import re
 from ftplib import FTP
 import ftplib
 
+import boto.swf
 import boto.s3
 from boto.s3.connection import S3Connection
 
@@ -20,9 +18,6 @@ from elifetools import parseJATS as parser
 from elifetools import xmlio
 from activity.objects import Activity
 
-"""
-PMCDeposit activity
-"""
 
 class activity_PMCDeposit(Activity):
 

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -15,7 +15,6 @@ import boto.s3
 from boto.s3.connection import S3Connection
 
 import provider.s3lib as s3lib
-import provider.simpleDB as dblib
 from provider.article_structure import ArticleInfo, file_parts
 from elifetools import parseJATS as parser
 from elifetools import xmlio
@@ -48,9 +47,6 @@ class activity_PMCDeposit(Activity):
         self.EPS_DIR = self.get_tmp_dir() + os.sep + "eps_dir"
         self.TIF_DIR = self.get_tmp_dir() + os.sep + "tif_dir"
         self.OUTPUT_DIR = self.get_tmp_dir() + os.sep + "output_dir"
-
-        # Data provider where email body is saved
-        self.db = dblib.SimpleDB(settings)
 
         # Bucket settings
         self.input_bucket = None
@@ -144,10 +140,6 @@ class activity_PMCDeposit(Activity):
 
             if ftp_status is True:
                 self.upload_article_zip_to_s3()
-
-                # Send email
-                file_size = self.file_size(os.path.join(self.ZIP_DIR, self.zip_file_name))
-                self.add_email_to_queue(self.journal, volume, fid, revision, self.zip_file_name, file_size)
 
         # Return the activity result, True or False
         if verified is True and ftp_status is True:
@@ -310,10 +302,6 @@ class activity_PMCDeposit(Activity):
             else:
                 return None
         return None
-
-    def file_size(self, file_name):
-        return os.path.getsize(file_name)
-
 
     def unzip_or_move_file(self, file_name, to_dir, do_unzip=True):
         """
@@ -527,132 +515,6 @@ class activity_PMCDeposit(Activity):
 
     def article_soup(self, xml_filename):
         return parser.parse_document(xml_filename)
-
-    def add_email_to_queue(self, journal, volume, fid, revision, file_name, file_size):
-        """
-        After do_activity is finished, send emails to recipients
-        on the status
-        """
-        # Connect to DB
-        db_conn = self.db.connect()
-
-        current_time = time.gmtime()
-
-        body = self.get_email_body(current_time, journal, volume, fid, revision,
-                                   file_name, file_size)
-
-        if revision:
-            subject = self.get_revision_email_subject(fid)
-        else:
-            subject = self.get_email_subject(current_time, journal, volume, fid, revision,
-                                             file_name, file_size)
-
-        sender_email = self.settings.ses_pmc_sender_email
-
-        recipient_email_list = self.email_recipients(revision)
-
-        for email in recipient_email_list:
-            # Add the email to the email queue
-            self.db.elife_add_email_to_email_queue(
-                recipient_email=email,
-                sender_email=sender_email,
-                email_type="PMCDeposit",
-                format="text",
-                subject=subject,
-                body=body)
-
-
-        return True
-
-    def email_recipients(self, revision):
-        """
-        Get a list of email recipients depending on the revision number
-        because for PMC we will redirect a revision email to different recipients
-        """
-        recipient_email_list = []
-
-        if revision:
-            settings_email_recipient = self.settings.ses_pmc_revision_recipient_email
-        else:
-            settings_email_recipient = self.settings.ses_pmc_recipient_email
-
-        # Handle multiple recipients, if specified
-        if type(settings_email_recipient) == list:
-            for email in settings_email_recipient:
-                recipient_email_list.append(email)
-        else:
-            recipient_email_list.append(settings_email_recipient)
-
-        return recipient_email_list
-
-    def get_revision_email_subject(self, fid):
-        """
-        Email subject line for notifying production about a PMC revision
-        """
-        subject = "You need to email PMC: article " + str(fid).zfill(5) + "!!!"
-        return subject
-
-    def get_email_subject(self, current_time, journal, volume, fid, revision,
-                          file_name, file_size):
-        date_format = '%Y-%m-%d %H:%M'
-        datetime_string = time.strftime(date_format, current_time)
-
-        subject = (journal + " PMC deposit " + datetime_string + ", article " + str(fid).zfill(5))
-        if revision:
-            subject += ", revision " + str(revision)
-
-        return subject
-
-    def email_body_revision_header(self, revision):
-        header = None
-        if revision:
-            header = "Production please forward this to PMC with details of what changed"
-        return header
-
-    def get_email_body(self, current_time, journal, volume, fid, revision,
-                       file_name, file_size):
-
-        body = ""
-
-        date_format = '%Y-%m-%dT%H:%M'
-        datetime_string = time.strftime(date_format, current_time)
-
-        # Header
-        if self.email_body_revision_header(revision):
-            body += self.email_body_revision_header(revision)
-            body += "\n\n"
-            # Include the subject line to be used
-            revision_email_subject = self.get_email_subject(current_time, journal, volume, fid,
-                                                            revision, file_name, file_size)
-            body += str(revision_email_subject)
-            body += "\n\n"
-
-        # Bulk of body
-        body += "PMCDeposit activity" + "\n"
-        body += "\n"
-
-        body += journal + " deposit date: " + datetime_string + "\n"
-        body += "\n"
-        body += "Journal title: " + journal + "\n"
-        body += "Volume: " + str(volume).zfill(2) + "\n"
-        body += "Article: " + str(fid).zfill(2) + "\n"
-
-        if revision:
-            revision_text = str(revision)
-        else:
-            revision_text = "n/a"
-        body += "Revision: " + revision_text + "\n"
-        body += "\n"
-        body += "Zip filename: " + file_name + "\n"
-        body += "File size (bytes): " + str(file_size) + "\n"
-
-        body += "\n"
-
-        body += "\n\nSincerely\n\neLife bot"
-
-        return body
-
-
 
     def create_activity_directories(self):
         """

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -97,16 +97,13 @@ class activity_PMCDeposit(Activity):
                 self.logger.info('folder was empty in PMCDeposit: ' + self.INPUT_DIR)
             verified = True
 
-
         folder = self.INPUT_DIR
         if self.logger:
             self.logger.info('processing files in folder ' + folder)
 
         self.unzip_article_files(self.file_list(folder))
 
-
         (fid, status, version, volume) = self.profile_article(self.document)
-
 
         # Rename the files
         file_name_map = self.rename_files_remove_version_number()
@@ -125,7 +122,7 @@ class activity_PMCDeposit(Activity):
                          file_name_map=file_name_map)
 
         # Get the new zip file name
-        # TODO - may need to take into account the r1 r2 revision numbers when replacing an article
+        # take into account the r1 r2 revision numbers when replacing an article
         revision = self.zip_revision_number(fid)
         self.zip_file_name = self.new_zip_filename(self.journal, volume, fid, revision)
         print(self.zip_file_name)
@@ -151,7 +148,6 @@ class activity_PMCDeposit(Activity):
         self.clean_tmp_dir()
 
         return result
-
 
     def set_ftp_settings(self, doi_id):
         """
@@ -215,7 +211,6 @@ class activity_PMCDeposit(Activity):
                 return True
         except:
             return False
-
 
     def download_files_from_s3(self, document):
 
@@ -321,10 +316,8 @@ class activity_PMCDeposit(Activity):
                 self.logger.info("going to move and not unzip " + file_name + " to " + to_dir)
             shutil.copyfile(file_name, to_dir + os.sep + self.file_name_from_name(file_name))
 
-
     def approve_file(self, file_name):
         return True
-
 
     def unzip_article_files(self, file_list):
 
@@ -333,7 +326,6 @@ class activity_PMCDeposit(Activity):
                 if self.logger:
                     self.logger.info("unzipping or moving file " + file_name)
                 self.unzip_or_move_file(file_name, self.TMP_DIR)
-
 
     def stripped_file_name_map(self, file_names):
         "from a list of file names, build a map of old to new file name with the version removed"
@@ -351,7 +343,6 @@ class activity_PMCDeposit(Activity):
             renamed_filename = '.'.join([part_without_version, extension])
             file_name_map[filename] = renamed_filename
         return file_name_map
-
 
     def rename_files_remove_version_number(self):
         """
@@ -462,7 +453,6 @@ class activity_PMCDeposit(Activity):
             new_zipfile.write(df, filename)
 
         new_zipfile.close()
-
 
     def profile_article(self, document):
         """

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -130,50 +130,6 @@ class TestPMCDeposit(unittest.TestCase):
         file_name_map = self.activity.stripped_file_name_map(file_names)
         self.assertEqual(file_name_map, expected_file_name_map)
 
-    @data(
-        (None, [""]),
-        (1, ["e@example.org", "life@example.org"])
-    )
-    @unpack
-    def test_email_recipients(self, revision, expected_recipients):
-        recipients = self.activity.email_recipients(revision)
-        self.assertEqual(recipients, expected_recipients)
-
-
-    @data(
-        (None, None),
-        (1, "Production please forward this to PMC with details of what changed")
-    )
-    @unpack
-    def test_email_body_revision_header(self, revision, expected_header):
-        header = self.activity.email_body_revision_header(revision)
-        self.assertEqual(header, expected_header)
-
-
-    @data(
-        (1471046585, "elife", 5, "00013", None, 1, 2,
-         "elife PMC deposit 2016-08-13 00:03, article 00013"),
-        (1471046585, "elife", 5, "00013", 2, 1, 2,
-         "elife PMC deposit 2016-08-13 00:03, article 00013, revision 2"),
-    )
-    @unpack
-    def test_get_email_subject(self, timestamp, journal, volume, fid, revision,
-                                         file_name, file_size, expected_subject):
-
-        current_time = time.gmtime(timestamp)
-        subject = self.activity.get_email_subject(current_time, journal, volume, fid, revision,
-                                         file_name, file_size)
-        self.assertEqual(subject, expected_subject)
-
-    @data(
-        ("00013", "You need to email PMC: article 00013!!!")
-    )
-    @unpack
-    def test_get_revision_email_subject(self, fid, expected_subject):
-        subject = self.activity.get_revision_email_subject(fid)
-        self.assertEqual(subject, expected_subject)
-
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/issues/issues/4857.

This is the simplest edit to remove all the emailing logic from the `PMCDeposit` activity. I did only a tiny bit of linting.

There is room in this file to do some more extensive refactoring: move the no-self-use functions out of the class, use the `ftp.py` provider instead of the duplicate functions in here, use the `storage_context` instead of connecting to S3 directly. I am open to suggestions whether those refactors should be in a separate PR (and at a later date), or whether it is good to just do it all now along with removing the emailing logic.