### PR TITLE
Ingest decision letter workflow, starter, S3 notification

### DIFF
--- a/newFileWorkflows.yaml
+++ b/newFileWorkflows.yaml
@@ -12,3 +12,8 @@ DigestInputFile:
   bucket_name_pattern: '.*elife-bot-digests-input$'
   file_name_pattern: '.*\.(docx|zip)'
   starter_name: 'IngestDigest'
+
+DecisionLetterInputFile:
+  bucket_name_pattern: '.*elife-bot-decision-letter-input$'
+  file_name_pattern: '.*\.(docx|zip)'
+  starter_name: 'IngestDecisionLetter'

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -86,10 +86,15 @@ def process_data_ingestarticlezip(workflow_data):
     return data
 
 
-def process_data_initialarticlezip(workflow_data):
+def process_data_s3_notification_default(workflow_data):
+    """definition for default data in response to an S3 notification"""
     data = {'info': S3NotificationInfo.from_dict(workflow_data),
             'run': str(uuid.uuid4())}
     return data
+
+
+def process_data_initialarticlezip(workflow_data):
+    return process_data_s3_notification_default(workflow_data)
 
 
 def process_data_postperfectpublication(workflow_data):
@@ -103,9 +108,11 @@ def process_data_pubmedarticledeposit(workflow_data):
 
 
 def process_data_ingestdigest(workflow_data):
-    data = {'info': S3NotificationInfo.from_dict(workflow_data),
-            'run': str(uuid.uuid4())}
-    return data
+    return process_data_s3_notification_default(workflow_data)
+
+
+def process_data_ingestdecisionletter(workflow_data):
+    return process_data_s3_notification_default(workflow_data)
 
 
 workflow_data_processors = {
@@ -114,7 +121,8 @@ workflow_data_processors = {
     'SilentCorrectionsIngest': process_data_initialarticlezip,
     'PostPerfectPublication': process_data_postperfectpublication,
     'PubmedArticleDeposit': process_data_pubmedarticledeposit,
-    'IngestDigest': process_data_ingestdigest
+    'IngestDigest': process_data_ingestdigest,
+    'IngestDecisionLetter': process_data_ingestdecisionletter
 }
 
 

--- a/register.py
+++ b/register.py
@@ -41,6 +41,7 @@ def start(settings):
     workflow_names.append("PMCDeposit")
     workflow_names.append("PostPerfectPublication")
     workflow_names.append("IngestDigest")
+    workflow_names.append("IngestDecisionLetter")
 
     for workflow_name in workflow_names:
         # Import the workflow libraries

--- a/starter/starter_IngestDecisionLetter.py
+++ b/starter/starter_IngestDecisionLetter.py
@@ -1,0 +1,78 @@
+import os
+# Add parent directory for imports
+parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.sys.path.insert(0, parentdir)
+
+import boto.swf
+import json
+from optparse import OptionParser
+from S3utility.s3_notification_info import S3NotificationInfo
+import starter.starter_helper as helper
+from starter.starter_helper import NullRequiredDataException
+
+
+class starter_IngestDecisionLetter():
+    def __init__(self):
+        self.const_name = "IngestDecisionLetter"
+
+    def start(self, settings, run, info):
+
+        # Log
+        logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
+
+        if hasattr(info, 'file_name') is False or info.file_name is None:
+            raise NullRequiredDataException("filename is Null. Did not get a filename.")
+
+        input_data = S3NotificationInfo.to_dict(info)
+        input_data['run'] = run
+
+        workflow_id, \
+        workflow_name, \
+        workflow_version, \
+        child_policy, \
+        execution_start_to_close_timeout, \
+        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input_data,
+                                                         info.file_name.replace('/', '_'),
+                                                         start_to_close_timeout=str(60 * 15))
+
+        # Simple connect
+        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+
+        try:
+            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name, workflow_version,
+                                                     settings.default_task_list, child_policy,
+                                                     execution_start_to_close_timeout, workflow_input)
+
+            logger.info('got response: \n%s', json.dumps(response, sort_keys=True, indent=4))
+
+        except NullRequiredDataException as null_exception:
+            logger.exception(null_exception.message)
+            raise
+
+        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
+            # There is already a running workflow with that ID, cannot start another
+            message = 'SWFWorkflowExecutionAlreadyStartedError: ' \
+                      'There is already a running workflow with ID %s' % workflow_id
+            logger.info(message)
+
+
+if __name__ == "__main__":
+
+    # Add options
+    PARSER = OptionParser()
+    PARSER.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
+                      help="set the environment to run, either dev or live")
+
+    (OPTIONS, ARGS) = PARSER.parse_args()
+    if OPTIONS.env:
+        ENV = OPTIONS.env
+
+    import settings as settingsLib
+    SETTINGS = settingsLib.get_settings(ENV)
+
+    STARTER_OBJECT = starter_IngestIngestDecisionLetter()
+
+    # note: this starter must be started by an S3Notification and not directly from command line
+    RUN = None
+    INFO = None
+    STARTER_OBJECT.start(settings=SETTINGS, run=RUN, info=INFO)

--- a/tests/starter/test_starter_ingest_decision_letter.py
+++ b/tests/starter/test_starter_ingest_decision_letter.py
@@ -1,0 +1,29 @@
+import unittest
+from starter.starter_IngestDecisionLetter import starter_IngestDecisionLetter
+from starter.starter_helper import NullRequiredDataException
+from S3utility.s3_notification_info import S3NotificationInfo
+import tests.settings_mock as settings_mock
+import tests.test_data as test_data
+from mock import patch
+from tests.classes_mock import FakeBotoConnection
+
+run_example = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
+class TestStarterIngestDecisionLetter(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_IngestDecisionLetter()
+
+    def test_ingest_decision_letter_starter_no_article(self):
+        self.assertRaises(NullRequiredDataException, self.starter.start,
+                          settings=settings_mock, run=run_example, info=test_data.data_error_lax)
+
+    @patch('starter.starter_helper.get_starter_logger')
+    @patch('boto.swf.layer1.Layer1')
+    def test_ingest_decision_letter_starter(self, fake_boto_conn, fake_logger):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.starter.start(settings=settings_mock, run=run_example,
+                           info=S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -140,6 +140,15 @@ ingest_digest_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                       u'bucket_name': u'exp-elife-bot-digests-input',
                       u'file_size': 14086}
 
+ingest_decision_letter_data = {
+  u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
+  u'event_time': u'2019-12-13T16:14:27.809576Z',
+  u'event_name': u'ObjectCreated:Put',
+  u'file_name': u'elife-12345.zip',
+  u'file_etag': u'e7f639f63171c097d4761e2d2efe8dc4',
+  u'bucket_name': u'continuumtest-elife-bot-decision-letter-input',
+  u'file_size': 14086}
+
 queue_worker_rules = {
     'ArticleZip': {
         'bucket_name_pattern': '.*elife-production-final$',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -165,6 +165,11 @@ queue_worker_rules = {
        'file_name_pattern': r'.*\.(docx|zip)',
        'starter_name': 'IngestDigest'
        },
+    'DecisionLetterInputFile': {
+       'bucket_name_pattern': '.*elife-bot-decision-letter-input$',
+       'file_name_pattern': r'.*\.(docx|zip)',
+       'starter_name': 'IngestDecisionLetter'
+       },
     }
 
 queue_worker_article_zip_data = {u'event_time': u'2016-07-28T16:14:27.809576Z',

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -42,6 +42,14 @@ class TestQueueWorker(unittest.TestCase):
         starter_name = self.worker.get_starter_name(rules, info)
         self.assertEqual(starter_name, expected_starter_name)
 
+    def test_get_starter_name_ingest_decision_letter(self):
+        "test S3 notification info matching for the ingest decision letter workflow"
+        rules = test_data.queue_worker_rules
+        info = S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data)
+        expected_starter_name = 'IngestDecisionLetter'
+        starter_name = self.worker.get_starter_name(rules, info)
+        self.assertEqual(starter_name, expected_starter_name)
+
     @patch('queue_worker.Message')
     @patch('tests.activity.classes_mock.FakeSQSQueue.read')
     @patch('queue_worker.QueueWorker.queues')

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -129,6 +129,20 @@ class TestQueueWorkflowStarter(unittest.TestCase):
         self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
         self.assertIsNotNone(data.get('run'))
 
+    def test_process_data_ingestdecisionletter(self):
+        workflow_data = {
+            'event_name': '',
+            'event_time': '',
+            'bucket_name': '',
+            'file_name': '',
+            'file_etag': '',
+            'file_size': '',
+        }
+        data = queue_workflow_starter.process_data_ingestdecisionletter(workflow_data)
+        s3_notification_dict = data.get("info").to_dict()
+        self.assertEqual(sorted(s3_notification_dict), sorted(workflow_data))
+        self.assertIsNotNone(data.get('run'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/workflow/test_helper.py
+++ b/tests/workflow/test_helper.py
@@ -1,0 +1,45 @@
+import unittest
+from workflow.helper import define_workflow_step
+
+
+class TestDefineWorkflowStep(unittest.TestCase):
+
+    def test_define_workflow_step(self):
+        """test defaults for define_workflow_step"""
+        activity_type = 'Name'
+        activity_input = None
+        step_definition = define_workflow_step(activity_type, activity_input)
+        self.assertEqual(step_definition.get('activity_type'), activity_type)
+        self.assertEqual(step_definition.get('input'), activity_input)
+        self.assertEqual(step_definition.get('activity_id'), activity_type)
+        self.assertEqual(step_definition.get('version'), '1')
+        self.assertIsNone(step_definition.get('control'))
+        self.assertEqual(step_definition.get('heartbeat_timeout'), 60 * 5)
+        self.assertEqual(step_definition.get('schedule_to_close_timeout'), 60 * 5)
+        self.assertEqual(step_definition.get('schedule_to_start_timeout'), 60 * 5)
+        self.assertEqual(step_definition.get('start_to_close_timeout'), 60 * 5)
+
+    def test_define_workflow_step_override(self):
+        """test overriding values for define_workflow_step"""
+        activity_type = 'Name'
+        activity_input = {"data": "foo"}
+        activity_id = 'Name_01'
+        version = '2'
+        control = 'control data'
+        heartbeat_timeout = 60 * 10
+        schedule_to_close_timeout = 60 * 10
+        schedule_to_start_timeout = 60 * 10
+        start_to_close_timeout = 60 * 10
+        step_definition = define_workflow_step(
+            activity_type, activity_input, activity_id, version, control, heartbeat_timeout,
+            schedule_to_close_timeout, schedule_to_start_timeout, start_to_close_timeout)
+        self.assertEqual(step_definition.get('activity_type'), activity_type)
+        self.assertEqual(step_definition.get('input'), activity_input)
+        self.assertEqual(step_definition.get('activity_id'), activity_id)
+        self.assertEqual(step_definition.get('version'), version)
+        self.assertEqual(step_definition.get('control'), control)
+        self.assertEqual(step_definition.get('heartbeat_timeout'), schedule_to_close_timeout)
+        self.assertEqual(
+            step_definition.get('schedule_to_close_timeout'), schedule_to_start_timeout)
+        self.assertEqual(step_definition.get('schedule_to_start_timeout'), start_to_close_timeout)
+        self.assertEqual(step_definition.get('start_to_close_timeout'), start_to_close_timeout)

--- a/tests/workflow/test_workflow_ingest_decision_letter.py
+++ b/tests/workflow/test_workflow_ingest_decision_letter.py
@@ -1,0 +1,13 @@
+import unittest
+import tests.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+from workflow.workflow_IngestDecisionLetter import workflow_IngestDecisionLetter
+
+
+class TestWorkflowIngestDecisionLetter(unittest.TestCase):
+    def setUp(self):
+        self.workflow = workflow_IngestDecisionLetter(
+            settings_mock, FakeLogger(), None, None, None, None)
+
+    def test_init(self):
+        self.assertEqual(self.workflow.name, 'IngestDecisionLetter')

--- a/workflow/helper.py
+++ b/workflow/helper.py
@@ -1,0 +1,29 @@
+from collections import OrderedDict
+
+
+def define_workflow_step(
+        activity_type,
+        activity_input,
+        activity_id=None,
+        version="1",
+        control=None,
+        heartbeat_timeout=60 * 5,
+        schedule_to_close_timeout=60 * 5,
+        schedule_to_start_timeout=60 * 5,
+        start_to_close_timeout=60 * 5):
+    """
+    Helper to populate workflow activity definitions
+    """
+    if not activity_id:
+        activity_id = activity_type
+    return OrderedDict([
+        ("activity_type", activity_type),
+        ("activity_id", activity_id),
+        ("version", version),
+        ("input", activity_input),
+        ("control", control),
+        ("heartbeat_timeout", heartbeat_timeout),
+        ("schedule_to_close_timeout", schedule_to_close_timeout),
+        ("schedule_to_start_timeout", schedule_to_start_timeout),
+        ("start_to_close_timeout", start_to_close_timeout),
+    ])

--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -1,0 +1,44 @@
+from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
+
+
+class workflow_IngestDecisionLetter(Workflow):
+    def __init__(self, settings, logger, conn=None, token=None, decision=None,
+                 maximum_page_size=100):
+        super(workflow_IngestDecisionLetter, self).__init__(
+            settings, logger, conn, token, decision, maximum_page_size)
+
+        # SWF Defaults
+        self.name = "IngestDecisionLetter"
+        self.version = "1"
+        self.description = "Ingest decision letter zip file"
+        self.default_execution_start_to_close_timeout = 60 * 5
+        self.default_task_start_to_close_timeout = 30
+
+        # Get the input from the JSON decision response
+        data = self.get_input()
+
+        # JSON format workflow definition, for now - may be from common YAML definition
+        workflow_definition = {
+            "name": self.name,
+            "version": self.version,
+            "task_list": self.settings.default_task_list,
+            "input": data,
+
+            "start":
+                {
+                    "requirements": None
+                },
+
+            "steps":
+                [
+                    define_workflow_step("PingWorker", data),
+                ],
+
+            "finish":
+                {
+                    "requirements": None
+                }
+        }
+
+        self.load_definition(workflow_definition)


### PR DESCRIPTION
A start on issue https://github.com/elifesciences/elife-bot/issues/965, this addresses the first five checkboxes.

To build out the workflow in small bites, this PR defines the workflow, its starter, and starts a workflow execution after an S3 notification comes into the message queue.

The workflow steps right now only includes `PingWorker`; the real activities to this workflow will be added later. The ping should mean, if all is correct here, that it will cause no trouble, and also do very little at this time.

I also started on issue https://github.com/elifesciences/elife-bot/issues/983 here too, where `workflow/helper.py` module contains a function to define a workflow step, using default values where possible. In future all the workflows can be refactored to use this, if the example here is good.

It was informative to look through the old workflow logic a little, where I noticed the `control` value for workflow activity steps is not used at all. I left it in as a possible value to customise, even though we haven't used it yet, and probably never will. We could possibly remove `control` all together as a separate PR, if this simplification is a good idea (more detail you can see on this line https://github.com/elifesciences/elife-bot/blob/develop/workflow/objects.py#L170 `'control data' is hardcoded in the `boto` call, and the value of `control` is not used).

In summary, this PR represents the basics to add a new workflow, ability to start that workflow, and to start a workflow from an S3 notification from a particularly named bucket. The actual effect of this workflow should be a `ping` and nothing more. This will allow adding activities one-by-one to this workflow and we can review and approve them each separately.