### PR TITLE
Clean tmp dir in do_activity() for some activities

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -139,6 +139,9 @@ class activity_PubRouterDeposit(Activity):
         # Return the activity result, True or False
         result = True
 
+        # Clean up disk
+        self.clean_tmp_dir()
+
         return result
 
     def get_outbox_folder(self, workflow):

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -119,6 +119,9 @@ class activity_PubmedArticleDeposit(Activity):
         if len(self.article_published_file_names) > 0:
             self.add_email_to_queue()
 
+        # Clean up disk
+        self.clean_tmp_dir()
+
         # return a value based on the activity_status
         if self.activity_status is True:
             return True

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -33,6 +33,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         "return the tmp dir name for the activity"
         return os.path.join(self.activity.get_tmp_dir(), self.activity.TMP_DIR)
 
+    @patch.object(activity_PubmedArticleDeposit, 'clean_tmp_dir')
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
     @patch.object(lax_provider, 'article_versions')
     @patch.object(activity_PubmedArticleDeposit, 'ftp_files_to_endpoint')
@@ -127,7 +128,8 @@ class TestPubmedArticleDeposit(unittest.TestCase):
     )
     def test_do_activity(self, test_data, fake_list_resources, fake_storage_context,
                          fake_ftp_files_to_endpoint, fake_article_versions,
-                         fake_email_queue):
+                         fake_email_queue, fake_clean_tmp_dir):
+        fake_clean_tmp_dir.return_value = None
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = test_data.get("outbox_filenames")


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/926

Small changes to reduce instance disk space after activities are completed. This is most useful right now for `continuumtest` and `end2end` environments where bucket contents accumulate and they can potentially fill the disk fast when these activities run each hour or each day.

Very small changes here - I didn't consider any other refactoring or linting at this time for these.