### PR TITLE
Python 3 tweaks

### DIFF
--- a/S3utility/s3_sqs_message.py
+++ b/S3utility/s3_sqs_message.py
@@ -37,6 +37,6 @@ class S3SQSMessage(Message):
         """
         if body is not None and len(body) > 0:
             self.payload = json.loads(body)
-        if body and 'Records' in self.payload.keys():
+        if body and 'Records' in list(self.payload.keys()):
             self.notification_type = 'S3Event'
         super(Message, self).set_body(body)

--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -183,7 +183,7 @@ class activity_ApplyVersionNumber(Activity):
 
     def rename_s3_objects(self, bucket, bucket_name, bucket_folder_name, file_name_map):
         # Rename S3 bucket objects directly
-        for old_name, new_name in file_name_map.iteritems():
+        for old_name, new_name in list(file_name_map.items()):
             # Do not need to rename if the old and new name are the same
             if old_name == new_name:
                 continue
@@ -200,7 +200,7 @@ class activity_ApplyVersionNumber(Activity):
 
 
     def find_xml_filename_in_map(self, file_name_map):
-        for old_name, new_name in file_name_map.items():
+        for old_name, new_name in list(file_name_map.items()):
             info = ArticleInfo(new_name)
             if info.file_type == 'ArticleXML':
                 return new_name

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -49,8 +49,8 @@ class activity_ConvertImagesToJPG(Activity):
             files_in_bucket = storage.list_resources(orig_resource)
     
             figures = []
-            figures += filter(article_structure.article_figure, files_in_bucket)
-            figures += filter(article_structure.inline_figure, files_in_bucket)
+            figures += list(filter(article_structure.article_figure, files_in_bucket))
+            figures += list(filter(article_structure.inline_figure, files_in_bucket))
     
             # download is not a IIIF asset but is currently kept for compatibility
             # download may become obsolete in future

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -229,8 +229,8 @@ class activity_CopyGlencoeStillImages(Activity):
         self.logger.info("files_in_cdn_no_extention " + str(cdn_all_files_no_extension))
         cdn_still_jpgs_without_video = []
         for still in cdn_still_jpgs_no_extension:
-            if (len(list(filter(
-                    lambda filename: filename == still, cdn_all_files_no_extension))) != 2):
+            if (len(list([
+                    fname for fname in cdn_all_files_no_extension if fname == still])) != 2):
                 cdn_still_jpgs_without_video.append(still)
 
         self.logger.info("cdn_still_jpgs_without_video " + str(cdn_still_jpgs_without_video))
@@ -238,4 +238,4 @@ class activity_CopyGlencoeStillImages(Activity):
 
 
 def remove_extension(filenames):
-    return list(map(lambda filename: os.path.splitext(filename)[0], filenames))
+    return list([os.path.splitext(filename)[0] for filename in filenames])

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -53,7 +53,7 @@ class activity_DepositAssets(Activity):
             # filter figures that have already been copied (see DepositIngestAssets activity)
             pre_ingest_assets = article_structure.pre_ingest_assets(files_in_bucket)
 
-            other_assets = filter(lambda asset: asset not in pre_ingest_assets, files_in_bucket)
+            other_assets = [asset for asset in files_in_bucket if asset not in pre_ingest_assets]
 
             # assets bucket
             cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -122,7 +122,7 @@ class activity_ExpandArticle(Activity):
 
     def get_next_version(self, article_id):
         version = lax_provider.article_highest_version(article_id, self.settings)
-        if isinstance(version, (int,long)) and version >= 1:
+        if isinstance(version, int) and version >= 1:
             version = str(version + 1)
         if version is None:
             return "-1"

--- a/activity/activity_ModifyArticleSubjects.py
+++ b/activity/activity_ModifyArticleSubjects.py
@@ -245,7 +245,7 @@ class activity_ModifyArticleSubjects(Activity):
         total = None
         #filename_plus_path = self.get_tmp_dir() + os.sep + xml_filename
         # download XML, rewrite it and upload it
-        for subject_group_type, subjects in subjects_map.items():
+        for subject_group_type, subjects in list(subjects_map.items()):
             total = self.rewrite_xml_file(article_xml_file, subject_group_type, subjects)
         return total
 

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -64,7 +64,7 @@ class activity_PMCDeposit(Activity):
             self.input_bucket = self.input_bucket_default
 
         # Create output directories
-        self.make_activity_directories(self.directories.values())
+        self.make_activity_directories(list(self.directories.values()))
 
         # Download the S3 objects
         download_status = self.download_files_from_s3(self.document)

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -223,7 +223,7 @@ class activity_PackagePOA(Activity):
             "poa_ethics": "poa_ethics.csv"
         }
 
-        for file_type, filename in file_types.items():
+        for file_type, filename in list(file_types.items()):
             # Download
             s3_key_name = self.ejp.find_latest_s3_file_name(file_type)
             bucket_name = self.settings.ejp_bucket

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -538,7 +538,7 @@ class activity_PubRouterDeposit(Activity):
         for article in self.articles_approved:
             remove_doi_list.append(article.doi)
 
-        for k, v in self.xml_file_to_doi_map.items():
+        for k, v in list(self.xml_file_to_doi_map.items()):
             if k in remove_doi_list:
                 processed_file_names.append(v)
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -99,7 +99,7 @@ class activity_PublishFinalPOA(Activity):
 
             article_filenames_map = self.profile_article_files()
 
-            for doi_id, filenames in article_filenames_map.items():
+            for doi_id, filenames in list(article_filenames_map.items()):
 
                 article_xml_file_name = self.article_xml_from_filename_map(filenames)
 
@@ -683,15 +683,16 @@ class activity_PublishFinalPOA(Activity):
 
         for filename in xml_files:
             matching_filename = self.get_filename_from_path(filename, ".xml")
-            pdf_filenames = map(lambda f: self.get_filename_from_path(f, ".pdf"), pdf_files)
-            pdf_filenames = map(lambda f: f.replace('decap_', ''), pdf_filenames)
+            pdf_filenames = [self.get_filename_from_path(f, ".pdf") for f in pdf_files]
+            pdf_filenames = [fname.replace('decap_', '') for fname in pdf_filenames]
+
             if matching_filename not in pdf_filenames:
                 shutil.move(filename, self.JUNK_DIR + "/")
 
         for filename in pdf_files:
             matching_filename = self.get_filename_from_path(filename, ".pdf")
             matching_filename = matching_filename.replace('decap_', '')
-            xml_filenames = map(lambda f: self.get_filename_from_path(f, ".xml"), xml_files)
+            xml_filenames = [self.get_filename_from_path(fname, ".xml") for fname in xml_files]
             if matching_filename not in xml_filenames:
                 shutil.move(filename, self.JUNK_DIR + "/")
 

--- a/activity/activity_S3Monitor.py
+++ b/activity/activity_S3Monitor.py
@@ -91,7 +91,7 @@ class activity_S3Monitor(Activity):
             date_attrs = self.get_expanded_date_attributes(
                 base_name='_runtime', date_format="%Y-%m-%dT%H:%M:%S.000Z",
                 timestamp=_runtime_timestamp, date_string=None)
-            for k, v in date_attrs.items():
+            for k, v in list(date_attrs.items()):
                 base_item_attrs[k] = v
 
         for folder in folders:
@@ -109,7 +109,7 @@ class activity_S3Monitor(Activity):
                 self.db.put_attributes("S3File", item_name, item_attrs)
             else:
                 # Update the item attributes by replacing values if present
-                for k, v in item_attrs.items():
+                for k, v in list(item_attrs.items()):
                     if item.has_key(k):
                         # Overwrite value
                         item[k] = v
@@ -151,7 +151,7 @@ class activity_S3Monitor(Activity):
                 date_attrs = self.get_expanded_date_attributes(
                     base_name='last_modified', date_format="%Y-%m-%dT%H:%M:%S.000Z",
                     timestamp=None, date_string=item_attrs['last_modified'])
-                for k, v in date_attrs.items():
+                for k, v in list(date_attrs.items()):
                     item_attrs[k] = v
 
             if item is None:
@@ -165,7 +165,7 @@ class activity_S3Monitor(Activity):
                     self.log_item_modified(item_name, item_attrs)
 
                 # Update the item attributes by replacing values if present
-                for k, v in item_attrs.items():
+                for k, v in list(item_attrs.items()):
                     if item.has_key(k):
                         # Overwrite value
                         item[k] = v

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -58,8 +58,8 @@ class activity_VerifyImageServer(Activity):
 
             results = self.retrieve_endpoints_check(original_figures, iiif_path_for_article)
 
-            bad_images = list(filter(lambda x: x[0] == False, results))
-
+            bad_images = list([x for x in results if x[0] == False])
+ 
             if len(bad_images) > 0:
                 # print endpoints that did not work
                 self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
@@ -79,5 +79,5 @@ class activity_VerifyImageServer(Activity):
             return self.ACTIVITY_PERMANENT_FAILURE
 
     def retrieve_endpoints_check(self, original_figures, iiif_path_for_article):
-        return list(map(lambda fig: iiif.try_endpoint(iiif.endpoint(self.settings, iiif_path_for_article, fig), self.logger),
-                        original_figures))
+        return list([iiif.try_endpoint(iiif.endpoint(
+            self.settings, iiif_path_for_article, fig), self.logger) for fig in original_figures])

--- a/activity/activity_VersionReasonDecider.py
+++ b/activity/activity_VersionReasonDecider.py
@@ -40,7 +40,7 @@ class activity_VersionReasonDecider(Activity):
                                 "Starting decision of version reason decision for " + article_id)
 
         # workflow_data = data.copy()
-        for key in data.keys():
+        for key in list(data.keys()):
             session.store_value(key, data[key])
 
         workflow_data = {'article_id': article_id, 'version': version, 'run': run}

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -185,7 +185,7 @@ class Activity(object):
         Create the directories in the activity tmp_dir
         """
         if not dir_names and self.directories and hasattr(self.directories, "values"):
-            dir_names = self.directories.values()
+            dir_names = list(self.directories.values())
         if not dir_names:
             self.logger.info("No dir_names to create in make_activity_directories()")
             return None

--- a/dashboard_queue.py
+++ b/dashboard_queue.py
@@ -3,6 +3,7 @@ import boto.sns
 from boto.sqs.message import Message
 import json
 import uuid
+from provider.utils import unicode_encode
 
 
 def send_message(message, settings):

--- a/dashboard_queue.py
+++ b/dashboard_queue.py
@@ -10,7 +10,7 @@ def send_message(message, settings):
     conn = boto.sns.connect_to_region(settings.sqs_region,
                                       aws_access_key_id=settings.aws_access_key_id,
                                       aws_secret_access_key=settings.aws_secret_access_key)
-    payload = unicode(json.dumps(message), "utf-8")
+    payload = unicode_encode(json.dumps(message))
     conn.publish(topic=settings.event_monitor_topic, message=payload)
 
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -156,9 +156,9 @@ class article(object):
         # Get the highest published version from lax
         try:
             # hack: work around circular dependency between lax_provider.py and article.py
-            from lax_provider import article_highest_version
+            from provider.lax_provider import article_highest_version
             version = article_highest_version(article_id, self.settings)
-            if not isinstance(version, (int,long)):
+            if not isinstance(version, int):
                 return False
         except:
             return False

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -14,13 +14,13 @@ Originally refactoring them from the PMCDeposit activity for reuse into FTPArtic
 
 def list_dir(dir_name):
     dir_list = os.listdir(dir_name)
-    dir_list = map(lambda item: dir_name + os.sep + item, dir_list)
+    dir_list = [dir_name + os.sep + item for item in dir_list]
     return dir_list
 
 
 def file_list(dir_name):
     dir_list = list_dir(dir_name)
-    return filter(lambda item: os.path.isfile(item), dir_list)
+    return [item for item in dir_list if os.path.isfile(item)]
 
 
 def file_name_from_name(file_name):
@@ -66,7 +66,7 @@ def rename_files_remove_version_number(files_dir, output_dir, logger=None):
 
     file_name_map = stripped_file_name_map(dirfiles, logger)
 
-    for old_name, new_name in file_name_map.items():
+    for old_name, new_name in list(file_name_map.items()):
         if new_name is not None:
             shutil.move(files_dir + os.sep + old_name, output_dir + os.sep + new_name)
 
@@ -101,7 +101,7 @@ def verify_rename_files(file_name_map):
     verified = True
     renamed_list = []
     not_renamed_list = []
-    for k, v in file_name_map.items():
+    for k, v in list(file_name_map.items()):
         if v is None:
             verified = False
             not_renamed_list.append(k)

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -38,11 +38,11 @@ def validate_sources(gc_data):
         'webm': 'video/webm; codecs="vp8.0, vorbis"',
         'ogv': 'video/ogg; codecs="theora, vorbis"',
     }
-    known_sources = sources.keys()
+    known_sources = list(sources.keys())
 
-    for v_id, v_data in gc_data.items():
+    for v_id, v_data in list(gc_data.items()):
         # we can't guarantee all of the sources will always be present
-        available_sources = filter(lambda mtype: mtype + "_href" in v_data, known_sources)
+        available_sources = [mtype for mtype in known_sources if mtype + "_href" in v_data]
 
         # fail if we have partial data
         msg = "number of available sources (%r) less than known sources for %r. missing: %s" % \
@@ -66,7 +66,7 @@ def metadata(msid, settings):
 
 def jpg_href_values(metadata):
 
-    return list((seq(metadata.items())
+    return list((seq(list(metadata.items()))
                 .filter(lambda key_value: 'jpg_href' in key_value[1])
                 .map(lambda k_v: k_v[1]['jpg_href'])))
 

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -94,7 +94,7 @@ def article_first_by_status(article_id, version, status, settings, auth=False):
 def article_highest_version(article_id, settings, auth=False):
     status_code, data = article_versions(article_id, settings, auth)
     if status_code == 200:
-        high_version = 0 if len(data) < 1 else max(map(lambda x: int(x["version"]), data))
+        high_version = 0 if len(data) < 1 else max([int(x["version"]) for x in data])
         return high_version
     elif status_code == 404:
         return "1"

--- a/provider/process.py
+++ b/provider/process.py
@@ -30,7 +30,7 @@ def monitor_interrupt(work):
     try:
         flag = Flag()
         def signal_handler(signum, _frame):
-            print("received signal %s" % signum)
+            print(("received signal %s" % signum))
             flag.stop_process()
         signal.signal(signal.SIGTERM, signal_handler)
         work(flag)

--- a/register.py
+++ b/register.py
@@ -56,7 +56,7 @@ def start(settings):
         # Now register it
         response = workflow_object.register()
 
-        print('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
+        print(('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)))
 
     activity_names = []
     activity_names.append("ReadyToPublish")
@@ -121,7 +121,7 @@ def start(settings):
         # Now register it
         response = activity_object.register()
 
-        print('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
+        print(('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4)))
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Part of the issue for Python 3 support https://github.com/elifesciences/issues/issues/4711

Because there is not 100% code coverage of the project, I was wondering whether there was any Python 3 incompatible code lurking in the untested parts. I used `2to3` to get recommendations of code changes.

More or all of the changes here are not too major nor are they incompatible with Python 3 (I think). 

- A couple `print()` statements with added parentheses
- removed `long` where mentioned
- replaced many `lambda` with list comprehensions (the suggestions provided by `2to3` were looking good)
- lots of `dict.items()`, `dict.keys()` etc. when used as an iterator are wrapped in a `list` call, e.g. `for key, value in list(my_dict.items()):`, because it seems implicitly casting as a `list` is preferred over letting it automatically be converted
- EDIT: also a usage of `unicode()` replaced (which failed the tests) in `dashboard_queue.py`