### PR TITLE
Use latest elifecrossref library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ arrow==0.4.4
 requests==2.20.0
 git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@344643eb175bd3e24e3a9b91b5d2de701dc99b1c#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1fcc330d6b817757d9e1624552306f9eb8ce1b02#egg=elifecrossref
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@0339bc8d13e92621898561740231e8d8d69e3f87#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@814bcf15dacfbbb0000ba592f7c3b1b047ee99bf#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator


### PR DESCRIPTION
Re library PR https://github.com/elifesciences/elife-crossref-xml-generation/pull/80
Re issue https://github.com/elifesciences/issues/issues/5193

Updating the `elifecrossref` library sha to the latest one will fix a bug with blank `<given_name/>` tag in Crossref deposit XML generated.