### PR TITLE
Fewer downstream recipients for  PMC resupply.

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -131,14 +131,14 @@ def choose_outboxes(status, outbox_map, run_type=None):
             outbox_list.append(outbox_map.get("pmc_resupply"))
         else:
             outbox_list.append(outbox_map.get("pmc"))
-        outbox_list.append(outbox_map.get("publication_email"))
-        outbox_list.append(outbox_map.get("pub_router"))
-        outbox_list.append(outbox_map.get("cengage"))
-        outbox_list.append(outbox_map.get("gooa"))
-        outbox_list.append(outbox_map.get("wos"))
-        outbox_list.append(outbox_map.get("scopus"))
-        outbox_list.append(outbox_map.get("cnpiec"))
-        outbox_list.append(outbox_map.get("cnki"))
+            outbox_list.append(outbox_map.get("publication_email"))
+            outbox_list.append(outbox_map.get("pub_router"))
+            outbox_list.append(outbox_map.get("cengage"))
+            outbox_list.append(outbox_map.get("gooa"))
+            outbox_list.append(outbox_map.get("wos"))
+            outbox_list.append(outbox_map.get("scopus"))
+            outbox_list.append(outbox_map.get("cnpiec"))
+            outbox_list.append(outbox_map.get("cnki"))
 
     return outbox_list
 


### PR DESCRIPTION
A few author publications emails were sent as a side-effect of some PMC resupply article deposits, due the logic of the `PublicationEmail` activity. Change it here so only pubmed and PMC will be scheduled downstream when a PMC resupply article is processed.