### PR TITLE
Fix Python 3 related bug saving templates from S3.

### DIFF
--- a/provider/templates.py
+++ b/provider/templates.py
@@ -5,6 +5,9 @@ from jinja2 import Environment, FileSystemLoader
 
 from boto.s3.connection import S3Connection
 
+from provider.utils import unicode_encode
+
+
 """
 Templates provider
 Connects to S3, discovers, downloads, and parses templates using jinja2
@@ -209,8 +212,8 @@ class Templates(object):
         loaded content in the case of running tests
         """
         if contents is not None:
-            with open(os.path.join(self.get_tmp_dir(), template_name), 'wb') as fp:
-                fp.write(contents)
+            with open(os.path.join(self.get_tmp_dir(), template_name), 'w') as fp:
+                fp.write(unicode_encode(contents))
             return True
 
         # Default

--- a/provider/templates.py
+++ b/provider/templates.py
@@ -209,7 +209,7 @@ class Templates(object):
         loaded content in the case of running tests
         """
         if contents is not None:
-            with open(os.path.join(self.get_tmp_dir(), template_name), 'w') as fp:
+            with open(os.path.join(self.get_tmp_dir(), template_name), 'wb') as fp:
                 fp.write(contents)
             return True
 


### PR DESCRIPTION
One more, hopefully final, fix related to Python 3 PR https://github.com/elifesciences/elife-bot/pull/945

The `PublicationEmail` activity which is triggered once per day is resulting in `Failed` status. It looks like saving template files from S3 is to be fixed. The message in `worker.log`:

```
2019-09-08T16:45:05Z ERROR worker_17966 Failed to download templates
Traceback (most recent call last):
  File "/opt/elife-bot/activity/activity_PublicationEmail.py", line 54, in do_activity
    templates_downloaded = self.download_templates()
  File "/opt/elife-bot/activity/activity_PublicationEmail.py", line 231, in download_templates
    self.templates.download_email_templates_from_s3()
  File "/opt/elife-bot/provider/templates.py", line 173, in download_email_templates_from_s3
    self.download_templates_from_s3(self.get_email_templates_list())
  File "/opt/elife-bot/provider/templates.py", line 163, in download_templates_from_s3
    template_name=t)
  File "/opt/elife-bot/provider/templates.py", line 198, in download_template_from_s3
    self.save_template_contents_to_tmp_dir(template_name, contents)
  File "/opt/elife-bot/provider/templates.py", line 213, in save_template_contents_to_tmp_dir
    fp.write(contents)
TypeError: write() argument must be str, not bytes
```