### PR TITLE
Install Python 3 venv, test on py36 in travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   #- "3.2"
   #- "3.3"
   #- "3.4"
-  #- "3.5"
+  - "3.5" # Ubuntu 16.04
   - "3.6"
   #- "3.5-dev" # 3.5 development branch
   #- "nightly" # currently points to 3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   #- "3.3"
   #- "3.4"
   #- "3.5"
+  - "3.6"
   #- "3.5-dev" # 3.5 development branch
   #- "nightly" # currently points to 3.6-dev
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
-dist: trusty
+dist: xenial # Ubuntu 16.04, elife runtime, travis default
 
 python:
   #- "2.6"
-  - "2.7"
+  #- "2.7" # EOL, no longer supported
   #- "3.2"
   #- "3.3"
   #- "3.4"
   - "3.5" # Ubuntu 16.04
-  - "3.6"
+  - "3.6" # Ubuntu 18.04
   #- "3.5-dev" # 3.5 development branch
   #- "nightly" # currently points to 3.6-dev
 # command to install dependencies

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -112,7 +112,7 @@ class activity_EmailDigest(Activity):
             output_file = output.digest_docx(digest_content, full_file_name)
         except UnicodeEncodeError as exception:
             self.logger.exception("EmailDigest generate_output exception. Message: %s",
-                                  exception.message)
+                                  exception)
             return False, None
         return True, output_file
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -112,7 +112,7 @@ class activity_PublishFinalPOA(Activity):
                         # One possible error is an entirely blank XML file or a malformed xml file
                         if self.logger:
                             self.logger.exception("Exception when converting XML for doi %s, %s" %
-                                                  (str(doi_id), e.message))
+                                                  (str(doi_id), e))
                         continue
 
                 revision = self.next_revision_number(doi_id)

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -114,7 +114,7 @@ class activity_UpdateRepository(Activity):
         try:
             xml_file = article_xml_repo.get_contents(repo_file)
         except GithubException as e:
-            self.logger.info("GithubException - description: " + e.message)
+            self.logger.info("GithubException - description: " + str(e))
             self.logger.info("GithubException: file " + repo_file + " may not exist in github yet. We will try to add it in the repo.")
             try:
                 response = article_xml_repo.create_file(repo_file, "Creates XML", content)
@@ -123,7 +123,7 @@ class activity_UpdateRepository(Activity):
             return "File " + repo_file + " successfully added. Commit: " + str(response)
 
         except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + e.message)
+            self.logger.info("Exception: file " + repo_file + ". Error: " + str(e))
             raise
 
         try:
@@ -139,13 +139,13 @@ class activity_UpdateRepository(Activity):
             return "File " + repo_file + " successfully updated. Commit: " + str(response)
 
         except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + e.message)
+            self.logger.info("Exception: file " + repo_file + ". Error: " + str(e))
             raise
 
     def _retry_or_cancel(self, e):
         if e.status == 409:
             self.logger.warning("Retrying because of exception: %s", e)
-            raise RetryException(e.message)
+            raise RetryException(str(e))
         else:
             raise e
 

--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -65,7 +65,7 @@ class activity_VerifyLaxResponse(Activity):
             self.logger.exception("Exception when Verifying Lax Response")
             self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
                                     "Error when verifying lax response" + article_id +
-                                    " message:" + str(e.message))
+                                    " message:" + str(e))
             return self.ACTIVITY_PERMANENT_FAILURE
 
 

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,10 @@ fi
 
 echo "Found Python: $($python --version)"
 
+if [ "$ENVIRONMENT_NAME" == "ci" ]; then
+    rm -rf venv/
+fi
+
 if [ ! -d venv ]; then
     # build venv if one doesn't exist
     $python -m venv venv

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,6 @@ fi
 
 echo "Virtualenv Python: $(venv/bin/python --version)"
 
-pip install --upgrade pip
-
 # remove any old compiled python files
 find ./ -maxdepth 1 -name '*.pyc' -delete
 find provider/ -maxdepth 1 -name '*.pyc' -delete
@@ -39,6 +37,7 @@ find starter/ -maxdepth 1 -name '*.pyc' -delete
 find S3utility/ -maxdepth 1 -name '*.pyc' -delete
 
 source venv/bin/activate
+pip install --upgrade pip
 grep "git+" requirements.txt > source-requirements.txt
 #pip uninstall -r source-requirements.txt -y
 pip install --ignore-installed -r source-requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,8 @@ find S3utility/ -maxdepth 1 -name '*.pyc' -delete
 
 source venv/bin/activate
 grep "git+" requirements.txt > source-requirements.txt
-pip uninstall -r source-requirements.txt -y
+#pip uninstall -r source-requirements.txt -y
+pip install --ignore-installed -r source-requirements.txt
 pip install -r requirements.txt
 # pip install -r source-requirements.txt --no-cache-dir # only if old revisions are still 'sticking'
 rm source-requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -1,30 +1,11 @@
 #!/bin/bash
 set -e
 
-python=''
-pybinlist=("python3.6" "python3.5" "python3.4")
-
-for pybin in ${pybinlist[*]}; do
-    which "$pybin" &> /dev/null || continue
-    python=$pybin
-    break
-done
-
-if [ -z "$python" ]; then
-    echo "no usable python found, exiting"
-    exit 1
-fi
-
-echo "Found Python: $($python --version)"
-
 if [ "$ENVIRONMENT_NAME" == "ci" ]; then
     rm -rf venv/
 fi
 
-if [ ! -d venv ]; then
-    # build venv if one doesn't exist
-    $python -m venv venv
-fi
+. mkvenv.sh
 
 echo "Virtualenv Python: $(venv/bin/python --version)"
 
@@ -37,7 +18,14 @@ find starter/ -maxdepth 1 -name '*.pyc' -delete
 find S3utility/ -maxdepth 1 -name '*.pyc' -delete
 
 source venv/bin/activate
-pip install --upgrade pip
+
+# fixes issues installing wheel packages, hides deprecation warnings
+pip install "pip~=19.2" --upgrade
+
+# fixes python-docx issue #594 
+# https://github.com/python-openxml/python-docx/issues/594
+pip install "setuptools>=40.6" --upgrade
+
 grep "git+" requirements.txt > source-requirements.txt
 #pip uninstall -r source-requirements.txt -y
 pip install --ignore-installed -r source-requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 set -e
 
+python=''
+pybinlist=("python3.6" "python3.5" "python3.4")
+
+for pybin in ${pybinlist[*]}; do
+    which "$pybin" &> /dev/null || continue
+    python=$pybin
+    break
+done
+
+if [ -z "$python" ]; then
+    echo "no usable python found, exiting"
+    exit 1
+fi
+
 if [ ! -d venv ]; then
     # build venv if one doesn't exist
-    virtualenv --python=`which python2` venv
+    $python -m venv venv
 fi
 
 # remove any old compiled python files

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,8 @@ fi
 
 echo "Virtualenv Python: $(venv/bin/python --version)"
 
+pip install --upgrade pip
+
 # remove any old compiled python files
 find ./ -maxdepth 1 -name '*.pyc' -delete
 find provider/ -maxdepth 1 -name '*.pyc' -delete

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,14 @@ if [ -z "$python" ]; then
     exit 1
 fi
 
+echo "Found Python: $($python --version)"
+
 if [ ! -d venv ]; then
     # build venv if one doesn't exist
     $python -m venv venv
 fi
+
+echo "Virtualenv Python: $(venv/bin/$python --version)"
 
 # remove any old compiled python files
 find ./ -maxdepth 1 -name '*.pyc' -delete

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ if [ ! -d venv ]; then
     $python -m venv venv
 fi
 
-echo "Virtualenv Python: $(venv/bin/$python --version)"
+echo "Virtualenv Python: $(venv/bin/python --version)"
 
 # remove any old compiled python files
 find ./ -maxdepth 1 -name '*.pyc' -delete

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -122,7 +122,7 @@ class LaxResponseAdapter:
 
             return workflow_starter_message
         except Exception as e:
-            self.logger.error("Error parsing Lax message. Message: " + e.message)
+            self.logger.error("Error parsing Lax message. Message: " + str(e))
             raise
 
     @newrelic.agent.background_task(group='lax_response_adapter.py')

--- a/mkvenv.sh
+++ b/mkvenv.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+python=''
+pybinlist=("python3.6" "python3.5" "python3.4")
+
+for pybin in ${pybinlist[*]}; do
+    which "$pybin" &> /dev/null || continue
+    python=$pybin
+    break
+done
+
+if [ -z "$python" ]; then
+    echo "no usable python found, exiting"
+    exit 1
+fi
+
+if [ ! -e "venv/bin/$python" ]; then
+    echo "could not find venv/bin/$python, recreating venv"
+    rm -rf venv
+    $python -m venv venv
+else
+    echo "using $python"
+fi

--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -43,7 +43,7 @@ def resize(format, filep, info, logger):
     except Exception as e:
         message = "error resizing image %s" % info.filename
         logger.error(message, exc_info=True)
-        raise RuntimeError("%s (%s)" % (message, e.message))
+        raise RuntimeError("%s (%s)" % (message, str(e)))
 
     filename = info.filename
     if format.get('prefix') is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pylint==1.6.4
 pyGithub==1.27.1
 pyFunctional==1.2.0
 func_timeout==4.3.0
-python-docx==0.8.6
+python-docx==0.8.10
 git+https://github.com/elifesciences/digest-parser.git@cd3a47af45db64a1731cc5ae9d0647ec3511a120#egg=digestparser
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium
 psutil==5.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,11 @@ ndg-httpsclient==0.4.2
 pyasn1==0.1.9
 pyOpenSSL==18.0.0
 newrelic==2.72.0.52
-pylint==1.6.4
+pylint==2.3.1
 pyGithub==1.27.1
 pyFunctional==1.2.0
 func_timeout==4.3.0
+# versions of python-docx>=0.8.9 have issues installing on python 3.5.2 (xenial default)
 python-docx==0.8.10
 git+https://github.com/elifesciences/digest-parser.git@cd3a47af45db64a1731cc5ae9d0647ec3511a120#egg=digestparser
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium

--- a/tests/activity/test_activity_email_video.py
+++ b/tests/activity/test_activity_email_video.py
@@ -112,7 +112,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = test_data.get("xml_file")
         fake_first.return_value = test_data.get("first_vor")
-        fake_download_email_templates.return_value = self.fake_download_video_email_templates(
+        self.fake_download_video_email_templates(
             self.activity.get_tmp_dir(), test_data.get("templates_warmed"))
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # do the activity
@@ -138,8 +138,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         """test cases for exceptions in send_email"""
         article_object = article()
         article_object.doi_id = 666
-        fake_download_email_templates.return_value = self.fake_download_video_email_templates(
-            self.activity.get_tmp_dir(), True)
+        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
         fake_smtp_send_messages.return_value = OrderedDict([("error", 1), ("success", 1)])
         # call the method
         return_value = self.activity.send_email(
@@ -169,8 +168,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
     @patch.object(Templates, 'download_video_email_templates_from_s3')
     def test_template_get_email_headers_00013(self, fake_download_email_templates):
 
-        fake_download_email_templates.return_value = self.fake_download_video_email_templates(
-            self.activity.get_tmp_dir(), True)
+        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
 
         email_type = "video_article_publication"
 
@@ -198,8 +196,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
     @patch.object(Templates, 'download_video_email_templates_from_s3')
     def test_template_get_email_body_00353(self, fake_download_email_templates):
 
-        fake_download_email_templates.return_value = self.fake_download_video_email_templates(
-            self.activity.get_tmp_dir(), True)
+        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
 
         email_type = "video_article_publication"
 

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -60,14 +60,6 @@ class TestPackagePOA(unittest.TestCase):
             except IOError:
                 pass
 
-    def fake_clean_tmp_dir(self):
-        """
-        Disable the default clean_tmp_dir() when do_activity runs
-        so tests can introspect the files first
-        Then can run clean_tmp_dir() in the tearDown later
-        """
-        pass
-
     def check_ds_zip_exists(self, ds_zip):
         """
         After do_activity, check the directory contains a zip with ds_zip file name
@@ -122,8 +114,7 @@ class TestPackagePOA(unittest.TestCase):
     def test_process_poa_zipfile(self, test_data, fake_copy_pdf_to_output_dir):
         "test processing the zip file directly"
         self.poa.make_activity_directories()
-        fake_copy_pdf_to_output_dir.return_value = self.fake_copy_pdf_to_hw_staging_dir(
-            test_data.get('poa_decap_pdf'))
+        self.fake_copy_pdf_to_hw_staging_dir(test_data.get('poa_decap_pdf'))
         file_path = self.fake_download_poa_zip(test_data.get('filename'))
         print(file_path)
         self.assertEqual(self.poa.process_poa_zipfile(file_path), test_data.get('expected'))
@@ -218,11 +209,9 @@ class TestPackagePOA(unittest.TestCase):
             fake_article_publication_date.return_value = test_data["pub_date"]
         else:
             fake_article_publication_date.return_value = None
-        fake_clean_tmp_dir.return_value = self.fake_clean_tmp_dir()
 
         # For now mock the PDF decapitator during tests
-        fake_copy_pdf_to_output_dir.return_value = self.fake_copy_pdf_to_hw_staging_dir(
-            test_data.get('poa_decap_pdf'))
+        self.fake_copy_pdf_to_hw_staging_dir(test_data.get('poa_decap_pdf'))
 
         param_data = json.loads('{"data": {"document": "' +
                                 str(test_data["poa_input_zip"]) + '"}}')

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -186,9 +186,8 @@ class TestPublicationEmail(unittest.TestCase):
             fake_article_versions.return_value = (
                 200, pass_test_data.get("lax_article_versions_response_data"))
 
-            fake_download_email_templates.return_value = (
-                self.fake_download_email_templates_from_s3(
-                    self.activity.get_tmp_dir(), pass_test_data["templates_warmed"]))
+            self.fake_download_email_templates_from_s3(
+                self.activity.get_tmp_dir(), pass_test_data["templates_warmed"])
 
             fake_list_resources.return_value = pass_test_data["article_xml_filenames"]
 
@@ -285,8 +284,7 @@ class TestPublicationEmail(unittest.TestCase):
     @patch.object(Templates, 'download_email_templates_from_s3')
     def test_template_get_email_headers_00013(self, fake_download_email_templates):
 
-        fake_download_email_templates.return_value = self.fake_download_email_templates_from_s3(
-            self.activity.get_tmp_dir(), True)
+        self.fake_download_email_templates_from_s3(self.activity.get_tmp_dir(), True)
 
         email_type = "author_publication_email_VOR_no_POA"
 
@@ -323,8 +321,7 @@ class TestPublicationEmail(unittest.TestCase):
     @patch.object(Templates, 'download_email_templates_from_s3')
     def test_template_get_email_body_00353(self, fake_download_email_templates):
 
-        fake_download_email_templates.return_value = self.fake_download_email_templates_from_s3(
-            self.activity.get_tmp_dir(), True)
+        self.fake_download_email_templates_from_s3(self.activity.get_tmp_dir(), True)
 
         email_type = "author_publication_email_Feature"
 

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -207,8 +207,7 @@ class TestPublishFinalPOA(unittest.TestCase):
 
         for test_data in self.do_activity_passes:
 
-            fake_download_files_from_s3.return_value = self.fake_download_files_from_s3(
-                test_data["outbox_file_list"])
+            self.fake_download_files_from_s3(test_data["outbox_file_list"])
 
             param_data = None
             success = self.poa.do_activity(param_data)


### PR DESCRIPTION
Very basic switch in `install.sh` to use Python 3, I shamelessly copied most of it from https://github.com/elifesciences/bot-lax-adaptor/blob/develop/mkvenv.sh.

I updated the travis-ci tests to run in both py27 and py36 for now.

There could be more to be done in builder things to use Python 3, please comment on what those may be, if you can think of them.

Rolling this out, the old `venv` folder may need to be deleted, or new instances created fresh.