### PR TITLE
CSV file matches, tests for old and new names.

### DIFF
--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -290,21 +290,21 @@ class EJP(object):
         # For each file_type, specify a unique file name fragment to filter on
         #  with regular expression search
         fn_fragment = {}
-        fn_fragment["author"] = "ejp_query_tool_query_id_152_15a"
-        fn_fragment["editor"] = "ejp_query_tool_query_id_158_15b"
-        fn_fragment["poa_manuscript"] = "ejp_query_tool_query_id_176_POA_Manuscript"
-        fn_fragment["poa_author"] = "ejp_query_tool_query_id_177_POA_Author"
-        fn_fragment["poa_license"] = "ejp_query_tool_query_id_178_POA_License"
-        fn_fragment["poa_subject_area"] = "ejp_query_tool_query_id_179_POA_Subject_Area"
-        fn_fragment["poa_received"] = "ejp_query_tool_query_id_180_POA_Received"
-        fn_fragment["poa_research_organism"] = "ejp_query_tool_query_id_182_POA_Research_Organism"
-        fn_fragment["poa_abstract"] = "ejp_query_tool_query_id_196_POA_Abstract"
-        fn_fragment["poa_title"] = "ejp_query_tool_query_id_191_POA_Title"
-        fn_fragment["poa_keywords"] = "ejp_query_tool_query_id_226_POA_Keywords"
-        fn_fragment["poa_group_authors"] = "ejp_query_tool_query_id_242_POA_Group_Authors"
-        fn_fragment["poa_datasets"] = "ejp_query_tool_query_id_1061_POA_Datasets"
-        fn_fragment["poa_funding"] = "ejp_query_tool_query_id_1062_POA_Funding"
-        fn_fragment["poa_ethics"] = "ejp_query_tool_query_id_198_POA_Ethics"
+        fn_fragment["author"] = "_15a\)_Accepted_Paper_Details"
+        fn_fragment["editor"] = "_15b\)_Accepted_Paper_Details"
+        fn_fragment["poa_manuscript"] = "_POA_Manuscript"
+        fn_fragment["poa_author"] = "_POA_Author"
+        fn_fragment["poa_license"] = "_POA_License"
+        fn_fragment["poa_subject_area"] = "_POA_Subject_Area"
+        fn_fragment["poa_received"] = "_POA_Received"
+        fn_fragment["poa_research_organism"] = "_POA_Research_Organism"
+        fn_fragment["poa_abstract"] = "_POA_Abstract"
+        fn_fragment["poa_title"] = "_POA_Title"
+        fn_fragment["poa_keywords"] = "_POA_Keywords"
+        fn_fragment["poa_group_authors"] = "_POA_Group_Authors"
+        fn_fragment["poa_datasets"] = "_POA_Datasets"
+        fn_fragment["poa_funding"] = "_POA_Funding"
+        fn_fragment["poa_ethics"] = "_POA_Ethics"
 
         if file_list is None:
             file_list = self.ejp_bucket_file_list()

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -132,7 +132,8 @@ class TestProviderEJP(unittest.TestCase):
         ('poa_license', 'ejp_query_tool_query_id_178_POA_License_2014_03_19_eLife.csv'),
         ('poa_subject_area', 'ejp_query_tool_query_id_179_POA_Subject_Area_2014_03_19_eLife.csv'),
         ('poa_received', 'ejp_query_tool_query_id_180_POA_Received_2014_03_19_eLife.csv'),
-        ('poa_research_organism', 'ejp_query_tool_query_id_182_POA_Research_Organism_2014_03_19_eLife.csv'),
+        ('poa_research_organism',
+         'ejp_query_tool_query_id_182_POA_Research_Organism_2014_03_19_eLife.csv'),
     )
     @unpack
     def test_find_latest_s3_file_name(self, file_type, expected_s3_key_name,
@@ -146,7 +147,76 @@ class TestProviderEJP(unittest.TestCase):
         # assert results
         self.assertEqual(s3_key_name, expected_s3_key_name)
 
+    @patch('provider.ejp.EJP.ejp_bucket_file_list')
+    @data(
+        ('author', 'ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_06_10_eLife.csv'),
+        ('editor', 'ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_06_10_eLife.csv'),
+        ('poa_manuscript', 'ejp_query_tool_query_id_POA_Manuscript_2019_06_10_eLife.csv'),
+        ('poa_author', 'ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'),
+        ('poa_license', 'ejp_query_tool_query_id_POA_License_2019_06_10_eLife.csv'),
+        ('poa_subject_area', 'ejp_query_tool_query_id_POA_Subject_Area_2019_06_10_eLife.csv'),
+        ('poa_received', 'ejp_query_tool_query_id_POA_Received_2019_06_10_eLife.csv'),
+        ('poa_research_organism',
+         'ejp_query_tool_query_id_POA_Research_Organism_2019_06_10_eLife.csv'),
+        ('poa_abstract', 'ejp_query_tool_query_id_POA_Abstract_2019_06_10_eLife.csv'),
+        ('poa_title', 'ejp_query_tool_query_id_POA_Title_2019_06_10_eLife.csv'),
+        ('poa_keywords', 'ejp_query_tool_query_id_POA_Keywords_2019_06_10_eLife.csv'),
+        ('poa_group_authors', 'ejp_query_tool_query_id_POA_Group_Authors_2019_06_10_eLife.csv'),
+        ('poa_datasets', 'ejp_query_tool_query_id_POA_Datasets_2019_06_10_eLife.csv'),
+        ('poa_funding', 'ejp_query_tool_query_id_POA_Funding_2019_06_10_eLife.csv'),
+        ('poa_ethics', 'ejp_query_tool_query_id_POA_Ethics_2019_06_10_eLife.csv'),
+    )
+    @unpack
+    def test_find_latest_s3_file_name_mixed(self, file_type, expected_s3_key_name,
+                                            fake_ejp_bucket_file_list):
+        """mixture of old and new file naming find the latest CSV file names"""
+        bucket_list_file_old = os.path.join("tests", "test_data", "ejp_bucket_list.json")
+        bucket_list_file_new = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
+        # mock things
+        ejp_bucket_file_list = []
+        with open(bucket_list_file_old, 'r') as open_file:
+            ejp_bucket_file_list += json.loads(open_file.read())
+        with open(bucket_list_file_new, 'r') as open_file:
+            ejp_bucket_file_list += json.loads(open_file.read())
+        fake_ejp_bucket_file_list.return_value = ejp_bucket_file_list
+        # call the function
+        s3_key_name = self.ejp.find_latest_s3_file_name(file_type)
+        # assert results
+        self.assertEqual(s3_key_name, expected_s3_key_name)
 
+    @patch('provider.ejp.EJP.ejp_bucket_file_list')
+    @data(
+        ('author', 'ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_06_10_eLife.csv'),
+        ('editor', 'ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_06_10_eLife.csv'),
+        ('poa_manuscript', 'ejp_query_tool_query_id_POA_Manuscript_2019_06_10_eLife.csv'),
+        ('poa_author', 'ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'),
+        ('poa_license', 'ejp_query_tool_query_id_POA_License_2019_06_10_eLife.csv'),
+        ('poa_subject_area', 'ejp_query_tool_query_id_POA_Subject_Area_2019_06_10_eLife.csv'),
+        ('poa_received', 'ejp_query_tool_query_id_POA_Received_2019_06_10_eLife.csv'),
+        ('poa_research_organism',
+         'ejp_query_tool_query_id_POA_Research_Organism_2019_06_10_eLife.csv'),
+        ('poa_abstract', 'ejp_query_tool_query_id_POA_Abstract_2019_06_10_eLife.csv'),
+        ('poa_title', 'ejp_query_tool_query_id_POA_Title_2019_06_10_eLife.csv'),
+        ('poa_keywords', 'ejp_query_tool_query_id_POA_Keywords_2019_06_10_eLife.csv'),
+        ('poa_group_authors', 'ejp_query_tool_query_id_POA_Group_Authors_2019_06_10_eLife.csv'),
+        ('poa_datasets', 'ejp_query_tool_query_id_POA_Datasets_2019_06_10_eLife.csv'),
+        ('poa_funding', 'ejp_query_tool_query_id_POA_Funding_2019_06_10_eLife.csv'),
+        ('poa_ethics', 'ejp_query_tool_query_id_POA_Ethics_2019_06_10_eLife.csv'),
+    )
+    @unpack
+    def test_find_latest_s3_file_name_new(self, file_type, expected_s3_key_name,
+                                          fake_ejp_bucket_file_list):
+        """from new file naming find the latest CSV file names"""
+        bucket_list_file_new = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
+        # mock things
+        ejp_bucket_file_list = []
+        with open(bucket_list_file_new, 'r') as open_file:
+            ejp_bucket_file_list += json.loads(open_file.read())
+        fake_ejp_bucket_file_list.return_value = ejp_bucket_file_list
+        # call the function
+        s3_key_name = self.ejp.find_latest_s3_file_name(file_type)
+        # assert results
+        self.assertEqual(s3_key_name, expected_s3_key_name)
 
 
 if __name__ == '__main__':

--- a/tests/test_data/ejp_bucket_list_new.json
+++ b/tests/test_data/ejp_bucket_list_new.json
@@ -1,0 +1,162 @@
+[
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_04e)_DEs_assigned_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_04e)_DEs_assigned_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Manuscript_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Manuscript_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Author_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_License_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_License_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Subject_Area_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Subject_Area_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Received_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Received_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Research_Organism_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Research_Organism_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Group_Authors_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Group_Authors_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Title_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Title_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Datasets_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Datasets_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Funding_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Funding_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Ethics_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Ethics_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Keywords_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Keywords_2019_06_10_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1559260800,
+        "last_modified": "2019-05-31T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Abstract_2019_05_31_eLife.csv"
+    },
+    {
+        "last_modified_timestamp": 1560124800,
+        "last_modified": "2019-06-10T00:00:00.000Z",
+        "name": "ejp_query_tool_query_id_POA_Abstract_2019_06_10_eLife.csv"
+    }
+]


### PR DESCRIPTION
Very basic way to satisfy item one on issue https://github.com/elifesciences/elife-bot/issues/916.

The file name fragments used in matching CSV files names is shortened, which allows matching both the old and new file naming formats.

I expanded the tests to show how it works on both the old CSV file names, a mixture of old and new names together, or just the new file names.

As mentioned on the issue, once the file names are switched over, then we can expand the file name matches to be longer, for example `"ejp_query_tool_query_id_POA_Manuscript"` instead of just `"_POA_Manuscript"` just in case a query with a similar name is created. Since it is using `re.search`, the pattern could also incorporate matching the `_2019_06_10_eLife.csv` portion of file names if the date numbering is always consistent, which it has been so far.

I have omitted additional refactoring of the S3 bucket operations at this time, so this can be reviewed and possibly deployed soon, in case the EJP file name change is imminent.