### PR TITLE
Fix bytes to str in execution_context S3Session.

### DIFF
--- a/provider/execution_context.py
+++ b/provider/execution_context.py
@@ -4,6 +4,7 @@ from boto.s3.key import Key
 from boto.exception import S3ResponseError
 from pydoc import locate
 import json
+from provider.utils import unicode_encode
 
 
 def get_session(settings, input_data, session_key):
@@ -96,7 +97,7 @@ class S3Session(object):
         value = None
         try:
             value = s3_key.get_contents_as_string()
-            value = json.loads(value)
+            value = json.loads(unicode_encode(value))
         except S3ResponseError:
             if self.input_data is not None and key in self.input_data:
                 value = self.input_data[key]

--- a/tests/provider/test_execution_context.py
+++ b/tests/provider/test_execution_context.py
@@ -1,0 +1,26 @@
+import unittest
+import json
+from mock import patch
+from provider.utils import unicode_encode
+from provider.execution_context import S3Session
+from tests.activity.classes_mock import FakeS3Connection
+from tests import settings_mock
+
+
+class TestS3Session(unittest.TestCase):
+
+    @patch('provider.execution_context.S3Session.get_full_key')
+    @patch('boto.s3.key.Key.get_contents_as_string')
+    @patch('provider.execution_context.S3Connection')
+    def test_get_value(self, fake_s3_connection, fake_get_contents_as_string, fake_get_full_key):
+        session_value = b'{"foo": "bar"}'
+        expected = json.loads(unicode_encode(session_value))
+        fake_get_full_key.return_value = None
+        fake_s3_connection.return_value = FakeS3Connection()
+        fake_get_contents_as_string.return_value = session_value
+        s3_session_object = S3Session(settings_mock, None, None)
+        self.assertEqual(s3_session_object.get_value(None), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -10,6 +10,8 @@ production_bucket = "production_bucket"
 
 bucket = ""
 
+s3_session_bucket = "origin_bucket"
+
 aws_access_key_id = ""
 aws_secret_access_key = ""
 


### PR DESCRIPTION
Bug fix for PR https://github.com/elifesciences/elife-bot/pull/945 which is not passing `end2end` tests.

There was (and still is) poor test coverage for `provider/execution_context.py`, where a bug with converting an S3 key `bytes` value to `str` failed.

Here, convert the value using an existing function from `provider/utils.py` in order to load it with `json.loads()`.

If the tests are green in this PR, I will merge this to see if `end2end` testing can progress futher, possibly uncovering more Python 3 compatibility glitches.