### PR TITLE
Replace dict.has_key() with in.

### DIFF
--- a/activity/activity_S3Monitor.py
+++ b/activity/activity_S3Monitor.py
@@ -110,7 +110,7 @@ class activity_S3Monitor(Activity):
             else:
                 # Update the item attributes by replacing values if present
                 for k, v in list(item_attrs.items()):
-                    if item.has_key(k):
+                    if k in item:
                         # Overwrite value
                         item[k] = v
                     else:
@@ -166,7 +166,7 @@ class activity_S3Monitor(Activity):
 
                 # Update the item attributes by replacing values if present
                 for k, v in list(item_attrs.items()):
-                    if item.has_key(k):
+                    if k in item:
                         # Overwrite value
                         item[k] = v
                     else:


### PR DESCRIPTION
Bug fix after Python 3 deployment, as I watched the `worker.log`, the `S3Monitor` activity reported an error:

```
2019-09-06T22:31:25Z ERROR worker_28016 error executing activity activity_S3Monitor
Traceback (most recent call last):
  File "worker.py", line 65, in work
    activity_result = activity_object.do_activity(data)
  File "/opt/elife-bot/activity/activity_S3Monitor.py", line 64, in do_activity
    _runtime_timestamp, prefix, delimiter)
  File "/opt/elife-bot/activity/activity_S3Monitor.py", line 169, in update_keys_and_folder_items
    if item.has_key(k):
AttributeError: 'Item' object has no attribute 'has_key'
```

It seems `has_key()` on a `dict` is removed in Python 3.

Here it is replaced with using `in` keyword logic.