### PR TITLE
Fix log arguments, test case for ArchiveArticle.

### DIFF
--- a/activity/activity_ArchiveArticle.py
+++ b/activity/activity_ArchiveArticle.py
@@ -100,9 +100,8 @@ class activity_ArchiveArticle(Activity):
                 with open(file_path, 'wb') as open_file:
                     self.logger.info("Downloading %s to %s", (storage_resource_origin, file_path))
                     storage.get_resource_to_file(storage_resource_origin, open_file)
-        except IOError as exception:
-            self.logger.exception(
-                "Failed to download file %s. details: %s" % (key_name, str(exception)))
+        except IOError:
+            self.logger.exception("Failed to download file %s.", key_name)
             return None
         return True
 

--- a/activity/activity_ArchiveArticle.py
+++ b/activity/activity_ArchiveArticle.py
@@ -102,7 +102,7 @@ class activity_ArchiveArticle(Activity):
                     storage.get_resource_to_file(storage_resource_origin, open_file)
         except IOError as exception:
             self.logger.exception(
-                "Failed to download file %s. details: %s" % key_name, str(exception))
+                "Failed to download file %s. details: %s" % (key_name, str(exception)))
             return None
         return True
 

--- a/tests/activity/test_activity_archive_article.py
+++ b/tests/activity/test_activity_archive_article.py
@@ -79,6 +79,18 @@ class TestArchiveArticle(unittest.TestCase):
         success = self.activity.do_activity(activity_test_data.data_example_before_publish)
         self.assertEqual(success, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
+    @patch.object(FakeStorageContext, 'get_resource_to_file')
+    @patch.object(FakeStorageContext, 'list_resources')
+    @patch.object(activity_module, 'storage_context')
+    def test_download_files_failure(
+            self, fake_storage_context, fake_list_resources, fake_get_resource_to_file):
+        """test exception in download_files for test coverage"""
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_list_resources.return_value = ['fake_bucket_file.zip']
+        fake_get_resource_to_file.side_effect = Exception("Something went wrong!")
+        success = self.activity.download_files("bucket_name", "expanded_folder", "zip_dir_path")
+        self.assertIsNone(success)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4827.

Arguments need to be wrapped in parentheses. I added a test case that covers where the error was too.