### PR TITLE
activity_id for the dupe activity in the workflow.

### DIFF
--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -147,7 +147,7 @@ class workflow_IngestArticleZip(Workflow):
                     },
                     {
                         "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoe",
+                        "activity_id": "VerifyGlencoeAgain",
                         "version": "1",
                         "input": data,
                         "control": None,

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -191,7 +191,7 @@ class workflow_SilentCorrectionsIngest(Workflow):
                     },
                     {
                         "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoe",
+                        "activity_id": "VerifyGlencoeAgain",
                         "version": "1",
                         "input": data,
                         "control": None,


### PR DESCRIPTION
A small tweak after PR https://github.com/elifesciences/elife-bot/pull/954, if the `activity_id` is unique then the activity should be run twice in the same workflow at the appropriate time.

I think we can rely on `end2end` tests as green for this to be acceptable.