### PR TITLE
Fix re.search of bytes string in glencoe_check.

### DIFF
--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -2,6 +2,8 @@ import sys, json
 import requests
 import re
 from functional import seq
+from provider.utils import unicode_encode
+
 
 '''
 glencoe_resp = {
@@ -72,7 +74,7 @@ def jpg_href_values(metadata):
 
 
 def has_videos(xml_str):
-    if re.search(r'<media[^>]*mimetype="video".*?>', xml_str):
+    if re.search(r'<media[^>]*mimetype="video".*?>', unicode_encode(xml_str)):
         return True
     return False
 

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -52,7 +52,8 @@ class TestGlencoeCheck(unittest.TestCase):
             ('<media mimetype="video" mime-subtype="mp4" id="fig3video1" xlink:href="elife-00666-fig3-video1.mp4"></media>', True),
             ('<media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
             ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/><media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
-            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/>', False)
+            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/>', False),
+            (b'<media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
         ]
         for xml_str, expected in cases:
             self.assertEqual(glencoe_check.has_videos(xml_str), expected)


### PR DESCRIPTION
Next bug fix of code from PR https://github.com/elifesciences/elife-bot/pull/945.

Another instance where `bytes` is returned from an S3 key I think.

The may not be the last bug, but I will try to continue for each unless I can locate a theme. So far the theme could be S3 objects are always bytes and must be cast as `str` whenever appropriate.