### PR TITLE
Utils refactor

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -368,7 +368,7 @@ class activity_PackagePOA(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         subject = (
             self.name + " " + activity_status_text + " doi: " + str(self.doi) + ", " +
@@ -387,7 +387,7 @@ class activity_PackagePOA(Activity):
         date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Bulk of body
         body += self.name + " status:" + "\n"
@@ -446,15 +446,3 @@ def approve_for_packaging(doi_id):
     if doi_id is None:
         return False
     return True
-
-
-def get_activity_status_text(activity_status):
-    """
-    Given the activity status boolean, return a human
-    readable text version
-    """
-    if activity_status is True:
-        activity_status_text = "Success!"
-    else:
-        activity_status_text = "FAILED."
-    return activity_status_text

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -7,6 +7,7 @@ import arrow
 import boto.s3
 from boto.s3.connection import S3Connection
 
+from provider import utils
 import provider.simpleDB as dblib
 import provider.article as articlelib
 import provider.s3lib as s3lib
@@ -35,8 +36,8 @@ class activity_PubRouterDeposit(Activity):
         self.description = ("Download article XML from pub_router outbox, \
                             approve each for publication, and deposit files via FTP to pub router.")
 
-        # Create output directories
-        self.date_stamp = self.set_datestamp()
+        # Set date_stamp
+        self.date_stamp = utils.set_datestamp()
 
         # Data provider where email body is saved
         self.db = dblib.SimpleDB(settings)
@@ -328,12 +329,6 @@ class activity_PubRouterDeposit(Activity):
             starter_status = False
 
         return starter_status
-
-    def set_datestamp(self):
-        a = arrow.utcnow()
-        date_stamp = (str(a.datetime.year) + str(a.datetime.month).zfill(2) +
-                      str(a.datetime.day).zfill(2))
-        return date_stamp
 
     def download_files_from_s3_outbox(self):
         """
@@ -716,18 +711,6 @@ class activity_PubRouterDeposit(Activity):
 
         return recipient_email_list
 
-    def get_activity_status_text(self, activity_status):
-        """
-        Given the activity status boolean, return a human
-        readable text version
-        """
-        if activity_status is True:
-            activity_status_text = "Success!"
-        else:
-            activity_status_text = "FAILED."
-
-        return activity_status_text
-
     def get_admin_email_subject(self, current_time):
         """
         Assemble the email subject
@@ -735,7 +718,7 @@ class activity_PubRouterDeposit(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         subject = (self.name + " " + str(self.workflow) + " " + activity_status_text +
                    ", " + datetime_string +
@@ -753,7 +736,7 @@ class activity_PubRouterDeposit(Activity):
         date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Bulk of body
         body += "Workflow type:" + str(self.workflow)

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -464,7 +464,7 @@ class activity_PublicationEmail(Activity):
         current_time = time.gmtime()
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
-        activity_status_text = get_activity_status_text(activity_status)
+        activity_status_text = utils.get_activity_status_text(activity_status)
 
         body = get_admin_email_body_head(self.name, activity_status_text, self.admin_email_content)
         body += email_provider.get_admin_email_body_foot(
@@ -646,7 +646,7 @@ def get_to_folder_name(published_folder):
     """
     to_folder = None
 
-    date_folder_name = set_datestamp()
+    date_folder_name = utils.set_datestamp()
     to_folder = published_folder + date_folder_name + "/"
 
     return to_folder
@@ -686,14 +686,6 @@ def choose_recipient_authors(authors, article_type, feature_article,
     return recipient_authors
 
 
-def set_datestamp():
-    arrow_date = arrow.utcnow()
-    date_stamp = (
-        str(arrow_date.datetime.year) + str(arrow_date.datetime.month).zfill(2) +
-        str(arrow_date.datetime.day).zfill(2))
-    return date_stamp
-
-
 def is_feature_article(article):
     if (article.is_in_display_channel("Feature article") is True or
             article.is_in_display_channel("Feature Article") is True):
@@ -731,16 +723,3 @@ def choose_email_type(article_type, is_poa, was_ever_poa, feature_article):
                 email_type = "author_publication_email_VOR_no_POA"
 
     return email_type
-
-
-def get_activity_status_text(activity_status):
-    """
-    Given the activity status boolean, return a human
-    readable text version
-    """
-    if activity_status is True:
-        activity_status_text = "Success!"
-    else:
-        activity_status_text = "FAILED."
-
-    return activity_status_text

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -18,6 +18,7 @@ from elifetools import xmlio
 import boto.s3
 from boto.s3.connection import S3Connection
 
+from provider import utils
 import provider.s3lib as s3lib
 import provider.simpleDB as dblib
 import provider.lax_provider as lax_provider
@@ -880,18 +881,6 @@ class activity_PublishFinalPOA(Activity):
 
         return True
 
-    def get_activity_status_text(self, activity_status):
-        """
-        Given the activity status boolean, return a human
-        readable text version
-        """
-        if activity_status is True:
-            activity_status_text = "Success!"
-        else:
-            activity_status_text = "FAILED."
-
-        return activity_status_text
-
     def get_email_subject(self, current_time):
         """
         Assemble the email subject
@@ -899,7 +888,7 @@ class activity_PublishFinalPOA(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Count the files moved from the outbox, the files that were processed
         files_count = 0
@@ -923,7 +912,7 @@ class activity_PublishFinalPOA(Activity):
         date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Bulk of body
         body += self.name + " status:" + "\n"

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -9,6 +9,7 @@ import re
 import requests
 from collections import namedtuple
 
+from provider import utils
 import provider.simpleDB as dblib
 import provider.article as articlelib
 from provider.ftp import FTP
@@ -43,7 +44,7 @@ class activity_PubmedArticleDeposit(Activity):
             "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
         }
 
-        self.date_stamp = self.set_datestamp()
+        self.date_stamp = utils.set_datestamp()
 
         # Data provider where email body is saved
         self.db = dblib.SimpleDB(settings)
@@ -129,12 +130,6 @@ class activity_PubmedArticleDeposit(Activity):
             return True
         else:
             return self.ACTIVITY_PERMANENT_FAILURE
-
-    def set_datestamp(self):
-        a = arrow.utcnow()
-        date_stamp = (str(a.datetime.year) + str(a.datetime.month).zfill(2) +
-                      str(a.datetime.day).zfill(2))
-        return date_stamp
 
     def download_files_from_s3_outbox(self):
         """
@@ -431,18 +426,6 @@ class activity_PubmedArticleDeposit(Activity):
 
         return True
 
-    def get_activity_status_text(self, activity_status):
-        """
-        Given the activity status boolean, return a human
-        readable text version
-        """
-        if activity_status is True:
-            activity_status_text = "Success!"
-        else:
-            activity_status_text = "FAILED."
-
-        return activity_status_text
-
     def get_email_subject(self, current_time):
         """
         Assemble the email subject
@@ -450,7 +433,7 @@ class activity_PubmedArticleDeposit(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Count the files moved from the outbox, the files that were processed
         files_count = 0
@@ -475,7 +458,7 @@ class activity_PubmedArticleDeposit(Activity):
         date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = self.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.activity_status)
 
         # Bulk of body
         body += self.name + " status:" + "\n"

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -93,9 +93,9 @@ def unicode_encode(string):
 
 
 def set_datestamp():
-    a = arrow.utcnow()
-    date_stamp = (str(a.datetime.year) + str(a.datetime.month).zfill(2) +
-                  str(a.datetime.day).zfill(2))
+    arrow_date = arrow.utcnow()
+    date_stamp = (str(arrow_date.datetime.year) + str(arrow_date.datetime.month).zfill(2) +
+                  str(arrow_date.datetime.day).zfill(2))
     return date_stamp
 
 


### PR DESCRIPTION
In issue https://github.com/elifesciences/elife-bot/issues/936, since I moved `set_datestamp()` and `get_activity_status_text()` to provider/utils.py, they can be reused in other activities. A little more code reuse it better than none!