### PR TITLE
DepositCrossref refactor and new crossref provider

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -94,7 +94,10 @@ class activity_DepositCrossref(Activity):
         # Send email
         # Only if there were files approved for publishing
         if len(self.article_published_file_names) > 0:
-            self.send_admin_email(outbox_s3_key_names, http_detail_list)
+            self.statuses["email"] = self.send_admin_email(outbox_s3_key_names, http_detail_list)
+
+        self.logger.info(
+            "%s statuses: %s" % (self.name, self.statuses))
 
         return True
 

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -151,6 +151,7 @@ class activity_DepositCrossref(Activity):
         Using the POA generateCrossrefXml module
         """
         article_xml_files = glob.glob(self.directories.get("INPUT_DIR") + "/*.xml")
+        crossref_config = crossref.elifecrossref_config(self.settings)
 
         for xml_file in article_xml_files:
             generate_status = True
@@ -165,10 +166,9 @@ class activity_DepositCrossref(Activity):
             else:
                 article = article_list[0]
 
-            if self.approve_to_generate(article) is not True:
+            if crossref.approve_to_generate(crossref_config, article) is not True:
                 generate_status = False
             else:
-                crossref_config = crossref.elifecrossref_config(self.settings)
                 try:
                     # Will write the XML to the TMP_DIR
                     generate.crossref_xml_to_disk(article_list, crossref_config)
@@ -184,25 +184,6 @@ class activity_DepositCrossref(Activity):
 
         # Any files generated is a sucess, even if one failed
         return True
-
-    def approve_to_generate(self, article):
-        """
-        Given an article object, decide if crossref deposit should be
-        generated from it
-        """
-        approved = None
-        # Embargo if the pub date is in the future
-        crossref_config = crossref.elifecrossref_config(self.settings)
-        article_pub_date = crossref.article_first_pub_date(crossref_config, article)
-        if article_pub_date:
-            now_date = time.gmtime()
-            # if Pub date is later than now, do not approve
-            approved = bool(article_pub_date.date < now_date)
-        else:
-            # No pub date, then we approve it
-            approved = True
-
-        return approved
 
     def approve_for_publishing(self):
         """

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -295,15 +295,15 @@ class activity_DepositCrossref(Activity):
         for xml_file in xml_files:
             files = {'file': open(xml_file, 'rb')}
 
-            r = requests.post(url, data=payload, files=files)
+            response = requests.post(url, data=payload, files=files)
 
             # Check for good HTTP status code
-            if r.status_code != 200:
+            if response.status_code != 200:
                 status = False
-            # print r.text
+            # print response.text
             self.http_request_status_text.append("XML file: " + xml_file)
-            self.http_request_status_text.append("HTTP status: " + str(r.status_code))
-            self.http_request_status_text.append("HTTP response: " + r.text)
+            self.http_request_status_text.append("HTTP status: " + str(response.status_code))
+            self.http_request_status_text.append("HTTP response: " + response.text)
 
         return status
 

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -120,23 +120,12 @@ class activity_DepositCrossref(Activity):
                 return False
         return True
 
-    def article_first_pub_date(self, article):
-        "find the first article pub date from the list of crossref config pub_date_types"
-        pub_date = None
-        crossref_config = crossref.elifecrossref_config(self.settings)
-        if crossref_config.get('pub_date_types'):
-            # check for any useable pub date
-            for pub_date_type in crossref_config.get('pub_date_types'):
-                if article.get_date(pub_date_type):
-                    pub_date = article.get_date(pub_date_type)
-                    break
-        return pub_date
-
     def get_article_list(self, article_xml_files):
         articles = crossref.parse_article_xml(article_xml_files, self.directories.get("TMP_DIR"))
+        crossref_config = crossref.elifecrossref_config(self.settings)
         for article in articles:
             # Check for a pub date
-            article_pub_date = self.article_first_pub_date(article)
+            article_pub_date = crossref.article_first_pub_date(crossref_config, article)
             # if no date was found then look for one on Lax
             if not article_pub_date:
                 lax_pub_date = lax_provider.article_publication_date(
@@ -203,7 +192,8 @@ class activity_DepositCrossref(Activity):
         """
         approved = None
         # Embargo if the pub date is in the future
-        article_pub_date = self.article_first_pub_date(article)
+        crossref_config = crossref.elifecrossref_config(self.settings)
+        article_pub_date = crossref.article_first_pub_date(crossref_config, article)
         if article_pub_date:
             now_date = time.gmtime()
             # if Pub date is later than now, do not approve

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -3,7 +3,6 @@ import json
 import time
 import glob
 import requests
-import arrow
 from activity.objects import Activity
 from provider.storage_provider import storage_context
 import provider.simpleDB as dblib
@@ -75,7 +74,7 @@ class activity_DepositCrossref(Activity):
         # Create output directories
         self.make_activity_directories()
 
-        date_stamp = self.set_datestamp()
+        date_stamp = utils.set_datestamp()
 
         outbox_s3_key_names = self.get_outbox_s3_key_names()
 
@@ -119,12 +118,6 @@ class activity_DepositCrossref(Activity):
         result = True
 
         return result
-
-    def set_datestamp(self):
-        a = arrow.utcnow()
-        date_stamp = (str(a.datetime.year) + str(a.datetime.month).zfill(2) +
-                      str(a.datetime.day).zfill(2))
-        return date_stamp
 
     def download_files_from_s3_outbox(self, outbox_s3_key_names):
         """from the s3 outbox folder,  download the .xml files"""
@@ -420,18 +413,6 @@ class activity_DepositCrossref(Activity):
 
         return True
 
-    def get_activity_status_text(self, activity_status):
-        """
-        Given the activity status boolean, return a human
-        readable text version
-        """
-        if activity_status is True:
-            activity_status_text = "Success!"
-        else:
-            activity_status_text = "FAILED."
-
-        return activity_status_text
-
     def get_email_subject(self, current_time, outbox_s3_key_names):
         """
         Assemble the email subject
@@ -439,7 +420,7 @@ class activity_DepositCrossref(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Count the files moved from the outbox, the files that were processed
         files_count = 0
@@ -463,7 +444,7 @@ class activity_DepositCrossref(Activity):
         date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Bulk of body
         body += self.name + " status:" + "\n"

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -120,19 +120,14 @@ class activity_DepositCrossref(Activity):
         return True
 
     def get_article_list(self, article_xml_files):
+        """turn XML into article objects and populate their data"""
         articles = crossref.parse_article_xml(article_xml_files, self.directories.get("TMP_DIR"))
         crossref_config = crossref.elifecrossref_config(self.settings)
         for article in articles:
             # Check for a pub date otherwise set one
             crossref.set_article_pub_date(article, crossref_config, self.settings, self.logger)
-
             # Check for a version number
-            if not article.version:
-                lax_version = lax_provider.article_highest_version(
-                    article.manuscript, self.settings)
-                if lax_version:
-                    article.version = lax_version
-
+            crossref.set_article_version(article, self.settings)
         return articles
 
     def generate_crossref_xml(self):

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -395,7 +395,7 @@ class activity_DepositCrossref(Activity):
 
         recipient_email_list = []
         # Handle multiple recipients, if specified
-        if type(self.settings.ses_admin_email) == list:
+        if isinstance(self.settings.ses_admin_email, list):
             for email in self.settings.ses_admin_email:
                 recipient_email_list.append(email)
         else:

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -52,8 +52,7 @@ class activity_DepositCrossref(Activity):
         """
         Activity, do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         # Create output directories
         self.make_activity_directories()

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -98,7 +98,7 @@ class activity_DepositCrossref(Activity):
 
             if self.publish_status is True:
                 # Clean up outbox
-                print("Moving files from outbox folder to published folder")
+                self.logger.info("Moving files from outbox folder to published folder")
                 self.clean_outbox(self.article_published_file_names, date_stamp)
                 self.upload_crossref_xml_to_s3(date_stamp)
                 self.outbox_status = True

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -312,7 +312,7 @@ class activity_DepositCrossref(Activity):
 
         return status
 
-    def get_outbox_s3_key_names(self, force=None):
+    def get_outbox_s3_key_names(self):
         """get a list of .xml S3 key names from the outbox"""
         storage = storage_context(self.settings)
         storage_provider = self.settings.storage_provider + "://"
@@ -372,7 +372,7 @@ class activity_DepositCrossref(Activity):
 
         for file_name in glob.glob(self.directories.get("TMP_DIR") + "/*.xml"):
             resource_dest = (
-                storage_provider + s3_folder_name +
+                storage_provider + bucket_name + "/" + s3_folder_name +
                 article_processing.file_name_from_name(file_name))
             storage.set_resource_from_filename(resource_dest, file_name)
 

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -58,7 +58,8 @@ class activity_DepositCrossref(Activity):
 
         date_stamp = utils.set_datestamp()
 
-        outbox_s3_key_names = self.get_outbox_s3_key_names()
+        outbox_s3_key_names = crossref.get_outbox_s3_key_names(
+            self.settings, self.publish_bucket, self.outbox_folder)
 
         # Download the S3 objects
         self.download_files_from_s3_outbox(outbox_s3_key_names)
@@ -155,16 +156,6 @@ class activity_DepositCrossref(Activity):
             self.settings.crossref_login_id, self.settings.crossref_login_passwd)
         return crossref.upload_files_to_endpoint(
             self.settings.crossref_url, payload, xml_files)
-
-    def get_outbox_s3_key_names(self):
-        """get a list of .xml S3 key names from the outbox"""
-        storage = storage_context(self.settings)
-        storage_provider = self.settings.storage_provider + "://"
-        orig_resource = (
-            storage_provider + self.publish_bucket + "/" + self.outbox_folder.rstrip('/'))
-        s3_key_names = storage.list_resources(orig_resource)
-        # return only the .xml files
-        return [key_name for key_name in s3_key_names if key_name.endswith('.xml')]
 
     def upload_crossref_xml_to_s3(self, date_stamp):
         """

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -96,10 +96,7 @@ class activity_DepositCrossref(Activity):
         if len(self.article_published_file_names) > 0:
             self.send_admin_email(outbox_s3_key_names, http_detail_list)
 
-        # Return the activity result, True or False
-        result = True
-
-        return result
+        return True
 
     def download_files_from_s3_outbox(self, outbox_s3_key_names):
         """from the s3 outbox folder,  download the .xml files"""

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -95,7 +95,8 @@ class activity_DepositCrossref(Activity):
             # Clean up outbox
             self.logger.info("Moving files from outbox folder to published folder")
             to_folder = crossref.get_to_folder_name(self.published_folder, date_stamp)
-            crossref.clean_outbox(self.settings, self.publish_bucket, self.outbox_folder, to_folder, self.good_xml_files)
+            crossref.clean_outbox(self.settings, self.publish_bucket, self.outbox_folder,
+                                  to_folder, self.good_xml_files)
             self.upload_crossref_xml_to_s3(date_stamp)
             self.statuses["outbox"] = True
 

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -1,19 +1,13 @@
 import os
-import boto.swf
 import json
 import time
-import arrow
-from collections import namedtuple
-import requests
 import glob
-import re
-
+import requests
+import arrow
 from activity.objects import Activity
-
 from provider.storage_provider import storage_context
 import provider.simpleDB as dblib
 import provider.article as articlelib
-import provider.s3lib as s3lib
 from provider import article_processing, lax_provider, utils
 from elifecrossref import generate
 from elifecrossref.conf import raw_config, parse_raw_config

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -144,20 +144,8 @@ class activity_DepositCrossref(Activity):
         return article_object_map
 
     def approve_for_publishing(self):
-        """
-        Final checks before publishing files to the endpoint
-        """
-        status = None
-
-        # Check for empty directory
-        article_xml_files = glob.glob(self.directories.get("INPUT_DIR") + "/*.xml")
-        if len(article_xml_files) <= 0:
-            status = False
-        else:
-            # Default until full sets of files checker is built
-            status = True
-
-        return status
+        """check if any files were generated before publishing files to the endpoint"""
+        return bool(glob.glob(self.directories.get("INPUT_DIR") + "/*.xml"))
 
     def deposit_files_to_endpoint(self, file_type="/*.xml", sub_dir=None):
         """Using an HTTP POST, deposit the file to the endpoint"""

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -361,10 +361,19 @@ class activity_DepositCrossref(Activity):
         After do_activity is finished, send emails to recipients
         on the status
         """
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        activity_status_text = utils.get_activity_status_text(self.statuses.get("activity"))
 
-        current_time = time.gmtime()
-        body = self.get_email_body(current_time, outbox_s3_key_names, http_detail_list)
-        subject = self.get_email_subject(current_time, outbox_s3_key_names)
+        body = get_email_body_head(self.name, activity_status_text, self.statuses)
+        body += get_email_body_middle(
+            outbox_s3_key_names, self.article_published_file_names,
+            self.article_not_published_file_names, http_detail_list)
+        body += email_provider.get_admin_email_body_foot(
+            self.get_activityId(), self.get_workflowId(), datetime_string, self.settings.domain)
+
+        subject = get_email_subject(
+            datetime_string, activity_status_text, self.name,
+            self.settings.domain, outbox_s3_key_names)
         sender_email = self.settings.ses_poa_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
@@ -382,93 +391,85 @@ class activity_DepositCrossref(Activity):
 
         return True
 
-    def get_email_subject(self, current_time, outbox_s3_key_names):
-        """
-        Assemble the email subject
-        """
-        date_format = '%Y-%m-%d %H:%M'
-        datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = utils.get_activity_status_text(self.statuses.get("activity"))
+def get_email_subject(datetime_string, activity_status_text, name, domain, outbox_s3_key_names):
+    """
+    Assemble the email subject
+    """
+    # Count the files moved from the outbox, the files that were processed
+    files_count = 0
+    if outbox_s3_key_names:
+        files_count = len(outbox_s3_key_names)
 
-        # Count the files moved from the outbox, the files that were processed
-        files_count = 0
-        if outbox_s3_key_names:
-            files_count = len(outbox_s3_key_names)
+    subject = (
+        name + " " + activity_status_text + " files: " + str(files_count) +
+        ", " + datetime_string + ", eLife SWF domain: " + domain)
 
-        subject = (self.name + " " + activity_status_text +
-                   " files: " + str(files_count) +
-                   ", " + datetime_string +
-                   ", eLife SWF domain: " + self.settings.domain)
+    return subject
 
-        return subject
 
-    def get_email_body(self, current_time, outbox_s3_key_names, http_detail_list):
-        """
-        Format the body of the email
-        """
+def get_email_body_head(name, activity_status_text, statuses):
+    """
+    Format the body of the email
+    """
 
-        body = ""
+    body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+    # Bulk of body
+    body += name + " status:" + "\n"
+    body += "\n"
+    body += activity_status_text + "\n"
+    body += "\n"
 
-        activity_status_text = utils.get_activity_status_text(self.statuses.get("activity"))
+    body += "activity_status: " + str(statuses.get("activity")) + "\n"
+    body += "generate_status: " + str(statuses.get("generate")) + "\n"
+    body += "approve_status: " + str(statuses.get("approve")) + "\n"
+    body += "publish_status: " + str(statuses.get("publish")) + "\n"
+    body += "outbox_status: " + str(statuses.get("outbox")) + "\n"
 
-        # Bulk of body
-        body += self.name + " status:" + "\n"
+    body += "\n"
+
+    return body
+
+
+def get_email_body_middle(outbox_s3_key_names, published_file_names,
+                          not_published_file_names, http_detail_list):
+    """
+    Format the body of the email
+    """
+
+    body = ""
+
+    body += "\n"
+    body += "Outbox files: " + "\n"
+
+    files_count = 0
+    if outbox_s3_key_names:
+        files_count = len(outbox_s3_key_names)
+    if files_count > 0:
+        for name in outbox_s3_key_names:
+            body += name + "\n"
+    else:
+        body += "No files in outbox." + "\n"
+
+    # Report on published files
+    if len(published_file_names) > 0:
         body += "\n"
-        body += activity_status_text + "\n"
+        body += "Published files generated crossref XML: " + "\n"
+        for name in published_file_names:
+            body += name.split(os.sep)[-1] + "\n"
+
+    # Report on not published files
+    if len(not_published_file_names) > 0:
         body += "\n"
+        body += "Files not approved or failed crossref XML: " + "\n"
+        for name in not_published_file_names:
+            body += name.split(os.sep)[-1] + "\n"
 
-        body += "activity_status: " + str(self.statuses.get("activity")) + "\n"
-        body += "generate_status: " + str(self.statuses.get("generate")) + "\n"
-        body += "approve_status: " + str(self.statuses.get("approve")) + "\n"
-        body += "publish_status: " + str(self.statuses.get("publish")) + "\n"
-        body += "outbox_status: " + str(self.statuses.get("outbox")) + "\n"
+    body += "\n"
+    body += "-------------------------------\n"
+    body += "HTTP deposit details: " + "\n"
+    for text in http_detail_list:
+        body += str(text) + "\n"
 
-        body += "\n"
-        body += "Outbox files: " + "\n"
-
-        files_count = 0
-        if outbox_s3_key_names:
-            files_count = len(outbox_s3_key_names)
-        if files_count > 0:
-            for name in outbox_s3_key_names:
-                body += name + "\n"
-        else:
-            body += "No files in outbox." + "\n"
-
-        # Report on published files
-        if len(self.article_published_file_names) > 0:
-            body += "\n"
-            body += "Published files generated crossref XML: " + "\n"
-            for name in self.article_published_file_names:
-                body += name.split(os.sep)[-1] + "\n"
-
-        # Report on not published files
-        if len(self.article_not_published_file_names) > 0:
-            body += "\n"
-            body += "Files not approved or failed crossref XML: " + "\n"
-            for name in self.article_not_published_file_names:
-                body += name.split(os.sep)[-1] + "\n"
-
-        body += "\n"
-        body += "-------------------------------\n"
-        body += "HTTP deposit details: " + "\n"
-        for text in http_detail_list:
-            body += str(text) + "\n"
-
-        body += "\n"
-        body += "-------------------------------\n"
-        body += "SWF workflow details: " + "\n"
-        body += "activityId: " + str(self.get_activityId()) + "\n"
-        body += "As part of workflowId: " + str(self.get_workflowId()) + "\n"
-        body += "As at " + datetime_string + "\n"
-        body += "Domain: " + self.settings.domain + "\n"
-
-        body += "\n"
-
-        body += "\n\nSincerely\n\neLife bot"
-
-        return body
+    return body

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -88,12 +88,12 @@ class activity_DepositCrossref(Activity):
             except:
                 self.statuses["publish"] = False
 
-            if self.statuses.get("publish") is True:
-                # Clean up outbox
-                self.logger.info("Moving files from outbox folder to published folder")
-                self.clean_outbox(self.good_xml_files, date_stamp)
-                self.upload_crossref_xml_to_s3(date_stamp)
-                self.statuses["outbox"] = True
+        if self.statuses.get("publish") is True:
+            # Clean up outbox
+            self.logger.info("Moving files from outbox folder to published folder")
+            self.clean_outbox(self.good_xml_files, date_stamp)
+            self.upload_crossref_xml_to_s3(date_stamp)
+            self.statuses["outbox"] = True
 
         # Set the activity status of this activity based on successes
         self.statuses["activity"] = bool(

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -104,10 +104,8 @@ class activity_DepositCrossref(Activity):
                 self.outbox_status = True
 
         # Set the activity status of this activity based on successes
-        if self.publish_status is not False and self.generate_status is not False:
-            self.activity_status = True
-        else:
-            self.activity_status = False
+        self.activity_status = bool(
+            self.publish_status is not False and self.generate_status is not False)
 
         # Send email
         # Only if there were files approved for publishing
@@ -253,11 +251,8 @@ class activity_DepositCrossref(Activity):
         article_pub_date = self.article_first_pub_date(article)
         if article_pub_date:
             now_date = time.gmtime()
-            if article_pub_date.date < now_date:
-                approved = True
-            else:
-                # Pub date is later than now, do not approve
-                approved = False
+            # if Pub date is later than now, do not approve
+            approved = bool(article_pub_date.date < now_date)
         else:
             # No pub date, then we approve it
             approved = True

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -23,6 +23,7 @@ from elifearticle.article import ArticleDate
 DepositCrossref activity
 """
 
+
 class activity_DepositCrossref(Activity):
 
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
@@ -193,16 +194,20 @@ class activity_DepositCrossref(Activity):
             article_pub_date = self.article_first_pub_date(article)
             # if no date was found then look for one on Lax
             if not article_pub_date:
-                lax_pub_date = lax_provider.article_publication_date(article.manuscript, self.settings, self.logger)
+                lax_pub_date = lax_provider.article_publication_date(
+                    article.manuscript, self.settings, self.logger)
                 if lax_pub_date:
                     date_struct = time.strptime(lax_pub_date, utils.S3_DATE_FORMAT)
-                    crossref_config = self.elifecrossref_config(self.settings.elifecrossref_config_section)
-                    pub_date_object = ArticleDate(crossref_config.get('pub_date_types')[0], date_struct)
+                    crossref_config = self.elifecrossref_config(
+                        self.settings.elifecrossref_config_section)
+                    pub_date_object = ArticleDate(
+                        crossref_config.get('pub_date_types')[0], date_struct)
                     article.add_date(pub_date_object)
 
             # Check for a version number
             if not article.version:
-                lax_version = lax_provider.article_highest_version(article.manuscript, self.settings)
+                lax_version = lax_provider.article_highest_version(
+                    article.manuscript, self.settings)
                 if lax_version:
                     article.version = lax_version
 
@@ -272,7 +277,6 @@ class activity_DepositCrossref(Activity):
 
         return approved
 
-
     def approve_for_publishing(self):
         """
         Final checks before publishing files to the endpoint
@@ -314,7 +318,7 @@ class activity_DepositCrossref(Activity):
             # Check for good HTTP status code
             if r.status_code != 200:
                 status = False
-            #print r.text
+            # print r.text
             self.http_request_status_text.append("XML file: " + xml_file)
             self.http_request_status_text.append("HTTP status: " + str(r.status_code))
             self.http_request_status_text.append("HTTP response: " + r.text)
@@ -381,7 +385,7 @@ class activity_DepositCrossref(Activity):
 
         for file_name in glob.glob(self.directories.get("TMP_DIR") + "/*.xml"):
             resource_dest = (
-                storage_provider + s3_folder_name + 
+                storage_provider + s3_folder_name +
                 article_processing.file_name_from_name(file_name))
             storage.set_resource_from_filename(resource_dest, file_name)
 
@@ -394,7 +398,7 @@ class activity_DepositCrossref(Activity):
         db_conn = self.db.connect()
 
         # Note: Create a verified sender email address, only done once
-        #conn.verify_email_address(self.settings.ses_sender_email)
+        # conn.verify_email_address(self.settings.ses_sender_email)
 
         current_time = time.gmtime()
 

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -467,7 +467,7 @@ class activity_PublicationEmail(Activity):
         activity_status_text = get_activity_status_text(activity_status)
 
         body = get_admin_email_body_head(self.name, activity_status_text, self.admin_email_content)
-        body += get_admin_email_body_foot(
+        body += email_provider.get_admin_email_body_foot(
             self.get_activityId(), self.get_workflowId(), datetime_string, self.settings.domain)
         subject = get_admin_email_subject(
             datetime_string, activity_status_text, self.name, self.settings.domain)
@@ -594,21 +594,6 @@ def get_admin_email_body_head(name, activity_status_text, details):
     body_head += details + "\n"
     body_head += "\n"
     return body_head
-
-
-def get_admin_email_body_foot(activity_id, workflow_id, datetime_string, domain):
-    """Format the footer of the body of the email"""
-    body_foot = ""
-    body_foot += "\n"
-    body_foot += "-------------------------------\n"
-    body_foot += "SWF workflow details: " + "\n"
-    body_foot += "activityId: " + str(activity_id) + "\n"
-    body_foot += "As part of workflowId: " + str(workflow_id) + "\n"
-    body_foot += "As at " + datetime_string + "\n"
-    body_foot += "Domain: " + domain + "\n"
-    body_foot += "\n"
-    body_foot += "\n\nSincerely\n\neLife bot"
-    return body_foot
 
 
 def get_admin_email_subject(datetime_string, activity_status_text, name, domain):

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -44,6 +44,15 @@ def set_article_pub_date(article, crossref_config, settings, logger):
             article.add_date(pub_date_object)
 
 
+def set_article_version(article, settings):
+    """if there is no version then set it from lax data"""
+    if not article.version:
+        lax_version = lax_provider.article_highest_version(
+            article.manuscript, settings)
+        if lax_version:
+            article.version = lax_version
+
+
 def article_first_pub_date(crossref_config, article):
     "find the first article pub date from the list of crossref config pub_date_types"
     pub_date = None

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -1,3 +1,4 @@
+import time
 from elifecrossref import generate
 from elifecrossref.conf import raw_config, parse_raw_config
 
@@ -36,3 +37,22 @@ def article_first_pub_date(crossref_config, article):
                 pub_date = article.get_date(pub_date_type)
                 break
     return pub_date
+
+
+def approve_to_generate(crossref_config, article):
+    """
+    Given an article object, decide if crossref deposit should be
+    generated from it
+    """
+    approved = None
+    # Embargo if the pub date is in the future
+    article_pub_date = article_first_pub_date(crossref_config, article)
+    if article_pub_date:
+        now_date = time.gmtime()
+        # if Pub date is later than now, do not approve
+        approved = bool(article_pub_date.date < now_date)
+    else:
+        # No pub date, then we approve it
+        approved = True
+
+    return approved

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -1,0 +1,18 @@
+from elifecrossref import generate
+
+
+def parse_article_xml(article_xml_files, tmp_dir):
+    """Given a list of article XML files, parse into objects"""
+    articles = []
+    generate.TMP_DIR = tmp_dir
+    # convert one file at a time
+    for article_xml in article_xml_files:
+        article_list = None
+        try:
+            # Convert the XML file as a list to a list of article objects
+            article_list = generate.build_articles([article_xml])
+        except:
+            continue
+        if article_list:
+            articles.append(article_list[0])
+    return articles

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -24,3 +24,15 @@ def parse_article_xml(article_xml_files, tmp_dir):
         if article_list:
             articles.append(article_list[0])
     return articles
+
+
+def article_first_pub_date(crossref_config, article):
+    "find the first article pub date from the list of crossref config pub_date_types"
+    pub_date = None
+    if crossref_config.get('pub_date_types'):
+        # check for any useable pub date
+        for pub_date_type in crossref_config.get('pub_date_types'):
+            if article.get_date(pub_date_type):
+                pub_date = article.get_date(pub_date_type)
+                break
+    return pub_date

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -1,4 +1,12 @@
 from elifecrossref import generate
+from elifecrossref.conf import raw_config, parse_raw_config
+
+
+def elifecrossref_config(settings):
+    "parse the config values from the elifecrossref config"
+    return parse_raw_config(raw_config(
+        settings.elifecrossref_config_section,
+        settings.elifecrossref_config_file))
 
 
 def parse_article_xml(article_xml_files, tmp_dir):

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -1,4 +1,5 @@
 import time
+import requests
 from elifearticle.article import ArticleDate
 from elifecrossref import generate
 from elifecrossref.conf import raw_config, parse_raw_config
@@ -82,3 +83,35 @@ def approve_to_generate(crossref_config, article):
         approved = True
 
     return approved
+
+
+def crossref_data_payload(crossref_login_id, crossref_login_passwd, operation='doMDUpload'):
+    """assemble a requests data payload for Crossref endpoint"""
+    return {
+        'operation': operation,
+        'login_id': crossref_login_id,
+        'login_passwd': crossref_login_passwd
+    }
+
+
+def upload_files_to_endpoint(url, payload, xml_files):
+    """Using an HTTP POST, deposit the file to the Crossref endpoint"""
+
+    # Default return status
+    status = True
+    http_detail_list = []
+
+    for xml_file in xml_files:
+        files = {'file': open(xml_file, 'rb')}
+
+        response = requests.post(url, data=payload, files=files)
+
+        # Check for good HTTP status code
+        if response.status_code != 200:
+            status = False
+        # print response.text
+        http_detail_list.append("XML file: " + xml_file)
+        http_detail_list.append("HTTP status: " + str(response.status_code))
+        http_detail_list.append("HTTP response: " + response.text)
+
+    return status, http_detail_list

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -249,3 +249,86 @@ def upload_crossref_xml_to_s3(settings, bucket_name, to_folder, file_names):
             storage_provider + bucket_name + "/" + to_folder +
             article_processing.file_name_from_name(file_name))
         storage.set_resource_from_filename(resource_dest, file_name)
+
+
+def get_email_subject(datetime_string, activity_status_text, name, domain, outbox_s3_key_names):
+    """
+    Assemble the email subject
+    """
+    # Count the files moved from the outbox, the files that were processed
+    files_count = 0
+    if outbox_s3_key_names:
+        files_count = len(outbox_s3_key_names)
+
+    subject = (
+        name + " " + activity_status_text + " files: " + str(files_count) +
+        ", " + datetime_string + ", eLife SWF domain: " + domain)
+
+    return subject
+
+
+def get_email_body_head(name, activity_status_text, statuses):
+    """
+    Format the body of the email
+    """
+
+    body = ""
+
+    # Bulk of body
+    body += name + " status:" + "\n"
+    body += "\n"
+    body += activity_status_text + "\n"
+    body += "\n"
+
+    body += "activity_status: " + str(statuses.get("activity")) + "\n"
+    body += "generate_status: " + str(statuses.get("generate")) + "\n"
+    body += "approve_status: " + str(statuses.get("approve")) + "\n"
+    body += "publish_status: " + str(statuses.get("publish")) + "\n"
+    body += "outbox_status: " + str(statuses.get("outbox")) + "\n"
+
+    body += "\n"
+
+    return body
+
+
+def get_email_body_middle(outbox_s3_key_names, published_file_names,
+                          not_published_file_names, http_detail_list):
+    """
+    Format the body of the email
+    """
+
+    body = ""
+
+    body += "\n"
+    body += "Outbox files: " + "\n"
+
+    files_count = 0
+    if outbox_s3_key_names:
+        files_count = len(outbox_s3_key_names)
+    if files_count > 0:
+        for name in outbox_s3_key_names:
+            body += name + "\n"
+    else:
+        body += "No files in outbox." + "\n"
+
+    # Report on published files
+    if len(published_file_names) > 0:
+        body += "\n"
+        body += "Published files generated crossref XML: " + "\n"
+        for name in published_file_names:
+            body += name.split(os.sep)[-1] + "\n"
+
+    # Report on not published files
+    if len(not_published_file_names) > 0:
+        body += "\n"
+        body += "Files not approved or failed crossref XML: " + "\n"
+        for name in not_published_file_names:
+            body += name.split(os.sep)[-1] + "\n"
+
+    body += "\n"
+    body += "-------------------------------\n"
+    body += "HTTP deposit details: " + "\n"
+    for text in http_detail_list:
+        body += str(text) + "\n"
+
+    return body

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -175,6 +175,17 @@ def get_to_folder_name(folder_name, date_stamp):
     return folder_name + date_stamp + "/"
 
 
+def get_outbox_s3_key_names(settings, bucket_name, outbox_folder):
+    """get a list of .xml S3 key names from the outbox"""
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+    orig_resource = (
+        storage_provider + bucket_name + "/" + outbox_folder.rstrip('/'))
+    s3_key_names = storage.list_resources(orig_resource)
+    # return only the .xml files
+    return [key_name for key_name in s3_key_names if key_name.endswith('.xml')]
+
+
 def clean_outbox(settings, bucket_name, outbox_folder, to_folder, published_file_names):
     """Clean out the S3 outbox folder"""
 

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -5,7 +5,7 @@ import requests
 from elifearticle.article import ArticleDate
 from elifecrossref import generate
 from elifecrossref.conf import raw_config, parse_raw_config
-from provider import lax_provider, utils
+from provider import article_processing, lax_provider, utils
 from provider.storage_provider import storage_context
 
 
@@ -235,3 +235,17 @@ def clean_outbox(settings, bucket_name, outbox_folder, to_folder, published_file
 
         # Then delete the old key if successful
         storage.delete_resource(orig_resource)
+
+
+def upload_crossref_xml_to_s3(settings, bucket_name, to_folder, file_names):
+    """
+    Upload a copy of the crossref XML to S3 for reference
+    """
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+
+    for file_name in file_names:
+        resource_dest = (
+            storage_provider + bucket_name + "/" + to_folder +
+            article_processing.file_name_from_name(file_name))
+        storage.set_resource_from_filename(resource_dest, file_name)

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -6,6 +6,12 @@ from elifecrossref.conf import raw_config, parse_raw_config
 from provider import lax_provider, utils
 
 
+def override_tmp_dir(tmp_dir):
+    """explicit override of TMP_DIR in the generate module"""
+    if tmp_dir:
+        generate.TMP_DIR = tmp_dir
+
+
 def elifecrossref_config(settings):
     "parse the config values from the elifecrossref config"
     return parse_raw_config(raw_config(
@@ -13,10 +19,10 @@ def elifecrossref_config(settings):
         settings.elifecrossref_config_file))
 
 
-def parse_article_xml(article_xml_files, tmp_dir):
+def parse_article_xml(article_xml_files, tmp_dir=None):
     """Given a list of article XML files, parse into objects"""
+    override_tmp_dir(tmp_dir)
     articles = []
-    generate.TMP_DIR = tmp_dir
     # convert one file at a time
     for article_xml in article_xml_files:
         article_list = None

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -121,3 +121,20 @@ def upload_files_to_endpoint(url, payload, xml_files):
         http_detail_list.append("HTTP response: " + response.text)
 
     return status, http_detail_list
+
+
+def generate_crossref_xml_to_disk(article_object_map, crossref_config, good_xml_files,
+                                  bad_xml_files, submission_type="journal"):
+    """from the article object generate crossref deposit XML"""
+    for xml_file, article in list(article_object_map.items()):
+        try:
+            # Will write the XML to the TMP_DIR
+            generate.crossref_xml_to_disk(
+                [article], crossref_config, submission_type=submission_type)
+            # Add filename to the list of good files
+            good_xml_files.append(xml_file)
+        except:
+            # Add the file to the list of bad files
+            bad_xml_files.append(xml_file)
+    # Any files generated is a sucess, even if one failed
+    return True

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -243,3 +243,18 @@ def valid_recipient_object(recipient):
     if recipient.e_mail is not None and str(recipient.e_mail).strip() == "":
         return False
     return True
+
+
+def get_admin_email_body_foot(activity_id, workflow_id, datetime_string, domain):
+    """Format the footer of the body of the email"""
+    body_foot = ""
+    body_foot += "\n"
+    body_foot += "-------------------------------\n"
+    body_foot += "SWF workflow details: " + "\n"
+    body_foot += "activityId: " + str(activity_id) + "\n"
+    body_foot += "As part of workflowId: " + str(workflow_id) + "\n"
+    body_foot += "As at " + datetime_string + "\n"
+    body_foot += "Domain: " + domain + "\n"
+    body_foot += "\n"
+    body_foot += "\n\nSincerely\n\neLife bot"
+    return body_foot

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -4,6 +4,7 @@ import smtplib
 import unicodedata
 import traceback
 from collections import OrderedDict
+from string import Template
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -247,14 +248,11 @@ def valid_recipient_object(recipient):
 
 def get_admin_email_body_foot(activity_id, workflow_id, datetime_string, domain):
     """Format the footer of the body of the email"""
-    body_foot = ""
-    body_foot += "\n"
-    body_foot += "-------------------------------\n"
-    body_foot += "SWF workflow details: " + "\n"
-    body_foot += "activityId: " + str(activity_id) + "\n"
-    body_foot += "As part of workflowId: " + str(workflow_id) + "\n"
-    body_foot += "As at " + datetime_string + "\n"
-    body_foot += "Domain: " + domain + "\n"
-    body_foot += "\n"
-    body_foot += "\n\nSincerely\n\neLife bot"
-    return body_foot
+    string_template = None
+    with open('template/admin_email_body_foot.txt', 'r') as open_file:
+        string_template = Template(open_file.read())
+    if string_template:
+        return string_template.safe_substitute(
+            activity_id=activity_id, workflow_id=workflow_id, datetime_string=datetime_string,
+            domain=domain)
+    return ''

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,6 +1,7 @@
 import re
 import urllib
 import base64
+import arrow
 
 S3_DATE_FORMAT = '%Y%m%d%H%M%S'
 PUB_DATE_FORMAT = "%Y-%m-%d"
@@ -89,3 +90,23 @@ def unicode_encode(string):
     except (UnicodeDecodeError, TypeError, AttributeError):
         string = unicode_decode(string)
     return string
+
+
+def set_datestamp():
+    a = arrow.utcnow()
+    date_stamp = (str(a.datetime.year) + str(a.datetime.month).zfill(2) +
+                  str(a.datetime.day).zfill(2))
+    return date_stamp
+
+
+def get_activity_status_text(activity_status):
+    """
+    Given the activity status boolean, return a human
+    readable text version
+    """
+    if activity_status is True:
+        activity_status_text = "Success!"
+    else:
+        activity_status_text = "FAILED."
+
+    return activity_status_text

--- a/template/admin_email_body_foot.txt
+++ b/template/admin_email_body_foot.txt
@@ -1,0 +1,12 @@
+
+-------------------------------
+SWF workflow details:
+activityId: $activity_id
+As part of workflowId: $workflow_id
+As at $datetime_string
+Domain: $domain
+
+
+Sincerely
+
+eLife bot

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -189,10 +189,11 @@ def fake_clean_tmp_dir():
     shutil.rmtree(tmp_dir)
 
 class FakeResponse:
-    def __init__(self, status_code, response_json):
+    def __init__(self, status_code, response_json=None, text=""):
         self.status_code = status_code
         self.response_json = response_json
         self.content = None
+        self.text = text
 
     def json(self):
         return self.response_json

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -79,6 +79,10 @@ xml_info_queue = 'test-elife-xml-info'
 
 video_url = ""
 
+crossref_url = ""
+crossref_login_id = ""
+crossref_login_passwd = ""
+
 # PDF cover
 pdf_cover_generator = "url_here"
 

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -52,6 +52,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": True,
             "expected_outbox_status": True,
+            "expected_email_status": True,
             "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
@@ -75,6 +76,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": True,
             "expected_outbox_status": True,
+            "expected_email_status": True,
             "expected_activity_status": True,
             "expected_file_count": 2,
         },
@@ -86,6 +88,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": None,
             "expected_outbox_status": None,
+            "expected_email_status": None,
             "expected_activity_status": True,
             "expected_file_count": 0,
         },
@@ -97,6 +100,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": False,
             "expected_outbox_status": None,
+            "expected_email_status": True,
             "expected_activity_status": False,
             "expected_file_count": 1,
         },
@@ -121,6 +125,8 @@ class TestDepositCrossref(unittest.TestCase):
             self.activity.statuses.get("publish"), test_data.get("expected_publish_status"))
         self.assertEqual(
             self.activity.statuses.get("outbox"), test_data.get("expected_outbox_status"))
+        self.assertEqual(
+            self.activity.statuses.get("email"), test_data.get("expected_email_status"))
         self.assertEqual(
             self.activity.statuses.get("activity"), test_data.get("expected_activity_status"))
         # Count crossref XML file in the tmp directory

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -3,7 +3,7 @@ from activity.activity_DepositCrossref import activity_DepositCrossref
 import shutil
 from mock import patch
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 from provider.article import article
 from provider.simpleDB import SimpleDB
 from provider import lax_provider
@@ -129,6 +129,14 @@ class TestDepositCrossref(unittest.TestCase):
         article = articles[0]
         self.assertIsNotNone(article.get_date('pub'), 'date of type pub not found in article get_date()')
         self.assertIsNotNone(article.version, 'version is None in article')
+
+
+    @patch('activity.activity_DepositCrossref.storage_context')
+    def test_get_outbox_s3_key_names(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
+        key_names = self.activity.get_outbox_s3_key_names()
+        # returns the default file name from FakeStorageContext in the test scenario
+        self.assertEqual(key_names, ['elife-00353-v1.xml'])
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -45,6 +45,7 @@ class TestDepositCrossref(unittest.TestCase):
     @patch.object(activity_module, 'storage_context')
     @data(
         {
+            "comment": "Article 15747",
             "article_xml_filenames": ['elife-15747-v2.xml'],
             "post_status_code": 200,
             "expected_result": True,
@@ -68,6 +69,7 @@ class TestDepositCrossref(unittest.TestCase):
                 ]
         },
         {
+            "comment": "Multiple files to deposit",
             "article_xml_filenames": [
                 'elife-18753-v1.xml', 'elife-23065-v1.xml', 'fake-00000-v1.xml'],
             "post_status_code": 200,
@@ -81,6 +83,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 2,
         },
         {
+            "comment": "No files to deposit",
             "article_xml_filenames": [],
             "post_status_code": 200,
             "expected_result": True,
@@ -93,6 +96,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 0,
         },
         {
+            "comment": "API endpoint 404",
             "article_xml_filenames": ['elife-18753-v1.xml'],
             "post_status_code": 404,
             "expected_result": True,
@@ -117,18 +121,15 @@ class TestDepositCrossref(unittest.TestCase):
         result = self.activity.do_activity()
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
-        self.assertEqual(
-            self.activity.statuses.get("approve"), test_data.get("expected_approve_status"))
-        self.assertEqual(
-            self.activity.statuses.get("generate"), test_data.get("expected_generate_status"))
-        self.assertEqual(
-            self.activity.statuses.get("publish"), test_data.get("expected_publish_status"))
-        self.assertEqual(
-            self.activity.statuses.get("outbox"), test_data.get("expected_outbox_status"))
-        self.assertEqual(
-            self.activity.statuses.get("email"), test_data.get("expected_email_status"))
-        self.assertEqual(
-            self.activity.statuses.get("activity"), test_data.get("expected_activity_status"))
+        # check statuses assertions
+        for status_name in ['approve', 'generate', 'publish', 'outbox', 'email', 'activity']:
+            status_value = self.activity.statuses.get(status_name)
+            expected = test_data.get("expected_" + status_name + "_status")
+            self.assertEqual(
+                status_value, expected,
+                '{expected} {status_name} status not equal to {status_value} in {comment}'.format(
+                    expected=expected, status_name=status_name, status_value=status_value,
+                    comment=test_data.get("comment")))
         # Count crossref XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
         self.assertEqual(file_count, test_data.get("expected_file_count"))

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -37,7 +37,6 @@ class TestDepositCrossref(unittest.TestCase):
         shutil.copy(source_doc, dest_doc)
 
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
-    @patch.object(activity_DepositCrossref, 'upload_crossref_xml_to_s3')
     @patch.object(activity_DepositCrossref, 'clean_outbox')
     @patch.object(activity_DepositCrossref, 'deposit_files_to_endpoint')
     @patch.object(FakeStorageContext, 'list_resources')
@@ -92,7 +91,7 @@ class TestDepositCrossref(unittest.TestCase):
     )
     def test_do_activity(self, test_data, fake_storage_context, fake_list_resources,
                          fake_deposit_files_to_endpoint,
-                         fake_clean_outbox, fake_upload_crossref_xml_to_s3,
+                         fake_clean_outbox,
                          fake_elife_add_email_to_email_queue):
         fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
         # copy XML files into the input directory

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -26,7 +26,7 @@ class TestDepositCrossref(unittest.TestCase):
         self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
             activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
-    
+
     def input_dir(self):
         "return the staging dir name for the activity"
         return self.activity.directories.get("INPUT_DIR")
@@ -56,13 +56,19 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
                 '<doi>10.7554/eLife.15747</doi>',
-                '<publication_date media_type="online"><month>06</month><day>16</day><year>2016</year></publication_date>',
+                ('<publication_date media_type="online"><month>06</month><day>16</day>' +
+                 '<year>2016</year></publication_date>'),
                 '<item_number item_number_type="article_number">e15747</item_number>',
-                '<citation key="bib13"><journal_title>BMC Biology</journal_title><author>Gilbert</author><volume>12</volume><cYear>2014</cYear><article_title>The Earth Microbiome project: successes and aspirations</article_title><doi>10.1186/s12915-014-0069-1</doi><elocation_id>69</elocation_id></citation>'
+                ('<citation key="bib13"><journal_title>BMC Biology</journal_title>' +
+                 '<author>Gilbert</author><volume>12</volume><cYear>2014</cYear>' +
+                 '<article_title>The Earth Microbiome project: successes and aspirations' +
+                 '</article_title><doi>10.1186/s12915-014-0069-1</doi>' +
+                 '<elocation_id>69</elocation_id></citation>')
                 ]
         },
         {
-            "article_xml_filenames": ['elife-18753-v1.xml', 'elife-23065-v1.xml', 'fake-00000-v1.xml'],
+            "article_xml_filenames": [
+                'elife-18753-v1.xml', 'elife-23065-v1.xml', 'fake-00000-v1.xml'],
             "post_status_code": 200,
             "expected_result": True,
             "expected_approve_status": True,
@@ -117,18 +123,21 @@ class TestDepositCrossref(unittest.TestCase):
                 crossref_xml = fp.read().decode('utf8')
                 for expected in test_data.get("expected_crossref_xml_contains"):
                     self.assertTrue(
-                        expected in crossref_xml, '{expected} not found in crossref_xml {path}'.format(
+                        expected in crossref_xml,
+                        '{expected} not found in crossref_xml {path}'.format(
                             expected=expected, path=crossref_xml_filename_path))
 
     @patch('provider.lax_provider.article_versions')
     def test_parse_article_xml(self, mock_lax_provider_article_versions):
         "example where there is not pub date and no version for an article"
-        mock_lax_provider_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        articles = self.activity.parse_article_xml(['tests/test_data/crossref/elife_poa_e03977.xml'])
+        mock_lax_provider_article_versions.return_value = (
+            200, test_case_data.lax_article_versions_response_data)
+        articles = self.activity.parse_article_xml(
+            ['tests/test_data/crossref/elife_poa_e03977.xml'])
         article = articles[0]
-        self.assertIsNotNone(article.get_date('pub'), 'date of type pub not found in article get_date()')
+        self.assertIsNotNone(
+            article.get_date('pub'), 'date of type pub not found in article get_date()')
         self.assertIsNotNone(article.version, 'version is None in article')
-
 
     @patch('activity.activity_DepositCrossref.storage_context')
     def test_get_outbox_s3_key_names(self, fake_storage_context):

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -3,6 +3,7 @@ import unittest
 import shutil
 from mock import patch
 from ddt import ddt, data
+from provider import crossref
 import activity.activity_DepositCrossref as activity_module
 from activity.activity_DepositCrossref import activity_DepositCrossref
 from tests.classes_mock import FakeSMTPServer
@@ -145,12 +146,13 @@ class TestDepositCrossref(unittest.TestCase):
                             expected=expected, path=crossref_xml_filename_path))
 
     @patch('provider.lax_provider.article_versions')
-    def test_get_article_list(self, mock_article_versions):
+    def test_get_article_objects(self, mock_article_versions):
         "example where there is not pub date and no version for an article"
         mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        articles = self.activity.get_article_list(
-            ['tests/test_data/crossref/elife_poa_e03977.xml'])
-        article = articles[0]
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        xml_file = 'tests/test_data/crossref/elife_poa_e03977.xml'
+        articles = self.activity.get_article_objects([xml_file], crossref_config)
+        article = articles[xml_file]
         self.assertIsNotNone(
             article.get_date('pub'), 'date of type pub not found in article get_date()')
         self.assertIsNotNone(article.version, 'version is None in article')

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -37,7 +37,6 @@ class TestDepositCrossref(unittest.TestCase):
         shutil.copy(source_doc, dest_doc)
 
     @patch.object(SimpleDB, 'elife_add_email_to_email_queue')
-    @patch.object(activity_DepositCrossref, 'clean_outbox')
     @patch.object(activity_DepositCrossref, 'deposit_files_to_endpoint')
     @patch.object(FakeStorageContext, 'list_resources')
     @patch('activity.activity_DepositCrossref.storage_context')
@@ -91,7 +90,6 @@ class TestDepositCrossref(unittest.TestCase):
     )
     def test_do_activity(self, test_data, fake_storage_context, fake_list_resources,
                          fake_deposit_files_to_endpoint,
-                         fake_clean_outbox,
                          fake_elife_add_email_to_email_queue):
         fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
         # copy XML files into the input directory

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -1,17 +1,15 @@
+import os
 import unittest
-from activity.activity_DepositCrossref import activity_DepositCrossref
 import shutil
 from mock import patch
-import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
-from provider.article import article
+from ddt import ddt, data
 from provider.simpleDB import SimpleDB
-from provider import lax_provider
+from activity.activity_DepositCrossref import activity_DepositCrossref
+from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
+import tests.activity.settings_mock as settings_mock
 import tests.activity.test_activity_data as activity_test_data
 import tests.activity.helpers as helpers
 import tests.test_data as test_case_data
-import os
-from ddt import ddt, data
 
 
 @ddt

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -50,6 +50,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_approve_status": True,
             "expected_generate_status": True,
             "expected_publish_status": True,
+            "expected_outbox_status": True,
             "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
@@ -72,6 +73,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_approve_status": True,
             "expected_generate_status": True,
             "expected_publish_status": True,
+            "expected_outbox_status": True,
             "expected_activity_status": True,
             "expected_file_count": 2,
         },
@@ -82,6 +84,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_approve_status": False,
             "expected_generate_status": True,
             "expected_publish_status": None,
+            "expected_outbox_status": None,
             "expected_activity_status": True,
             "expected_file_count": 0,
         },
@@ -92,6 +95,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_approve_status": True,
             "expected_generate_status": True,
             "expected_publish_status": False,
+            "expected_outbox_status": None,
             "expected_activity_status": False,
             "expected_file_count": 1,
         },
@@ -108,10 +112,16 @@ class TestDepositCrossref(unittest.TestCase):
         result = self.activity.do_activity()
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
-        self.assertEqual(self.activity.approve_status, test_data.get("expected_approve_status"))
-        self.assertEqual(self.activity.generate_status, test_data.get("expected_generate_status"))
-        self.assertEqual(self.activity.publish_status, test_data.get("expected_publish_status"))
-        self.assertEqual(self.activity.activity_status, test_data.get("expected_activity_status"))
+        self.assertEqual(
+            self.activity.statuses.get("approve"), test_data.get("expected_approve_status"))
+        self.assertEqual(
+            self.activity.statuses.get("generate"), test_data.get("expected_generate_status"))
+        self.assertEqual(
+            self.activity.statuses.get("publish"), test_data.get("expected_publish_status"))
+        self.assertEqual(
+            self.activity.statuses.get("outbox"), test_data.get("expected_outbox_status"))
+        self.assertEqual(
+            self.activity.statuses.get("activity"), test_data.get("expected_activity_status"))
         # Count crossref XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
         self.assertEqual(file_count, test_data.get("expected_file_count"))

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -4,6 +4,7 @@ import shutil
 from mock import patch
 from ddt import ddt, data
 from provider import crossref
+from provider.storage_provider import storage_context
 import activity.activity_DepositCrossref as activity_module
 from activity.activity_DepositCrossref import activity_DepositCrossref
 from tests.classes_mock import FakeSMTPServer
@@ -43,6 +44,7 @@ class TestDepositCrossref(unittest.TestCase):
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
+    @patch('provider.crossref.clean_outbox')
     @patch.object(activity_module, 'storage_context')
     @data(
         {
@@ -110,10 +112,11 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_list_resources, fake_request,
-                         fake_email_smtp_connect):
+    def test_do_activity(self, test_data, fake_storage_context, fake_clean_outbox,
+                         fake_list_resources, fake_request, fake_email_smtp_connect):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
+        fake_clean_outbox.return_value = True
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
         # mock the POST to endpoint

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -4,7 +4,6 @@ import shutil
 from mock import patch
 from ddt import ddt, data
 from provider import crossref
-from provider.storage_provider import storage_context
 import activity.activity_DepositCrossref as activity_module
 from activity.activity_DepositCrossref import activity_DepositCrossref
 from tests.classes_mock import FakeSMTPServer
@@ -115,8 +114,8 @@ class TestDepositCrossref(unittest.TestCase):
     def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
                          fake_list_resources, fake_request, fake_email_smtp_connect):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
-        fake_provider_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_provider_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
         # mock the POST to endpoint

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -97,7 +97,8 @@ class TestDepositCrossref(unittest.TestCase):
         },
     )
     def test_do_activity(self, test_data, fake_storage_context, fake_list_resources, fake_request,
-                         fake_elife_add_email_to_email_queue):
+                         fake_add_email):
+        fake_add_email.return_value = None
         fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
@@ -117,8 +118,8 @@ class TestDepositCrossref(unittest.TestCase):
         if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
             # Open the first crossref XML and check some of its contents
             crossref_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
-            with open(crossref_xml_filename_path, 'rb') as fp:
-                crossref_xml = fp.read().decode('utf8')
+            with open(crossref_xml_filename_path, 'rb') as open_file:
+                crossref_xml = open_file.read().decode('utf8')
                 for expected in test_data.get("expected_crossref_xml_contains"):
                     self.assertTrue(
                         expected in crossref_xml,
@@ -126,10 +127,9 @@ class TestDepositCrossref(unittest.TestCase):
                             expected=expected, path=crossref_xml_filename_path))
 
     @patch('provider.lax_provider.article_versions')
-    def test_parse_article_xml(self, mock_lax_provider_article_versions):
+    def test_parse_article_xml(self, mock_article_versions):
         "example where there is not pub date and no version for an article"
-        mock_lax_provider_article_versions.return_value = (
-            200, test_case_data.lax_article_versions_response_data)
+        mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
         articles = self.activity.parse_article_xml(
             ['tests/test_data/crossref/elife_poa_e03977.xml'])
         article = articles[0]

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -44,7 +44,7 @@ class TestDepositCrossref(unittest.TestCase):
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.crossref.clean_outbox')
+    @patch('provider.crossref.storage_context')
     @patch.object(activity_module, 'storage_context')
     @data(
         {
@@ -112,11 +112,11 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_clean_outbox,
+    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
                          fake_list_resources, fake_request, fake_email_smtp_connect):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
-        fake_clean_outbox.return_value = True
+        fake_provider_storage_context.return_value = FakeStorageContext()
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
         # mock the POST to endpoint
@@ -159,13 +159,6 @@ class TestDepositCrossref(unittest.TestCase):
         self.assertIsNotNone(
             article.get_date('pub'), 'date of type pub not found in article get_date()')
         self.assertIsNotNone(article.version, 'version is None in article')
-
-    @patch.object(activity_module, 'storage_context')
-    def test_get_outbox_s3_key_names(self, fake_storage_context):
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
-        key_names = self.activity.get_outbox_s3_key_names()
-        # returns the default file name from FakeStorageContext in the test scenario
-        self.assertEqual(key_names, ['elife-00353-v1.xml'])
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -44,7 +44,6 @@ class TestDepositCrossref(unittest.TestCase):
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
     @patch('provider.crossref.storage_context')
-    @patch.object(activity_module, 'storage_context')
     @data(
         {
             "comment": "Article 15747",
@@ -111,11 +110,10 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
-                         fake_list_resources, fake_request, fake_email_smtp_connect):
+    def test_do_activity(self, test_data, fake_storage_context, fake_list_resources,
+                         fake_request, fake_email_smtp_connect):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
-        fake_storage_context.return_value = FakeStorageContext()
-        fake_provider_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
+        fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
         # mock the POST to endpoint

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -145,10 +145,10 @@ class TestDepositCrossref(unittest.TestCase):
                             expected=expected, path=crossref_xml_filename_path))
 
     @patch('provider.lax_provider.article_versions')
-    def test_parse_article_xml(self, mock_article_versions):
+    def test_get_article_list(self, mock_article_versions):
         "example where there is not pub date and no version for an article"
         mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        articles = self.activity.parse_article_xml(
+        articles = self.activity.get_article_list(
             ['tests/test_data/crossref/elife_poa_e03977.xml'])
         article = articles[0]
         self.assertIsNotNone(

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -7,6 +7,8 @@ from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageCon
 from provider.article import article
 from provider.simpleDB import SimpleDB
 from provider import lax_provider
+import tests.activity.test_activity_data as activity_test_data
+import tests.activity.helpers as helpers
 import tests.test_data as test_case_data
 import os
 from ddt import ddt, data
@@ -22,7 +24,9 @@ class TestDepositCrossref(unittest.TestCase):
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
-
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
+    
     def input_dir(self):
         "return the staging dir name for the activity"
         return self.activity.directories.get("INPUT_DIR")

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -219,6 +219,16 @@ class TestCrossrefProvider(unittest.TestCase):
         self.assertEqual(key_names, ['elife-00353-v1.xml'])
 
     @patch('provider.crossref.storage_context')
+    def test_download_files_from_s3_outbox(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext()
+        bucket_name = ''
+        outbox_folder = ''
+        key_names = crossref.get_outbox_s3_key_names(settings_mock, bucket_name, outbox_folder)
+        result = crossref.download_files_from_s3_outbox(
+            settings_mock, bucket_name, key_names, self.directory.path, FakeLogger())
+        self.assertTrue(result)
+
+    @patch('provider.crossref.storage_context')
     def test_clean_outbox(self, fake_storage_context):
         fake_storage_context.return_value = FakeStorageContext(self.directory)
         # copy two files in for cleaning

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -212,6 +212,13 @@ class TestCrossrefProvider(unittest.TestCase):
         self.assertEqual(crossref.get_to_folder_name(folder_name, date_stamp), expected)
 
     @patch('provider.crossref.storage_context')
+    def test_get_outbox_s3_key_names(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext('tests/test_data/crossref')
+        key_names = crossref.get_outbox_s3_key_names(settings_mock, '', '')
+        # returns the default file name from FakeStorageContext in the test scenario
+        self.assertEqual(key_names, ['elife-00353-v1.xml'])
+
+    @patch('provider.crossref.storage_context')
     def test_clean_outbox(self, fake_storage_context):
         fake_storage_context.return_value = FakeStorageContext(self.directory)
         # copy two files in for cleaning

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -2,7 +2,7 @@ import time
 import unittest
 from mock import patch
 from testfixtures import TempDirectory
-from provider import crossref
+import provider.crossref as crossref
 import tests.settings_mock as settings_mock
 import tests.test_data as test_case_data
 from tests.activity.classes_mock import FakeLogger

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -232,6 +232,19 @@ class TestCrossrefProvider(unittest.TestCase):
             settings_mock, bucket_name, key_names, self.directory.path, FakeLogger())
         self.assertTrue(result)
 
+    @patch.object(FakeStorageContext, 'get_resource_to_file')
+    @patch('provider.crossref.storage_context')
+    def test_download_files_from_s3_outbox_failure(self, fake_storage_context, fake_get_resource):
+        """test IOError exception for coverage"""
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_get_resource.side_effect = IOError
+        bucket_name = ''
+        outbox_folder = ''
+        key_names = crossref.get_outbox_s3_key_names(settings_mock, bucket_name, outbox_folder)
+        result = crossref.download_files_from_s3_outbox(
+            settings_mock, bucket_name, key_names, self.directory.path, FakeLogger())
+        self.assertFalse(result)
+
     @patch('provider.crossref.storage_context')
     def test_clean_outbox(self, fake_storage_context):
         fake_storage_context.return_value = FakeStorageContext(self.directory)

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -1,0 +1,111 @@
+import time
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from provider import crossref
+import tests.settings_mock as settings_mock
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeLogger
+
+
+class TestCrossrefProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.good_xml_file = "tests/test_data/crossref/elife-18753-v1.xml"
+        self.bad_xml_file = "tests/files_source/elife-00353-v1_bad_pub_date"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_elifecrossref_config(self):
+        """test reading the crossref config file"""
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        self.assertIsNotNone(crossref_config)
+
+    def test_parse_article_xml(self):
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        self.assertEqual(len(articles), 1)
+
+    def test_parse_article_xml_exception(self):
+        articles = crossref.parse_article_xml([self.bad_xml_file], self.directory)
+        self.assertEqual(len(articles), 0)
+
+    @patch('provider.lax_provider.article_versions')
+    def test_set_article_pub_date(self, mock_article_versions):
+        """test for when the date is missing and uses lax data"""
+        mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        # reset the dates
+        article.dates = {}
+        # now set the date
+        crossref.set_article_pub_date(article, crossref_config, settings_mock, FakeLogger())
+        self.assertEqual(len(article.dates), 1)
+
+    def test_set_article_version(self):
+        """test version when it is already present"""
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        # set the version but it is already set
+        crossref.set_article_version(article, settings_mock)
+        self.assertEqual(article.version, 1)
+
+    @patch('provider.lax_provider.article_versions')
+    def test_set_article_version_missing(self, mock_article_versions):
+        """test setting version when missing"""
+        mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        # reset the version
+        article.version = None
+        # now set the version
+        crossref.set_article_version(article, settings_mock)
+        self.assertEqual(article.version, 3)
+
+    def test_article_first_pub_date(self):
+        """test finding a pub date in the article dates"""
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        # get the pub date
+        pub_date_object = crossref.article_first_pub_date(crossref_config, article)
+        expected_date = time.strptime("2016-07-15 UTC", "%Y-%m-%d %Z")
+        self.assertEqual(pub_date_object.date_type, "pub")
+        self.assertEqual(pub_date_object.date, expected_date)
+
+    def test_approve_to_generate(self):
+        """test approving based on the pub date"""
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        approved = crossref.approve_to_generate(crossref_config, article)
+        self.assertTrue(approved)
+
+    @patch('time.gmtime')
+    def test_approve_to_generate_not_approved(self, mock_gmtime):
+        """test approving if the pub date is after the mock current date"""
+        mock_gmtime.return_value = (1, 1, 1, 1, 1, 1, 1, 1, 0)
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        approved = crossref.approve_to_generate(crossref_config, article)
+        self.assertFalse(approved)
+
+    def test_approve_to_generate_no_date(self):
+        """test approving when there is no pub date"""
+        crossref_config = crossref.elifecrossref_config(settings_mock)
+        # build an article
+        articles = crossref.parse_article_xml([self.good_xml_file], self.directory)
+        article = articles[0]
+        # reset the dates
+        article.dates = {}
+        approved = crossref.approve_to_generate(crossref_config, article)
+        self.assertTrue(approved)

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -132,3 +132,17 @@ class TestListEmailRecipients(unittest.TestCase):
             self.assertTrue(
                 expected in str(email_message),
                 'Fragment %s not found in email %s' % (expected, str(email_message)))
+
+    def test_get_admin_email_body_foot(self):
+        """test simple string Template rendering"""
+        activity_id = 'DepositCrossref'
+        workflow_id = 'DepositCrossref'
+        datetime_string = '2019-08-21T16:00:13.000Z'
+        domain = 'Publish'
+        email_body_foot = email_provider.get_admin_email_body_foot(
+            activity_id, workflow_id, datetime_string, domain)
+        self.assertTrue('SWF workflow details:' in email_body_foot)
+        self.assertTrue(('activityId: %s' % activity_id) in email_body_foot)
+        self.assertTrue(('As part of workflowId: %s' % workflow_id) in email_body_foot)
+        self.assertTrue(('As at %s' % datetime_string) in email_body_foot)
+        self.assertTrue(('Domain: %s' % domain) in email_body_foot)

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -55,3 +55,6 @@ fastly_api_key = 'fake_fastly_api_key'
 
 elifepubmed_config_file = 'tests/activity/pubmed.cfg'
 elifepubmed_config_section = 'elife'
+
+elifecrossref_config_file = 'tests/activity/crossref.cfg'
+elifecrossref_config_section = 'elife'

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -42,6 +42,10 @@ digest_auth_key = 'digest_auth_key'
 
 no_download_extensions = 'tif'
 
+crossref_url = ""
+crossref_login_id = ""
+crossref_login_passwd = ""
+
 # Logging
 setLevel = "INFO"
 


### PR DESCRIPTION
In regards to issue https://github.com/elifesciences/elife-bot/issues/936.

The primary motivation was to make any logic that could be reused in the `DepositCrossref` activity available for reuse, resulting in a new `crossref.py` provider module.

Additionally, the steps of refactoring in the issue mentioned above was done, including storage logic, emailing, activity status tracking.

I moved `get_admin_email_body_foot()` over to `email_provider.py`, because it could also be reused, and is why the `PublicationEmail` module is altered on this PR.

In the end, I managed to move as much of the logic to `crossref.py` that I think could be reused, including the bucket upload and downloading, Crossref API communication, parsing XML into objects, and admin email subject and body content.

Soon, when we add a new activity for depositing peer reviews to Crossref, building that new activity will be much easier, and result in less duplicate code.