### PR TITLE
Require Image and image caption validating digest.

### DIFF
--- a/provider/digest_provider.py
+++ b/provider/digest_provider.py
@@ -348,6 +348,10 @@ def validate_digest(digest_content):
         error_messages.append('Digest text is missing')
     if digest_content and not digest_content.title:
         error_messages.append('Digest title is missing')
+    if digest_content and not digest_content.image:
+        error_messages.append('Digest image is missing')
+    elif digest_content and not digest_content.image.caption:
+        error_messages.append('Digest image caption is missing')
     return not bool(error_messages), error_messages
 
 

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from digestparser.objects import Digest
+from digestparser.objects import Digest, Image
 from provider.article import article
 
 
@@ -47,7 +47,7 @@ def instantiate_article(article_type, doi, is_poa=None, was_ever_poa=None):
     return article_object
 
 
-def create_digest(author=None, doi=None, text=None, title=None):
+def create_digest(author=None, doi=None, text=None, title=None, image=None):
     "for testing generate a Digest object an populate it"
     digest_content = Digest()
     digest_content.author = author
@@ -56,4 +56,16 @@ def create_digest(author=None, doi=None, text=None, title=None):
         digest_content.text = text
     if title:
         digest_content.title = title
+    if image:
+        digest_content.image = image
     return digest_content
+
+
+def create_digest_image(caption=None, file_name=None):
+    "for testing generate a Digest Image object an populate it"
+    digest_image = Image()
+    if caption:
+        digest_image.caption = caption
+    if file_name:
+        digest_image.file = file_name
+    return digest_image


### PR DESCRIPTION
In response to a digest that failed to be ingested to the endpoint when the research article was published. The image caption content was not parsed from the digest `.docx` file, due to some whitespace in the section heading.

At this time, every digest has an image, and every image should have a caption. When validating the digest, check for these too. If when a digest `.zip` file is first ingested, if it fails validation against these rules, then an error email will be sent so the content can be corrected and re-deposited. It will reduce the potential errors when validating against the digest schema.