### PR TITLE
Schedule crossref in silent corrections

### DIFF
--- a/activity/activity_ScheduleCrossref.py
+++ b/activity/activity_ScheduleCrossref.py
@@ -54,7 +54,7 @@ class activity_ScheduleCrossref(Activity):
                 self.logger.info(
                     'ScheduleCrossref will not deposit article %s' +
                     ' ingested by silent-correction, its version of %s does not equal the' +
-                    ' highest version is %s', (article_id, version, highest_version))
+                    ' highest version which is %s', (article_id, version, highest_version))
                 return True
 
         conn = S3Connection(self.settings.aws_access_key_id,

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -1,6 +1,7 @@
 import unittest
 from activity.activity_ScheduleCrossref import activity_ScheduleCrossref
 from mock import mock, patch
+from provider import lax_provider
 from tests.activity.classes_mock import FakeSession
 from tests.activity.classes_mock import FakeS3Connection
 from tests.activity.classes_mock import FakeLogger
@@ -47,6 +48,18 @@ class TestScheduleCrossref(unittest.TestCase):
             fake_key = None
         fake_get_article_xml_key.return_value = (fake_key, xml_filename)
 
+        result = self.activity.do_activity(testdata.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
+
+
+    @patch.object(lax_provider, 'article_highest_version')
+    @patch('activity.activity_ScheduleCrossref.get_session')
+    def test_do_activity_silent_correction(self, fake_session_mock, fake_highest_version):
+        expected_result = True
+        session_dict = testdata.session_example
+        session_dict['run_type'] = 'silent-correction'
+        fake_session_mock.return_value = FakeSession(session_dict)
+        fake_highest_version.return_value = 2
         result = self.activity.do_activity(testdata.ExpandArticle_data)
         self.assertEqual(result, expected_result)
 

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -58,6 +58,17 @@ class workflow_SilentCorrectionsProcess(Workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "ScheduleCrossref",
+                        "activity_id": "ScheduleCrossref",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/692

For `run_type` of `"silent-correction"`, if the version of the article does not equal the highest version of the article already published, then log it and return `True`, not `"scheduling"` it for Crossref deposit.

This guards against overwriting Crossref metadata with a previous, older, version of article metadata when a silent correction is done for an older version, while allowing Crossref deposits to happen automatically if the most recent version of an article is silently corrected.