### PR TITLE
Add eLife API video helper to Lens template.

### DIFF
--- a/template/lens_article.html
+++ b/template/lens_article.html
@@ -34,6 +34,7 @@
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     <script src='../dist/lens.js'></script>
+    <script src="../dist/elife_api.js"></script>
 
     <script>
 
@@ -59,6 +60,7 @@
             query_string[pair[0]].push(pair[1]);
           }
         }
+        elifeApiCall();
         return query_string;
       } ();
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/4975 for eLife API video data.

This change to the Lens template will load the video_data.

Tested on our `dev` environment to ensure no typos, and all seems well.