### PR TITLE
Typo, use local time instead of UTC, fix test case.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -166,7 +166,7 @@ def conditional_starts(current_datetime):
 
         # Author emails once per day 17:45 local time
         # (used to be set to 16:45 UTC during British Summer Time for 17:45 local UK time)
-        if current_time.tm_hour == 17:
+        if local_current_time.tm_hour == 17:
             conditional_start_list.append(OrderedDict([
                 ("starter_name", "starter_PublicationEmail"),
                 ("workflow_id", "PublicationEmail"),

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -262,7 +262,7 @@ class TestConditionalStarts(unittest.TestCase):
     @data(
         {
             "comment": "17:45 UTC",
-            "date_time": "1970-01-01 17:45:00 UTC",
+            "date_time": "2019-10-27 17:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
                 "starter_PublicationEmail",
@@ -277,7 +277,7 @@ class TestConditionalStarts(unittest.TestCase):
             ]
         },
     )
-    def test_conditional_starts_17_45_utc(self, test_data):
+    def test_conditional_starts_17_45_utc_october_27_2019(self, test_data):
         self.conditional_start_test_run(test_data)
 
     @data(


### PR DESCRIPTION
Fixing a simple typo, merged in PR https://github.com/elifesciences/elife-bot/pull/941, where the cron starter for `PublicationEmail` should happen based on the timezone aware `local_current_time` and not the UTC based `current_time`.

Updated the related test scenario to show how it would work in GMT.