### PR TITLE
Fix Exception has no 'message' member (no-member).

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -112,7 +112,7 @@ class activity_EmailDigest(Activity):
             output_file = output.digest_docx(digest_content, full_file_name)
         except UnicodeEncodeError as exception:
             self.logger.exception("EmailDigest generate_output exception. Message: %s",
-                                  exception.message)
+                                  str(exception))
             return False, None
         return True, output_file
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -108,11 +108,11 @@ class activity_PublishFinalPOA(Activity):
 
                     try:
                         self.convert_xml(doi_id, xml_file, filenames, new_filenames)
-                    except Exception as e:
+                    except Exception as exception:
                         # One possible error is an entirely blank XML file or a malformed xml file
                         if self.logger:
                             self.logger.exception("Exception when converting XML for doi %s, %s" %
-                                                  (str(doi_id), e.message))
+                                                  (str(doi_id), str(exception)))
                         continue
 
                 revision = self.next_revision_number(doi_id)

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -113,17 +113,17 @@ class activity_UpdateRepository(Activity):
 
         try:
             xml_file = article_xml_repo.get_contents(repo_file)
-        except GithubException as e:
-            self.logger.info("GithubException - description: " + e.message)
+        except GithubException as exception:
+            self.logger.info("GithubException - description: " + str(exception))
             self.logger.info("GithubException: file " + repo_file + " may not exist in github yet. We will try to add it in the repo.")
             try:
                 response = article_xml_repo.create_file(repo_file, "Creates XML", content)
-            except GithubException as e:
-                self._retry_or_cancel(e)
+            except GithubException as exception:
+                self._retry_or_cancel(exception)
             return "File " + repo_file + " successfully added. Commit: " + str(response)
 
-        except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + e.message)
+        except Exception as exception:
+            self.logger.info("Exception: file " + repo_file + ". Error: " + str(exception))
             raise
 
         try:
@@ -134,18 +134,18 @@ class activity_UpdateRepository(Activity):
             #there are changes
             try:
                 response = article_xml_repo.update_file(repo_file , "Updates xml", content, xml_file.sha)
-            except GithubException as e:
-                self._retry_or_cancel(e)
+            except GithubException as exception:
+                self._retry_or_cancel(exception)
             return "File " + repo_file + " successfully updated. Commit: " + str(response)
 
-        except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + e.message)
+        except Exception as exception:
+            self.logger.info("Exception: file " + repo_file + ". Error: " + str(exception))
             raise
 
-    def _retry_or_cancel(self, e):
-        if e.status == 409:
-            self.logger.warning("Retrying because of exception: %s", e)
-            raise RetryException(e.message)
+    def _retry_or_cancel(self, exception):
+        if exception.status == 409:
+            self.logger.warning("Retrying because of exception: %s", str(exception))
+            raise RetryException(str(exception))
         else:
-            raise e
+            raise exception
 

--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -61,11 +61,11 @@ class activity_VerifyLaxResponse(Activity):
                                     " result from lax:" + str(data['result']) + '; message from lax: ' + message)
             return self.ACTIVITY_PERMANENT_FAILURE
 
-        except Exception as e:
+        except Exception as exception:
             self.logger.exception("Exception when Verifying Lax Response")
             self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
                                     "Error when verifying lax response" + article_id +
-                                    " message:" + str(e.message))
+                                    " message:" + str(exception))
             return self.ACTIVITY_PERMANENT_FAILURE
 
 

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -121,8 +121,8 @@ class LaxResponseAdapter:
                 self.logger.info("calling workflow PostPerfectPublication")
 
             return workflow_starter_message
-        except Exception as e:
-            self.logger.error("Error parsing Lax message. Message: " + e.message)
+        except Exception as exception:
+            self.logger.error("Error parsing Lax message. Message: " + str(exception))
             raise
 
     @newrelic.agent.background_task(group='lax_response_adapter.py')

--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -40,10 +40,10 @@ def resize(format, filep, info, logger):
             # destroy the image after saving output to release memory
             image.destroy()
 
-    except Exception as e:
+    except Exception as exception:
         message = "error resizing image %s" % info.filename
         logger.error(message, exc_info=True)
-        raise RuntimeError("%s (%s)" % (message, e.message))
+        raise RuntimeError("%s (%s)" % (message, str(exception)))
 
     filename = info.filename
     if format.get('prefix') is not None:


### PR DESCRIPTION
I noticed the linting output in a build log, where the code had `e.message` when logging an `Exception`. Switched these over to `str(exception)`, and renamed any single character variable names.