### PR TITLE
Crossref peer reviews if DOI does not exist

### DIFF
--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -255,13 +255,22 @@ class activity_DepositCrossrefPeerReview(Activity):
 def prune_article_object_map(article_object_map, logger):
     """remove any articles from the map that should not be deposited as peer reviews"""
     # prune any articles with no review_articles
-    good_article_object_map = OrderedDict()
+    peer_review_article_object_map = OrderedDict()
     for file_name, article in article_object_map.items():
         if article.review_articles:
+            peer_review_article_object_map[file_name] = article
+        else:
+            logger.info(
+                'Pruning article %s from Crossref peer review deposit, it has no peer reviews' %
+                article.doi)
+    good_article_object_map = OrderedDict()
+    for file_name, article in peer_review_article_object_map.items():
+        # check DOI exists
+        if crossref.doi_exists(article.doi, logger):
             good_article_object_map[file_name] = article
         else:
             logger.info(
-                'Pruning article %s from Crossref peer review deposit, it has no peer reviews',
+                'Pruning article %s from Crossref peer review deposit, DOI does not exist' %
                 article.doi)
     return good_article_object_map
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -13,7 +13,7 @@ import provider.s3lib as s3lib
 from elifetools import parseJATS as parser
 from provider.article_structure import ArticleInfo
 from provider.storage_provider import storage_context
-from provider.utils import pad_msid
+from provider.utils import pad_msid, get_doi_url
 
 """
 Article data provider
@@ -138,7 +138,7 @@ class article(object):
             self.doi = parser.doi(soup)
             if self.doi:
                 self.doi_id = self.get_doi_id(self.doi)
-                self.doi_url = self.get_doi_url(self.doi)
+                self.doi_url = get_doi_url(self.doi)
                 self.lens_url = self.get_lens_url(self.doi)
                 self.tweet_url = self.get_tweet_url(self.doi)
 
@@ -227,7 +227,7 @@ class article(object):
         """
         Given a DOI, return a tweet URL
         """
-        doi_url = self.get_doi_url(doi)
+        doi_url = get_doi_url(doi)
         f = {"text": doi_url + " @eLife"}
         if hasattr(urllib, 'urlencode'):
             tweet_url = "http://twitter.com/intent/tweet?" + urllib.urlencode(f)
@@ -235,13 +235,6 @@ class article(object):
             # python 3
             tweet_url = "http://twitter.com/intent/tweet?" + urllib.parse.urlencode(f)
         return tweet_url
-
-    def get_doi_url(self, doi):
-        """
-        Given a DOI, get the URL for the DOI
-        """
-        doi_url = "https://doi.org/" + doi
-        return doi_url
 
     def get_lens_url(self, doi):
         """

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -336,3 +336,15 @@ def get_email_body_middle(outbox_s3_key_names, published_file_names,
         body += str(text) + "\n"
 
     return body
+
+
+def doi_exists(doi, logger):
+    """given a DOI check if it exists in Crossref"""
+    exists = False
+    doi_url = utils.get_doi_url(doi)
+    response = requests.head(doi_url)
+    if 300 <= response.status_code < 400:
+        exists = True
+    elif response.status_code < 300 or response.status_code >= 500:
+        logger.info('Status code for %s was %s' % (doi, response.status_code))
+    return exists

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -110,3 +110,10 @@ def get_activity_status_text(activity_status):
         activity_status_text = "FAILED."
 
     return activity_status_text
+
+
+def get_doi_url(doi):
+    """
+    Given a DOI, get the URL for the DOI
+    """
+    return "https://doi.org/%s" % doi

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -62,10 +62,6 @@ class TestProviderArticle(unittest.TestCase):
             ("http://twitter.com/intent/tweet?text=https%3A%2F%2Fdoi.org" +
              "%2F10.7554%2FeLife.08411+%40eLife"))
 
-    def test_get_doi_url(self):
-        doi_url = self.articleprovider.get_doi_url("10.7554/eLife.08411")
-        self.assertEqual(doi_url, "https://doi.org/10.7554/eLife.08411")
-
     def test_get_lens_url(self):
         lens_url = self.articleprovider.get_lens_url("10.7554/eLife.08411")
         self.assertEqual(lens_url, "https://lens.elifesciences.org/08411")

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -276,3 +276,26 @@ class TestCrossrefProvider(unittest.TestCase):
             os.listdir(activity_test_data.ExpandArticle_files_dest_folder)
             if file_name.endswith('.xml')]
         self.assertEqual(uploaded_files, expected)
+
+
+class TestDoiExists(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.doi = '10.7554/eLife.99999'
+
+    @patch('requests.head')
+    def test_doi_exists_302(self, fake_request):
+        fake_request.return_value = FakeResponse(302)
+        self.assertTrue(crossref.doi_exists(self.doi, self.logger))
+
+    @patch('requests.head')
+    def test_doi_exists_404(self, fake_request):
+        fake_request.return_value = FakeResponse(404)
+        self.assertFalse(crossref.doi_exists(self.doi, self.logger))
+
+    @patch('requests.head')
+    def test_doi_exists_200(self, fake_request):
+        fake_request.return_value = FakeResponse(200)
+        self.assertFalse(crossref.doi_exists(self.doi, self.logger))
+        self.assertEqual(self.logger.loginfo, 'Status code for 10.7554/eLife.99999 was 200')

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -103,6 +103,10 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(encoded_value, expected)
         self.assertEqual(type(encoded_value), expected_type)
 
+    def test_get_doi_url(self):
+        doi_url = utils.get_doi_url("10.7554/eLife.08411")
+        self.assertEqual(doi_url, "https://doi.org/10.7554/eLife.08411")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5226

Part of the prosposed improvements on issue https://github.com/elifesciences/issues/issues/5223 for checking DOI exists before depositing peer review metadata to Crossref.

Considering the timeline for getting peer review deposits going live, I will merge this if tests are green. This workflow is not enabled live yet, and has only been used for manually triggered deposits so far. A subseqent PR will tie in the automatic deposits.