### PR TITLE
Letterparser config

### DIFF
--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -3,10 +3,18 @@
 import os
 import docker
 from letterparser import parse
+from letterparser.conf import raw_config, parse_raw_config
 import log
 
 IDENTITY = "process_%s" % os.getpid()
 LOGGER = log.logger("letterparser_provider.log", 'INFO', IDENTITY, loggerName=__name__)
+
+
+def letterparser_config(settings):
+    """parse the config values from letterparser.cfg"""
+    return parse_raw_config(raw_config(
+        settings.letterparser_config_section,
+        settings.letterparser_config_file))
 
 
 def parse_file(file_name, config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,14 @@ Jinja2==2.10.1
 arrow==0.4.4
 requests==2.20.0
 git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@344643eb175bd3e24e3a9b91b5d2de701dc99b1c#egg=elifearticle
+git+https://github.com/elifesciences/elife-article.git@53afe11590971788a64fb4790ea96a0967280e1b#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@0339bc8d13e92621898561740231e8d8d69e3f87#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@814bcf15dacfbbb0000ba592f7c3b1b047ee99bf#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
 docker==4.0.2
-git+https://github.com/elifesciences/decision-letter-parser.git@a70ed001a2148675c1c8a60d95ec5196c4f806cc#egg=letterparser
+git+https://github.com/elifesciences/decision-letter-parser.git@711e70d279644c38e80f4df9fe8dc5a2169344c8#egg=letterparser
 PyYAML==4.2b2
 Wand==0.5.1
 paramiko==2.4.2

--- a/settings-example.py
+++ b/settings-example.py
@@ -159,6 +159,10 @@ class exp():
     packagepoa_config_file = 'packagepoa.cfg'
     packagepoa_config_section = 'elife'
 
+    # Decision letter parser
+    letterparser_config_file = 'letterparser.cfg'
+    letterparser_config_section = 'elife'
+
     # PubMed FTP settings
     PUBMED_FTP_URI = ""
     PUBMED_FTP_USERNAME = ""
@@ -419,6 +423,10 @@ class dev():
     packagepoa_config_file = 'packagepoa.cfg'
     packagepoa_config_section = 'elife'
 
+    # Decision letter parser
+    letterparser_config_file = 'letterparser.cfg'
+    letterparser_config_section = 'elife'
+
     # PubMed FTP settings
     PUBMED_FTP_URI = ""
     PUBMED_FTP_USERNAME = ""
@@ -671,6 +679,10 @@ class live():
     jatsgenerator_config_section = 'elife'
     packagepoa_config_file = 'packagepoa.cfg'
     packagepoa_config_section = 'elife'
+
+    # Decision letter parser
+    letterparser_config_file = 'letterparser.cfg'
+    letterparser_config_section = 'elife'
 
     # PubMed FTP settings
     PUBMED_FTP_URI = ""

--- a/tests/activity/letterparser.cfg
+++ b/tests/activity/letterparser.cfg
@@ -1,0 +1,13 @@
+[DEFAULT]
+doi_pattern:
+preamble: 
+docker_image: pandoc/core:2.7
+fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
+video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
+
+[elife]
+doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
+preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+docker_image: elifesciences/pandoc:2.7
+fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
+video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -3,6 +3,7 @@
 import unittest
 import docker
 from mock import patch
+import tests.settings_mock as settings_mock
 import provider.letterparser_provider as letterparser_provider
 
 
@@ -11,6 +12,11 @@ class TestLetterParserProvider(unittest.TestCase):
     def setUp(self):
         self.file_name = 'tests/fixtures/letterparser/sections.docx'
         self.blank_config = {}
+
+    def test_letterparser_config(self):
+        """test reading the letterparser config file"""
+        config = letterparser_provider.letterparser_config(settings_mock)
+        self.assertEqual(config.get("docker_image"), "elifesciences/pandoc:2.7")
 
     def test_parse_file(self):
         """test parsing docx file with pandoc which may be called via Docker"""

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -66,3 +66,6 @@ elifecrossref_config_file = 'tests/activity/crossref.cfg'
 elifecrossref_config_section = 'elife'
 
 big_query_project_id = ''
+
+letterparser_config_file = 'tests/activity/letterparser.cfg'
+letterparser_config_section = 'elife'


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5233 to use pandoc docker image.

Following a similar pattern to how this project loads the `crossref.cfg` config file, the file name and config section is specified in `settings.py`, and that is loaded by the provider.

Also updated to use the latest `letterparser` and `elifearticle` libraries, which are not specifically related to loading a config, but newer is better for future development of the activities and workflow.

I hope it is ok I add you as a reivewer @giorgiosironi, if you choose to review.