### PR TITLE
Copy glencoe retry

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -1,5 +1,4 @@
 import json
-import time
 import os
 import requests
 from activity.objects import Activity
@@ -147,9 +146,8 @@ class activity_CopyGlencoeStillImages(Activity):
         first_chars_error = str(exception)[:21]
         if first_chars_error == "article has no videos":
             if has_videos:
-                # article has videos but Glencoe 404, wait and then retry again
+                # article has videos but Glencoe 404, retry this activity again
                 end_event = self.end_event_glencoe_retry(exception, article_id, version, run)
-                time.sleep(60)
                 return end_event, self.ACTIVITY_TEMPORARY_FAILURE
             else:
                 end_event = self.end_event_glencoe_404(article_id, version, run)

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -58,21 +58,22 @@ class activity_CopyGlencoeStillImages(Activity):
         session = get_session(self.settings, data, run)
         article_id = session.get_value('article_id')
         version = session.get_value('version')
-        file_name = session.get_value('file_name')
-        expanded_folder = session.get_value('expanded_folder')
-        poa = False
-        if "poa" in file_name:
-            poa = True
-        # check XML for if it has videos
-        jats_file = download_jats(
-            self.settings, expanded_folder, self.get_tmp_dir(), self.logger)
-        with open(jats_file, 'r') as open_file:
-            has_videos = glencoe_check.has_videos(open_file.read())
+        poa = bool("poa" in session.get_value('file_name'))
+        has_videos = self.get_has_videos(session.get_value('expanded_folder'))
         # start the image download events
         (start_msg, end_msg, success) = self.get_events(article_id, poa, version, run, has_videos)
         self.emit_monitor_event(*start_msg)
         self.emit_monitor_event(*end_msg)
         return success
+
+    def get_has_videos(self, expanded_folder):
+        """download the session JATS XML file and see if it has videos inside"""
+        has_videos = None
+        jats_file = download_jats(
+            self.settings, expanded_folder, self.get_tmp_dir(), self.logger)
+        with open(jats_file, 'r') as open_file:
+            has_videos = glencoe_check.has_videos(open_file.read())
+        return has_videos
 
     def get_events(self, article_id, poa, version=None, run=None, has_videos=None):
 

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -1,12 +1,12 @@
-from activity.objects import Activity
 import json
 import time
+import os
+import requests
+from activity.objects import Activity
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from provider.article_processing import download_jats
 import provider.glencoe_check as glencoe_check
-import os
-import requests
 
 
 """
@@ -40,7 +40,7 @@ class activity_CopyGlencoeStillImages(Activity):
             if 'standalone' in data and data['standalone']:
                 return self.do_as_standalone(data)
             return self.do_as_session(data)
-        except Exception as e:
+        except:
             self.logger.exception("Error starting Copy Glencoe Still Images activity")
             return self.ACTIVITY_PERMANENT_FAILURE
 
@@ -86,7 +86,7 @@ class activity_CopyGlencoeStillImages(Activity):
     def process_poa(self, article_id, version=None, run=None):
         """poa are simple, they do not have videos"""
         end_event = [self.settings, article_id, version, run, self.pretty_name, "end",
-                        "Article is POA, no need for video check yet. " + article_id]
+                     "Article is POA, no need for video check yet. " + article_id]
         return end_event, self.ACTIVITY_SUCCESS
 
     def process_vor(self, article_id, version=None, run=None, has_videos=None):
@@ -103,7 +103,7 @@ class activity_CopyGlencoeStillImages(Activity):
     def end_event_glencoe_retry(self, exception, article_id, version, run):
         self.logger.info(exception)
         return [self.settings, article_id, version, run, self.pretty_name, "error",
-                "Glencoe video is not available for article " + article_id + 
+                "Glencoe video is not available for article " + article_id +
                 '; message: ' + str(exception)]
 
     def end_event_glencoe_404(self, article_id, version, run):
@@ -137,8 +137,8 @@ class activity_CopyGlencoeStillImages(Activity):
             end_event, result = self.handle_glencoe_metadata_assertion(
                 exception, article_id, version, run, has_videos)
             return metadata, end_event, result
-        except Exception as e:
-            end_event = self.end_event_checking_error(e, article_id, version, run)
+        except Exception as exception:
+            end_event = self.end_event_checking_error(exception, article_id, version, run)
             return metadata, end_event, self.ACTIVITY_PERMANENT_FAILURE
 
     def handle_glencoe_metadata_assertion(self, exception, article_id, version, run, has_videos):
@@ -154,7 +154,7 @@ class activity_CopyGlencoeStillImages(Activity):
             else:
                 end_event = self.end_event_glencoe_404(article_id, version, run)
                 return end_event, self.ACTIVITY_SUCCESS
-        end_event = self.end_event_checking_error(e, article_id, version, run)
+        end_event = self.end_event_checking_error(exception, article_id, version, run)
         return end_event, self.ACTIVITY_PERMANENT_FAILURE
 
     def process_glencoe_metadata(self, metadata, article_id, version, run):
@@ -162,13 +162,11 @@ class activity_CopyGlencoeStillImages(Activity):
         try:
             glencoe_jpgs = glencoe_check.jpg_href_values(metadata)
             self.logger.info("glencoe_jpgs from glencoe metadata " + str(glencoe_jpgs))
-            bad_files = []
             if len(glencoe_jpgs) > 0:
                 cdn_still_jpgs = self.store_jpgs(glencoe_jpgs, article_id)
 
-                bad_files = self.validate_jpgs_against_cdn(self.list_files_from_cdn(article_id),
-                                                            cdn_still_jpgs,
-                                                            article_id)
+                self.validate_jpgs_against_cdn(
+                    self.list_files_from_cdn(article_id), cdn_still_jpgs)
 
             dashboard_message = ("Finished Copying Glencoe still images to CDN: %s" + \
                                 "Article: %s") % \
@@ -176,12 +174,12 @@ class activity_CopyGlencoeStillImages(Activity):
             self.logger.info(dashboard_message)
 
             end_event = [self.settings, article_id, version, run, self.pretty_name, "end",
-                            dashboard_message]
+                         dashboard_message]
             return end_event, self.ACTIVITY_SUCCESS
 
-        except Exception as e:
+        except Exception as exception:
             self.logger.exception("Error when copying Glencoe still images.")
-            end_event = self.end_event_copying_error(e, article_id, version, run)
+            end_event = self.end_event_copying_error(exception, article_id, version, run)
             return end_event, self.ACTIVITY_PERMANENT_FAILURE
 
     def store_jpgs(self, glencoe_jpgs, article_id):
@@ -201,43 +199,45 @@ class activity_CopyGlencoeStillImages(Activity):
 
     def store_file(self, path, article_id):
         storage = storage_context(self.settings)
-        r = requests.get(path)
-        if r.status_code == 200:
+        request = requests.get(path)
+        if request.status_code == 200:
             resource = self.s3_resources(path, article_id)
             self.logger.info("S3 resource: " + resource)
             jpg_filename = os.path.split(resource)[-1]
             storage.set_resource_from_string(
                 resource,
-                r.content,
-                content_type=r.headers['content-type']
+                request.content,
+                content_type=request.headers['content-type']
             )
             return jpg_filename
         else:
-            raise RuntimeError("Glencoe returned a %s status code for %s" % (r.status_code, path))
+            raise RuntimeError("Glencoe returned a %s status code for %s" % (request.status_code, path))
 
 
     def list_files_from_cdn(self, article_id):
         storage = storage_context(self.settings)
-        article_path_in_cdn = self.settings.storage_provider + "://" + \
-                              self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
-                              article_id
+        article_path_in_cdn = (
+            self.settings.storage_provider + "://" + self.settings.publishing_buckets_prefix +
+            self.settings.ppp_cdn_bucket + "/" + article_id)
         return storage.list_resources(article_path_in_cdn)
 
-    def validate_jpgs_against_cdn(self, cdn_all_files, cdn_still_jpgs, article_id):
+    def validate_jpgs_against_cdn(self, cdn_all_files, cdn_still_jpgs):
         """checks that for each element of cdn_still_jpgs there are two files in the CDN.
 
         They are supposed to be a video and its still image"""
-        cdn_still_jpgs_no_extension = self._remove_extension(cdn_still_jpgs)
+        cdn_still_jpgs_no_extension = remove_extension(cdn_still_jpgs)
         self.logger.info("cdn_still_jpgs_no_extension " + str(cdn_still_jpgs_no_extension))
-        cdn_all_files_no_extension = self._remove_extension(cdn_all_files)
+        cdn_all_files_no_extension = remove_extension(cdn_all_files)
         self.logger.info("files_in_cdn_no_extention " + str(cdn_all_files_no_extension))
         cdn_still_jpgs_without_video = []
         for still in cdn_still_jpgs_no_extension:
-            if len(list(filter(lambda filename: filename == still, cdn_all_files_no_extension))) != 2:
+            if (len(list(filter(
+                    lambda filename: filename == still, cdn_all_files_no_extension))) != 2):
                 cdn_still_jpgs_without_video.append(still)
 
         self.logger.info("cdn_still_jpgs_without_video " + str(cdn_still_jpgs_without_video))
         return cdn_still_jpgs_without_video
 
-    def _remove_extension(self, filenames):
-        return list(map(lambda filename: os.path.splitext(filename)[0], filenames))
+
+def remove_extension(filenames):
+    return list(map(lambda filename: os.path.splitext(filename)[0], filenames))

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -16,6 +16,7 @@ activity_CopyGlencoeStillImages.py activity
 class ValidationException(RuntimeError):
     pass
 
+
 class activity_CopyGlencoeStillImages(Activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_CopyGlencoeStillImages, self).__init__(
@@ -166,9 +167,8 @@ class activity_CopyGlencoeStillImages(Activity):
                 self.validate_jpgs_against_cdn(
                     self.list_files_from_cdn(article_id), cdn_still_jpgs)
 
-            dashboard_message = ("Finished Copying Glencoe still images to CDN: %s" + \
-                                "Article: %s") % \
-                                (cdn_still_jpgs, article_id)
+            dashboard_message = ("Finished Copying Glencoe still images to CDN: %sArticle: %s" %
+                                 (cdn_still_jpgs, article_id))
             self.logger.info(dashboard_message)
 
             end_event = [self.settings, article_id, version, run, self.pretty_name, "end",
@@ -190,9 +190,9 @@ class activity_CopyGlencoeStillImages(Activity):
     def s3_resources(self, path, article_id):
         filename = os.path.split(path)[1]
         filename = glencoe_check.force_article_id(filename, article_id)
-        cdn = self.settings.storage_provider + "://" + \
-               self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" + \
-               article_id + "/" + filename
+        cdn = (self.settings.storage_provider + "://" +
+               self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" +
+               article_id + "/" + filename)
         return cdn
 
     def store_file(self, path, article_id):
@@ -209,8 +209,8 @@ class activity_CopyGlencoeStillImages(Activity):
             )
             return jpg_filename
         else:
-            raise RuntimeError("Glencoe returned a %s status code for %s" % (request.status_code, path))
-
+            raise RuntimeError("Glencoe returned a %s status code for %s" %
+                               (request.status_code, path))
 
     def list_files_from_cdn(self, article_id):
         storage = storage_context(self.settings)

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -55,7 +55,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Given
         activity_data = test_activity_data.data_example_before_publish
         activity_data['standalone'] = True
-        activity_data['standalone_is_poa'] = False
+        activity_data['standalone_is_poa'] = True
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
         fake_processing_storage_context.return_value = FakeStorageContext()
@@ -222,8 +222,8 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         cdn_still_jpgs = test_activity_data.cdn_folder_jpgs_article_07398
 
         # When
-        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(cdn_all_files, cdn_still_jpgs,
-                                                                                 "07398")
+        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(
+            cdn_all_files, cdn_still_jpgs)
 
         # Then
         self.assertEqual(0, len(result_bad_files))
@@ -236,8 +236,8 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         cdn_still_jpgs = ["elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg"]
 
         # When
-        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(cdn_all_files, cdn_still_jpgs,
-                                                                                 "00230")
+        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(
+            cdn_all_files, cdn_still_jpgs)
 
         # Then
         self.assertEqual(0, len(result_bad_files))
@@ -252,8 +252,8 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
                              "elife-1234500230-media3-v1.jpg"]
 
         # When
-        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(cdn_all_files, cdn_still_jpgs,
-                                                                                 "00230")
+        result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(
+            cdn_all_files, cdn_still_jpgs)
 
         # Then
         self.assertEqual(1, len(result_bad_files))

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -40,6 +40,13 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
 
+    @patch.object(activity_CopyGlencoeStillImages, 'do_as_session')
+    def test_do_activity_exception(self, fake_do_as_session):
+        """test do_activity exception for coverage"""
+        fake_do_as_session.side_effect = Exception("An error occurred")
+        result = self.copyglencoestillimages.do_activity()
+        self.assertEqual(self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE, result)
+
     @patch('provider.article_processing.storage_context')
     @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -1,15 +1,16 @@
 import unittest
-import tests.activity.settings_mock as settings_mock
-from activity.activity_CopyGlencoeStillImages import activity_CopyGlencoeStillImages
 from mock import patch, MagicMock
+from activity.activity_CopyGlencoeStillImages import activity_CopyGlencoeStillImages
+import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeSession, FakeStorageContext, FakeLogger
 import tests.activity.test_activity_data as test_activity_data
-import provider.glencoe_check as glencoe_check
+
 
 class TestCopyGlencoeStillImages(unittest.TestCase):
 
     def setUp(self):
-        self.copyglencoestillimages = activity_CopyGlencoeStillImages(settings_mock, None, None, None, None)
+        self.copyglencoestillimages = activity_CopyGlencoeStillImages(
+            settings_mock, None, None, None, None)
         self.copyglencoestillimages.logger = FakeLogger()
 
     @patch('provider.article_processing.storage_context')
@@ -25,14 +26,15 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
                          fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
+        fake_emit.return_value = None
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
         fake_store_jpgs.return_value = test_activity_data.jpgs_added_in_cdn
-        fake_list_files_from_cdn.return_value = test_activity_data.cdn_folder_files + \
-                                                test_activity_data.jpgs_added_in_cdn
+        fake_list_files_from_cdn.return_value = (
+            test_activity_data.cdn_folder_files + test_activity_data.jpgs_added_in_cdn)
 
         # When
         result = self.copyglencoestillimages.do_activity(activity_data)
@@ -63,14 +65,15 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         activity_data = test_activity_data.data_example_before_publish
         activity_data['standalone'] = True
         activity_data['standalone_is_poa'] = True
+        fake_emit.return_value = None
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
         fake_store_jpgs.return_value = test_activity_data.jpgs_added_in_cdn
-        fake_list_files_from_cdn.return_value = test_activity_data.cdn_folder_files + \
-                                                test_activity_data.jpgs_added_in_cdn
+        fake_list_files_from_cdn.return_value = (
+            test_activity_data.cdn_folder_files + test_activity_data.jpgs_added_in_cdn)
 
         # When
         result = self.copyglencoestillimages.do_activity(activity_data)
@@ -82,15 +85,16 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('provider.lax_provider.get_xml_file_name')
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
-    def test_do_activity_success_POA(self, fake_emit, fake_session, fake_get_xml_file_name,
+    def test_do_activity_success_poa(self, fake_emit, fake_session, fake_get_xml_file_name,
                                      fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
-        session_POA = test_activity_data.session_example.copy()
+        session_poa = test_activity_data.session_example.copy()
+        fake_emit.return_value = None
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
-        session_POA['file_name'] = 'elife-00353-poa-v1.zip'
-        fake_session.return_value = FakeSession(session_POA)
+        session_poa['file_name'] = 'elife-00353-poa-v1.zip'
+        fake_session.return_value = FakeSession(session_poa)
 
         # When
         result = self.copyglencoestillimages.do_activity(activity_data)
@@ -105,11 +109,12 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
-    def test_do_activity_error(self, fake_emit, fake_session, fake_storage_context, 
+    def test_do_activity_error(self, fake_emit, fake_session, fake_storage_context,
                                fake_glencoe_metadata, fake_store_jpgs, fake_get_xml_file_name,
                                fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
+        fake_emit.return_value = None
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
         fake_processing_storage_context.return_value = FakeStorageContext()
@@ -122,43 +127,51 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
 
         # Then
         self.assertEqual(result, self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE)
-        fake_emit.assert_called_with(settings_mock,
-                                     activity_data["article_id"],
-                                     activity_data["version"],
-                                     activity_data["run"],
-                                     self.copyglencoestillimages.pretty_name,
-                                     "error",
-                                     "An error occurred when checking/copying Glencoe still images. Article " +
-                                     activity_data["article_id"] + "; message: Something went wrong!")
+        fake_emit.assert_called_with(
+            settings_mock,
+            activity_data["article_id"],
+            activity_data["version"],
+            activity_data["run"],
+            self.copyglencoestillimages.pretty_name,
+            "error",
+            "An error occurred when checking/copying Glencoe still images. Article " +
+            activity_data["article_id"] + "; message: Something went wrong!")
 
     @patch('provider.glencoe_check.metadata')
     def test_get_glencoe_metadata_no_videos_for_article(self, fake_glencoe_metadata):
         # Given
-        fake_glencoe_metadata.side_effect = AssertionError("article has no videos - url requested: ...")
+        fake_glencoe_metadata.side_effect = AssertionError(
+            "article has no videos - url requested: ...")
         # When
         has_videos = False
         metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(
-            test_activity_data.data_example_before_publish.get('article_id'), 
-            test_activity_data.data_example_before_publish.get('version'), 
-            test_activity_data.data_example_before_publish.get('run'), 
+            test_activity_data.data_example_before_publish.get('article_id'),
+            test_activity_data.data_example_before_publish.get('version'),
+            test_activity_data.data_example_before_publish.get('run'),
             has_videos)
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
+        self.assertIsNone(metadata)
+        self.assertEqual(len(end_event), 7)
 
     @patch('time.sleep')
     @patch('provider.glencoe_check.metadata')
     def test_get_glencoe_metadata_retry(self, fake_glencoe_metadata, fake_sleep):
         # Given
-        fake_glencoe_metadata.side_effect = AssertionError("article has no videos - url requested: ...")
+        fake_glencoe_metadata.side_effect = AssertionError(
+            "article has no videos - url requested: ...")
+        fake_sleep.return_value = None
         # When
         has_videos = True
         metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(
-            test_activity_data.data_example_before_publish.get('article_id'), 
-            test_activity_data.data_example_before_publish.get('version'), 
-            test_activity_data.data_example_before_publish.get('run'), 
+            test_activity_data.data_example_before_publish.get('article_id'),
+            test_activity_data.data_example_before_publish.get('version'),
+            test_activity_data.data_example_before_publish.get('run'),
             has_videos)
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_TEMPORARY_FAILURE, result)
+        self.assertIsNone(metadata)
+        self.assertEqual(len(end_event), 7)
 
     @patch('provider.glencoe_check.metadata')
     def test_get_glencoe_metadata_unhandled_assertion(self, fake_glencoe_metadata):
@@ -167,12 +180,14 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # When
         has_videos = False
         metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(
-            test_activity_data.data_example_before_publish.get('article_id'), 
-            test_activity_data.data_example_before_publish.get('version'), 
-            test_activity_data.data_example_before_publish.get('run'), 
+            test_activity_data.data_example_before_publish.get('article_id'),
+            test_activity_data.data_example_before_publish.get('version'),
+            test_activity_data.data_example_before_publish.get('run'),
             has_videos)
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE, result)
+        self.assertIsNone(metadata)
+        self.assertEqual(len(end_event), 7)
 
     @patch('provider.glencoe_check.metadata')
     def test_get_glencoe_metadata_exception(self, fake_glencoe_metadata):
@@ -181,12 +196,14 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # When
         has_videos = True
         metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(
-            test_activity_data.data_example_before_publish.get('article_id'), 
-            test_activity_data.data_example_before_publish.get('version'), 
-            test_activity_data.data_example_before_publish.get('run'), 
+            test_activity_data.data_example_before_publish.get('article_id'),
+            test_activity_data.data_example_before_publish.get('version'),
+            test_activity_data.data_example_before_publish.get('run'),
             has_videos)
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE, result)
+        self.assertIsNone(metadata)
+        self.assertEqual(len(end_event), 7)
 
     def test_validate_jpgs_against_cdn(self):
         # Given
@@ -202,9 +219,10 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
 
     def test_validate_pgs_against_cdn_long_article_ids(self):
         # Given
-        cdn_all_files = ["elife-1234500230-media1-v1.wmv", "elife-1234500230-media2-v1.mp4",
-                        "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
-                        "elife-1234500230-fig1-figsupp1-v2-1084w.jpg"]
+        cdn_all_files = [
+            "elife-1234500230-media1-v1.wmv", "elife-1234500230-media2-v1.mp4",
+            "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
+            "elife-1234500230-fig1-figsupp1-v2-1084w.jpg"]
         cdn_still_jpgs = ["elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg"]
 
         # When
@@ -214,14 +232,15 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Then
         self.assertEqual(0, len(result_bad_files))
 
-
     def test_validate_pgs_against_cdn_long_article_ids_one_missing(self):
         # Given
-        cdn_all_files = ["elife-1234500230-media1-v1.wmv", "elife-1234500230-media2-v1.mp4",
-                        "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
-                        "elife-1234500230-fig1-figsupp1-v2-1084w.jpg"]
-        cdn_still_jpgs = ["elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
-                             "elife-1234500230-media3-v1.jpg"]
+        cdn_all_files = [
+            "elife-1234500230-media1-v1.wmv", "elife-1234500230-media2-v1.mp4",
+            "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
+            "elife-1234500230-fig1-figsupp1-v2-1084w.jpg"]
+        cdn_still_jpgs = [
+            "elife-1234500230-media1-v1.jpg", "elife-1234500230-media2-v1.jpg",
+            "elife-1234500230-media3-v1.jpg"]
 
         # When
         result_bad_files = self.copyglencoestillimages.validate_jpgs_against_cdn(
@@ -232,12 +251,15 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
 
     @patch('requests.get')
     @patch('activity.activity_CopyGlencoeStillImages.storage_context')
-    def test_store_file_according_to_the_current_article_id_whatever_is_the_filename_on_glencoe(self, fake_storage_context, fake_requests_get):
+    def test_store_file_according_to_the_current_article_id_whatever_is_the_filename_on_glencoe(
+            self, fake_storage_context, fake_requests_get):
         fake_storage_context.return_value = FakeStorageContext()
         fake_requests_get.return_value = MagicMock()
         fake_requests_get.return_value.status_code = 200
-        cdn_jpg_filename = self.copyglencoestillimages.store_file("http://glencoe.com/some-dir/elife-00666-media1.jpg", "12345600666")
+        cdn_jpg_filename = self.copyglencoestillimages.store_file(
+            "http://glencoe.com/some-dir/elife-00666-media1.jpg", "12345600666")
         self.assertEqual(cdn_jpg_filename, "elife-12345600666-media1.jpg")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -48,6 +48,37 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
+    def test_do_activity_success_standalone(
+            self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
+            fake_store_jpgs, fake_list_files_from_cdn, fake_get_xml_file_name,
+            fake_processing_storage_context):
+        # Given
+        activity_data = test_activity_data.data_example_before_publish
+        activity_data['standalone'] = True
+        activity_data['standalone_is_poa'] = False
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_session.return_value = FakeSession(test_activity_data.session_example)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
+        fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
+        fake_store_jpgs.return_value = test_activity_data.jpgs_added_in_cdn
+        fake_list_files_from_cdn.return_value = test_activity_data.cdn_folder_files + \
+                                                test_activity_data.jpgs_added_in_cdn
+
+        # When
+        result = self.copyglencoestillimages.do_activity(activity_data)
+
+        # Then
+        self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
+
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
+    @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
+    @patch('provider.glencoe_check.metadata')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
+    @patch('activity.activity_CopyGlencoeStillImages.get_session')
+    @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_success_no_videos_for_article(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
                          fake_store_jpgs, fake_list_files_from_cdn, fake_get_xml_file_name,
                          fake_processing_storage_context):

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -161,6 +161,20 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_TEMPORARY_FAILURE, result)
 
     @patch('provider.glencoe_check.metadata')
+    def test_get_glencoe_metadata_unhandled_assertion(self, fake_glencoe_metadata):
+        # Given
+        fake_glencoe_metadata.side_effect = AssertionError("")
+        # When
+        has_videos = False
+        metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(
+            test_activity_data.data_example_before_publish.get('article_id'), 
+            test_activity_data.data_example_before_publish.get('version'), 
+            test_activity_data.data_example_before_publish.get('run'), 
+            has_videos)
+        # Then
+        self.assertEqual(self.copyglencoestillimages.ACTIVITY_PERMANENT_FAILURE, result)
+
+    @patch('provider.glencoe_check.metadata')
     def test_get_glencoe_metadata_exception(self, fake_glencoe_metadata):
         # Given
         fake_glencoe_metadata.side_effect = Exception("An error occurred")

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -154,13 +154,11 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         self.assertIsNone(metadata)
         self.assertEqual(len(end_event), 7)
 
-    @patch('time.sleep')
     @patch('provider.glencoe_check.metadata')
-    def test_get_glencoe_metadata_retry(self, fake_glencoe_metadata, fake_sleep):
+    def test_get_glencoe_metadata_retry(self, fake_glencoe_metadata):
         # Given
         fake_glencoe_metadata.side_effect = AssertionError(
             "article has no videos - url requested: ...")
-        fake_sleep.return_value = None
         # When
         has_videos = True
         metadata, end_event, result = self.copyglencoestillimages.get_glencoe_metadata(

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -12,6 +12,8 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         self.copyglencoestillimages = activity_CopyGlencoeStillImages(settings_mock, None, None, None, None)
         self.copyglencoestillimages.logger = FakeLogger()
 
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
@@ -19,11 +21,14 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
-                         fake_store_jpgs, fake_list_files_from_cdn):
+                         fake_store_jpgs, fake_list_files_from_cdn, fake_get_xml_file_name,
+                         fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
         fake_store_jpgs.return_value = test_activity_data.jpgs_added_in_cdn
         fake_list_files_from_cdn.return_value = test_activity_data.cdn_folder_files + \
@@ -35,6 +40,8 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
 
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
@@ -42,11 +49,14 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_success_no_videos_for_article(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
-                         fake_store_jpgs, fake_list_files_from_cdn):
+                         fake_store_jpgs, fake_list_files_from_cdn, fake_get_xml_file_name,
+                         fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.side_effect = AssertionError("article has no videos - url requested: ...")
 
         # When
@@ -55,12 +65,17 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
 
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
-    def test_do_activity_success_POA(self, fake_emit, fake_session):
+    def test_do_activity_success_POA(self, fake_emit, fake_session, fake_get_xml_file_name,
+                                     fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
         session_POA = test_activity_data.session_example.copy()
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         session_POA['file_name'] = 'elife-00353-poa-v1.zip'
         fake_session.return_value = FakeSession(session_POA)
 
@@ -70,16 +85,22 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         # Then
         self.assertEqual(self.copyglencoestillimages.ACTIVITY_SUCCESS, result)
 
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
     @patch('activity.activity_CopyGlencoeStillImages.storage_context')
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
-    def test_do_activity_error(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata, fake_store_jpgs):
+    def test_do_activity_error(self, fake_emit, fake_session, fake_storage_context, 
+                               fake_glencoe_metadata, fake_store_jpgs, fake_get_xml_file_name,
+                               fake_processing_storage_context):
         # Given
         activity_data = test_activity_data.data_example_before_publish
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
         fake_store_jpgs.side_effect = Exception("Something went wrong!")
 
@@ -97,7 +118,46 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
                                      "An error occurred when checking/copying Glencoe still images. Article " +
                                      activity_data["article_id"] + "; message: Something went wrong!")
 
+    @patch('time.sleep')
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch('provider.glencoe_check.metadata')
+    @patch('activity.activity_CopyGlencoeStillImages.storage_context')
+    @patch('activity.activity_CopyGlencoeStillImages.get_session')
+    @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
+    def test_do_activity_retry(self, fake_emit, fake_session, fake_storage_context, 
+                               fake_glencoe_metadata, fake_get_xml_file_name,
+                               fake_processing_storage_context, fake_sleep):
+        # Given
+        activity_data = test_activity_data.data_example_before_publish.copy()
+        activity_data['expanded_folder'] = 'email_video'
+        activity_data['article_id'] = '00007'
+        fake_storage_context.return_value = FakeStorageContext()
+        session_video_xml = test_activity_data.session_example.copy()
+        session_video_xml['expanded_folder'] = 'email_video'
+        session_video_xml['article_id'] = '00007'
+        fake_session.return_value = FakeSession(session_video_xml)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00007-v1.xml"
+        fake_glencoe_metadata.side_effect = AssertionError("article has no videos - url requested: ...")
 
+        # When
+        result = self.copyglencoestillimages.do_activity(activity_data)
+
+        # Then
+        self.assertEqual(result, self.copyglencoestillimages.ACTIVITY_TEMPORARY_FAILURE)
+        fake_emit.assert_called_with(settings_mock,
+                                     activity_data["article_id"],
+                                     activity_data["version"],
+                                     activity_data["run"],
+                                     self.copyglencoestillimages.pretty_name,
+                                     "error",
+                                     "Glencoe video is not available for article " +
+                                     activity_data["article_id"] + 
+                                     "; message: article has no videos - url requested: ...")
+
+    @patch('provider.article_processing.storage_context')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(activity_CopyGlencoeStillImages, 'list_files_from_cdn')
     @patch.object(activity_CopyGlencoeStillImages, 'store_jpgs')
     @patch('provider.glencoe_check.metadata')
@@ -105,12 +165,15 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     @patch('activity.activity_CopyGlencoeStillImages.get_session')
     @patch.object(activity_CopyGlencoeStillImages, 'emit_monitor_event')
     def test_do_activity_bad_files(self, fake_emit, fake_session, fake_storage_context, fake_glencoe_metadata,
-                                   fake_store_jpgs, fake_list_files_from_cdn):
+                                   fake_store_jpgs, fake_list_files_from_cdn, fake_get_xml_file_name,
+                                   fake_processing_storage_context):
         # updated July 2018: bad files will not cause an error, we do not need to check for these
         # Given
         activity_data = test_activity_data.data_example_before_publish
         fake_storage_context.return_value = FakeStorageContext()
         fake_session.return_value = FakeSession(test_activity_data.session_example)
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "elife-00353-v1.xml"
         fake_glencoe_metadata.return_value = test_activity_data.glencoe_metadata
         self.copyglencoestillimages.logger = MagicMock()
         fake_list_files_from_cdn.return_value = test_activity_data.cdn_folder_files

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -10,8 +10,8 @@ bucket_dest_file_name = "test_dest.json"
 session_example = {
             'version': '1',
             'article_id': '00353',
-            'run': '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
-            'expanded_folder': '00353.1/1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
+            'run': 'cf9c7e86-7355-4bb4-b48e-0bc284221251',
+            'expanded_folder': '00353.1/cf9c7e86-7355-4bb4-b48e-0bc284221251',
             'update_date': '2012-12-13T00:00:00Z',
             'file_name': 'elife-00353-vor-v1.zip',
             'filename_last_element': 'elife-00353-vor-r1.zip'


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/912

The commit from June 12th is where I think I figured out where to `time.sleep(60)` when trying to copy Glencoe still images. It relies on also getting a copy of the article XML (as made available from session data), and if there are videos in the XML, but Glencoe request is a `404`, then we should wait for Glencoe to finish processing videos, because they're not ready yet.

I was a little confused by all the options of poa / non-poa, Glencoe assertions or exceptions. The tests I added had to mock many of the modules, as the other tests for `do_activity()` often do.

Today, I refactored the activity code as best I could see doing it for some improvements. 
- The `standalone`, `poa` and `vor` logic is slightly more separate. 
- There is only one situation (when processing `vor`) that produces a `start_event` and that is moved.
- I moved the `end_event` building to their own methods for (hopefully) better readability
- Getting Glencoe `metadata` was separated from processing the metadata, to more clearly define when we look for requests status code assertions.

There's room for more simplification of the test cases, by testing functions other than `do_activity()` in some cases, but it might loose some features such as testing the actual messages emitted to the queue.

@giorgiosironi I wonder if there is feedback you wish to provide on this PR please?

I'm fairly confident the actual functionality and integrity of the activity remains the same, and I really only added a new situation that returns `self.ACTIVITY_TEMPORARY_FAILURE` after the `time.sleep(60)` to avoid the failure of missing still images reported on the dashboard.
