### PR TITLE
Sub article asset file name support

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -85,6 +85,8 @@ class ArticleInfo(object):
             # determine the file_type based on the extra file parts
             if parent_name.startswith('resp') and child_name.startswith('fig'):
                 self.file_type = "Figure"
+            elif parent_name.startswith('sa') and child_name.startswith('fig'):
+                self.file_type = "Figure"
             elif parent_name.startswith('app') and child_name.startswith('fig'):
                 self.file_type = "Figure"
             elif parent_name.startswith('box') and child_name.startswith('fig'):

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -171,6 +171,8 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666.pdf', 'expected': 'Other'},
         {'input': 'elife-00666-supp99.xml', 'expected': 'Other'},
         {'input': 'elife-00666-supp99-v1.xml', 'expected': 'Other'},
+        {'input': 'elife-00666-sa1-fig1-v1.tif', 'expected': 'Figure'},
+        {'input': 'elife-00666-sa2-video1.mp4', 'expected': 'Other'},
           )
     def test_get_file_type_from_zip_filename(self, input, expected):
         self.articleinfo = ArticleInfo(input)
@@ -217,7 +219,8 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-table3-data1-v1.xlsx', 'expected': False},
         {'input': 'elife-00666-video1.mp4', 'expected': False},
         {'input': 'elife-00666-video1-data1-v1.xlsx', 'expected': False},
-        {'input': 'elife-00666-supp1-v1.tif', 'expected': False}
+        {'input': 'elife-00666-supp1-v1.tif', 'expected': False},
+        {'input': 'elife-00666-sa1-fig1-v1.tif', 'expected': True}
           )
     def test_article_figure(self, input, expected):
         self.assertEqual(article_structure.article_figure(input), expected)
@@ -302,8 +305,9 @@ class TestArticleStructure(unittest.TestCase):
         result = article_structure.is_video_file(filename)
         self.assertFalse(result)
 
-    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif', u'elife-11792-video1.mp4',
-          u'elife-99999-resp-media1.avi', u'elife-00005-media1.mov')
+    @data(u'elife-11792-media2.mp4', u'elife-15224-fig1-figsupp1-media.tif',
+          u'elife-11792-video1.mp4', u'elife-99999-resp-media1.avi',
+          u'elife-00005-media1.mov', u'elife-00666-sa2-video1.mp4')
     def test_is_video_file_true(self,filename):
         result = article_structure.is_video_file(filename)
         self.assertTrue(result)


### PR DESCRIPTION
Regarding PR https://github.com/elifesciences/XML-mapping/pull/95 in the kitchen sink XML repo, there is a possible new file naming for assets in the `<sub-article>` tags, where the peer review decision letter and author response are.

The file name may contain an `-sa` token, whereas before it was `-resp` for assets from the author response.

Before I forget, this is to recognise assets with these names as a `Figure` type when asking the `article_structure` provider.

I also added the video file name to the test scenarios to be sure it is considered a video file.

No rush to review, I don't think we'll see these file names for some months from now.