### PR TITLE
VerifyGlencoe again just before IngestToLax.

### DIFF
--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -146,6 +146,17 @@ class workflow_IngestArticleZip(Workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "VerifyGlencoe",
+                        "activity_id": "VerifyGlencoe",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
                         "activity_type": "IngestToLax",
                         "activity_id": "IngestToLax",
                         "version": "1",

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -190,6 +190,17 @@ class workflow_SilentCorrectionsIngest(Workflow):
                         "start_to_close_timeout": 60 * 15
                     },
                     {
+                        "activity_type": "VerifyGlencoe",
+                        "activity_id": "VerifyGlencoe",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 15,
+                        "schedule_to_close_timeout": 60 * 15,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 15
+                    },
+                    {
                         "activity_type": "IngestToLax",
                         "activity_id": "IngestToLax",
                         "version": "1",


### PR DESCRIPTION
Potential improvement raised and discussed on https://github.com/elifesciences/issues/issues/5074.

Even though we verify the video files exist earlier in a publication workflow, the video metadata may be missing when Lax looks for it.

Here, verify the video metadata is present just prior to ingesting to Lax. `VerifyGlencoe` knows if an article has videos, and if the video metadata is not there, it will retry 10 seconds later until the metadata is available.