### PR TITLE
Require a valid digest to have a title.

### DIFF
--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -346,6 +346,8 @@ def validate_digest(digest_content):
         error_messages.append('Digest DOI is missing')
     if digest_content and not digest_content.text:
         error_messages.append('Digest text is missing')
+    if digest_content and not digest_content.title:
+        error_messages.append('Digest title is missing')
     return not bool(error_messages), error_messages
 
 

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -47,11 +47,13 @@ def instantiate_article(article_type, doi, is_poa=None, was_ever_poa=None):
     return article_object
 
 
-def create_digest(author=None, doi=None, text=None):
+def create_digest(author=None, doi=None, text=None, title=None):
     "for testing generate a Digest object an populate it"
     digest_content = Digest()
     digest_content.author = author
     digest_content.doi = doi
     if text:
         digest_content.text = text
+    if title:
+        digest_content.title = title
     return digest_content

--- a/tests/provider/test_digest_provider.py
+++ b/tests/provider/test_digest_provider.py
@@ -216,7 +216,7 @@ class TestValidateDigest(unittest.TestCase):
 
     def test_validate_digest(self):
         "approving good Digest content"
-        digest_content = create_digest('Anonymous', '10.7554/eLife.99999', ['text'])
+        digest_content = create_digest('Anonymous', '10.7554/eLife.99999', ['text'], 'Title')
         expected_status = True
         expected_error_messages = []
         status, error_messages = digest_provider.validate_digest(digest_content)
@@ -237,14 +237,14 @@ class TestValidateDigest(unittest.TestCase):
         digest_content = Digest()
         expected_status = False
         expected_error_messages = ['Digest author is missing', 'Digest DOI is missing',
-                                   'Digest text is missing']
+                                   'Digest text is missing', 'Digest title is missing']
         status, error_messages = digest_provider.validate_digest(digest_content)
         self.assertEqual(status, expected_status)
         self.assertEqual(error_messages, expected_error_messages)
 
     def test_validate_digest_digest_no_author(self):
         "approving an empty Digest"
-        digest_content = create_digest(None, '10.7554/eLife.99999', ['text'])
+        digest_content = create_digest(None, '10.7554/eLife.99999', ['text'], 'Title')
         expected_status = False
         expected_error_messages = ['Digest author is missing']
         status, error_messages = digest_provider.validate_digest(digest_content)
@@ -253,7 +253,7 @@ class TestValidateDigest(unittest.TestCase):
 
     def test_validate_digest_digest_no_doi(self):
         "approving an empty Digest"
-        digest_content = create_digest('Anonymous', None, ['text'])
+        digest_content = create_digest('Anonymous', None, ['text'], 'Title')
         expected_status = False
         expected_error_messages = ['Digest DOI is missing']
         status, error_messages = digest_provider.validate_digest(digest_content)
@@ -262,9 +262,18 @@ class TestValidateDigest(unittest.TestCase):
 
     def test_validate_digest_digest_no_text(self):
         "approving an empty Digest"
-        digest_content = create_digest('Anonymous', '10.7554/eLife.99999', None)
+        digest_content = create_digest('Anonymous', '10.7554/eLife.99999', None, 'Title')
         expected_status = False
         expected_error_messages = ['Digest text is missing']
+        status, error_messages = digest_provider.validate_digest(digest_content)
+        self.assertEqual(status, expected_status)
+        self.assertEqual(error_messages, expected_error_messages)
+
+    def test_validate_digest_digest_no_title(self):
+        "approving an invalid Digest"
+        digest_content = create_digest('Anonymous', '10.7554/eLife.99999', ['text'], None)
+        expected_status = False
+        expected_error_messages = ['Digest title is missing']
         status, error_messages = digest_provider.validate_digest(digest_content)
         self.assertEqual(status, expected_status)
         self.assertEqual(error_messages, expected_error_messages)


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/elife-bot/issues/960.

We will have fewer surprises when articles are published and the digest title was invalid against the API schema if we validate it has a title at the point when the digest `.docx` file is originally ingested.