### PR TITLE
Use post_as_data() in PostDigestJATS.

### DIFF
--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -199,7 +199,7 @@ def post_payload(digest, jats_content, api_key):
 
 def post_jats_to_endpoint(url, payload, logger):
     """issue the POST"""
-    resp = post_as_params(url, payload)
+    resp = post_as_data(url, payload)
     # Check for good HTTP status code
     if resp.status_code != 200:
         response_error_message = (


### PR DESCRIPTION
We are going to go directly to issuing a `POST` with data as the data of the request, instead of the data as URI parameters, as we did in PR https://github.com/elifesciences/elife-bot/pull/908.

Tests are passing, and I will merge and deploy so it ready for Monday morning.