### PR TITLE
Peer review tweaks

### DIFF
--- a/starter/starter_DepositCrossrefPeerReview.py
+++ b/starter/starter_DepositCrossrefPeerReview.py
@@ -1,3 +1,8 @@
+import os
+# Add parent directory for imports
+parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.sys.path.insert(0, parentdir)
+
 import boto.swf
 import log
 import json

--- a/tests/provider/test_bigquery.py
+++ b/tests/provider/test_bigquery.py
@@ -13,10 +13,10 @@ from tests import bigquery_test_data, settings_mock
 
 class TestBigQueryProvider(unittest.TestCase):
 
-    @patch('google.auth.crypt.RSASigner.from_service_account_info')
+    @patch('google.auth.default')
     def test_get_client(self, fake_account_info):
         """mocked client for test coverage"""
-        fake_account_info.return_value = None
+        fake_account_info.return_value = None, None
         client = bigquery.get_client(settings_mock, FakeLogger())
         self.assertTrue(isinstance(client, Client))
 


### PR DESCRIPTION
Some tweaks / fixes to PR https://github.com/elifesciences/elife-bot/pull/971

The starter was hard to load locally because it wants to import the `log` module.

The tests for getting a big query client was mocking the wrong auth method - I have changed it to mock `"default"` instead of the function that loads credentials from a file.