### PR TITLE
Switch tempfile mode from r+ to w+b.

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -64,7 +64,7 @@ class activity_UpdateRepository(Activity):
                 bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
 
                 #download xml
-                with tempfile.TemporaryFile(mode='r+') as tmp:
+                with tempfile.TemporaryFile(mode='w+b') as tmp:
                     storage_provider = self.settings.storage_provider + "://"
                     published_path = storage_provider + self.settings.publishing_buckets_prefix + \
                                         self.settings.ppp_cdn_bucket


### PR DESCRIPTION
A bug as a result of merging PR https://github.com/elifesciences/elife-bot/pull/945 to Python 3 upgrade.

Another issue related to trying to write a bytes-like object as a string. I think this may be due to the file pointer mode was `"r+"` (and it still worked somehow), whereas I think a better mode will be the default `"w+b"`.

Unit tests pass, so I would like to see the result from `end2end` testing that uses real buckets.