### PR TITLE
Publication email

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -180,7 +180,7 @@ class activity_PublicationEmail(Activity):
         storage = storage_context(self.settings)
         storage_provider = self.settings.storage_provider + "://"
         orig_resource = storage_provider + bucket_name + "/" + self.outbox_folder
-        files_in_bucket = storage.list_resources(orig_resource)
+        files_in_bucket = storage.list_resources(orig_resource.rstrip("/"))
 
         for name in files_in_bucket:
             # Download objects from S3 and save to disk

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -29,7 +29,6 @@ class activity_PublicationEmail(Activity):
 
         # Templates provider
         self.templates = templates.Templates(settings, self.get_tmp_dir())
-        print(self.get_tmp_dir())
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/921  - a couple of fixes for PR https://github.com/elifesciences/elife-bot/pull/931 that was just merged.

Storage provider when listing resources does not like having a `/` at the end of the path. This is stripped out for that call. The folder names themselves are unchanged because other logic expects to find the slash character.