### PR TITLE
Remove PMC email settings.

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -99,11 +99,6 @@ class exp():
     ses_poa_sender_email = "sender@example.com"
     ses_poa_recipient_email = "admin@example.com"
 
-    # PMC email settings
-    ses_pmc_sender_email = "sender@example.com"
-    ses_pmc_recipient_email = "admin@example.com"
-    ses_pmc_revision_recipient_email = "sender@example.com"
-
     # Digest email settings
     digest_config_file = 'digest.cfg'
     digest_config_section = 'elife'
@@ -361,11 +356,6 @@ class dev():
     ses_poa_sender_email = "sender@example.com"
     ses_poa_recipient_email = "admin@example.com"
 
-    # PMC email settings
-    ses_pmc_sender_email = "sender@example.com"
-    ses_pmc_recipient_email = "admin@example.com"
-    ses_pmc_revision_recipient_email = "sender@example.com"
-
     # Digest email settings
     digest_config_file = 'digest.cfg'
     digest_config_section = 'elife'
@@ -619,11 +609,6 @@ class live():
     # POA email settings
     ses_poa_sender_email = "sender@example.com"
     ses_poa_recipient_email = "admin@example.com"
-
-    # PMC email settings
-    ses_pmc_sender_email = "sender@example.com"
-    ses_pmc_recipient_email = "admin@example.com"
-    ses_pmc_revision_recipient_email = "sender@example.com"
 
     # Digest email settings
     digest_config_file = 'digest.cfg'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -51,10 +51,6 @@ PMC_FTP_USERNAME = ""
 PMC_FTP_PASSWORD = ""
 PMC_FTP_CWD = ""
 
-ses_pmc_sender_email = ""
-ses_pmc_recipient_email = ""
-ses_pmc_revision_recipient_email = ["e@example.org", "life@example.org"]
-
 digest_config_file = 'tests/activity/digest.cfg'
 digest_config_section = 'elife'
 digest_sender_email = "sender@example.org"


### PR DESCRIPTION
These PMC email settings are no longer used as of merging PR https://github.com/elifesciences/elife-bot/pull/900. I should have removed these settings too. Tests still pass (I expected they would) which is good to know. I'll merge this after no review - there's no much to see here!