### PR TITLE
PMC resupply

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -193,7 +193,7 @@ class activity_CreateDigestMediumPost(Activity):
             approve_status = False
 
         # check silent correction
-        if run_type == "silent-correction":
+        if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
             approve_status = False
         else:
             first_vor_status = digest_provider.approve_by_first_vor(

--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -57,7 +57,7 @@ class activity_EmailVideoArticlePublished(Activity):
             return self.ACTIVITY_SUCCESS
 
         # do not send if silent-correction
-        if run_type == "silent-correction":
+        if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
             self.logger.info(
                 ("Silent correction of article %s " +
                  "no email to send in Email Video Article Published ") % article_id)

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -217,7 +217,8 @@ class activity_IngestDigestToEndpoint(Activity):
         run_type_status = digest_provider.approve_by_run_type(
             self.settings, self.logger, article_id, run_type, version)
         first_vor_status = digest_provider.approve_by_first_vor(self.settings, self.logger, article_id, version, status)
-        if first_vor_status is False and run_type != "silent-correction":
+        if (first_vor_status is False and
+                run_type not in ["silent-correction", "silent-correction-pmc-resupply"]):
             # not the first vor and not a silent correction, do not approve
             approve_status = False
         elif run_type_status is False:

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -72,6 +72,10 @@ class activity_PMCDeposit(Activity):
         # Data passed to this activity
         self.document = data["data"]["document"]
 
+        # set the FTP folder for resupplies
+        if "folder" in data["data"]:
+            self.FTP_SUBDIR = [data["data"]["folder"]]
+
         # Custom bucket, if specified
         if "bucket" in data["data"]:
             self.input_bucket = data["data"]["bucket"]

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -105,9 +105,9 @@ class activity_PubRouterDeposit(Activity):
 
         for article in self.articles_approved:
             # Start a workflow for each article this is approved to publish
-            if self.workflow in ["PMC", "PMC_Resupply"]:
+            if self.workflow in ["PMC", "PMC-Resupply"]:
                 folder = ""
-                if self.workflow == "PMC_Resupply":
+                if self.workflow == "PMC-Resupply":
                     folder = "resupplies"
                 zip_file_name = self.archive_zip_file_name(article)
                 starter_status = self.start_pmc_deposit_workflow(article, zip_file_name, folder)
@@ -160,7 +160,7 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/outbox/"
         elif workflow == "PMC":
             return "pmc/outbox/"
-        elif workflow == "PMC_Resupply":
+        elif workflow == "PMC-Resupply":
             return "pmc_resupply/outbox/"
         elif workflow == "CNPIEC":
             return "cnpiec/outbox/"
@@ -185,7 +185,7 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/published/"
         elif workflow == "PMC":
             return "pmc/published/"
-        elif workflow == "PMC_Resupply":
+        elif workflow == "PMC-Resupply":
             return "pmc_resupply/published/"
         elif workflow == "CNPIEC":
             return "cnpiec/published/"

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -105,9 +105,12 @@ class activity_PubRouterDeposit(Activity):
 
         for article in self.articles_approved:
             # Start a workflow for each article this is approved to publish
-            if self.workflow == 'PMC':
+            if self.workflow in ["PMC", "PMC_Resupply"]:
+                folder = ""
+                if self.workflow == "PMC_Resupply":
+                    folder = "resupplies"
                 zip_file_name = self.archive_zip_file_name(article)
-                starter_status = self.start_pmc_deposit_workflow(article, zip_file_name)
+                starter_status = self.start_pmc_deposit_workflow(article, zip_file_name, folder)
             else:
                 starter_status = self.start_ftp_article_workflow(article)
 
@@ -157,6 +160,8 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/outbox/"
         elif workflow == "PMC":
             return "pmc/outbox/"
+        elif workflow == "PMC_Resupply":
+            return "pmc_resupply/outbox/"
         elif workflow == "CNPIEC":
             return "cnpiec/outbox/"
         elif workflow == "CNKI":
@@ -180,6 +185,8 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/published/"
         elif workflow == "PMC":
             return "pmc/published/"
+        elif workflow == "PMC_Resupply":
+            return "pmc_resupply/published/"
         elif workflow == "CNPIEC":
             return "cnpiec/published/"
         elif workflow == "CNKI":
@@ -280,7 +287,7 @@ class activity_PubRouterDeposit(Activity):
         return s3_key_name
 
 
-    def start_pmc_deposit_workflow(self, article, zip_file_name):
+    def start_pmc_deposit_workflow(self, article, zip_file_name, folder=""):
         """
         Start a PMCDeposit workflow for the article object, by looking up
         the archive zip file for the article DOI
@@ -298,6 +305,7 @@ class activity_PubRouterDeposit(Activity):
         # Input data
         data = {}
         data['document'] = zip_file_name
+        data['folder'] = folder
         input_json = {}
         input_json['data'] = data
         input = json.dumps(input_json)

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -106,9 +106,10 @@ class activity_PubRouterDeposit(Activity):
         for article in self.articles_approved:
             # Start a workflow for each article this is approved to publish
             if self.workflow in ["PMC", "PMC-Resupply"]:
-                folder = ""
                 if self.workflow == "PMC-Resupply":
                     folder = "resupplies"
+                else:
+                    folder = ""
                 zip_file_name = self.archive_zip_file_name(article)
                 starter_status = self.start_pmc_deposit_workflow(article, zip_file_name, folder)
             else:
@@ -455,7 +456,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ['PMC']:
+        if workflow not in ['PMC', 'PMC-Resupply']:
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(article.doi, workflow)
                 if was_ever_published is True:
@@ -477,7 +478,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if a PMC zip file exists for this article
-        if workflow != 'PMC':
+        if workflow not in ['PMC', 'PMC-Resupply']:
             for article in articles:
                 if not self.does_source_zip_exist_from_s3(doi_id=article.doi_id):
                     if self.logger:
@@ -488,7 +489,7 @@ class activity_PubRouterDeposit(Activity):
                     remove_article_doi.append(article.doi)
 
         # For PMC workflows, check the archive zip file exists
-        if workflow == 'PMC':
+        if workflow in ['PMC', 'PMC-Resupply']:
             for article in articles:
                 zip_file_name = self.archive_zip_file_name(article)
                 if not zip_file_name:

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -42,6 +42,7 @@ class activity_ScheduleDownstream(Activity):
         run = data['run']
         expanded_folder_name = data['expanded_folder']
         status = data['status'].lower()
+        run_type = data.get("run_type")
 
         self.emit_monitor_event(self.settings, article_id, version, run,
                                 "Schedule Downstream", "start",
@@ -51,7 +52,7 @@ class activity_ScheduleDownstream(Activity):
             xml_file_name = get_xml_file_name(
                 self.settings, expanded_folder_name, expanded_bucket_name, version)
             xml_key_name = expanded_folder_name + "/" + xml_file_name
-            outbox_list = choose_outboxes(status, outbox_map())
+            outbox_list = choose_outboxes(status, outbox_map(), run_type)
 
             for outbox in outbox_list:
                 self.rename_and_copy_to_outbox(
@@ -105,6 +106,7 @@ def outbox_map():
     outboxes = OrderedDict()
     outboxes["pubmed"] = "pubmed/outbox/"
     outboxes["pmc"] = "pmc/outbox/"
+    outboxes["pmc_resupply"] = "pmc_resupply/outbox/"
     outboxes["publication_email"] = "publication_email/outbox/"
     outboxes["pub_router"] = "pub_router/outbox/"
     outboxes["cengage"] = "cengage/outbox/"
@@ -116,7 +118,7 @@ def outbox_map():
     return outboxes
 
 
-def choose_outboxes(status, outbox_map):
+def choose_outboxes(status, outbox_map, run_type=None):
     outbox_list = []
 
     if status == "poa":
@@ -125,7 +127,10 @@ def choose_outboxes(status, outbox_map):
 
     elif status == "vor":
         outbox_list.append(outbox_map.get("pubmed"))
-        outbox_list.append(outbox_map.get("pmc"))
+        if run_type == "silent-correction-pmc-resupply":
+            outbox_list.append(outbox_map.get("pmc_resupply"))
+        else:
+            outbox_list.append(outbox_map.get("pmc"))
         outbox_list.append(outbox_map.get("publication_email"))
         outbox_list.append(outbox_map.get("pub_router"))
         outbox_list.append(outbox_map.get("cengage"))

--- a/cron.py
+++ b/cron.py
@@ -128,6 +128,14 @@ def run_cron(settings):
                 workflow_id="PublicationEmail",
                 start_seconds=60 * 31)
 
+        # PMC resupply deposits once per day 20:45 UTC
+        if current_time.tm_hour == 20:
+            workflow_conditional_start(
+                settings=settings,
+                starter_name="starter_PubRouterDeposit",
+                workflow_id="PubRouterDeposit_PMC-Resupply",
+                start_seconds=60 * 31)
+
         # Pub router deposits once per day 23:45 UTC
         if current_time.tm_hour == 23:
             workflow_conditional_start(

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -280,7 +280,7 @@ def approve_by_run_type(settings, logger, article_id, run_type, version):
     "determine ingest approval based on the run_type and version"
     approve_status = None
     # VoR and is a silent correction, consult Lax for if it is not the highest version
-    if run_type == "silent-correction":
+    if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
         highest_version = lax_provider.article_highest_version(article_id, settings)
         try:
             if int(version) < int(highest_version):

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -63,6 +63,7 @@ class starter_PubRouterDeposit():
                 or workflow == 'WoS'
                 or workflow == 'Scopus'
                 or workflow == 'PMC'
+                or workflow == 'PMC-Resupply'
                 or workflow == 'CNPIEC'
                 or workflow == 'CNKI'):
             workflow_id = "PubRouterDeposit_" + workflow

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -30,7 +30,7 @@ class starter_SilentCorrectionsIngest():
         input = S3NotificationInfo.to_dict(info)
         input['run'] = run
         input['version_lookup_function'] = "article_highest_version"
-        input['run_type'] = "silent-correction"
+        input['run_type'] = get_run_type(info)
         input['force'] = True
 
         workflow_id, \
@@ -59,6 +59,13 @@ class starter_SilentCorrectionsIngest():
             # There is already a running workflow with that ID, cannot start another
             message = 'SWFWorkflowExecutionAlreadyStartedError: There is already a running workflow with ID %s' % workflow_id
             logger.info(message)
+
+
+def get_run_type(info):
+    """get the run_type by looking at the S3 notification info"""
+    if hasattr(info, 'file_name') and info.file_name.startswith('pmc-resupply/'):
+        return "silent-correction-pmc-resupply"
+    return "silent-correction"
 
 
 if __name__ == "__main__":

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -26,6 +26,27 @@ class TestScheduleDownstream(unittest.TestCase):
         # check assertions
         self.assertEqual(result, expected_result)
 
+    def test_choose_outboxes_poa(self):
+        outbox_list = activity_module.choose_outboxes("poa", activity_module.outbox_map())
+        self.assertTrue("pubmed/outbox/" in outbox_list)
+        self.assertFalse("pmc/outbox/" in outbox_list)
+
+    def test_choose_outboxes_vor(self):
+        outbox_list = activity_module.choose_outboxes("vor", activity_module.outbox_map())
+        self.assertTrue("pmc/outbox/" in outbox_list)
+        self.assertTrue("pub_router/outbox/" in outbox_list)
+
+    def test_choose_outboxes_vor_silent(self):
+        outbox_list = activity_module.choose_outboxes(
+            "vor", activity_module.outbox_map(), "silent-correction")
+        self.assertTrue("pmc/outbox/" in outbox_list)
+        self.assertFalse("pmc_resupply/outbox/" in outbox_list)
+
+    def test_choose_outboxes_vor_silent_pmc_resupply(self):
+        outbox_list = activity_module.choose_outboxes(
+            "vor", activity_module.outbox_map(), "silent-correction-pmc-resupply")
+        self.assertFalse("pmc/outbox/" in outbox_list)
+        self.assertTrue("pmc_resupply/outbox/" in outbox_list)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -1,31 +1,35 @@
 import unittest
 from ddt import ddt, data
+from mock import patch
 import starter.starter_SilentCorrectionsIngest as starter_module
 from starter.starter_SilentCorrectionsIngest import starter_SilentCorrectionsIngest
 from starter.starter_helper import NullRequiredDataException
 from S3utility.s3_notification_info import S3NotificationInfo
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from mock import patch
 from tests.classes_mock import FakeBotoConnection
+from tests.activity.classes_mock import FakeLogger
 
-run_example = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+RUN_EXAMPLE = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
 
 @ddt
 class TestStarterSilentCorrectionsIngest(unittest.TestCase):
     def setUp(self):
-        self.stater_silent_corrections_ingest = starter_SilentCorrectionsIngest()
+        self.starter_silent_corrections_ingest = starter_SilentCorrectionsIngest()
 
     def test_silent_corrections_ingest_starter_no_article(self):
-        self.assertRaises(NullRequiredDataException, self.stater_silent_corrections_ingest.start,
-                          settings=settings_mock, run=run_example, info=test_data.data_error_lax)
+        self.assertRaises(NullRequiredDataException, self.starter_silent_corrections_ingest.start,
+                          settings=settings_mock, run=RUN_EXAMPLE, info=test_data.data_error_lax)
 
     @patch('starter.starter_helper.get_starter_logger')
     @patch('boto.swf.layer1.Layer1')
     def test_silent_corrections_ingest_starter_(self, fake_boto_conn, fake_logger):
+        fake_logger.return_value = FakeLogger()
         fake_boto_conn.return_value = FakeBotoConnection()
-        self.stater_silent_corrections_ingest.start(settings=settings_mock, run=run_example,
-                                             info=S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data))
+        self.starter_silent_corrections_ingest.start(
+            settings=settings_mock, run=RUN_EXAMPLE,
+            info=S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data))
 
     @data(
         {
@@ -46,7 +50,3 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
         info.file_name = scenario_test_data.get('file_name')
         return_value = starter_module.get_run_type(info)
         self.assertEqual(return_value, scenario_test_data.get('expected'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -1,4 +1,6 @@
 import unittest
+from ddt import ddt, data
+import starter.starter_SilentCorrectionsIngest as starter_module
 from starter.starter_SilentCorrectionsIngest import starter_SilentCorrectionsIngest
 from starter.starter_helper import NullRequiredDataException
 from S3utility.s3_notification_info import S3NotificationInfo
@@ -9,6 +11,7 @@ from tests.classes_mock import FakeBotoConnection
 
 run_example = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
 
+@ddt
 class TestStarterSilentCorrectionsIngest(unittest.TestCase):
     def setUp(self):
         self.stater_silent_corrections_ingest = starter_SilentCorrectionsIngest()
@@ -23,6 +26,26 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
         fake_boto_conn.return_value = FakeBotoConnection()
         self.stater_silent_corrections_ingest.start(settings=settings_mock, run=run_example,
                                              info=S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data))
+
+    @data(
+        {
+            'file_name': '',
+            'expected': 'silent-correction'
+        },
+        {
+            'file_name': 'elife-00353-vor-r1.zip',
+            'expected': 'silent-correction'
+        },
+        {
+            'file_name': 'pmc-resupply/elife-00353-vor-r1.zip',
+            'expected': 'silent-correction-pmc-resupply'
+        }
+    )
+    def test_get_run_type(self, scenario_test_data):
+        info = S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data)
+        info.file_name = scenario_test_data.get('file_name')
+        return_value = starter_module.get_run_type(info)
+        self.assertEqual(return_value, scenario_test_data.get('expected'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Logic as outlined in issue https://github.com/elifesciences/issues/issues/4889 up to where we could potentially deploy it for a test with a couple zip files. The code shouldn't impact any existing PMC deposits.

There's some potential for some refactoring in the files edited here if you feel like it is a good time to do it before merging. That could include, for example, to change `PMCDeposit` activity to use the FTP provider instead of the separate function it is using right now.