### PR TITLE
Emit message after sent video emails successfully.

### DIFF
--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -105,6 +105,7 @@ class activity_EmailVideoArticlePublished(Activity):
                     "Failed to send email for article %s to %s in Email Video Article Published " %
                     (article_id, recipient.get("e_mail")))
 
+        self.emit_activity_end_message(article_id, version, run)
         return self.ACTIVITY_SUCCESS
 
     def choose_recipients(self):


### PR DESCRIPTION
I noticed when reviewing dashboard data today that if `EmailVideoArticlePublished` actually sends emails successfully, it remains showing as in process. To fix this, here, emit the end message to the dashboard before the final return statement.