### PR TITLE
Refactor PMCDeposit activity

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -66,8 +66,7 @@ class activity_PMCDeposit(Activity):
         """
         Activity, do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         # Data passed to this activity
         self.document = data["data"]["document"]
@@ -92,13 +91,12 @@ class activity_PMCDeposit(Activity):
         # Check for an empty folder and respond true
         #  if we do not do this it will continue to attempt this activity
         if file_list(self.directories.get("INPUT_DIR")):
-            if self.logger:
-                self.logger.info('folder was empty in PMCDeposit: ' + self.directories.get("INPUT_DIR"))
+            self.logger.info(('folder was empty in PMCDeposit: ' +
+                              self.directories.get("INPUT_DIR")))
             verified = True
 
         folder = self.directories.get("INPUT_DIR")
-        if self.logger:
-            self.logger.info('processing files in folder ' + folder)
+        self.logger.info('processing files in folder ' + folder)
 
         self.unzip_article_files(file_list(folder))
 
@@ -108,13 +106,12 @@ class activity_PMCDeposit(Activity):
         file_name_map = self.rename_files_remove_version_number()
 
         (verified, renamed_list, not_renamed_list) = self.verify_rename_files(file_name_map)
-        if self.logger:
-            self.logger.info("verified " + folder + ": " + str(verified))
-            self.logger.info(file_name_map)
+
+        self.logger.info("verified " + folder + ": " + str(verified))
+        self.logger.info(file_name_map)
 
         if len(not_renamed_list) > 0:
-            if self.logger:
-                self.logger.info("not renamed " + str(not_renamed_list))
+            self.logger.info("not renamed " + str(not_renamed_list))
 
         # Convert the XML
         self.convert_xml(xml_file=self.article_xml_file(),
@@ -132,7 +129,8 @@ class activity_PMCDeposit(Activity):
 
         ftp_status = None
         if verified and self.zip_file_name:
-            ftp_status = self.ftp_to_endpoint(file_list(self.directories.get("ZIP_DIR")), self.FTP_SUBDIR, passive=True)
+            ftp_status = self.ftp_to_endpoint(
+                file_list(self.directories.get("ZIP_DIR")), self.FTP_SUBDIR, passive=True)
 
             if ftp_status is True:
                 self.upload_article_zip_to_s3()
@@ -213,13 +211,13 @@ class activity_PMCDeposit(Activity):
 
     def download_files_from_s3(self, document):
 
-        if self.logger:
-            self.logger.info('downloading VoR file ' + document)
+        self.logger.info('downloading VoR file ' + document)
 
         subfolder_name = ""
 
         # Connect to S3 and bucket
-        s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
+        s3_conn = S3Connection(
+            self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(self.input_bucket)
 
         s3_key_name = document
@@ -257,7 +255,8 @@ class activity_PMCDeposit(Activity):
         bucket_name = self.publish_bucket
 
         # Connect to S3 and bucket
-        s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
+        s3_conn = S3Connection(
+            self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(bucket_name)
 
         for file_name in file_list(self.directories.get("ZIP_DIR")):
@@ -295,15 +294,13 @@ class activity_PMCDeposit(Activity):
         """
         if self.file_extension(file_name) == 'zip' and do_unzip is True:
             # Unzip
-            if self.logger:
-                self.logger.info("going to unzip " + file_name + " to " + to_dir)
+            self.logger.info("going to unzip " + file_name + " to " + to_dir)
             myzip = zipfile.ZipFile(file_name, 'r')
             myzip.extractall(to_dir)
 
         elif self.file_extension(file_name):
             # Copy
-            if self.logger:
-                self.logger.info("going to move and not unzip " + file_name + " to " + to_dir)
+            self.logger.info("going to move and not unzip " + file_name + " to " + to_dir)
             shutil.copyfile(file_name, to_dir + os.sep + self.file_name_from_name(file_name))
 
     def approve_file(self, file_name):
@@ -313,8 +310,7 @@ class activity_PMCDeposit(Activity):
 
         for file_name in article_file_list:
             if self.approve_file(file_name):
-                if self.logger:
-                    self.logger.info("unzipping or moving file " + file_name)
+                self.logger.info("unzipping or moving file " + file_name)
                 self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
 
     def stripped_file_name_map(self, file_names):
@@ -346,7 +342,9 @@ class activity_PMCDeposit(Activity):
 
         for old_name, new_name in file_name_map.items():
             if new_name is not None:
-                shutil.move(self.directories.get("TMP_DIR") + os.sep + old_name, self.directories.get("OUTPUT_DIR") + os.sep + new_name)
+                shutil.move(
+                    self.directories.get("TMP_DIR") + os.sep + old_name,
+                    self.directories.get("OUTPUT_DIR") + os.sep + new_name)
 
         return file_name_map
 
@@ -397,7 +395,8 @@ class activity_PMCDeposit(Activity):
         prefix = self.published_zip_folder + '/'
 
         # Connect to S3 and bucket
-        s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
+        s3_conn = S3Connection(
+            self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(bucket_name)
 
         s3_key_names = s3lib.get_s3_key_names_from_bucket(
@@ -430,8 +429,7 @@ class activity_PMCDeposit(Activity):
 
     def create_new_zip(self, zip_file_name):
 
-        if self.logger:
-            self.logger.info("creating new PMC zip file named " + zip_file_name)
+        self.logger.info("creating new PMC zip file named " + zip_file_name)
 
         new_zipfile = zipfile.ZipFile(self.directories.get("ZIP_DIR") + os.sep + zip_file_name,
                                       'w', zipfile.ZIP_DEFLATED, allowZip64=True)

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -157,12 +157,10 @@ class activity_PMCDeposit(Activity):
         return ftp_status
 
     def download_files_from_s3(self, document):
-
+        """download input zip document from the bucket"""
         self.logger.info('downloading VoR file ' + document)
         bucket_name = self.input_bucket
 
-        "download files from the expanded folder"
-        # download expanded folder
         storage = storage_context(self.settings)
         storage_provider = self.settings.storage_provider + "://"
         orig_resource = storage_provider + bucket_name

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -103,7 +103,7 @@ class activity_PMCDeposit(Activity):
         # Get the new zip file name
         # take into account the r1 r2 revision numbers when replacing an article
         revision = self.zip_revision_number(fid)
-        self.zip_file_name = self.new_zip_filename(self.journal, volume, fid, revision)
+        self.zip_file_name = new_zip_filename(self.journal, volume, fid, revision)
         print(self.zip_file_name)
         self.create_new_zip(self.zip_file_name)
 
@@ -235,16 +235,6 @@ class activity_PMCDeposit(Activity):
 
         return revision
 
-    def new_zip_filename(self, journal, volume, fid, revision=None):
-
-        filename = journal
-        filename = filename + '-' + str(volume).zfill(2)
-        filename = filename + '-' + str(fid).zfill(5)
-        if revision:
-            filename = filename + '.r' + str(revision)
-        filename += '.zip'
-        return filename
-
     def create_new_zip(self, zip_file_name):
 
         self.logger.info("creating new PMC zip file named " + zip_file_name)
@@ -277,6 +267,17 @@ class activity_PMCDeposit(Activity):
                     return file_name
 
         return file_name
+
+
+def new_zip_filename(journal, volume, fid, revision=None):
+
+    filename = journal
+    filename = filename + '-' + str(volume).zfill(2)
+    filename = filename + '-' + str(fid).zfill(5)
+    if revision:
+        filename = filename + '.r' + str(revision)
+    filename += '.zip'
+    return filename
 
 
 def profile_article(document):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -1,6 +1,5 @@
 import os
 import json
-from collections import OrderedDict
 import zipfile
 import shutil
 import re
@@ -8,13 +7,11 @@ import glob
 import boto.swf
 import boto.s3
 from boto.s3.connection import S3Connection
-
 import provider.s3lib as s3lib
-from provider.article_structure import ArticleInfo, file_parts
+from provider.article_structure import ArticleInfo
 from provider import article_processing
 from provider.ftp import FTP
 from elifetools import parseJATS as parser
-from elifetools import xmlio
 from activity.objects import Activity
 
 

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -5,10 +5,6 @@ import zipfile
 import shutil
 import re
 import glob
-
-from ftplib import FTP
-import ftplib
-
 import boto.swf
 import boto.s3
 from boto.s3.connection import S3Connection
@@ -57,13 +53,6 @@ class activity_PMCDeposit(Activity):
         # journal
         self.journal = 'elife'
 
-        # Outgoing FTP settings are set later
-        self.FTP_URI = None
-        self.FTP_USERNAME = None
-        self.FTP_PASSWORD = None
-        self.FTP_CWD = None
-        self.FTP_SUBDIR = []
-
     def do_activity(self, data=None):
         """
         Activity, do the work
@@ -72,10 +61,6 @@ class activity_PMCDeposit(Activity):
 
         # Data passed to this activity
         self.document = data["data"]["document"]
-
-        # set the FTP folder for resupplies
-        if "folder" in data["data"]:
-            self.FTP_SUBDIR = [data["data"]["folder"]]
 
         # Custom bucket, if specified
         if "bucket" in data["data"]:

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -44,9 +44,6 @@ class activity_PMCDeposit(Activity):
         self.published_folder = "pmc/published"
         self.published_zip_folder = "pmc/zip"
 
-        # journal
-        self.journal = 'elife'
-
         self.document = None
         self.input_bucket = None
         self.zip_file_name = None
@@ -84,6 +81,7 @@ class activity_PMCDeposit(Activity):
         unzip_article_files(input_zip_file_name, self.directories.get("TMP_DIR"), self.logger)
 
         # Profile the article
+        journal = get_journal(self.document)
         xml_search_folders = [
             self.directories.get("TMP_DIR"),
             self.directories.get("OUTPUT_DIR")]
@@ -109,7 +107,7 @@ class activity_PMCDeposit(Activity):
         # Get the new zip file name
         # take into account the r1 r2 revision numbers when replacing an article
         revision = self.zip_revision_number(fid)
-        self.zip_file_name = new_zip_filename(self.journal, volume, fid, revision)
+        self.zip_file_name = new_zip_filename(journal, volume, fid, revision)
         self.logger.info("new PMC zip file name: " + str(self.zip_file_name))
         zip_file_path = self.directories.get("ZIP_DIR") + os.sep + self.zip_file_name
         create_new_zip(zip_file_path, self.directories.get("OUTPUT_DIR"), self.logger)
@@ -242,6 +240,13 @@ def create_new_zip(zip_file_name, files_dir, logger):
         for article_file_name in dirfiles:
             filename = article_file_name.split(os.sep)[-1]
             new_zipfile.write(article_file_name, filename)
+
+
+def get_journal(document):
+    """ get the journal name from the input zip file """
+    if document:
+        info = ArticleInfo(article_processing.file_name_from_name(document))
+        return info.journal
 
 
 def article_xml_file(folders):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -93,7 +93,8 @@ class activity_PMCDeposit(Activity):
         file_name_map = article_processing.rename_files_remove_version_number(
             self.directories.get("TMP_DIR"), self.directories.get("OUTPUT_DIR"), self.logger)
 
-        (verified, renamed_list, not_renamed_list) = self.verify_rename_files(file_name_map)
+        (verified, renamed_list, not_renamed_list) = article_processing.verify_rename_files(
+            file_name_map)
 
         self.logger.info("verified " + folder + ": " + str(verified))
         self.logger.info(file_name_map)
@@ -232,24 +233,6 @@ class activity_PMCDeposit(Activity):
         for file_name in article_file_list:
             self.logger.info("unzipping or moving file " + file_name)
             self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
-
-    def verify_rename_files(self, file_name_map):
-        """
-        Each file name as key should have a non None value as its value
-        otherwise the file did not get renamed to something new and the
-        rename file process was not complete
-        """
-        verified = True
-        renamed_list = []
-        not_renamed_list = []
-        for k, v in file_name_map.items():
-            if v is None:
-                verified = False
-                not_renamed_list.append(k)
-            else:
-                renamed_list.append(k)
-
-        return (verified, renamed_list, not_renamed_list)
 
     def zip_revision_number(self, fid):
         """

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -100,7 +100,7 @@ class activity_PMCDeposit(Activity):
 
         self.unzip_article_files(file_list(folder))
 
-        (fid, status, version, volume) = self.profile_article(self.document)
+        fid, volume = self.profile_article(self.document)
 
         # Rename the files
         file_name_map = self.rename_files_remove_version_number()
@@ -447,26 +447,15 @@ class activity_PMCDeposit(Activity):
         Temporary, profile the article by folder names in test data set
         In real code we still want this to return the same values
         """
-        # Temporary setting of version values from directory names
-
         soup = self.article_soup(self.article_xml_file())
 
         # elife id / doi id / manuscript id
         fid = parser.doi(soup).split('.')[-1]
 
-        # article status
-        if parser.is_poa(soup) is True:
-            status = 'poa'
-        else:
-            status = 'vor'
-
-        # version
-        version = self.version_number(document)
-
         # volume
         volume = parser.volume(soup)
 
-        return (fid, status, version, volume)
+        return fid, volume
 
     def version_number(self, document):
         version = None

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -77,10 +77,8 @@ class activity_PMCDeposit(Activity):
                               self.directories.get("INPUT_DIR")))
             verified = True
 
-        folder = self.directories.get("INPUT_DIR")
-        self.logger.info('processing files in folder ' + folder)
-
-        self.unzip_article_files(article_processing.file_list(folder))
+        input_zip_file_name = os.path.join(self.directories.get("INPUT_DIR"), self.document)
+        unzip_article_files(input_zip_file_name, self.directories.get("TMP_DIR"), self.logger)
 
         xml_search_folders = [
             self.directories.get("TMP_DIR"),
@@ -95,7 +93,7 @@ class activity_PMCDeposit(Activity):
         (verified, renamed_list, not_renamed_list) = article_processing.verify_rename_files(
             file_name_map)
 
-        self.logger.info("verified " + folder + ": " + str(verified))
+        self.logger.info("verified " + self.directories.get("INPUT_DIR") + ": " + str(verified))
         self.logger.info(file_name_map)
 
         if len(not_renamed_list) > 0:
@@ -191,28 +189,6 @@ class activity_PMCDeposit(Activity):
                 article_processing.file_name_from_name(file_name))
             storage.set_resource_from_filename(resource_dest, file_name)
 
-    def unzip_or_move_file(self, file_name, to_dir, do_unzip=True):
-        """
-        If file extension is zip, then unzip contents
-        If file the extension
-        """
-        if article_processing.file_extension(file_name) == 'zip' and do_unzip is True:
-            # Unzip
-            self.logger.info("going to unzip " + file_name + " to " + to_dir)
-            myzip = zipfile.ZipFile(file_name, 'r')
-            myzip.extractall(to_dir)
-
-        elif article_processing.file_extension(file_name):
-            # Copy
-            self.logger.info("going to move and not unzip " + file_name + " to " + to_dir)
-            shutil.copyfile(file_name, to_dir + os.sep +
-                            article_processing.file_name_from_name(file_name))
-
-    def unzip_article_files(self, article_file_list):
-        for file_name in article_file_list:
-            self.logger.info("unzipping or moving file " + file_name)
-            self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
-
     def zip_revision_number(self, fid):
         """
         Look at previously supplied files and determine the
@@ -239,6 +215,15 @@ class activity_PMCDeposit(Activity):
                 revision = int(revision_match.group(1)) + 1
 
         return revision
+
+
+def unzip_article_files(zip_file_name, to_dir, logger):
+    """ If file extension is zip, then unzip contents """
+    if article_processing.file_extension(zip_file_name) == 'zip':
+        # Unzip
+        logger.info("going to unzip " + zip_file_name + " to " + to_dir)
+        with zipfile.ZipFile(zip_file_name, 'r') as open_file:
+            open_file.extractall(to_dir)
 
 
 def create_new_zip(zip_file_name, files_dir, logger):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -109,7 +109,8 @@ class activity_PMCDeposit(Activity):
         revision = self.zip_revision_number(fid)
         self.zip_file_name = new_zip_filename(self.journal, volume, fid, revision)
         self.logger.info("new PMC zip file name: " + str(self.zip_file_name))
-        self.create_new_zip(self.zip_file_name)
+        zip_file_path = self.directories.get("ZIP_DIR") + os.sep + self.zip_file_name
+        create_new_zip(zip_file_path, self.directories.get("OUTPUT_DIR"), self.logger)
 
         ftp_status = None
         if verified and self.zip_file_name:
@@ -239,20 +240,16 @@ class activity_PMCDeposit(Activity):
 
         return revision
 
-    def create_new_zip(self, zip_file_name):
 
-        self.logger.info("creating new PMC zip file named " + zip_file_name)
+def create_new_zip(zip_file_name, files_dir, logger):
 
-        new_zipfile = zipfile.ZipFile(self.directories.get("ZIP_DIR") + os.sep + zip_file_name,
-                                      'w', zipfile.ZIP_DEFLATED, allowZip64=True)
+    logger.info("creating new PMC zip file named " + zip_file_name)
 
-        dirfiles = article_processing.file_list(self.directories.get("OUTPUT_DIR"))
-
-        for df in dirfiles:
-            filename = df.split(os.sep)[-1]
-            new_zipfile.write(df, filename)
-
-        new_zipfile.close()
+    with zipfile.ZipFile(zip_file_name, 'w', zipfile.ZIP_DEFLATED, allowZip64=True) as new_zipfile:
+        dirfiles = article_processing.file_list(files_dir)
+        for article_file_name in dirfiles:
+            filename = article_file_name.split(os.sep)[-1]
+            new_zipfile.write(article_file_name, filename)
 
 
 def article_xml_file(folders):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -101,8 +101,7 @@ class activity_PMCDeposit(Activity):
             self.logger.info("not renamed " + str(not_renamed_list))
 
         # Convert the XML
-        self.convert_xml(xml_file=self.article_xml_file(),
-                         file_name_map=file_name_map)
+        article_processing.convert_xml(self.article_xml_file(), file_name_map)
 
         # Get the new zip file name
         # take into account the r1 r2 revision numbers when replacing an article
@@ -285,23 +284,6 @@ class activity_PMCDeposit(Activity):
                 renamed_list.append(k)
 
         return (verified, renamed_list, not_renamed_list)
-
-    def convert_xml(self, xml_file, file_name_map):
-
-        # Register namespaces
-        xmlio.register_xmlns()
-
-        root, doctype_dict = xmlio.parse(xml_file, return_doctype_dict=True)
-
-        # Convert xlink href values
-        total = xmlio.convert_xlink_href(root, file_name_map)
-
-        # Start the file output
-        reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)
-
-        f = open(xml_file, 'wb')
-        f.write(reparsed_string)
-        f.close()
 
     def zip_revision_number(self, fid):
         """

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -197,27 +197,30 @@ class activity_PMCDeposit(Activity):
         Look at previously supplied files and determine the
         next revision number
         """
-        revision = None
-
         storage = storage_context(self.settings)
         storage_provider = self.settings.storage_provider + "://"
         orig_resource = storage_provider + self.publish_bucket + "/" + self.published_zip_folder
 
         s3_key_names = storage.list_resources(orig_resource)
 
-        s3_key_name = s3lib.latest_pmc_zip_revision(fid, s3_key_names)
+        return next_revision_number(fid, s3_key_names)
 
-        if s3_key_name:
-            # Found an existing PMC zip file, look for a revision number
-            revision_match = re.match(r'.*r(.*)\.zip$', s3_key_name)
-            if revision_match is None:
-                # There is a zip but no revision number, use 1
-                revision = 1
-            else:
-                # Use the latest revision plus 1
-                revision = int(revision_match.group(1)) + 1
 
-        return revision
+def next_revision_number(fid, s3_key_names):
+    """Given article id and existing zip file names return the next revision number"""
+    revision = None
+    s3_key_name = s3lib.latest_pmc_zip_revision(fid, s3_key_names)
+
+    if s3_key_name:
+        # Found an existing PMC zip file, look for a revision number
+        revision_match = re.match(r'.*r(.*)\.zip$', s3_key_name)
+        if revision_match is None:
+            # There is a zip but no revision number, use 1
+            revision = 1
+        else:
+            # Use the latest revision plus 1
+            revision = int(revision_match.group(1)) + 1
+    return revision
 
 
 def unzip_article_files(zip_file_name, to_dir, logger):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -87,7 +87,7 @@ class activity_PMCDeposit(Activity):
 
         self.unzip_article_files(article_processing.file_list(folder))
 
-        fid, volume = self.profile_article(self.document)
+        fid, volume = profile_article(self.article_xml_file())
 
         # Rename the files
         file_name_map = article_processing.rename_files_remove_version_number(
@@ -292,28 +292,6 @@ class activity_PMCDeposit(Activity):
 
         new_zipfile.close()
 
-    def profile_article(self, document):
-        """
-        Temporary, profile the article by folder names in test data set
-        In real code we still want this to return the same values
-        """
-        soup = self.article_soup(self.article_xml_file())
-
-        # elife id / doi id / manuscript id
-        fid = parser.doi(soup).split('.')[-1]
-
-        # volume
-        volume = parser.volume(soup)
-
-        return fid, volume
-
-    def version_number(self, document):
-        version = None
-        m = re.search(r'-v([0-9]*?)[\.|-]', document)
-        if m is not None:
-            version = m.group(1)
-        return version
-
     def article_xml_file(self):
         """
         Two directories the XML file might be in depending on the step
@@ -332,5 +310,18 @@ class activity_PMCDeposit(Activity):
 
         return file_name
 
-    def article_soup(self, xml_filename):
-        return parser.parse_document(xml_filename)
+
+def profile_article(document):
+    """
+    Temporary, profile the article by folder names in test data set
+    In real code we still want this to return the same values
+    """
+    soup = parser.parse_document(document)
+
+    # elife id / doi id / manuscript id
+    fid = parser.doi(soup).split('.')[-1]
+
+    # volume
+    volume = parser.volume(soup)
+
+    return fid, volume

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -375,7 +375,6 @@ class activity_PMCDeposit(Activity):
 
         # Convert xlink href values
         total = xmlio.convert_xlink_href(root, file_name_map)
-        # TODO - compare whether all file names were converted
 
         # Start the file output
         reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -228,15 +228,10 @@ class activity_PMCDeposit(Activity):
             shutil.copyfile(file_name, to_dir + os.sep +
                             article_processing.file_name_from_name(file_name))
 
-    def approve_file(self, file_name):
-        return True
-
     def unzip_article_files(self, article_file_list):
-
         for file_name in article_file_list:
-            if self.approve_file(file_name):
-                self.logger.info("unzipping or moving file " + file_name)
-                self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
+            self.logger.info("unzipping or moving file " + file_name)
+            self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
 
     def stripped_file_name_map(self, file_names):
         "from a list of file names, build a map of old to new file name with the version removed"

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -485,11 +485,13 @@ class activity_PMCDeposit(Activity):
         file_name = None
 
         for file_name in file_list(self.TMP_DIR):
-            if file_name.endswith('.xml'):
+            info = ArticleInfo(self.file_name_from_name(file_name))
+            if info.file_type == 'ArticleXML':
                 return file_name
         if not file_name:
             for file_name in file_list(self.OUTPUT_DIR):
-                if file_name.endswith('.xml'):
+                info = ArticleInfo(self.file_name_from_name(file_name))
+                if info.file_type == 'ArticleXML':
                     return file_name
 
         return file_name

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -221,17 +221,11 @@ class activity_PMCDeposit(Activity):
         """
         revision = None
 
-        bucket_name = self.publish_bucket
-        prefix = self.published_zip_folder + '/'
+        storage = storage_context(self.settings)
+        storage_provider = self.settings.storage_provider + "://"
+        orig_resource = storage_provider + self.publish_bucket + "/" + self.published_zip_folder
 
-        # Connect to S3 and bucket
-        s3_conn = S3Connection(
-            self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
-        bucket = s3_conn.lookup(bucket_name)
-
-        s3_key_names = s3lib.get_s3_key_names_from_bucket(
-            bucket=bucket,
-            prefix=prefix)
+        s3_key_names = storage.list_resources(orig_resource)
 
         s3_key_name = s3lib.latest_pmc_zip_revision(fid, s3_key_names)
 

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -1,7 +1,6 @@
 import os
 import json
 import zipfile
-import shutil
 import re
 import glob
 import provider.s3lib as s3lib

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -136,10 +136,7 @@ class activity_PMCDeposit(Activity):
                 self.upload_article_zip_to_s3()
 
         # Return the activity result, True or False
-        if verified is True and ftp_status is True:
-            result = True
-        else:
-            result = False
+        result = bool(verified and ftp_status)
 
         # Clean up disk
         self.clean_tmp_dir()

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -90,7 +90,8 @@ class activity_PMCDeposit(Activity):
         fid, volume = self.profile_article(self.document)
 
         # Rename the files
-        file_name_map = self.rename_files_remove_version_number()
+        file_name_map = article_processing.rename_files_remove_version_number(
+            self.directories.get("TMP_DIR"), self.directories.get("OUTPUT_DIR"), self.logger)
 
         (verified, renamed_list, not_renamed_list) = self.verify_rename_files(file_name_map)
 
@@ -231,41 +232,6 @@ class activity_PMCDeposit(Activity):
         for file_name in article_file_list:
             self.logger.info("unzipping or moving file " + file_name)
             self.unzip_or_move_file(file_name, self.directories.get("TMP_DIR"))
-
-    def stripped_file_name_map(self, file_names):
-        "from a list of file names, build a map of old to new file name with the version removed"
-        file_name_map = OrderedDict()
-        for df in file_names:
-            filename = df.split(os.sep)[-1]
-            info = ArticleInfo(filename)
-            prefix, extension = file_parts(filename)
-            if info.versioned is True and info.version is not None:
-                # Use part before the -v number
-                part_without_version = prefix.split('-v')[0]
-            else:
-                # Not a versioned file, use the whole file prefix
-                part_without_version = prefix
-            renamed_filename = '.'.join([part_without_version, extension])
-            file_name_map[filename] = renamed_filename
-        return file_name_map
-
-    def rename_files_remove_version_number(self):
-        """
-        Rename files to not include the version number, if present
-        Pre-PPP files will not have a version number, for before PPP is launched
-        """
-        # Get a list of all files
-        dirfiles = article_processing.file_list(self.directories.get("TMP_DIR"))
-
-        file_name_map = self.stripped_file_name_map(dirfiles)
-
-        for old_name, new_name in file_name_map.items():
-            if new_name is not None:
-                shutil.move(
-                    self.directories.get("TMP_DIR") + os.sep + old_name,
-                    self.directories.get("OUTPUT_DIR") + os.sep + new_name)
-
-        return file_name_map
 
     def verify_rename_files(self, file_name_map):
         """

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -79,9 +79,11 @@ class activity_PMCDeposit(Activity):
             # Retry activity again
             return self.ACTIVITY_TEMPORARY_FAILURE
 
+        # Unzip the input zip file contents
         input_zip_file_name = os.path.join(self.directories.get("INPUT_DIR"), self.document)
         unzip_article_files(input_zip_file_name, self.directories.get("TMP_DIR"), self.logger)
 
+        # Profile the article
         xml_search_folders = [
             self.directories.get("TMP_DIR"),
             self.directories.get("OUTPUT_DIR")]
@@ -112,6 +114,7 @@ class activity_PMCDeposit(Activity):
         zip_file_path = self.directories.get("ZIP_DIR") + os.sep + self.zip_file_name
         create_new_zip(zip_file_path, self.directories.get("OUTPUT_DIR"), self.logger)
 
+        # FTP the zip
         ftp_status = None
         if verified and self.zip_file_name:
             ftp_status = self.ftp_to_endpoint(self.directories.get("ZIP_DIR"))

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -49,6 +49,7 @@ class Activity(object):
 
         self.tmp_base_dir = "tmp"
         self.tmp_dir = None
+        self.directories = None
 
     def describe(self):
         """
@@ -183,13 +184,22 @@ class Activity(object):
         """
         Create the directories in the activity tmp_dir
         """
-        if not dir_names:
+        if not dir_names and self.directories and hasattr(self.directories, "values"):
             dir_names = self.directories.values()
+        if not dir_names:
+            self.logger.info("No dir_names to create in make_activity_directories()")
+            return None
+        # Now try to find or make directories
         for dir_name in dir_names:
+            if os.path.isdir(dir_name):
+                # directory exists, continue
+                continue
             try:
                 os.mkdir(dir_name)
-            except OSError:
-                pass
+            except OSError as exception:
+                self.logger.exception(str(exception))
+                raise
+        return True
 
     def open_file_from_tmp_dir(self, filename, mode='r'):
         """

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -179,6 +179,18 @@ class Activity(object):
 
         return self.tmp_dir
 
+    def make_activity_directories(self, dir_names=None):
+        """
+        Create the directories in the activity tmp_dir
+        """
+        if not dir_names:
+            dir_names = self.directories.values()
+        for dir_name in dir_names:
+            try:
+                os.mkdir(dir_name)
+            except OSError:
+                pass
+
     def open_file_from_tmp_dir(self, filename, mode='r'):
         """
         Read the file from the tmp_dir

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -59,10 +59,7 @@ def stripped_file_name_map(file_names, logger=None):
 
 
 def rename_files_remove_version_number(files_dir, output_dir, logger=None):
-    """
-    Rename files to not include the version number, if present
-    Pre-PPP files will not have a version number, for before PPP is launched
-    """
+    """Rename files to not include the version number, if present"""
 
     # Get a list of all files
     dirfiles = file_list(files_dir)

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -1,9 +1,11 @@
 import os
 import shutil
 import dateutil.parser
+from collections import OrderedDict
 from elifetools import xmlio
 from provider import utils, lax_provider
 from provider.storage_provider import storage_context
+from provider.article_structure import ArticleInfo, file_parts
 
 """
 Functions for processing article zip and XML for reuse by different activities
@@ -34,39 +36,38 @@ def file_extension(file_name):
     return None
 
 
+def stripped_file_name_map(file_names, logger=None):
+    "from a list of file names, build a map of old to new file name with the version removed"
+    file_name_map = OrderedDict()
+    for df in file_names:
+        filename = df.split(os.sep)[-1]
+        info = ArticleInfo(filename)
+        prefix, extension = file_parts(filename)
+        if info.versioned is True and info.version is not None:
+            # Use part before the -v number
+            part_without_version = prefix.split('-v')[0]
+        else:
+            # Not a versioned file, use the whole file prefix
+            part_without_version = prefix
+        renamed_filename = '.'.join([part_without_version, extension])
+        if renamed_filename:
+            file_name_map[filename] = renamed_filename
+        else:
+            if logger:
+                logger.info('there is no renamed file for ' + filename)
+    return file_name_map
+
+
 def rename_files_remove_version_number(files_dir, output_dir, logger=None):
     """
     Rename files to not include the version number, if present
     Pre-PPP files will not have a version number, for before PPP is launched
     """
 
-    file_name_map = {}
-
     # Get a list of all files
     dirfiles = file_list(files_dir)
 
-    for df in dirfiles:
-        filename = df.split(os.sep)[-1]
-
-        # Get the new file name
-        file_name_map[filename] = None
-
-        # TODO strip the -v1 from it
-        file_extension = filename.split('.')[-1]
-        if '-v' in filename:
-            # Use part before the -v number
-            part_without_version = filename.split('-v')[0]
-        else:
-            # No -v found, use the file name minus the extension
-            part_without_version = ''.join(filename.split('.')[0:-1])
-
-        renamed_filename = part_without_version + '.' + file_extension
-
-        if renamed_filename:
-            file_name_map[filename] = renamed_filename
-        else:
-            if logger:
-                logger.info('there is no renamed file for ' + filename)
+    file_name_map = stripped_file_name_map(dirfiles, logger)
 
     for old_name, new_name in file_name_map.items():
         if new_name is not None:

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -15,9 +15,23 @@ def list_dir(dir_name):
     dir_list = map(lambda item: dir_name + os.sep + item, dir_list)
     return dir_list
 
+
 def file_list(dir_name):
     dir_list = list_dir(dir_name)
     return filter(lambda item: os.path.isfile(item), dir_list)
+
+
+def file_name_from_name(file_name):
+    name = file_name.split(os.sep)[-1]
+    return name
+
+
+def file_extension(file_name):
+    name = file_name_from_name(file_name)
+    if name:
+        if len(name.split('.')) > 1:
+            return name.split('.')[-1]
+    return None
 
 
 def rename_files_remove_version_number(files_dir, output_dir, logger=None):

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -89,6 +89,21 @@ class FakeSQSQueue:
     def delete_message(self, message):
         pass
 
+
+class FakeFTP:
+    def __init__(self, ftp_instance=None):
+        self.ftp_instance = ftp_instance
+
+    def ftp_connect(self, **kwargs):
+        return self.ftp_instance
+
+    def ftp_to_endpoint(self, **kwargs):
+        pass
+
+    def ftp_disconnect(self, ftp_instance=None):
+        pass
+
+
 class FakeStorageProviderConnection:
     def get_connection(self, aws_access_key_id, aws_secret_access_key):
         return None

--- a/tests/activity/test_activity_object.py
+++ b/tests/activity/test_activity_object.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from activity.objects import Activity
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+
+
+class TestActivity(unittest.TestCase):
+
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = Activity(settings_mock, fake_logger, None, None, None)
+        # create a tmp directory before os.mkdir is potentially mocked
+        self.activity.make_tmp_dir()
+
+    def tearDown(self):
+        self.activity.directories = None
+        self.activity.clean_tmp_dir()
+
+    def tmp_dir_folder_name(self, dir_name):
+        return os.path.join(self.activity.get_tmp_dir(), dir_name)
+
+    def test_make_activity_directories_none(self):
+        """test creating activity directories with None values"""
+        self.assertIsNone(self.activity.make_activity_directories())
+
+    def test_make_activity_directories_new(self):
+        """test creating a new activity directory passed as an argument"""
+        dir_names = [self.tmp_dir_folder_name('foo'), self.tmp_dir_folder_name('bar')]
+        self.assertTrue(self.activity.make_activity_directories(dir_names))
+
+    def test_make_activity_directories_property(self):
+        """test creating a new activity directory from object property"""
+        self.activity.directories = {"foo": self.tmp_dir_folder_name('foo')}
+        self.assertTrue(self.activity.make_activity_directories())
+
+    def test_make_activity_directories_bad_property(self):
+        """test bad directories object property"""
+        self.activity.directories = ["list_not_supported_here"]
+        self.assertIsNone(self.activity.make_activity_directories())
+        self.assertEqual(
+            self.activity.logger.loginfo, "No dir_names to create in make_activity_directories()")
+
+    def test_make_activity_directories_exists(self):
+        """test creating a new activity directory passed as an argument"""
+        dir_name = self.tmp_dir_folder_name('foo')
+        os.mkdir(dir_name)
+        dir_names = [dir_name]
+        self.assertTrue(self.activity.make_activity_directories(dir_names))
+
+    @patch("activity.objects.os.mkdir")
+    def test_make_activity_directories_exception(self, fake_mkdir):
+        """test creating a new activity directory exception catching"""
+        dir_names = [self.tmp_dir_folder_name('foo')]
+        fake_mkdir.side_effect = Exception("Something went wrong!")
+        self.assertRaises(Exception, self.activity.make_activity_directories, dir_names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -1,5 +1,4 @@
 import unittest
-import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
 from collections import OrderedDict
 import shutil
@@ -128,7 +127,7 @@ class TestPMCDeposit(unittest.TestCase):
         file_name_map = self.activity.stripped_file_name_map(file_names)
         self.assertEqual(file_name_map, expected_file_name_map)
 
-    @patch.object(activity_module, 'file_list')
+    @patch('provider.article_processing.file_list')
     @data(
         (
             ['folder_name/elife-36842-v2.xml'],

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -107,26 +107,6 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.assertEqual(False, success)
 
-    @data(
-        (
-            ['elife-99999.xml',
-             'elife-99999-fig1-v1.tif',
-             'elife-99999-video1.mp4',
-             'elife-99999-video2.mp4',
-             ],
-            OrderedDict([
-                ('elife-99999.xml', 'elife-99999.xml'),
-                ('elife-99999-fig1-v1.tif', 'elife-99999-fig1.tif'),
-                ('elife-99999-video1.mp4', 'elife-99999-video1.mp4'),
-                ('elife-99999-video2.mp4', 'elife-99999-video2.mp4')
-                ])
-            ),
-    )
-    @unpack
-    def test_stripped_file_name_map(self, file_names, expected_file_name_map):
-        file_name_map = self.activity.stripped_file_name_map(file_names)
-        self.assertEqual(file_name_map, expected_file_name_map)
-
     @patch('provider.article_processing.file_list')
     @data(
         (

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -5,7 +5,7 @@ from mock import patch
 from ddt import ddt, data, unpack
 from activity.activity_PMCDeposit import activity_PMCDeposit
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext, FakeFTP
 
 
 @ddt
@@ -51,13 +51,13 @@ class TestPMCDeposit(unittest.TestCase):
         return file_list
 
     @patch.object(activity_PMCDeposit, 'clean_tmp_dir')
-    @patch.object(activity_PMCDeposit, 'ftp_to_endpoint')
+    @patch('activity.activity_PMCDeposit.FTP')
     @patch.object(FakeStorageContext, 'list_resources')
     @patch('activity.activity_PMCDeposit.storage_context')
-    def test_do_activity(self, fake_storage_context, fake_list_resources, fake_ftp_to_endpoint,
+    def test_do_activity(self, fake_storage_context, fake_list_resources, fake_ftp,
                          fake_clean_tmp_dir):
 
-        fake_ftp_to_endpoint.return_value = True
+        fake_ftp.return_value = FakeFTP()
         fake_clean_tmp_dir.return_value = None
 
         for test_data in self.do_activity_passes:

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -19,6 +19,7 @@ class TestPMCDeposit(unittest.TestCase):
     def setUp(self):
         fake_logger = FakeLogger()
         self.activity = activity_PMCDeposit(settings_mock, fake_logger, None, None, None)
+        self.activity.make_activity_directories()
 
         self.do_activity_passes = []
 
@@ -50,14 +51,14 @@ class TestPMCDeposit(unittest.TestCase):
     def fake_download_files_from_s3(self, document):
         source_doc = "tests/test_data/pmc/" + document
         #print source_doc
-        dest_doc = self.activity.INPUT_DIR + os.sep + document
+        dest_doc = self.activity.directories.get("INPUT_DIR") + os.sep + document
         #print dest_doc
         shutil.copy(source_doc, dest_doc)
 
 
     def zip_file_list(self, zip_file_name):
         file_list = None
-        zip_file_path = self.activity.ZIP_DIR + os.sep + zip_file_name
+        zip_file_path = self.activity.directories.get("ZIP_DIR") + os.sep + zip_file_name
         with zipfile.ZipFile(zip_file_path, 'r') as open_zip_file:
             file_list = open_zip_file.namelist()
         return file_list
@@ -71,8 +72,6 @@ class TestPMCDeposit(unittest.TestCase):
     def test_do_activity(self, fake_download_files_from_s3, fake_ftp_to_endpoint,
                          fake_upload_article_zip_to_s3, fake_s3_mock, fake_s3_key_names,
                          fake_clean_tmp_dir):
-
-        self.activity.create_activity_directories()
 
         for test_data in self.do_activity_passes:
 
@@ -96,8 +95,6 @@ class TestPMCDeposit(unittest.TestCase):
     @patch.object(activity_PMCDeposit, 'download_files_from_s3')
     def test_do_activity_failed_ftp_to_endpoint(self, fake_download_files_from_s3, fake_ftp_to_endpoint,
                          fake_upload_article_zip_to_s3, fake_s3_mock, fake_s3_key_names):
-
-        self.activity.create_activity_directories()
 
         test_data = self.do_activity_passes[0]
 
@@ -145,7 +142,6 @@ class TestPMCDeposit(unittest.TestCase):
     @unpack
     def test_article_xml_file(self, list_of_files, expected, fake_file_list):
         fake_file_list.return_value = list_of_files
-        self.activity.create_activity_directories()
         self.assertEqual(self.activity.article_xml_file(), expected)
 
 

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -51,21 +51,22 @@ class TestPMCDeposit(unittest.TestCase):
         return file_list
 
     @patch.object(activity_PMCDeposit, 'clean_tmp_dir')
-    @patch('activity.activity_PMCDeposit.s3lib.get_s3_key_names_from_bucket')
-    @patch('activity.activity_PMCDeposit.S3Connection')
     @patch.object(activity_PMCDeposit, 'upload_article_zip_to_s3')
     @patch.object(activity_PMCDeposit, 'ftp_to_endpoint')
+    @patch.object(FakeStorageContext, 'list_resources')
     @patch('activity.activity_PMCDeposit.storage_context')
-    def test_do_activity(self, fake_storage_context, fake_ftp_to_endpoint,
-                         fake_upload_article_zip_to_s3, fake_s3_mock, fake_s3_key_names,
-                         fake_clean_tmp_dir):
+    def test_do_activity(self, fake_storage_context, fake_list_resources, fake_ftp_to_endpoint,
+                         fake_upload_article_zip_to_s3, fake_clean_tmp_dir):
+
+        fake_upload_article_zip_to_s3.return_value = None
+        fake_ftp_to_endpoint.return_value = None
+        fake_ftp_to_endpoint.return_value = True
 
         for test_data in self.do_activity_passes:
 
             fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
-            fake_s3_key_names.return_value = test_data["pmc_zip_key_names"]
-            fake_ftp_to_endpoint.return_value = True
-
+            fake_list_resources.return_value = test_data["pmc_zip_key_names"]
+            
             success = self.activity.do_activity(test_data["input_data"])
 
             self.assertEqual(True, success)

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -7,6 +7,8 @@ import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext, FakeFTP
+import tests.activity.test_activity_data as activity_test_data
+import tests.activity.helpers as helpers
 
 
 @ddt
@@ -57,6 +59,8 @@ class TestPMCDeposit(unittest.TestCase):
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
 
     def zip_file_list(self, zip_file_name):
         file_list = None

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -1,4 +1,5 @@
 import unittest
+import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
 from collections import OrderedDict
 import shutil
@@ -129,6 +130,23 @@ class TestPMCDeposit(unittest.TestCase):
     def test_stripped_file_name_map(self, file_names, expected_file_name_map):
         file_name_map = self.activity.stripped_file_name_map(file_names)
         self.assertEqual(file_name_map, expected_file_name_map)
+
+    @patch.object(activity_module, 'file_list')
+    @data(
+        (
+            ['folder_name/elife-36842-v2.xml'],
+             'folder_name/elife-36842-v2.xml'
+        ),
+        (
+            ['folder_name/elife-36842-supp9-v2.xml', 'folder_name/elife-36842-v2.xml'],
+             'folder_name/elife-36842-v2.xml'
+        ),
+    )
+    @unpack
+    def test_article_xml_file(self, list_of_files, expected, fake_file_list):
+        fake_file_list.return_value = list_of_files
+        self.activity.create_activity_directories()
+        self.assertEqual(self.activity.article_xml_file(), expected)
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -3,6 +3,7 @@ import unittest
 import zipfile
 from mock import patch
 from ddt import ddt, data, unpack
+import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext, FakeFTP
@@ -87,6 +88,9 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.assertEqual(False, success)
 
+
+@ddt
+class TestArticleXMLFile(unittest.TestCase):
     @patch('provider.article_processing.file_list')
     @data(
         (
@@ -97,11 +101,16 @@ class TestPMCDeposit(unittest.TestCase):
             ['folder_name/elife-36842-supp9-v2.xml', 'folder_name/elife-36842-v2.xml'],
             'folder_name/elife-36842-v2.xml'
         ),
+        (
+            ['folder_name/not-an-xml-file.txt'],
+            None
+        ),
     )
     @unpack
     def test_article_xml_file(self, list_of_files, expected, fake_file_list):
         fake_file_list.return_value = list_of_files
-        self.assertEqual(self.activity.article_xml_file(), expected)
+        xml_search_folders = ["folder_name"]
+        self.assertEqual(activity_module.article_xml_file(xml_search_folders), expected)
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -91,11 +91,11 @@ class TestPMCDeposit(unittest.TestCase):
     @data(
         (
             ['folder_name/elife-36842-v2.xml'],
-             'folder_name/elife-36842-v2.xml'
+            'folder_name/elife-36842-v2.xml'
         ),
         (
             ['folder_name/elife-36842-supp9-v2.xml', 'folder_name/elife-36842-v2.xml'],
-             'folder_name/elife-36842-v2.xml'
+            'folder_name/elife-36842-v2.xml'
         ),
     )
     @unpack

--- a/tests/provider/test_article_processing.py
+++ b/tests/provider/test_article_processing.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import zipfile
+from collections import OrderedDict
 from ddt import ddt, data, unpack
 from testfixtures import tempdir
 from testfixtures import TempDirectory
@@ -64,7 +65,6 @@ class TestArticleProcessing(unittest.TestCase):
             xml_content = fp.read()
             self.assertTrue(expected_xml_contains in xml_content)
 
-
     def test_verify_rename_files(self):
         verified, renamed_list, not_renamed_list = article_processing.verify_rename_files(
             self.file_name_map_19405)
@@ -80,6 +80,25 @@ class TestArticleProcessing(unittest.TestCase):
         self.assertEqual(len(renamed_list), 0)
         self.assertEqual(len(not_renamed_list), 1)
 
+    @data(
+        (
+            ['elife-99999.xml',
+             'elife-99999-fig1-v1.tif',
+             'elife-99999-video1.mp4',
+             'elife-99999-video2.mp4',
+             ],
+            OrderedDict([
+                ('elife-99999.xml', 'elife-99999.xml'),
+                ('elife-99999-fig1-v1.tif', 'elife-99999-fig1.tif'),
+                ('elife-99999-video1.mp4', 'elife-99999-video1.mp4'),
+                ('elife-99999-video2.mp4', 'elife-99999-video2.mp4')
+                ])
+            ),
+    )
+    @unpack
+    def test_stripped_file_name_map(self, file_names, expected_file_name_map):
+        file_name_map = article_processing.stripped_file_name_map(file_names)
+        self.assertEqual(file_name_map, expected_file_name_map)
 
     def test_rename_files_remove_version_number(self):
         zip_file = 'elife-19405-vor-v1-20160802113816.zip'


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/elife-bot/issues/925

A list of changes on the issue above are done to `activity/activity_PMCDeposit.py`.

I think the primary motivation was to fix a bug with finding the article XML file, and the original code was confused when there were more than one `.xml` file in the zip package. After reviewing the activity, I identified many ways the code could be cleaned up while working on it.

Using some existing functions from `provider/article_processing.py` (and improving them, I think) made it possible to remove some duplicate code. I think a new function was moved there too.

I also changed a hard-coded `elife` as the journal name, which instead gets the journal name from the zip file name now.

It will now return `self.ACTIVITY_TEMPORARY_FAILURE` as the result if it is unable to download the PMC zip file specified. The older logic was more convoluted. I'm not sure the retry adds much value, except to guard against temporary network or disk errors.

Added a new `FakeFTP` class for testing, which results in higher test coverage when mocking FTP upload logic.

I hope the files here are an improvement over the original code. This is not perfect, but I think it is more straightforward.