### PR TITLE
Schedule crossref peer review

### DIFF
--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -59,16 +59,16 @@ class activity_ScheduleCrossrefPeerReview(Activity):
                 self.emit_monitor_event(
                     self.settings, article_id, version, run, self.pretty_name, "end", log_message)
                 return True
-        else:
-            # check article XML has <sub-article> tag before queuing it
-            if self.xml_sub_article_exists(expanded_folder_name) is False:
-                log_message = (
-                    '%s finds version %s of %s has no sub-article for peer review depositing' %
-                    (self.name, version, article_id))
-                self.logger.info(log_message)
-                self.emit_monitor_event(
-                    self.settings, article_id, version, run, self.pretty_name, "end", log_message)
-                return True
+
+        # check article XML has <sub-article> tag before queuing it
+        if self.xml_sub_article_exists(expanded_folder_name) is False:
+            log_message = (
+                '%s finds version %s of %s has no sub-article for peer review depositing' %
+                (self.name, version, article_id))
+            self.logger.info(log_message)
+            self.emit_monitor_event(
+                self.settings, article_id, version, run, self.pretty_name, "end", log_message)
+            return True
 
         try:
             xml_file_name = lax_provider.get_xml_file_name(

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -61,7 +61,7 @@ class activity_ScheduleCrossrefPeerReview(Activity):
                 return True
         else:
             # check article XML has <sub-article> tag before queuing it
-            if not self.xml_sub_article_exists(expanded_folder_name):
+            if self.xml_sub_article_exists(expanded_folder_name) is False:
                 log_message = (
                     '%s finds version %s of %s has no sub-article for peer review depositing' %
                     (self.name, version, article_id))

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -52,8 +52,8 @@ class activity_ScheduleCrossrefPeerReview(Activity):
             if str(version) != str(highest_version):
                 log_message = (
                     ('%s will not deposit article %s' +
-                    ' ingested by silent-correction, its version of %s does not equal the' +
-                    ' highest version which is %s') %
+                     ' ingested by silent-correction, its version of %s does not equal the' +
+                     ' highest version which is %s') %
                     (self.name, article_id, version, highest_version))
                 self.logger.info(log_message)
                 self.emit_monitor_event(

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -1,6 +1,6 @@
 import json
 
-from provider import lax_provider
+from provider import crossref, lax_provider
 from provider.article_processing import download_jats
 from provider.storage_provider import storage_context
 from provider.execution_context import get_session
@@ -102,10 +102,9 @@ class activity_ScheduleCrossrefPeerReview(Activity):
     def xml_sub_article_exists(self, expanded_folder_name):
         jats_file = download_jats(
             self.settings, expanded_folder_name, self.get_tmp_dir(), self.logger)
-        with open(jats_file, 'r') as open_file:
-            article_xml = open_file.read()
-            if '<sub-article' in article_xml:
-                return True
+        article_objects = crossref.parse_article_xml([jats_file], self.get_tmp_dir())
+        if article_objects and article_objects[0].review_articles:
+            return True
         return False
 
     def copy_article_xml_to_outbox(self, dest_bucket_name, new_key_name,

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -51,9 +51,9 @@ class activity_ScheduleCrossrefPeerReview(Activity):
             highest_version = lax_provider.article_highest_version(article_id, self.settings)
             if str(version) != str(highest_version):
                 log_message = (
-                    '%s will not deposit article %s' +
+                    ('%s will not deposit article %s' +
                     ' ingested by silent-correction, its version of %s does not equal the' +
-                    ' highest version which is %s' %
+                    ' highest version which is %s') %
                     (self.name, article_id, version, highest_version))
                 self.logger.info(log_message)
                 self.emit_monitor_event(

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -1,0 +1,119 @@
+import json
+
+from provider import lax_provider
+from provider.article_processing import download_jats
+from provider.storage_provider import storage_context
+from provider.execution_context import get_session
+from activity.objects import Activity
+
+
+class activity_ScheduleCrossrefPeerReview(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_ScheduleCrossrefPeerReview, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "ScheduleCrossrefPeerReview"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Queue the article XML for depositing peer reviews to Crossref."
+        self.logger = logger
+        self.pretty_name = "Schedule Crossref Peer Review"
+
+        # For copying to S3 bucket outbox
+        self.crossref_outbox_folder = "crossref_peer_review/outbox/"
+
+    def do_activity(self, data=None):
+
+        if self.logger:
+            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        expanded_bucket_name = (
+            self.settings.publishing_buckets_prefix + self.settings.expanded_bucket)
+        outbox_bucket_name = self.settings.poa_packaging_bucket
+
+        run = data['run']
+        session = get_session(self.settings, data, run)
+
+        version = session.get_value('version')
+        article_id = session.get_value('article_id')
+        expanded_folder_name = session.get_value('expanded_folder')
+
+        self.emit_monitor_event(
+            self.settings, article_id, version, run, self.pretty_name, "start",
+            "Starting to schedule crossref peer review deposit for " + article_id)
+
+        # if is a silent-correction workflow, only deposit for the most recent article version
+        run_type = session.get_value("run_type")
+        if run_type == "silent-correction":
+            highest_version = lax_provider.article_highest_version(article_id, self.settings)
+            if str(version) != str(highest_version):
+                log_message = (
+                    '%s will not deposit article %s' +
+                    ' ingested by silent-correction, its version of %s does not equal the' +
+                    ' highest version which is %s' %
+                    (self.name, article_id, version, highest_version))
+                self.logger.info(log_message)
+                self.emit_monitor_event(
+                    self.settings, article_id, version, run, self.pretty_name, "end", log_message)
+                return True
+        else:
+            # check article XML has <sub-article> tag before queuing it
+            if not self.xml_sub_article_exists(expanded_folder_name):
+                log_message = (
+                    '%s finds version %s of %s has no sub-article for peer review depositing' %
+                    (self.name, version, article_id))
+                self.logger.info(log_message)
+                self.emit_monitor_event(
+                    self.settings, article_id, version, run, self.pretty_name, "end", log_message)
+                return True
+
+        try:
+            xml_file_name = lax_provider.get_xml_file_name(
+                self.settings, expanded_folder_name, expanded_bucket_name, version)
+
+            xml_key_name = expanded_folder_name + "/" + xml_file_name
+
+            new_key_name = self.crossref_outbox_folder + xml_file_name
+
+            self.copy_article_xml_to_outbox(
+                dest_bucket_name=outbox_bucket_name,
+                new_key_name=new_key_name,
+                source_bucket_name=expanded_bucket_name,
+                old_key_name=xml_key_name)
+
+            self.emit_monitor_event(
+                self.settings, article_id, version, run, self.pretty_name, "end",
+                "Finished scheduling of crossref peer review deposit " + article_id +
+                " for version " + version + " run " + str(run))
+
+        except Exception as exception:
+            self.logger.exception("Exception when scheduling crossref peer review deposit")
+            self.emit_monitor_event(
+                self.settings, article_id, version, run, self.pretty_name, "error",
+                "Error scheduling crossref peer review deposit " + article_id +
+                " message:" + str(exception))
+            return False
+
+        return True
+
+    def xml_sub_article_exists(self, expanded_folder_name):
+        jats_file = download_jats(
+            self.settings, expanded_folder_name, self.get_tmp_dir(), self.logger)
+        with open(jats_file, 'r') as open_file:
+            article_xml = open_file.read()
+            if '<sub-article' in article_xml:
+                return True
+        return False
+
+    def copy_article_xml_to_outbox(self, dest_bucket_name, new_key_name,
+                                   source_bucket_name, old_key_name):
+        "copy the XML file to an S3 outbox folder, for now"
+        storage = storage_context(self.settings)
+        storage_provider = self.settings.storage_provider + "://"
+        orig_resource = storage_provider + source_bucket_name + "/" + old_key_name
+        dest_resource = storage_provider + dest_bucket_name + "/" + new_key_name
+        self.logger.info("%s Copying %s to %s " % (self.name, orig_resource, dest_resource))
+        storage.copy_resource(orig_resource, dest_resource)

--- a/cron.py
+++ b/cron.py
@@ -104,6 +104,12 @@ def conditional_starts(current_datetime):
         # Jobs to start at the half past to quarter to the hour
         LOGGER.info("half past to quarter to the hour")
 
+        conditional_start_list.append(OrderedDict([
+            ("starter_name", "starter_DepositCrossrefPeerReview"),
+            ("workflow_id", "DepositCrossrefPeerReview"),
+            ("start_seconds", 60 * 31)
+        ]))
+
         # POA Publish once per day 12:30 local time
         #  (used to be set to 11:30 UTC during British Summer Time for 12:30 local UK time)
         if local_current_time.tm_hour == 12:
@@ -271,6 +277,7 @@ def start_workflow(settings, starter_name, workflow_id=None):
             "cron_NewS3POA",
             "starter_PublicationEmail",
             "starter_DepositCrossref",
+            "starter_DepositCrossrefPeerReview",
             "starter_PubmedArticleDeposit"]):
         starter_object.start(settings=settings)
 

--- a/register.py
+++ b/register.py
@@ -95,6 +95,7 @@ def start(settings):
     activity_names.append("PubRouterDeposit")
     activity_names.append("PMCDeposit")
     activity_names.append("ScheduleCrossref")
+    activity_names.append("ScheduleCrossrefPeerReview")
     activity_names.append("ScheduleDownstream")
     activity_names.append("ModifyArticleSubjects")
     activity_names.append("EmailDigest")

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 from activity.activity_ScheduleCrossref import activity_ScheduleCrossref
 from mock import mock, patch
 from provider import lax_provider
@@ -56,7 +57,7 @@ class TestScheduleCrossref(unittest.TestCase):
     @patch('activity.activity_ScheduleCrossref.get_session')
     def test_do_activity_silent_correction(self, fake_session_mock, fake_highest_version):
         expected_result = True
-        session_dict = testdata.session_example
+        session_dict = copy.copy(testdata.session_example)
         session_dict['run_type'] = 'silent-correction'
         fake_session_mock.return_value = FakeSession(session_dict)
         fake_highest_version.return_value = 2

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -38,6 +38,22 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         # check assertions
         self.assertEqual(result, expected_result)
 
+    @patch('provider.lax_provider.article_highest_version')
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @patch.object(activity_object, 'set_monitor_property')
+    def test_do_activity_silent_correction(self, fake_set_property, fake_emit_monitor,
+                                           fake_session_mock, fake_highest_version):
+        expected_result = True
+        fake_set_property.return_value = True
+        fake_emit_monitor.return_value = True
+        session_dict = activity_test_data.session_example
+        session_dict['run_type'] = 'silent-correction'
+        fake_session_mock.return_value = FakeSession(session_dict)
+        fake_highest_version.return_value = 2
+        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -1,0 +1,43 @@
+import unittest
+from mock import mock, patch
+import activity.activity_ScheduleCrossrefPeerReview as activity_module
+from activity.activity_ScheduleCrossrefPeerReview import (
+    activity_ScheduleCrossrefPeerReview as activity_object)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext
+import tests.activity.test_activity_data as activity_test_data
+
+
+class TestScheduleCrossrefPeerReview(unittest.TestCase):
+
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    @patch('provider.lax_provider.article_first_by_status')
+    @patch('provider.article.storage_context')
+    @patch.object(activity_module, 'storage_context')
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_object, 'xml_sub_article_exists')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @patch.object(activity_object, 'set_monitor_property')
+    def test_do_activity(self, fake_set_property, fake_emit_monitor,
+                         fake_sub_article_exists, fake_session_mock,
+                         fake_storage_context, fake_article_storage_context, fake_first):
+        expected_result = True
+        fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
+        fake_set_property.return_value = True
+        fake_emit_monitor.return_value = True
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_article_storage_context.return_value = FakeStorageContext()
+        fake_first.return_value = True
+        fake_sub_article_exists.return_value = True
+        self.activity.emit_monitor_event = mock.MagicMock()
+        # do the activity
+        result = self.activity.do_activity(activity_test_data.data_example_before_publish)
+        # check assertions
+        self.assertEqual(result, expected_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 from mock import mock, patch
 import activity.activity_ScheduleCrossrefPeerReview as activity_module
 from activity.activity_ScheduleCrossrefPeerReview import (
@@ -47,7 +48,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         expected_result = True
         fake_set_property.return_value = True
         fake_emit_monitor.return_value = True
-        session_dict = activity_test_data.session_example
+        session_dict = copy.copy(activity_test_data.session_example)
         session_dict['run_type'] = 'silent-correction'
         fake_session_mock.return_value = FakeSession(session_dict)
         fake_highest_version.return_value = 2
@@ -76,6 +77,26 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         self.assertEqual(self.activity.logger.loginfo, (
             'ScheduleCrossrefPeerReview finds version 1 of 00353 has no sub-article'
             ' for peer review depositing'))
+
+    @patch.object(activity_object, 'copy_article_xml_to_outbox')
+    @patch('provider.lax_provider.article_highest_version')
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_object, 'xml_sub_article_exists')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @patch.object(activity_object, 'set_monitor_property')
+    def test_do_activity_exception(self, fake_set_property, fake_emit_monitor,
+                                   fake_sub_article_exists, fake_session_mock,
+                                   fake_highest_version, fake_copy_article):
+        expected_result = False
+        fake_sub_article_exists.return_value = True
+        fake_set_property.return_value = True
+        fake_emit_monitor.return_value = True
+        fake_copy_article.side_effect = Exception("Something went wrong!")
+        fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
+        fake_highest_version.return_value = 1
+        # do the activity
+        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -9,6 +9,10 @@ from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageCont
 import tests.activity.test_activity_data as activity_test_data
 
 
+def mock_xml_sub_article_exists(folder_name):
+    return False
+
+
 class TestScheduleCrossrefPeerReview(unittest.TestCase):
 
     def setUp(self):
@@ -54,13 +58,12 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
 
     @patch('provider.lax_provider.article_highest_version')
     @patch.object(activity_module, 'get_session')
-    @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
-    def test_do_activity_no_sub_article(self, fake_emit_monitor,
-                                        fake_sub_article_exists, fake_session_mock,
+    def test_do_activity_no_sub_article(self, fake_emit_monitor, fake_session_mock,
                                         fake_highest_version):
         expected_result = True
-        fake_sub_article_exists.return_value = False
+        # mock this function with a replacement function instead of MagicMock patch would give
+        self.activity.xml_sub_article_exists = mock_xml_sub_article_exists
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         result = self.activity.do_activity(activity_test_data.data_example_before_publish)

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -52,7 +52,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         session_dict['run_type'] = 'silent-correction'
         fake_session_mock.return_value = FakeSession(session_dict)
         fake_highest_version.return_value = 2
-        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        result = self.activity.do_activity(activity_test_data.data_example_before_publish)
         self.assertEqual(result, expected_result)
         self.assertEqual(self.activity.logger.loginfo, (
             'ScheduleCrossrefPeerReview will not deposit article 00353 ingested by'
@@ -72,7 +72,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_emit_monitor.return_value = True
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
-        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        result = self.activity.do_activity(activity_test_data.data_example_before_publish)
         self.assertEqual(result, expected_result)
         self.assertEqual(self.activity.logger.loginfo, (
             'ScheduleCrossrefPeerReview finds version 1 of 00353 has no sub-article'
@@ -95,7 +95,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         # do the activity
-        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        result = self.activity.do_activity(activity_test_data.data_example_before_publish)
         self.assertEqual(result, expected_result)
 
 

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -59,17 +59,22 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
             ' silent-correction, its version of 1 does not equal the highest version which is 2'))
 
     @patch('provider.lax_provider.article_highest_version')
+    @patch('provider.article.storage_context')
+    @patch.object(activity_module, 'storage_context')
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
     @patch.object(activity_object, 'set_monitor_property')
     def test_do_activity_no_sub_article(self, fake_set_property, fake_emit_monitor,
-                                        fake_sub_article_exists,
-                                        fake_session_mock, fake_highest_version):
+                                        fake_sub_article_exists, fake_session_mock,
+                                        fake_storage_context, fake_article_storage_context,
+                                        fake_highest_version):
         expected_result = True
         fake_sub_article_exists.return_value = False
         fake_set_property.return_value = True
         fake_emit_monitor.return_value = True
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_article_storage_context.return_value = FakeStorageContext()
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         result = self.activity.do_activity(activity_test_data.data_example_before_publish)

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -14,7 +14,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
-    @patch('provider.lax_provider.article_first_by_status')
+    @patch('provider.lax_provider.article_highest_version')
     @patch('provider.article.storage_context')
     @patch.object(activity_module, 'storage_context')
     @patch.object(activity_module, 'get_session')
@@ -23,14 +23,14 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
     @patch.object(activity_object, 'set_monitor_property')
     def test_do_activity(self, fake_set_property, fake_emit_monitor,
                          fake_sub_article_exists, fake_session_mock,
-                         fake_storage_context, fake_article_storage_context, fake_first):
+                         fake_storage_context, fake_article_storage_context, fake_highest_version):
         expected_result = True
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_set_property.return_value = True
         fake_emit_monitor.return_value = True
         fake_storage_context.return_value = FakeStorageContext()
         fake_article_storage_context.return_value = FakeStorageContext()
-        fake_first.return_value = True
+        fake_highest_version.return_value = 1
         fake_sub_article_exists.return_value = True
         self.activity.emit_monitor_event = mock.MagicMock()
         # do the activity

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -1,5 +1,7 @@
 import unittest
+import os
 import copy
+import shutil
 from mock import mock, patch
 import activity.activity_ScheduleCrossrefPeerReview as activity_module
 from activity.activity_ScheduleCrossrefPeerReview import (
@@ -84,6 +86,24 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         # do the activity
         result = self.activity.do_activity(activity_test_data.data_example_before_publish)
         self.assertEqual(result, expected_result)
+
+    @patch.object(activity_module, 'download_jats')
+    def test_xml_sub_article_exists(self, fake_download_jats):
+        file_name = 'elife-15747-v2.xml'
+        source_file = 'tests/test_data/crossref_peer_review/outbox/' + file_name
+        dest_file = os.path.join(self.activity.get_tmp_dir(), file_name)
+        shutil.copy(source_file, dest_file)
+        fake_download_jats.return_value = dest_file
+        self.assertTrue(self.activity.xml_sub_article_exists(''))
+
+    @patch.object(activity_module, 'download_jats')
+    def test_xml_sub_article_exists_not(self, fake_download_jats):
+        file_name = 'elife-00353-v1.xml'
+        source_file = 'tests/files_source/' + file_name
+        dest_file = os.path.join(self.activity.get_tmp_dir(), file_name)
+        shutil.copy(source_file, dest_file)
+        fake_download_jats.return_value = dest_file
+        self.assertFalse(self.activity.xml_sub_article_exists(''))
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -9,10 +9,6 @@ from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageCont
 import tests.activity.test_activity_data as activity_test_data
 
 
-def mock_xml_sub_article_exists(folder_name):
-    return False
-
-
 class TestScheduleCrossrefPeerReview(unittest.TestCase):
 
     def setUp(self):
@@ -58,12 +54,12 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
 
     @patch('provider.lax_provider.article_highest_version')
     @patch.object(activity_module, 'get_session')
+    @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
-    def test_do_activity_no_sub_article(self, fake_emit_monitor, fake_session_mock,
-                                        fake_highest_version):
+    def test_do_activity_no_sub_article(self, fake_emit_monitor, fake_sub_article_exists,
+                                        fake_session_mock, fake_highest_version):
         expected_result = True
-        # mock this function with a replacement function instead of MagicMock patch would give
-        self.activity.xml_sub_article_exists = mock_xml_sub_article_exists
+        fake_sub_article_exists.return_value = False
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         result = self.activity.do_activity(activity_test_data.data_example_before_publish)

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -21,14 +21,11 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
-    @patch.object(activity_object, 'set_monitor_property')
-    def test_do_activity(self, fake_set_property, fake_emit_monitor,
+    def test_do_activity(self, fake_emit_monitor,
                          fake_sub_article_exists, fake_session_mock,
                          fake_storage_context, fake_article_storage_context, fake_highest_version):
         expected_result = True
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
-        fake_set_property.return_value = True
-        fake_emit_monitor.return_value = True
         fake_storage_context.return_value = FakeStorageContext()
         fake_article_storage_context.return_value = FakeStorageContext()
         fake_highest_version.return_value = 1
@@ -42,12 +39,9 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
     @patch('provider.lax_provider.article_highest_version')
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'emit_monitor_event')
-    @patch.object(activity_object, 'set_monitor_property')
-    def test_do_activity_silent_correction(self, fake_set_property, fake_emit_monitor,
+    def test_do_activity_silent_correction(self, fake_emit_monitor,
                                            fake_session_mock, fake_highest_version):
         expected_result = True
-        fake_set_property.return_value = True
-        fake_emit_monitor.return_value = True
         session_dict = copy.copy(activity_test_data.session_example)
         session_dict['run_type'] = 'silent-correction'
         fake_session_mock.return_value = FakeSession(session_dict)
@@ -59,22 +53,14 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
             ' silent-correction, its version of 1 does not equal the highest version which is 2'))
 
     @patch('provider.lax_provider.article_highest_version')
-    @patch('provider.article.storage_context')
-    @patch.object(activity_module, 'storage_context')
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
-    @patch.object(activity_object, 'set_monitor_property')
-    def test_do_activity_no_sub_article(self, fake_set_property, fake_emit_monitor,
+    def test_do_activity_no_sub_article(self, fake_emit_monitor,
                                         fake_sub_article_exists, fake_session_mock,
-                                        fake_storage_context, fake_article_storage_context,
                                         fake_highest_version):
         expected_result = True
         fake_sub_article_exists.return_value = False
-        fake_set_property.return_value = True
-        fake_emit_monitor.return_value = True
-        fake_storage_context.return_value = FakeStorageContext()
-        fake_article_storage_context.return_value = FakeStorageContext()
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         result = self.activity.do_activity(activity_test_data.data_example_before_publish)
@@ -88,14 +74,11 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
-    @patch.object(activity_object, 'set_monitor_property')
-    def test_do_activity_exception(self, fake_set_property, fake_emit_monitor,
+    def test_do_activity_exception(self, fake_emit_monitor,
                                    fake_sub_article_exists, fake_session_mock,
                                    fake_highest_version, fake_copy_article):
         expected_result = False
         fake_sub_article_exists.return_value = True
-        fake_set_property.return_value = True
-        fake_emit_monitor.return_value = True
         fake_copy_article.side_effect = Exception("Something went wrong!")
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -53,6 +53,29 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_highest_version.return_value = 2
         result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
         self.assertEqual(result, expected_result)
+        self.assertEqual(self.activity.logger.loginfo, (
+            'ScheduleCrossrefPeerReview will not deposit article 00353 ingested by'
+            ' silent-correction, its version of 1 does not equal the highest version which is 2'))
+
+    @patch('provider.lax_provider.article_highest_version')
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_object, 'xml_sub_article_exists')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @patch.object(activity_object, 'set_monitor_property')
+    def test_do_activity_no_sub_article(self, fake_set_property, fake_emit_monitor,
+                                        fake_sub_article_exists,
+                                        fake_session_mock, fake_highest_version):
+        expected_result = True
+        fake_sub_article_exists.return_value = False
+        fake_set_property.return_value = True
+        fake_emit_monitor.return_value = True
+        fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
+        fake_highest_version.return_value = 1
+        result = self.activity.do_activity(activity_test_data.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.activity.logger.loginfo, (
+            'ScheduleCrossrefPeerReview finds version 1 of 00353 has no sub-article'
+            ' for peer review depositing'))
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -69,17 +69,17 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
             'ScheduleCrossrefPeerReview finds version 1 of 00353 has no sub-article'
             ' for peer review depositing'))
 
-    @patch.object(activity_object, 'copy_article_xml_to_outbox')
+    @patch('provider.lax_provider.get_xml_file_name')
     @patch('provider.lax_provider.article_highest_version')
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_object, 'xml_sub_article_exists')
     @patch.object(activity_object, 'emit_monitor_event')
     def test_do_activity_exception(self, fake_emit_monitor,
                                    fake_sub_article_exists, fake_session_mock,
-                                   fake_highest_version, fake_copy_article):
+                                   fake_highest_version, fake_get_xml_file_name):
         expected_result = False
         fake_sub_article_exists.return_value = True
-        fake_copy_article.side_effect = Exception("Something went wrong!")
+        fake_get_xml_file_name.side_effect = Exception("Something went wrong!")
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_highest_version.return_value = 1
         # do the activity

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -189,10 +189,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 00:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_S3Monitor"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "S3Monitor_POA"
             ]
         }
@@ -227,11 +229,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-08-19 11:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_PublishPOA",
                 "starter_S3Monitor"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "PublishPOA",
                 "S3Monitor_POA"
             ]
@@ -246,11 +250,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-10-27 12:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_PublishPOA",
                 "starter_S3Monitor"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "PublishPOA",
                 "S3Monitor_POA"
             ]
@@ -286,11 +292,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 20:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_S3Monitor",
                 "starter_PubRouterDeposit"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "S3Monitor_POA",
                 "PubRouterDeposit_PMC"
             ]
@@ -305,11 +313,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 21:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_S3Monitor",
                 "starter_PubRouterDeposit"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "S3Monitor_POA",
                 "PubRouterDeposit_WoS"
             ]
@@ -345,11 +355,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 22:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_S3Monitor",
                 "starter_PubRouterDeposit"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "S3Monitor_POA",
                 "PubRouterDeposit_Scopus"
             ]
@@ -404,11 +416,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 23:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossrefPeerReview",
                 "starter_S3Monitor",
                 "starter_PubRouterDeposit"
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossrefPeerReview",
                 "S3Monitor_POA",
                 "PubRouterDeposit_CNPIEC"
             ]

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -69,6 +69,17 @@ class workflow_ProcessArticleZip(Workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "ScheduleCrossrefPeerReview",
+                        "activity_id": "ScheduleCrossrefPeerReview",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -69,6 +69,17 @@ class workflow_SilentCorrectionsProcess(Workflow):
                         "start_to_close_timeout": 60 * 5
                     },
                     {
+                        "activity_type": "ScheduleCrossrefPeerReview",
+                        "activity_id": "ScheduleCrossrefPeerReview",
+                        "version": "1",
+                        "input": data,
+                        "control": None,
+                        "heartbeat_timeout": 60 * 5,
+                        "schedule_to_close_timeout": 60 * 5,
+                        "schedule_to_start_timeout": 300,
+                        "start_to_close_timeout": 60 * 5
+                    },
+                    {
                         "activity_type": "IngestDigestToEndpoint",
                         "activity_id": "IngestDigestToEndpoint",
                         "version": "1",


### PR DESCRIPTION
Re: recent discussion on https://github.com/elifesciences/issues/issues/5223
Re: older ticket for overall plan https://github.com/elifesciences/elife-crossref-feed/issues/123

I chose to add a new activity named `ScheduleCrossrefPeerReview` for `"scheduling"` articles for peer review deposits because the logical checks are unique from other activities we have of this type. It will only attempt to schedule it if it is not part of a silent correction and the XML contains a `<sub-article>` tag, or it is a silent correction but only the most recent version of a silent correction.

In the cron, the `DepositCrossrefPeerReview` workflow is scheduled for each hour on the half hour.

Fixed a bug in the tests for the activity `ScheduleCrossref` where if you ran the full test suite, the override of a session variable would be retained for some reason. Instead it makes a `copy.copy()` of the session before changing the `run_type` on it.

I can go into more detail on this PR as required. It can perhaps serve as one example of PRs for review in our latest plan for developer team collaborations.