### PR TITLE
PMC resupply clean-up

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -193,7 +193,7 @@ class activity_CreateDigestMediumPost(Activity):
             approve_status = False
 
         # check silent correction
-        if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
+        if run_type == "silent-correction":
             approve_status = False
         else:
             first_vor_status = digest_provider.approve_by_first_vor(

--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -57,7 +57,7 @@ class activity_EmailVideoArticlePublished(Activity):
             return self.ACTIVITY_SUCCESS
 
         # do not send if silent-correction
-        if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
+        if run_type == "silent-correction":
             self.logger.info(
                 ("Silent correction of article %s " +
                  "no email to send in Email Video Article Published ") % article_id)

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -218,7 +218,7 @@ class activity_IngestDigestToEndpoint(Activity):
             self.settings, self.logger, article_id, run_type, version)
         first_vor_status = digest_provider.approve_by_first_vor(self.settings, self.logger, article_id, version, status)
         if (first_vor_status is False and
-                run_type not in ["silent-correction", "silent-correction-pmc-resupply"]):
+                run_type != "silent-correction"):
             # not the first vor and not a silent correction, do not approve
             approve_status = False
         elif run_type_status is False:

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -105,13 +105,9 @@ class activity_PubRouterDeposit(Activity):
 
         for article in self.articles_approved:
             # Start a workflow for each article this is approved to publish
-            if self.workflow in ["PMC", "PMC-Resupply"]:
-                if self.workflow == "PMC-Resupply":
-                    folder = "resupplies"
-                else:
-                    folder = ""
+            if self.workflow == "PMC":
                 zip_file_name = self.archive_zip_file_name(article)
-                starter_status = self.start_pmc_deposit_workflow(article, zip_file_name, folder)
+                starter_status = self.start_pmc_deposit_workflow(article, zip_file_name,)
             else:
                 starter_status = self.start_ftp_article_workflow(article)
 
@@ -161,8 +157,6 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/outbox/"
         elif workflow == "PMC":
             return "pmc/outbox/"
-        elif workflow == "PMC-Resupply":
-            return "pmc_resupply/outbox/"
         elif workflow == "CNPIEC":
             return "cnpiec/outbox/"
         elif workflow == "CNKI":
@@ -186,8 +180,6 @@ class activity_PubRouterDeposit(Activity):
             return "scopus/published/"
         elif workflow == "PMC":
             return "pmc/published/"
-        elif workflow == "PMC-Resupply":
-            return "pmc_resupply/published/"
         elif workflow == "CNPIEC":
             return "cnpiec/published/"
         elif workflow == "CNKI":
@@ -456,7 +448,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ['PMC', 'PMC-Resupply']:
+        if workflow != 'PMC':
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(article.doi, workflow)
                 if was_ever_published is True:
@@ -478,7 +470,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if a PMC zip file exists for this article
-        if workflow not in ['PMC', 'PMC-Resupply']:
+        if workflow != 'PMC':
             for article in articles:
                 if not self.does_source_zip_exist_from_s3(doi_id=article.doi_id):
                     if self.logger:
@@ -489,7 +481,7 @@ class activity_PubRouterDeposit(Activity):
                     remove_article_doi.append(article.doi)
 
         # For PMC workflows, check the archive zip file exists
-        if workflow in ['PMC', 'PMC-Resupply']:
+        if workflow == 'PMC':
             for article in articles:
                 zip_file_name = self.archive_zip_file_name(article)
                 if not zip_file_name:

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -106,7 +106,6 @@ def outbox_map():
     outboxes = OrderedDict()
     outboxes["pubmed"] = "pubmed/outbox/"
     outboxes["pmc"] = "pmc/outbox/"
-    outboxes["pmc_resupply"] = "pmc_resupply/outbox/"
     outboxes["publication_email"] = "publication_email/outbox/"
     outboxes["pub_router"] = "pub_router/outbox/"
     outboxes["cengage"] = "cengage/outbox/"
@@ -127,18 +126,15 @@ def choose_outboxes(status, outbox_map, run_type=None):
 
     elif status == "vor":
         outbox_list.append(outbox_map.get("pubmed"))
-        if run_type == "silent-correction-pmc-resupply":
-            outbox_list.append(outbox_map.get("pmc_resupply"))
-        else:
-            outbox_list.append(outbox_map.get("pmc"))
-            outbox_list.append(outbox_map.get("publication_email"))
-            outbox_list.append(outbox_map.get("pub_router"))
-            outbox_list.append(outbox_map.get("cengage"))
-            outbox_list.append(outbox_map.get("gooa"))
-            outbox_list.append(outbox_map.get("wos"))
-            outbox_list.append(outbox_map.get("scopus"))
-            outbox_list.append(outbox_map.get("cnpiec"))
-            outbox_list.append(outbox_map.get("cnki"))
+        outbox_list.append(outbox_map.get("pmc"))
+        outbox_list.append(outbox_map.get("publication_email"))
+        outbox_list.append(outbox_map.get("pub_router"))
+        outbox_list.append(outbox_map.get("cengage"))
+        outbox_list.append(outbox_map.get("gooa"))
+        outbox_list.append(outbox_map.get("wos"))
+        outbox_list.append(outbox_map.get("scopus"))
+        outbox_list.append(outbox_map.get("cnpiec"))
+        outbox_list.append(outbox_map.get("cnki"))
 
     return outbox_list
 

--- a/cron.py
+++ b/cron.py
@@ -128,14 +128,6 @@ def run_cron(settings):
                 workflow_id="PublicationEmail",
                 start_seconds=60 * 31)
 
-        # PMC resupply deposits once per day 20:45 UTC
-        if current_time.tm_hour == 20:
-            workflow_conditional_start(
-                settings=settings,
-                starter_name="starter_PubRouterDeposit",
-                workflow_id="PubRouterDeposit_PMC-Resupply",
-                start_seconds=60 * 31)
-
         # Pub router deposits once per day 23:45 UTC
         if current_time.tm_hour == 23:
             workflow_conditional_start(

--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -280,7 +280,7 @@ def approve_by_run_type(settings, logger, article_id, run_type, version):
     "determine ingest approval based on the run_type and version"
     approve_status = None
     # VoR and is a silent correction, consult Lax for if it is not the highest version
-    if run_type in ["silent-correction", "silent-correction-pmc-resupply"]:
+    if run_type == "silent-correction":
         highest_version = lax_provider.article_highest_version(article_id, settings)
         try:
             if int(version) < int(highest_version):

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -63,7 +63,6 @@ class starter_PubRouterDeposit():
                 or workflow == 'WoS'
                 or workflow == 'Scopus'
                 or workflow == 'PMC'
-                or workflow == 'PMC-Resupply'
                 or workflow == 'CNPIEC'
                 or workflow == 'CNKI'):
             workflow_id = "PubRouterDeposit_" + workflow

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -30,7 +30,7 @@ class starter_SilentCorrectionsIngest():
         input = S3NotificationInfo.to_dict(info)
         input['run'] = run
         input['version_lookup_function'] = "article_highest_version"
-        input['run_type'] = get_run_type(info)
+        input['run_type'] = "silent-correction"
         input['force'] = True
 
         workflow_id, \
@@ -59,13 +59,6 @@ class starter_SilentCorrectionsIngest():
             # There is already a running workflow with that ID, cannot start another
             message = 'SWFWorkflowExecutionAlreadyStartedError: There is already a running workflow with ID %s' % workflow_id
             logger.info(message)
-
-
-def get_run_type(info):
-    """get the run_type by looking at the S3 notification info"""
-    if hasattr(info, 'file_name') and info.file_name.startswith('pmc-resupply/'):
-        return "silent-correction-pmc-resupply"
-    return "silent-correction"
 
 
 if __name__ == "__main__":

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -62,10 +62,7 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch.object(activity_PubRouterDeposit, 'archive_zip_file_name')
     @patch.object(activity_PubRouterDeposit, 'download_files_from_s3_outbox')
     @patch.object(s3lib, 'get_s3_keys_from_bucket')
-    @data(
-        "PMC-Resupply",
-        "PMC"
-    )
+    @data("PMC")
     def test_do_activity_pmc(self, workflow_name, fake_get_s3_keys, fake_download,
                              fake_archive_zip_file_name, fake_start, fake_clean_outbox, 
                              fake_article_versions, fake_was_ever_poa):

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -40,13 +40,7 @@ class TestScheduleDownstream(unittest.TestCase):
         outbox_list = activity_module.choose_outboxes(
             "vor", activity_module.outbox_map(), "silent-correction")
         self.assertTrue("pmc/outbox/" in outbox_list)
-        self.assertFalse("pmc_resupply/outbox/" in outbox_list)
 
-    def test_choose_outboxes_vor_silent_pmc_resupply(self):
-        outbox_list = activity_module.choose_outboxes(
-            "vor", activity_module.outbox_map(), "silent-correction-pmc-resupply")
-        self.assertFalse("pmc/outbox/" in outbox_list)
-        self.assertTrue("pmc_resupply/outbox/" in outbox_list)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -30,23 +30,3 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
         self.starter_silent_corrections_ingest.start(
             settings=settings_mock, run=RUN_EXAMPLE,
             info=S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data))
-
-    @data(
-        {
-            'file_name': '',
-            'expected': 'silent-correction'
-        },
-        {
-            'file_name': 'elife-00353-vor-r1.zip',
-            'expected': 'silent-correction'
-        },
-        {
-            'file_name': 'pmc-resupply/elife-00353-vor-r1.zip',
-            'expected': 'silent-correction-pmc-resupply'
-        }
-    )
-    def test_get_run_type(self, scenario_test_data):
-        info = S3NotificationInfo.from_dict(test_data.silent_ingest_article_zip_data)
-        info.file_name = scenario_test_data.get('file_name')
-        return_value = starter_module.get_run_type(info)
-        self.assertEqual(return_value, scenario_test_data.get('expected'))


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/issues/issues/4889, the PMC resupply procedure is done now. We do not intend to use it again.

Here, the changes that added the new type of workflow are reversed. I did this by finding the terms in the code base and changing them until none were left.

Code tests are green (I think) so it is probably safe to merge. I was carefuly to check all the `not in` are now `!=` and `in` are `==` when matching workflow comparisons, but I might have missed something, if you get a chance to look it over @giorgiosironi - thanks!