### PR TITLE
Bug fix checking VoR published, manuscript not id.

### DIFF
--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -294,7 +294,7 @@ def check_doi_exists(article, logger):
 
 
 def check_vor_is_published(article, settings, logger):
-    status_version_map = lax_provider.article_status_version_map(article.id, settings)
+    status_version_map = lax_provider.article_status_version_map(article.manuscript, settings)
     if 'vor' in status_version_map:
         return True
     logger.info(


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/980

The `article.id` is not the numeric article number, instead use `article.manuscript`.