### PR TITLE
Refactor creating activity directories

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -30,7 +30,6 @@ class activity_EmailDigest(Activity):
         self.digest = None
 
         # Local directory settings
-        # Local directory settings
         self.directories = {
             "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
             "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -30,8 +30,8 @@ class activity_IngestDigestToEndpoint(Activity):
 
         # Local directory settings
         self.directories = {
-            "TEMP_DIR": self.get_tmp_dir() + os.sep + "tmp_dir",
-            "INPUT_DIR": self.get_tmp_dir() + os.sep + "input_dir"
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
         }
 
         # Track the success of some steps

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -29,11 +29,10 @@ class activity_IngestDigestToEndpoint(Activity):
                             " to be run when a research article is ingested")
 
         # Local directory settings
-        self.temp_dir = os.path.join(self.get_tmp_dir(), "tmp_dir")
-        self.input_dir = os.path.join(self.get_tmp_dir(), "input_dir")
-
-        # Create output directories
-        self.create_activity_directories()
+        self.directories = {
+            "TEMP_DIR": self.get_tmp_dir() + os.sep + "tmp_dir",
+            "INPUT_DIR": self.get_tmp_dir() + os.sep + "input_dir"
+        }
 
         # Track the success of some steps
         self.statuses = {
@@ -54,6 +53,8 @@ class activity_IngestDigestToEndpoint(Activity):
     def do_activity(self, data=None):
         self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
         success, run, session, article_id, version = self.session_data(data)
+
+        self.make_activity_directories()
 
         # get session data
         if success is not True:
@@ -87,12 +88,13 @@ class activity_IngestDigestToEndpoint(Activity):
 
             # Download digest from the S3 outbox
             docx_file = digest_provider.download_docx_from_s3(
-                self.settings, article_id, self.settings.bot_bucket, self.input_dir, self.logger)
+                self.settings, article_id, self.settings.bot_bucket,
+                self.directories.get("INPUT_DIR"), self.logger)
             if docx_file:
                 self.statuses["download"] = True
             if self.statuses.get("download") is not True:
                 self.logger.info("Unable to download digest file %s for article %s" %
-                                 (docx_file, article_id))
+                                    (docx_file, article_id))
                 return self.ACTIVITY_PERMANENT_FAILURE
             # find the image file name
             image_file = digest_provider.image_file_name_from_s3(
@@ -100,7 +102,8 @@ class activity_IngestDigestToEndpoint(Activity):
 
             # download jats file
             jats_file = download_jats(
-                self.settings, session.get_value("expanded_folder"), self.temp_dir, self.logger)
+                self.settings, session.get_value("expanded_folder"),
+                self.directories.get("TEMP_DIR"), self.logger)
             # related article data
             related = related_from_lax(article_id, version, self.settings, self.logger)
             # generate the digest content
@@ -231,23 +234,14 @@ class activity_IngestDigestToEndpoint(Activity):
         "generate the digest json content from the docx file and other data"
         json_content = None
         try:
-            json_content = json_output.build_json(docx_file, self.temp_dir, self.digest_config,
-                                                  jats_file, image_file, related)
+            json_content = json_output.build_json(
+                docx_file, self.directories.get("TEMP_DIR"), self.digest_config,
+                jats_file, image_file, related)
         except Exception as exception:
             self.logger.exception(
                 "Exception generating digest json for docx_file %s. Details: %s" %
                 (str(docx_file), str(exception)))
         return json_content
-
-    def create_activity_directories(self):
-        """
-        Create the directories in the activity tmp_dir
-        """
-        for dir_name in [self.temp_dir, self.input_dir]:
-            try:
-                os.mkdir(dir_name)
-            except OSError:
-                pass
 
 
 def related_from_lax(article_id, version, settings, logger=None, auth=True):

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -5,7 +5,6 @@ import zipfile
 import glob
 import shutil
 from collections import OrderedDict
-import boto.swf
 from jatsgenerator import generate
 from jatsgenerator import conf as jats_conf
 from packagepoa import transform
@@ -262,7 +261,7 @@ class activity_PackagePOA(Activity):
         # override the CSV directory in the ejp-csv-parser library
         jats_config = self.jatsgenerator_config(self.settings.jatsgenerator_config_section)
         generate.parse.data.CSV_PATH = self.directories.get("CSV") + os.sep
-        generate.parse.data.TMP_DIR =  self.directories.get("CSV_TMP")
+        generate.parse.data.TMP_DIR = self.directories.get("CSV_TMP")
         article = generate.build_article_from_csv(article_id, jats_config)
 
         if article:

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -4,6 +4,7 @@ import time
 import zipfile
 import glob
 import shutil
+from collections import OrderedDict
 import boto.swf
 from jatsgenerator import generate
 from jatsgenerator import conf as jats_conf
@@ -33,16 +34,15 @@ class activity_PackagePOA(Activity):
         self.description = "Process POA zip file input, repackage, and save to S3."
 
         # Activity directories
-        self.ejp_input_dir = os.path.join(self.get_tmp_dir(), 'ejp_input')
-        self.xml_output_dir = os.path.join(self.get_tmp_dir(), 'generated_xml_output')
-        self.csv_dir = os.path.join(self.get_tmp_dir(), 'csv_data')
-        self.csv_tmp_dir = os.path.join(self.get_tmp_dir(), 'csv_data', 'tmp')
-        self.decapitate_pdf_dir = os.path.join(self.get_tmp_dir(), 'decapitate_pdf_dir')
-        self.poa_tmp_dir = os.path.join(self.get_tmp_dir(), 'tmp')
-        self.output_dir = os.path.join(self.get_tmp_dir(), 'output_dir')
-
-        # Create output directories
-        self.create_activity_directories()
+        self.directories = OrderedDict([
+            ("EJP_INPUT", os.path.join(self.get_tmp_dir(), "ejp_input")),
+            ("XML_OUTPUT", os.path.join(self.get_tmp_dir(), "generated_xml_output")),
+            ("CSV", os.path.join(self.get_tmp_dir(), "csv_data")),
+            ("CSV_TMP", os.path.join(self.get_tmp_dir(), "csv_data", "tmp")),
+            ("DECAPITATE_PDF", os.path.join(self.get_tmp_dir(), "decapitate_pdf_dir")),
+            ("POA_TMP", os.path.join(self.get_tmp_dir(), "tmp")),
+            ("OUTPUT", os.path.join(self.get_tmp_dir(), "output_dir"))
+        ])
 
         # Create an EJP provider to access S3 bucket holding CSV files
         self.ejp = ejplib.EJP(settings, self.get_tmp_dir())
@@ -77,6 +77,9 @@ class activity_PackagePOA(Activity):
         """
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        # Create output directories
+        self.make_activity_directories()
 
         # Download the S3 object
         self.document = data["data"]["document"]
@@ -148,7 +151,7 @@ class activity_PackagePOA(Activity):
     def download_poa_zip(self, document):
         """
         Given the s3 object name as document, download it from the
-        POA delivery bucket and save file to disk in the ejp_input_dir
+        POA delivery bucket and save file to disk in the EJP_INPUT dir
         """
         bucket_name = self.settings.poa_bucket
         storage = storage_context(self.settings)
@@ -156,7 +159,7 @@ class activity_PackagePOA(Activity):
         orig_resource = storage_provider + bucket_name + "/"
 
         storage_resource_origin = orig_resource + document
-        filename_plus_path = self.ejp_input_dir + os.sep + document
+        filename_plus_path = os.path.join(self.directories.get("EJP_INPUT"), document)
         try:
             with open(filename_plus_path, 'wb') as open_file:
                 storage.get_resource_to_file(storage_resource_origin, open_file)
@@ -178,9 +181,9 @@ class activity_PackagePOA(Activity):
             return False
         poa_config = self.packagepoa_config(self.settings.packagepoa_config_section)
         # override the output directories
-        poa_config['output_dir'] = self.output_dir
-        poa_config['decapitate_pdf_dir'] = self.decapitate_pdf_dir
-        poa_config['tmp_dir'] = self.poa_tmp_dir
+        poa_config['output_dir'] = self.directories.get("OUTPUT")
+        poa_config['decapitate_pdf_dir'] = self.directories.get("DECAPITATE_PDF")
+        poa_config['tmp_dir'] = self.directories.get("POA_TMP")
         try:
             transform.process_zipfile(
                 zipfile_name=poa_zip_filename,
@@ -195,7 +198,7 @@ class activity_PackagePOA(Activity):
         After processing the zipfile there should be a PDF present, as a
         result of decapitating the file. If not, return false
         """
-        pdf_files = glob.glob(self.decapitate_pdf_dir + "/*.pdf")
+        pdf_files = glob.glob(self.directories.get("DECAPITATE_PDF") + "/*.pdf")
         if not pdf_files:
             return False
         return True
@@ -203,7 +206,7 @@ class activity_PackagePOA(Activity):
     def download_latest_csv(self):
         """
         Download the latest CSV files from S3, rename them, and
-        save to the csv_dir directory
+        save to the CSV directory
         """
 
         # Key: File types, value: file to save as to disk
@@ -240,7 +243,7 @@ class activity_PackagePOA(Activity):
                             file_type=file_type
                         ))
                 continue
-            filename_plus_path = self.csv_dir + os.sep + filename
+            filename_plus_path = os.path.join(self.directories.get("CSV"), filename)
             with open(filename_plus_path, 'wb') as open_file:
                 storage.get_resource_to_file(storage_resource_origin, open_file)
 
@@ -258,8 +261,8 @@ class activity_PackagePOA(Activity):
         result = None
         # override the CSV directory in the ejp-csv-parser library
         jats_config = self.jatsgenerator_config(self.settings.jatsgenerator_config_section)
-        generate.parse.data.CSV_PATH = self.csv_dir + os.sep
-        generate.parse.data.TMP_DIR = self.csv_tmp_dir
+        generate.parse.data.CSV_PATH = self.directories.get("CSV") + os.sep
+        generate.parse.data.TMP_DIR =  self.directories.get("CSV_TMP")
         article = generate.build_article_from_csv(article_id, jats_config)
 
         if article:
@@ -272,16 +275,16 @@ class activity_PackagePOA(Activity):
                 article.volume = volume
 
             # Override the output_dir in the jatsgenerator config
-            jats_config['target_output_dir'] = self.xml_output_dir
+            jats_config['target_output_dir'] = self.directories.get("XML_OUTPUT")
             result = generate.build_xml_to_disk(
                 article_id, article, jats_config, True)
         else:
             result = False
 
         # Copy to output_dir because we need it there
-        xml_files = glob.glob(self.xml_output_dir + "/*.xml")
+        xml_files = glob.glob(self.directories.get("XML_OUTPUT") + "/*.xml")
         for xml_file in xml_files:
-            shutil.copy(xml_file, self.output_dir)
+            shutil.copy(xml_file, self.directories.get("OUTPUT"))
 
         return result
 
@@ -290,17 +293,17 @@ class activity_PackagePOA(Activity):
         Copy local files to the S3 bucket outbox
         """
         # TODO: log which files will be created
-        pdf_files = glob.glob(self.decapitate_pdf_dir + "/*.pdf")
+        pdf_files = glob.glob(self.directories.get("DECAPITATE_PDF") + "/*.pdf")
         for file_name_path in pdf_files:
             # Copy decap PDF to S3 outbox
             self.copy_file_to_bucket(file_name_path)
 
-        xml_files = glob.glob(self.xml_output_dir + "/*.xml")
+        xml_files = glob.glob(self.directories.get("XML_OUTPUT") + "/*.xml")
         for file_name_path in xml_files:
             # Copy XML file to S3 outbox
             self.copy_file_to_bucket(file_name_path)
 
-        zip_files = glob.glob(self.output_dir + "/*.zip")
+        zip_files = glob.glob(self.directories.get("OUTPUT") + "/*.zip")
         for file_name_path in zip_files:
             # Copy supplements zip file to S3 outbox
             self.copy_file_to_bucket(file_name_path)
@@ -419,23 +422,6 @@ class activity_PackagePOA(Activity):
         body += "\n\nSincerely\n\neLife bot"
 
         return body
-
-    def create_activity_directories(self):
-        """
-        Create the directories in the activity tmp_dir
-        """
-        for dir_name in [
-                self.xml_output_dir,
-                self.csv_dir,
-                self.csv_tmp_dir,
-                self.ejp_input_dir,
-                self.decapitate_pdf_dir,
-                self.poa_tmp_dir,
-                self.output_dir]:
-            try:
-                os.mkdir(dir_name)
-            except OSError:
-                pass
 
 
 def get_doi_from_zip_file(filename=None):

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -107,7 +107,7 @@ class activity_PostDigestJATS(Activity):
                 post_jats_error_message = ""
             else:
                 self.statuses["post"] = False
-                post_jats_error_message = post_jats_return_value
+                post_jats_error_message = str(post_jats_return_value)
             # send email
             if self.statuses.get("post"):
                 self.statuses["email"] = self.send_email(self.digest, self.jats_content)

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -43,11 +43,13 @@ class activity_PublishFinalPOA(Activity):
                             + "and upload to final bucket.")
 
         # Local directory settings
-        self.TMP_DIR = self.get_tmp_dir() + os.sep + "tmp_dir"
-        self.INPUT_DIR = self.get_tmp_dir() + os.sep + "input_dir"
-        self.OUTPUT_DIR = self.get_tmp_dir() + os.sep + "output_dir"
-        self.JUNK_DIR = self.get_tmp_dir() + os.sep + "junk_dir"
-        self.DONE_DIR = self.get_tmp_dir() + os.sep + "done_dir"
+        self.directories = {
+            "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+            "OUTPUT_DIR": os.path.join(self.get_tmp_dir(), "output_dir"),
+            "JUNK_DIR": os.path.join(self.get_tmp_dir(), "junk_dir"),
+            "DONE_DIR": os.path.join(self.get_tmp_dir(), "done_dir")
+        }
 
         # Bucket for outgoing files
         self.input_bucket = settings.poa_packaging_bucket
@@ -79,7 +81,7 @@ class activity_PublishFinalPOA(Activity):
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         # Create output directories
-        self.create_activity_directories()
+        self.make_activity_directories()
 
         # Set the published folder name as todays date
         self.published_folder_name = (self.published_folder_prefix
@@ -106,7 +108,8 @@ class activity_PublishFinalPOA(Activity):
                 new_filenames = self.new_filenames(doi_id, filenames)
 
                 if article_xml_file_name:
-                    xml_file = self.INPUT_DIR + os.sep + article_xml_file_name
+                    xml_file = os.path.join(
+                        self.directories.get("INPUT_DIR"), article_xml_file_name)
 
                     try:
                         self.convert_xml(doi_id, xml_file, filenames, new_filenames)
@@ -176,7 +179,7 @@ class activity_PublishFinalPOA(Activity):
         """
         article_filenames_map = {}
 
-        for file in glob.glob(self.INPUT_DIR + '/*'):
+        for file in glob.glob(self.directories.get("INPUT_DIR") + '/*'):
             filename = file.split(os.sep)[-1]
             doi_id = self.doi_id_from_filename(filename)
             if doi_id:
@@ -476,8 +479,9 @@ class activity_PublishFinalPOA(Activity):
         for filename in filenames:
             new_filename = self.new_filename_from_old(filename, new_filenames)
             if new_filename:
-                old_filename_plus_path = self.INPUT_DIR + os.sep + filename
-                new_filename_plus_path = self.TMP_DIR + os.sep + new_filename
+                old_filename_plus_path = os.path.join(self.directories.get("INPUT_DIR"), filename)
+                new_filename_plus_path = os.path.join(
+                    self.directories.get("TMP_DIR"), new_filename)
                 if self.logger:
                     self.logger.info('moving poa file from %s to %s'
                                      % (old_filename_plus_path, new_filename_plus_path))
@@ -488,20 +492,20 @@ class activity_PublishFinalPOA(Activity):
         self.repackage_poa_ds_zip()
 
         # Create the zip
-        zip_filename_plus_path = self.OUTPUT_DIR + os.sep + zip_filename
+        zip_filename_plus_path = os.path.join(self.directories.get("OUTPUT_DIR"), zip_filename)
         new_zipfile = zipfile.ZipFile(zip_filename_plus_path,
                                       'w', zipfile.ZIP_DEFLATED, allowZip64=True)
 
         # Add the files
-        for file in glob.glob(self.TMP_DIR + '/*'):
+        for file in glob.glob(self.directories.get("TMP_DIR") + '/*'):
             filename = file.split(os.sep)[-1]
             new_zipfile.write(file, filename)
         new_zipfile.close()
 
         # Clean out the tmp_dir
-        for file in glob.glob(self.TMP_DIR + '/*'):
+        for file in glob.glob(self.directories.get("TMP_DIR") + '/*'):
             filename = file.split(os.sep)[-1]
-            new_filename_plus_path = self.DONE_DIR + os.sep + filename
+            new_filename_plus_path = os.path.join(self.directories.get("DONE_DIR"), filename)
             shutil.move(file, new_filename_plus_path)
 
     def repackage_poa_ds_zip(self):
@@ -509,7 +513,7 @@ class activity_PublishFinalPOA(Activity):
         If there is a ds zip file for this article files in the tmp_dir
         then repackage it
         """
-        zipfiles = glob.glob(self.TMP_DIR + '/*.zip')
+        zipfiles = glob.glob(self.directories.get("TMP_DIR") + '/*.zip')
         if len(zipfiles) == 1:
             zipfile_file = zipfiles[0]
             zipfile_filename = zipfile_file.split(os.sep)[-1]
@@ -520,32 +524,34 @@ class activity_PublishFinalPOA(Activity):
                 return
 
             # Extract the zip
-            myzip.extractall(self.TMP_DIR)
+            myzip.extractall(self.directories.get("TMP_DIR"))
             myzip.close()
 
             # Remove the manifest.xml file
             try:
-                shutil.move(self.TMP_DIR + os.sep + 'manifest.xml',
-                            self.JUNK_DIR + os.sep + 'manifest.xml')
+                shutil.move(os.path.join(self.directories.get("TMP_DIR"), 'manifest.xml'),
+                            os.path.join(self.directories.get("JUNK_DIR"), 'manifest.xml'))
                 if self.logger:
                     self.logger.info("moving PoA zip manifest.xml to the junk folder")
             except IOError:
                 pass
 
             # Move the old zip file
-            zipfiles_now = glob.glob(self.TMP_DIR + '/*.zip')
+            zipfiles_now = glob.glob(self.directories.get("TMP_DIR") + '/*.zip')
             for new_zipfile in zipfiles_now:
                 if not new_zipfile.endswith('_Supplemental_files.zip'):
                     # Old zip file, move it to junk
                     new_zipfile_filename = new_zipfile.split(os.sep)[-1]
-                    shutil.move(new_zipfile, self.JUNK_DIR + os.sep + new_zipfile_filename)
+                    shutil.move(new_zipfile, os.path.join(
+                        self.directories.get("JUNK_DIR"), new_zipfile_filename))
 
             # Then can rename the new zip file
-            zipfiles_now = glob.glob(self.TMP_DIR + '/*.zip')
+            zipfiles_now = glob.glob(self.directories.get("TMP_DIR") + '/*.zip')
             for new_zipfile in zipfiles_now:
                 if new_zipfile.endswith('_Supplemental_files.zip'):
                     # Rename the zip as the old zip
-                    shutil.move(new_zipfile, self.TMP_DIR + os.sep + zipfile_filename)
+                    shutil.move(new_zipfile, os.path.join(
+                        self.directories.get("TMP_DIR"), zipfile_filename))
 
 
     def new_filename_from_old(self, old_filename, new_filenames):
@@ -579,7 +585,7 @@ class activity_PublishFinalPOA(Activity):
         s3_conn = S3Connection(self.settings.aws_access_key_id, self.settings.aws_secret_access_key)
         bucket = s3_conn.lookup(bucket_name)
 
-        for file in glob.glob(self.OUTPUT_DIR + '/*.zip'):
+        for file in glob.glob(self.directories.get("OUTPUT_DIR") + '/*.zip'):
             s3_key_name = file.split(os.sep)[-1]
             s3key = boto.s3.key.Key(bucket)
             s3key.key = s3_key_name
@@ -616,7 +622,7 @@ class activity_PublishFinalPOA(Activity):
 
             filename = name.split("/")[-1]
 
-            filename_plus_path = self.INPUT_DIR + os.sep + filename
+            filename_plus_path = os.path.join(self.directories.get("INPUT_DIR"), filename)
 
             if self.logger:
                 self.logger.info('PublishFinalPOA downloading: %s' % filename_plus_path)
@@ -638,14 +644,14 @@ class activity_PublishFinalPOA(Activity):
         status = None
 
         # Check for empty directory
-        if len(glob.glob(self.INPUT_DIR + "/*")) <= 1:
+        if len(glob.glob(self.directories.get("INPUT_DIR") + "/*")) <= 1:
             status = False
         else:
             status = True
 
         # For each data supplements file, move invalid ones to not publish by FTP
         file_type = "/*_ds.zip"
-        zipfiles = glob.glob(self.INPUT_DIR + file_type)
+        zipfiles = glob.glob(self.directories.get("INPUT_DIR") + file_type)
         for input_zipfile in zipfiles:
             badfile = None
             filename = input_zipfile.split(os.sep)[-1]
@@ -673,27 +679,29 @@ class activity_PublishFinalPOA(Activity):
 
             if badfile:
                 # File is not good, move it somewhere
-                shutil.move(self.INPUT_DIR + os.sep + filename, self.JUNK_DIR + "/")
+                shutil.move(
+                    os.path.join(self.directories.get("INPUT_DIR"), filename),
+                    self.directories.get("JUNK_DIR") + "/")
 
         # For each xml or pdf file, check there is a matching pair
         xml_file_type = "/*.xml"
         pdf_file_type = "/*.pdf"
-        xml_files = glob.glob(self.INPUT_DIR + xml_file_type)
-        pdf_files = glob.glob(self.INPUT_DIR + pdf_file_type)
+        xml_files = glob.glob(self.directories.get("INPUT_DIR") + xml_file_type)
+        pdf_files = glob.glob(self.directories.get("INPUT_DIR") + pdf_file_type)
 
         for filename in xml_files:
             matching_filename = self.get_filename_from_path(filename, ".xml")
             pdf_filenames = map(lambda f: self.get_filename_from_path(f, ".pdf"), pdf_files)
             pdf_filenames = map(lambda f: f.replace('decap_', ''), pdf_filenames)
             if matching_filename not in pdf_filenames:
-                shutil.move(filename, self.JUNK_DIR + "/")
+                shutil.move(filename, self.directories.get("JUNK_DIR") + "/")
 
         for filename in pdf_files:
             matching_filename = self.get_filename_from_path(filename, ".pdf")
             matching_filename = matching_filename.replace('decap_', '')
             xml_filenames = map(lambda f: self.get_filename_from_path(f, ".xml"), xml_files)
             if matching_filename not in xml_filenames:
-                shutil.move(filename, self.JUNK_DIR + "/")
+                shutil.move(filename, self.directories.get("JUNK_DIR") + "/")
 
         return status
 
@@ -757,7 +765,7 @@ class activity_PublishFinalPOA(Activity):
         zip_file_article_number = self.get_filename_from_path(zip_filename, "_ds.zip")
 
         file_type = "/*.xml"
-        xml_files = glob.glob(self.INPUT_DIR + file_type)
+        xml_files = glob.glob(self.directories.get("INPUT_DIR") + file_type)
         xml_file_articles_numbers = []
         for f in xml_files:
             xml_file_articles_numbers.append(self.get_filename_from_path(f, ".xml"))
@@ -777,7 +785,7 @@ class activity_PublishFinalPOA(Activity):
         zip_file_article_number = self.get_filename_from_path(zip_filename, "_ds.zip")
 
         file_type = "/*.pdf"
-        pdf_files = glob.glob(self.INPUT_DIR + file_type)
+        pdf_files = glob.glob(self.directories.get("INPUT_DIR") + file_type)
         pdf_file_articles_numbers = []
         for f in pdf_files:
             pdf_file_name = self.get_filename_from_path(f, ".pdf")
@@ -976,18 +984,3 @@ class activity_PublishFinalPOA(Activity):
         body += "\n\nSincerely\n\neLife bot"
 
         return body
-
-
-    def create_activity_directories(self):
-        """
-        Create the directories in the activity tmp_dir
-        """
-        try:
-            os.mkdir(self.TMP_DIR)
-            os.mkdir(self.INPUT_DIR)
-            os.mkdir(self.OUTPUT_DIR)
-            os.mkdir(self.JUNK_DIR)
-            os.mkdir(self.DONE_DIR)
-
-        except OSError:
-            pass

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -27,11 +27,10 @@ class activity_ValidateDigestInput(Activity):
         self.digest = None
 
         # Local directory settings
-        self.temp_dir = os.path.join(self.get_tmp_dir(), "tmp_dir")
-        self.input_dir = os.path.join(self.get_tmp_dir(), "input_dir")
-
-        # Create output directories
-        self.create_activity_directories()
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
+        }
 
         # Track the success of some steps
         self.statuses = {
@@ -52,16 +51,19 @@ class activity_ValidateDigestInput(Activity):
         if self.logger:
             self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
+        self.make_activity_directories()
+
         # parse the data with the digest_provider
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
 
         # Download from S3
         self.input_file = digest_provider.download_digest_from_s3(
-            self.settings, real_filename, bucket_name, bucket_folder, self.input_dir)
+            self.settings, real_filename, bucket_name, bucket_folder,
+            self.directories.get("INPUT_DIR"))
 
         # Parse input and build digest
         self.statuses["build"], self.digest = digest_provider.build_digest(
-            self.input_file, self.temp_dir, self.logger, self.digest_config)
+            self.input_file, self.directories.get("TEMP_DIR"), self.logger, self.digest_config)
 
         # Approve files for emailing
         self.statuses["valid"], error_messages = digest_provider.validate_digest(self.digest)
@@ -100,16 +102,6 @@ class activity_ValidateDigestInput(Activity):
             email_provider.smtp_send(connection, sender_email, recipient,
                                      email_message, self.logger)
         return True
-
-    def create_activity_directories(self):
-        """
-        Create the directories in the activity tmp_dir
-        """
-        for dir_name in [self.temp_dir, self.input_dir]:
-            try:
-                os.mkdir(dir_name)
-            except OSError:
-                pass
 
 
 def error_email_subject(filename):

--- a/tests/activity/test_activity_create_digest_medium_post.py
+++ b/tests/activity/test_activity_create_digest_medium_post.py
@@ -105,7 +105,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
         fake_storage_context.return_value = bot_storage_context
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_post_content.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # lax mocking
         fake_highest_version.return_value = test_data.get('lax_highest_version')
         fake_first.return_value = test_data.get("first_vor")
@@ -200,7 +200,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
     def test_email_notification(self, fake_email_smtp_connect):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         return_value = self.activity.email_notification(99999)
         self.assertTrue(return_value)
         self.assertEqual(

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -11,33 +11,30 @@ import tests.test_data as test_case_data
 import os
 from ddt import ddt, data
 
+
 @ddt
 class TestDepositCrossref(unittest.TestCase):
 
     def setUp(self):
         fake_logger = FakeLogger()
         self.activity = activity_DepositCrossref(settings_mock, fake_logger, None, None, None)
-
+        self.activity.make_activity_directories()
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
 
-
     def input_dir(self):
         "return the staging dir name for the activity"
-        return os.path.join(self.activity.get_tmp_dir(), self.activity.INPUT_DIR)
-
+        return self.activity.directories.get("INPUT_DIR")
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
-        return os.path.join(self.activity.get_tmp_dir(), self.activity.TMP_DIR)
-
+        return self.activity.directories.get("TMP_DIR")
 
     def fake_download_files_from_s3_outbox(self, document):
         source_doc = "tests/test_data/crossref/" + document
         dest_doc = self.input_dir() + os.sep + document
         shutil.copy(source_doc, dest_doc)
-
 
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
     @patch.object(activity_DepositCrossref, 'upload_crossref_xml_to_s3')
@@ -123,7 +120,6 @@ class TestDepositCrossref(unittest.TestCase):
                     self.assertTrue(
                         expected in crossref_xml, '{expected} not found in crossref_xml {path}'.format(
                             expected=expected, path=crossref_xml_filename_path))
-
 
     @patch('provider.lax_provider.article_versions')
     def test_parse_article_xml(self, mock_lax_provider_article_versions):

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -130,7 +130,7 @@ class TestEmailDigest(unittest.TestCase):
     def test_do_activity(self, test_data, fake_storage_context, fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))
         filename_used = input_data(test_data.get("filename")).get("file_name")
@@ -165,10 +165,10 @@ class TestEmailDigest(unittest.TestCase):
                              'failed in {comment}'.format(comment=test_data.get("comment")))
         # check for a docx file in the output_dir
         if test_data.get("expected_output_dir_files"):
-            self.assertEqual(list_test_dir(self.activity.output_dir),
+            self.assertEqual(list_test_dir(self.activity.directories.get("OUTPUT_DIR")),
                              test_data.get("expected_output_dir_files"))
         # check email files and contents
-        email_files_filter = os.path.join(self.activity.temp_dir, "*.eml")
+        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
         email_files = glob.glob(email_files_filter)
         if "expected_email_count" in test_data:
             # assert 0 or more emails sent

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -91,15 +91,15 @@ class TestFTPArticle(unittest.TestCase):
     def test_move_or_repackage_pmc_zip(self, input_zip_file_path, doi_id, workflow,
                                        expected_zip_file, expected_zip_file_contents):
         # create activity directories
-        self.activity.create_activity_directories()
+        self.activity.make_activity_directories()
         # copy in some sample data
         dest_input_zip_file_path = os.path.join(
-            self.activity.get_tmp_dir(), self.activity.INPUT_DIR, input_zip_file_path.split('/')[-1])
+            self.activity.directories.get("INPUT_DIR"), input_zip_file_path.split('/')[-1])
         shutil.copy(input_zip_file_path, dest_input_zip_file_path)
         # call the activity function
         self.activity.move_or_repackage_pmc_zip(doi_id, workflow)
         # confirm the output
-        ftp_outbox_dir = os.path.join(self.activity.get_tmp_dir(), self.activity.FTP_TO_SOMEWHERE_DIR)
+        ftp_outbox_dir = self.activity.directories.get("FTP_TO_SOMEWHERE_DIR")
         self.assertTrue(expected_zip_file in os.listdir(ftp_outbox_dir))
         with zipfile.ZipFile(os.path.join(ftp_outbox_dir, expected_zip_file)) as zip_file:
             self.assertEqual(sorted(zip_file.namelist()), sorted(expected_zip_file_contents))
@@ -108,18 +108,18 @@ class TestFTPArticle(unittest.TestCase):
     def test_repackage_archive_zip_to_pmc_zip(self):
         input_zip_file_path = 'tests/test_data/pmc/elife-19405-vor-v1-20160802113816.zip'
         doi_id = 19405
-        zip_renamed_files_dir = os.path.join(self.activity.get_tmp_dir(), self.activity.RENAME_DIR)
-        pmc_zip_output_dir = os.path.join(self.activity.get_tmp_dir(), self.activity.INPUT_DIR)
+        # create activity directories
+        self.activity.make_activity_directories()
+        zip_renamed_files_dir = self.activity.directories.get("RENAME_DIR")
+        pmc_zip_output_dir = self.activity.directories.get("INPUT_DIR")
         expected_pmc_zip_file = os.path.join(pmc_zip_output_dir, 'elife-05-19405.zip')
         expected_article_xml_file = os.path.join(zip_renamed_files_dir, 'elife-19405.xml')
         expected_article_xml_string = b'elife-19405.pdf'
         expected_pmc_zip_file_contents = ['elife-19405.pdf', 'elife-19405.xml',
                                           'elife-19405-inf1.tif', 'elife-19405-fig1.tif']
-        # create activity directories
-        self.activity.create_activity_directories()
         # copy in some sample data
         dest_input_zip_file_path = os.path.join(
-            self.activity.get_tmp_dir(), self.activity.TMP_DIR, input_zip_file_path.split('/')[-1])
+            self.activity.directories.get("TMP_DIR"), input_zip_file_path.split('/')[-1])
         shutil.copy(input_zip_file_path, dest_input_zip_file_path)
         self.activity.repackage_archive_zip_to_pmc_zip(doi_id)
         # now can check the results

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -120,7 +120,7 @@ class TestPackagePOA(unittest.TestCase):
     def test_process_poa_zipfile(self, test_data, fake_copy_pdf_to_output_dir):
         "test processing the zip file directly"
         self.poa.make_activity_directories()
-        fake_copy_pdf_to_output_dir = self.fake_copy_pdf_to_hw_staging_dir(
+        fake_copy_pdf_to_output_dir.return_value = self.fake_copy_pdf_to_hw_staging_dir(
             test_data.get('poa_decap_pdf'))
         file_path = self.fake_download_poa_zip(test_data.get('filename'))
         print(file_path)
@@ -214,10 +214,10 @@ class TestPackagePOA(unittest.TestCase):
             fake_article_publication_date.return_value = test_data["pub_date"]
         else:
             fake_article_publication_date.return_value = None
-        fake_clean_tmp_dir = self.fake_clean_tmp_dir()
+        fake_clean_tmp_dir.return_value = self.fake_clean_tmp_dir()
 
         # For now mock the PDF decapitator during tests
-        fake_copy_pdf_to_output_dir = self.fake_copy_pdf_to_hw_staging_dir(
+        fake_copy_pdf_to_output_dir.return_value = self.fake_copy_pdf_to_hw_staging_dir(
             test_data.get('poa_decap_pdf'))
 
         param_data = json.loads('{"data": {"document": "' +

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -36,12 +36,12 @@ class TestPackagePOA(unittest.TestCase):
         csv_files = glob.glob(self.test_data_dir + "/*.csv")
         for file_name_path in csv_files:
             file_name = file_name_path.split(os.sep)[-1]
-            shutil.copy(file_name_path, self.poa.csv_dir + os.sep + file_name)
+            shutil.copy(file_name_path, os.path.join(self.poa.directories.get("CSV"), file_name))
 
     def fake_download_poa_zip(self, document):
         if document:
             source_doc = self.test_data_dir + "/" + document
-            dest_doc = self.poa.ejp_input_dir + os.sep + document
+            dest_doc = os.path.join(self.poa.directories.get("EJP_INPUT"), document)
             try:
                 shutil.copy(source_doc, dest_doc)
             except IOError:
@@ -52,7 +52,7 @@ class TestPackagePOA(unittest.TestCase):
     def fake_copy_pdf_to_hw_staging_dir(self, decap_pdf):
         if decap_pdf:
             source_doc = self.test_data_dir + "/" + decap_pdf
-            dest_doc = self.poa.decapitate_pdf_dir + os.sep + decap_pdf
+            dest_doc = os.path.join(self.poa.directories.get("DECAPITATE_PDF"), decap_pdf)
             try:
                 shutil.copy(source_doc, dest_doc)
             except IOError:
@@ -70,7 +70,7 @@ class TestPackagePOA(unittest.TestCase):
         """
         After do_activity, check the directory contains a zip with ds_zip file name
         """
-        file_names = glob.glob(self.poa.output_dir + os.sep + "*")
+        file_names = glob.glob(self.poa.directories.get("OUTPUT") + os.sep + "*")
         for file_name_path in file_names:
             if file_name_path.split(os.sep)[-1] == ds_zip:
                 return True
@@ -119,9 +119,11 @@ class TestPackagePOA(unittest.TestCase):
         )
     def test_process_poa_zipfile(self, test_data, fake_copy_pdf_to_output_dir):
         "test processing the zip file directly"
+        self.poa.make_activity_directories()
         fake_copy_pdf_to_output_dir = self.fake_copy_pdf_to_hw_staging_dir(
             test_data.get('poa_decap_pdf'))
         file_path = self.fake_download_poa_zip(test_data.get('filename'))
+        print(file_path)
         self.assertEqual(self.poa.process_poa_zipfile(file_path), test_data.get('expected'))
 
     @patch('activity.activity_PackagePOA.storage_context')
@@ -200,6 +202,8 @@ class TestPackagePOA(unittest.TestCase):
     def test_do_activity(self, test_data, fake_copy_pdf_to_output_dir, fake_clean_tmp_dir,
                          fake_article_publication_date, fake_ejp_bucket_file_list,
                          fake_storage_context):
+        # make directories first
+        self.poa.make_activity_directories()
         # mock things
         test_outbox_folder = activity_test_data.ExpandArticle_files_dest_folder
         bucket_list_file = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -125,7 +125,7 @@ class TestPostDigestJats(unittest.TestCase):
                          fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # POST response
         requests_method_mock.return_value = FakeResponse(test_data.get("post_status_code"), None)
         # do the activity
@@ -163,7 +163,7 @@ class TestPostDigestJats(unittest.TestCase):
     def test_do_activity_jats_failure(self, fake_digest_jats, fake_storage_context,
                                       fake_email_smtp_connect):
         fake_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         activity_data = input_data("DIGEST+99999.zip")
         fake_digest_jats.return_value = None
         result = self.activity.do_activity(activity_data)
@@ -175,7 +175,7 @@ class TestPostDigestJats(unittest.TestCase):
     def test_do_activity_post_failure(self, fake_post_jats, fake_storage_context,
                                       fake_email_smtp_connect):
         fake_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         activity_data = input_data("DIGEST+99999.zip")
         fake_post_jats.side_effect = Exception("Something went wrong!")
         result = self.activity.do_activity(activity_data)
@@ -330,7 +330,7 @@ class TestEmailErrorReport(unittest.TestCase):
     @patch.object(activity_module.email_provider, 'smtp_connect')
     def test_email_error_report(self, fake_email_smtp_connect):
         """test sending an email error"""
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         digest_content = Digest()
         digest_content.doi = '10.7554/eLife.99999'
         jats_content = {}

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -168,7 +168,7 @@ class TestPublishFinalPOA(unittest.TestCase):
         for file in file_list:
             source_doc = "tests/test_data/poa/outbox/" + file
             # print(source_doc)
-            dest_doc = self.poa.INPUT_DIR + os.sep + file
+            dest_doc = os.path.join(self.poa.directories.get("INPUT_DIR"), file)
             # print(dest_doc)
             shutil.copy(source_doc, dest_doc)
         self.poa.outbox_s3_key_names = file_list
@@ -209,10 +209,10 @@ class TestPublishFinalPOA(unittest.TestCase):
 
             self.assertEqual(self.poa.approve_status, test_data["approve_status"])
             self.assertEqual(self.poa.publish_status, test_data["publish_status"])
-            self.assertEqual(count_files_in_dir(self.poa.DONE_DIR),
+            self.assertEqual(count_files_in_dir(self.poa.directories.get("DONE_DIR")),
                              test_data["done_dir_file_count"])
             self.assertEqual(self.poa.activity_status, test_data["activity_status"])
-            self.assertTrue(compare_files_in_dir(self.poa.OUTPUT_DIR,
+            self.assertTrue(compare_files_in_dir(self.poa.directories.get("OUTPUT_DIR"),
                                                  test_data["output_dir_files"]))
             self.assertEqual(sorted(self.poa.done_xml_files),
                              sorted(test_data["done_xml_files"]))
@@ -227,7 +227,7 @@ class TestPublishFinalPOA(unittest.TestCase):
 
             # Check XML values if XML was approved
             if test_data["done_dir_file_count"] > 0:
-                xml_files = glob.glob(self.poa.DONE_DIR + "/*.xml")
+                xml_files = glob.glob(self.poa.directories.get("DONE_DIR") + "/*.xml")
                 for xml_file in xml_files:
                     self.assertTrue(check_xml_contents(xml_file, self.xml_file_values))
 

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -31,7 +31,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
-        return os.path.join(self.activity.get_tmp_dir(), self.activity.TMP_DIR)
+        return self.activity.directories.get("TMP_DIR")
 
     @patch.object(activity_PubmedArticleDeposit, 'clean_tmp_dir')
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -25,10 +25,6 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
                                        filter_out=['.gitkeep'])
 
-    def input_dir(self):
-        "return the staging dir name for the activity"
-        return os.path.join(self.activity.get_tmp_dir(), self.activity.INPUT_DIR)
-
     def tmp_dir(self):
         "return the tmp dir name for the activity"
         return self.activity.directories.get("TMP_DIR")

--- a/tests/activity/test_activity_validate_digest_input.py
+++ b/tests/activity/test_activity_validate_digest_input.py
@@ -111,7 +111,7 @@ class TestValidateDigestInput(unittest.TestCase):
     def test_do_activity(self, test_data, fake_storage_context, fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.temp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))
         filename_used = input_data(test_data.get("filename")).get("file_name")
@@ -145,7 +145,7 @@ class TestValidateDigestInput(unittest.TestCase):
             self.assertEqual(file_name, test_data.get("expected_digest_image_file"),
                              'failed in {comment}'.format(comment=test_data.get("comment")))
         # check email files and contents
-        email_files_filter = os.path.join(self.activity.temp_dir, "*.eml")
+        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
         email_files = glob.glob(email_files_filter)
         if "expected_email_count" in test_data:
             self.assertEqual(len(email_files), test_data.get("expected_email_count"))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/3644
Fixes https://github.com/elifesciences/elife-bot/issues/753

Based on the sample used in the `PMCDeposit` activity refactoring, this branch continues that theme of defining a dict `self.directories` in an activity class, creating those folders using `self.make_activity_directories()`, and then the folders can be referred to from the dict of folder names.

Some tests required changing to get them to work, if they needed the folder to exist first before mocking a call.

I used an `OrderedDict()` in `PackagePOA` because the `CSV_TMP` folder is a folder inside the `CSV` folder, and then we can be assured the parent folder exists before it tries to create the child folder.