### PR TITLE
Workflow definitions refactoring

### DIFF
--- a/workflow/helper.py
+++ b/workflow/helper.py
@@ -27,3 +27,53 @@ def define_workflow_step(
         ("schedule_to_start_timeout", schedule_to_start_timeout),
         ("start_to_close_timeout", start_to_close_timeout),
     ])
+
+
+def define_workflow_step_10(
+        activity_type,
+        activity_input,
+        activity_id=None,
+        version="1",
+        control=None,
+        heartbeat_timeout=60 * 10,
+        schedule_to_close_timeout=60 * 10,
+        schedule_to_start_timeout=60 * 5,
+        start_to_close_timeout=60 * 10):
+    """
+    Workflow step definition with 10 minute timeout defaults
+    """
+    return define_workflow_step(
+        activity_type=activity_type,
+        activity_input=activity_input,
+        activity_id=activity_id,
+        version=version,
+        control=control,
+        heartbeat_timeout=heartbeat_timeout,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout)
+
+
+def define_workflow_step_15(
+        activity_type,
+        activity_input,
+        activity_id=None,
+        version="1",
+        control=None,
+        heartbeat_timeout=60 * 15,
+        schedule_to_close_timeout=60 * 15,
+        schedule_to_start_timeout=60 * 5,
+        start_to_close_timeout=60 * 15):
+    """
+    Workflow step definition with 15 minute timeout defaults
+    """
+    return define_workflow_step(
+        activity_type=activity_type,
+        activity_input=activity_input,
+        activity_id=activity_id,
+        version=version,
+        control=control,
+        heartbeat_timeout=heartbeat_timeout,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout)

--- a/workflow/helper.py
+++ b/workflow/helper.py
@@ -29,7 +29,7 @@ def define_workflow_step(
     ])
 
 
-def define_workflow_step_10(
+def define_workflow_step_short(
         activity_type,
         activity_input,
         activity_id=None,
@@ -40,7 +40,7 @@ def define_workflow_step_10(
         schedule_to_start_timeout=60 * 5,
         start_to_close_timeout=60 * 10):
     """
-    Workflow step definition with 10 minute timeout defaults
+    Workflow step definition with short (10 minute) timeout defaults
     """
     return define_workflow_step(
         activity_type=activity_type,
@@ -54,7 +54,7 @@ def define_workflow_step_10(
         start_to_close_timeout=start_to_close_timeout)
 
 
-def define_workflow_step_15(
+def define_workflow_step_medium(
         activity_type,
         activity_input,
         activity_id=None,
@@ -65,7 +65,7 @@ def define_workflow_step_15(
         schedule_to_start_timeout=60 * 5,
         start_to_close_timeout=60 * 15):
     """
-    Workflow step definition with 15 minute timeout defaults
+    Workflow step definition with medium (15 minute) timeout defaults
     """
     return define_workflow_step(
         activity_type=activity_type,

--- a/workflow/workflow_AdminEmail.py
+++ b/workflow/workflow_AdminEmail.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-AdminEmail workflow
-"""
 
 class workflow_AdminEmail(Workflow):
 
@@ -29,40 +27,20 @@ class workflow_AdminEmail(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "AdminEmailHistory",
-                    "activity_id": "AdminEmailHistory",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 5,
-                    "schedule_to_close_timeout": 60 * 5,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 5
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("AdminEmailHistory", data),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)

--- a/workflow/workflow_ApproveArticlePublication.py
+++ b/workflow/workflow_ApproveArticlePublication.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-ApproveArticlePublication workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_ApproveArticlePublication(Workflow):
@@ -35,28 +32,8 @@ class workflow_ApproveArticlePublication(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "PublishToLax",
-                        "activity_id": "PublishToLax",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("PublishToLax", data),
                 ],
 
             "finish":

--- a/workflow/workflow_CopyGlencoeStillImages.py
+++ b/workflow/workflow_CopyGlencoeStillImages.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-CopyGlencoeStillImages workflow
-"""
 
 class workflow_CopyGlencoeStillImages(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_CopyGlencoeStillImages(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "CopyGlencoeStillImages",
-                    "activity_id": "CopyGlencoeStillImages",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 10,
-                    "schedule_to_close_timeout": 60 * 20,
-                    "schedule_to_start_timeout": 60 * 10,
-                    "start_to_close_timeout": 60 * 20
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "CopyGlencoeStillImages", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 20,
+                        schedule_to_start_timeout=60 * 10,
+                        start_to_close_timeout=60 * 20,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_DepositCrossref.py
+++ b/workflow/workflow_DepositCrossref.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-DepositCrossref workflow
-"""
 
 class workflow_DepositCrossref(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_DepositCrossref(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "DepositCrossref",
-                    "activity_id": "DepositCrossref",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 15,
-                    "schedule_to_close_timeout": 60 * 15,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 15
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "DepositCrossref", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_DepositCrossref.py
+++ b/workflow/workflow_DepositCrossref.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_15
 
 
 class workflow_DepositCrossref(Workflow):
@@ -34,13 +34,7 @@ class workflow_DepositCrossref(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "DepositCrossref", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_15("DepositCrossref", data),
                 ],
 
             "finish":

--- a/workflow/workflow_DepositCrossref.py
+++ b/workflow/workflow_DepositCrossref.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_15
+from workflow.helper import define_workflow_step, define_workflow_step_medium
 
 
 class workflow_DepositCrossref(Workflow):
@@ -34,7 +34,7 @@ class workflow_DepositCrossref(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_15("DepositCrossref", data),
+                    define_workflow_step_medium("DepositCrossref", data),
                 ],
 
             "finish":

--- a/workflow/workflow_DepositCrossrefPeerReview.py
+++ b/workflow/workflow_DepositCrossrefPeerReview.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_15
 
 
 class workflow_DepositCrossrefPeerReview(Workflow):
@@ -34,13 +34,7 @@ class workflow_DepositCrossrefPeerReview(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "DepositCrossrefPeerReview", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_15("DepositCrossrefPeerReview", data),
                 ],
 
             "finish":

--- a/workflow/workflow_DepositCrossrefPeerReview.py
+++ b/workflow/workflow_DepositCrossrefPeerReview.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_15
+from workflow.helper import define_workflow_step, define_workflow_step_medium
 
 
 class workflow_DepositCrossrefPeerReview(Workflow):
@@ -34,7 +34,7 @@ class workflow_DepositCrossrefPeerReview(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_15("DepositCrossrefPeerReview", data),
+                    define_workflow_step_medium("DepositCrossrefPeerReview", data),
                 ],
 
             "finish":

--- a/workflow/workflow_DepositCrossrefPeerReview.py
+++ b/workflow/workflow_DepositCrossrefPeerReview.py
@@ -1,4 +1,5 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
 
 class workflow_DepositCrossrefPeerReview(Workflow):
@@ -26,40 +27,26 @@ class workflow_DepositCrossrefPeerReview(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "DepositCrossrefPeerReview",
-                    "activity_id": "DepositCrossrefPeerReview",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 15,
-                    "schedule_to_close_timeout": 60 * 15,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 15
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "DepositCrossrefPeerReview", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)

--- a/workflow/workflow_FTPArticle.py
+++ b/workflow/workflow_FTPArticle.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-FTPArticle workflow
-"""
 
 class workflow_FTPArticle(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_FTPArticle(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "FTPArticle",
-                    "activity_id": "FTPArticle",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 30,
-                    "schedule_to_close_timeout": 60 * 120,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 120
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "FTPArticle", data,
+                        heartbeat_timeout=60 * 30,
+                        schedule_to_close_timeout=60 * 120,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 120,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_10, define_workflow_step_15
 
 
 class workflow_IngestArticleZip(Workflow):
@@ -33,72 +33,19 @@ class workflow_IngestArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "AcceptVersionReason", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
-                    define_workflow_step(
-                        "ApplyVersionNumber", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
-                    define_workflow_step(
-                        "VerifyGlencoe", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "ConvertImagesToJPG", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "DepositIngestAssets", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "CopyGlencoeStillImages", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_10("AcceptVersionReason", data),
+                    define_workflow_step_10("ApplyVersionNumber", data),
+                    define_workflow_step_15("VerifyGlencoe", data),
+                    define_workflow_step_15("ConvertImagesToJPG", data),
+                    define_workflow_step_15("DepositIngestAssets", data),
+                    define_workflow_step_15("CopyGlencoeStillImages", data),
                     define_workflow_step("DepositAssets", data),
                     define_workflow_step("InvalidateCdn", data),
-                    define_workflow_step(
-                        "VerifyImageServer", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
+                    define_workflow_step_15("VerifyImageServer", data),
+                    define_workflow_step_15(
                         "VerifyGlencoe", data,
-                        activity_id="VerifyGlencoeAgain",
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "IngestToLax", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
+                        activity_id="VerifyGlencoeAgain"),
+                    define_workflow_step_10("IngestToLax", data),
                 ],
 
             "finish":

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-IngestArticleZip workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_IngestArticleZip(Workflow):
@@ -35,139 +32,73 @@ class workflow_IngestArticleZip(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "AcceptVersionReason",
-                        "activity_id": "AcceptVersionReason",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-                    {
-                        "activity_type": "ApplyVersionNumber",
-                        "activity_id": "ApplyVersionNumber",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-                    {
-                        "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoe",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "ConvertImagesToJPG",
-                        "activity_id": "ConvertImagesToJPG",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "DepositIngestAssets",
-                        "activity_id": "DepositIngestAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "CopyGlencoeStillImages",
-                        "activity_id": "CopyGlencoeStillImages",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "DepositAssets",
-                        "activity_id": "DepositAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "InvalidateCdn",
-                        "activity_id": "InvalidateCdn",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "VerifyImageServer",
-                        "activity_id": "VerifyImageServer",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoeAgain",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "IngestToLax",
-                        "activity_id": "IngestToLax",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "AcceptVersionReason", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
+                    define_workflow_step(
+                        "ApplyVersionNumber", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
+                    define_workflow_step(
+                        "VerifyGlencoe", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "ConvertImagesToJPG", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "DepositIngestAssets", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "CopyGlencoeStillImages", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step("DepositAssets", data),
+                    define_workflow_step("InvalidateCdn", data),
+                    define_workflow_step(
+                        "VerifyImageServer", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "VerifyGlencoe", data,
+                        activity_id="VerifyGlencoeAgain",
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "IngestToLax", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
                 ],
 
             "finish":

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -1,5 +1,6 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_10, define_workflow_step_15
+from workflow.helper import (
+    define_workflow_step, define_workflow_step_short, define_workflow_step_medium)
 
 
 class workflow_IngestArticleZip(Workflow):
@@ -33,19 +34,19 @@ class workflow_IngestArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_10("AcceptVersionReason", data),
-                    define_workflow_step_10("ApplyVersionNumber", data),
-                    define_workflow_step_15("VerifyGlencoe", data),
-                    define_workflow_step_15("ConvertImagesToJPG", data),
-                    define_workflow_step_15("DepositIngestAssets", data),
-                    define_workflow_step_15("CopyGlencoeStillImages", data),
+                    define_workflow_step_short("AcceptVersionReason", data),
+                    define_workflow_step_short("ApplyVersionNumber", data),
+                    define_workflow_step_medium("VerifyGlencoe", data),
+                    define_workflow_step_medium("ConvertImagesToJPG", data),
+                    define_workflow_step_medium("DepositIngestAssets", data),
+                    define_workflow_step_medium("CopyGlencoeStillImages", data),
                     define_workflow_step("DepositAssets", data),
                     define_workflow_step("InvalidateCdn", data),
-                    define_workflow_step_15("VerifyImageServer", data),
-                    define_workflow_step_15(
+                    define_workflow_step_medium("VerifyImageServer", data),
+                    define_workflow_step_medium(
                         "VerifyGlencoe", data,
                         activity_id="VerifyGlencoeAgain"),
-                    define_workflow_step_10("IngestToLax", data),
+                    define_workflow_step_short("IngestToLax", data),
                 ],
 
             "finish":

--- a/workflow/workflow_IngestDigest.py
+++ b/workflow/workflow_IngestDigest.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-IngestDigest workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_IngestDigest(Workflow):
@@ -35,72 +32,12 @@ class workflow_IngestDigest(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "ValidateDigestInput",
-                        "activity_id": "ValidateDigestInput",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "EmailDigest",
-                        "activity_id": "EmailDigest",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "DepositDigestIngestAssets",
-                        "activity_id": "DepositDigestIngestAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "CopyDigestToOutbox",
-                        "activity_id": "CopyDigestToOutbox",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "PostDigestJATS",
-                        "activity_id": "PostDigestJATS",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("ValidateDigestInput", data),
+                    define_workflow_step("EmailDigest", data),
+                    define_workflow_step("DepositDigestIngestAssets", data),
+                    define_workflow_step("CopyDigestToOutbox", data),
+                    define_workflow_step("PostDigestJATS", data),
                 ],
 
             "finish":

--- a/workflow/workflow_InitialArticleZip.py
+++ b/workflow/workflow_InitialArticleZip.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-InitialArticleZip workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_InitialArticleZip(Workflow):
@@ -35,61 +32,35 @@ class workflow_InitialArticleZip(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "VersionLookup",
-                        "activity_id": "VersionLookup",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "ExpandArticle",
-                        "activity_id": "ExpandArticle",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "SendDashboardProperties",
-                        "activity_id": "SendDashboardProperties",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "VersionReasonDecider",
-                        "activity_id": "VersionReasonDecider",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    }
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "VersionLookup", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "ExpandArticle", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "SendDashboardProperties", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "VersionReasonDecider", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
                 ],
 
             "finish":

--- a/workflow/workflow_InitialArticleZip.py
+++ b/workflow/workflow_InitialArticleZip.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_15
 
 
 class workflow_InitialArticleZip(Workflow):
@@ -33,34 +33,10 @@ class workflow_InitialArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "VersionLookup", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "ExpandArticle", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "SendDashboardProperties", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "VersionReasonDecider", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_15("VersionLookup", data),
+                    define_workflow_step_15("ExpandArticle", data),
+                    define_workflow_step_15("SendDashboardProperties", data),
+                    define_workflow_step_15("VersionReasonDecider", data),
                 ],
 
             "finish":

--- a/workflow/workflow_InitialArticleZip.py
+++ b/workflow/workflow_InitialArticleZip.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_15
+from workflow.helper import define_workflow_step, define_workflow_step_medium
 
 
 class workflow_InitialArticleZip(Workflow):
@@ -33,10 +33,10 @@ class workflow_InitialArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_15("VersionLookup", data),
-                    define_workflow_step_15("ExpandArticle", data),
-                    define_workflow_step_15("SendDashboardProperties", data),
-                    define_workflow_step_15("VersionReasonDecider", data),
+                    define_workflow_step_medium("VersionLookup", data),
+                    define_workflow_step_medium("ExpandArticle", data),
+                    define_workflow_step_medium("SendDashboardProperties", data),
+                    define_workflow_step_medium("VersionReasonDecider", data),
                 ],
 
             "finish":

--- a/workflow/workflow_LensArticlePublish.py
+++ b/workflow/workflow_LensArticlePublish.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-LensArticlePublish workflow
-"""
 
 class workflow_LensArticlePublish(Workflow):
 
@@ -29,40 +27,20 @@ class workflow_LensArticlePublish(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "LensArticle",
-                    "activity_id": "LensArticle",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 5,
-                    "schedule_to_close_timeout": 60 * 5,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 5
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("LensArticle", data),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)

--- a/workflow/workflow_PMCDeposit.py
+++ b/workflow/workflow_PMCDeposit.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PMCDeposit workflow
-"""
 
 class workflow_PMCDeposit(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PMCDeposit(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PMCDeposit",
-                    "activity_id": "PMCDeposit",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 30,
-                    "schedule_to_close_timeout": 60 * 120,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 120
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PMCDeposit", data,
+                        heartbeat_timeout=60 * 30,
+                        schedule_to_close_timeout=60 * 120,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 120,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_PackagePOA.py
+++ b/workflow/workflow_PackagePOA.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PackagePOA workflow
-"""
 
 class workflow_PackagePOA(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PackagePOA(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PackagePOA",
-                    "activity_id": "PackagePOA",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 10,
-                    "schedule_to_close_timeout": 60 * 20,
-                    "schedule_to_start_timeout": 60 * 10,
-                    "start_to_close_timeout": 60 * 20
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PackagePOA", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 20,
+                        schedule_to_start_timeout=60 * 10,
+                        start_to_close_timeout=60 * 20,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_Ping.py
+++ b/workflow/workflow_Ping.py
@@ -1,7 +1,6 @@
 from workflow.objects import Workflow
-"""
-Ping workflow
-"""
+from workflow.helper import define_workflow_step
+
 
 class workflow_Ping(Workflow):
 
@@ -28,29 +27,19 @@ class workflow_Ping(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_15
 
 
 class workflow_PostPerfectPublication(Workflow):
@@ -33,13 +33,7 @@ class workflow_PostPerfectPublication(Workflow):
                 [
                     define_workflow_step("PingWorker", data),
                     define_workflow_step("VerifyPublishResponse", data),
-                    define_workflow_step(
-                        "ArchiveArticle", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_15("ArchiveArticle", data),
                     define_workflow_step("LensArticle", data),
                     define_workflow_step("ScheduleDownstream", data),
                     define_workflow_step("UpdateRepository", data),

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_15
+from workflow.helper import define_workflow_step, define_workflow_step_medium
 
 
 class workflow_PostPerfectPublication(Workflow):
@@ -33,7 +33,7 @@ class workflow_PostPerfectPublication(Workflow):
                 [
                     define_workflow_step("PingWorker", data),
                     define_workflow_step("VerifyPublishResponse", data),
-                    define_workflow_step_15("ArchiveArticle", data),
+                    define_workflow_step_medium("ArchiveArticle", data),
                     define_workflow_step("LensArticle", data),
                     define_workflow_step("ScheduleDownstream", data),
                     define_workflow_step("UpdateRepository", data),

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-PostPerfectPublication workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_PostPerfectPublication(Workflow):
@@ -34,116 +31,22 @@ class workflow_PostPerfectPublication(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "VerifyPublishResponse",
-                        "activity_id": "VerifyPublishResponse",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ArchiveArticle",
-                        "activity_id": "ArchiveArticle",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "LensArticle",
-                        "activity_id": "LensArticle",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60*5,
-                        "schedule_to_close_timeout": 60*5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60*5
-                    },
-                    {
-                        "activity_type": "ScheduleDownstream",
-                        "activity_id": "ScheduleDownstream",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "UpdateRepository",
-                        "activity_id": "UpdateRepository",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "EmailVideoArticlePublished",
-                        "activity_id": "EmailVideoArticlePublished",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "PublishDigest",
-                        "activity_id": "PublishDigest",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "CreateDigestMediumPost",
-                        "activity_id": "CreateDigestMediumPost",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "GeneratePDFCovers",
-                        "activity_id": "GeneratePDFCovers",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    }
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("VerifyPublishResponse", data),
+                    define_workflow_step(
+                        "ArchiveArticle", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step("LensArticle", data),
+                    define_workflow_step("ScheduleDownstream", data),
+                    define_workflow_step("UpdateRepository", data),
+                    define_workflow_step("EmailVideoArticlePublished", data),
+                    define_workflow_step("PublishDigest", data),
+                    define_workflow_step("CreateDigestMediumPost", data),
+                    define_workflow_step("GeneratePDFCovers", data),
                 ],
 
             "finish":

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_10
 
 
 class workflow_ProcessArticleZip(Workflow):
@@ -33,13 +33,7 @@ class workflow_ProcessArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "VerifyLaxResponse", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
+                    define_workflow_step_10("VerifyLaxResponse", data),
                     define_workflow_step("ScheduleCrossref", data),
                     define_workflow_step("ScheduleCrossrefPeerReview", data),
                     define_workflow_step("IngestDigestToEndpoint", data),

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_10
+from workflow.helper import define_workflow_step, define_workflow_step_short
 
 
 class workflow_ProcessArticleZip(Workflow):
@@ -33,7 +33,7 @@ class workflow_ProcessArticleZip(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_10("VerifyLaxResponse", data),
+                    define_workflow_step_short("VerifyLaxResponse", data),
                     define_workflow_step("ScheduleCrossref", data),
                     define_workflow_step("ScheduleCrossrefPeerReview", data),
                     define_workflow_step("IngestDigestToEndpoint", data),

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-ProcessArticleZip workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_ProcessArticleZip(Workflow):
@@ -35,72 +32,18 @@ class workflow_ProcessArticleZip(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "VerifyLaxResponse",
-                        "activity_id": "VerifyLaxResponse",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-                    {
-                        "activity_type": "ScheduleCrossref",
-                        "activity_id": "ScheduleCrossref",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ScheduleCrossrefPeerReview",
-                        "activity_id": "ScheduleCrossrefPeerReview",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "IngestDigestToEndpoint",
-                        "activity_id": "IngestDigestToEndpoint",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ReadyToPublish",
-                        "activity_id": "ReadyToPublish",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    }
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "VerifyLaxResponse", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
+                    define_workflow_step("ScheduleCrossref", data),
+                    define_workflow_step("ScheduleCrossrefPeerReview", data),
+                    define_workflow_step("IngestDigestToEndpoint", data),
+                    define_workflow_step("ReadyToPublish", data),
                 ],
 
             "finish":

--- a/workflow/workflow_PubRouterDeposit.py
+++ b/workflow/workflow_PubRouterDeposit.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PubRouterDeposit workflow
-"""
 
 class workflow_PubRouterDeposit(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PubRouterDeposit(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PubRouterDeposit",
-                    "activity_id": "PubRouterDeposit",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 25,
-                    "schedule_to_close_timeout": 60 * 25,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 25
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PubRouterDeposit", data,
+                        heartbeat_timeout=60 * 25,
+                        schedule_to_close_timeout=60 * 25,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 25,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_10
+from workflow.helper import define_workflow_step, define_workflow_step_short
 
 
 class workflow_PublicationEmail(Workflow):
@@ -34,7 +34,7 @@ class workflow_PublicationEmail(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_10("PublicationEmail", data),
+                    define_workflow_step_short("PublicationEmail", data),
                 ],
 
             "finish":

--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_10
 
 
 class workflow_PublicationEmail(Workflow):
@@ -34,13 +34,7 @@ class workflow_PublicationEmail(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "PublicationEmail", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
+                    define_workflow_step_10("PublicationEmail", data),
                 ],
 
             "finish":

--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PublicationEmail workflow
-"""
 
 class workflow_PublicationEmail(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PublicationEmail(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PublicationEmail",
-                    "activity_id": "PublicationEmail",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 10,
-                    "schedule_to_close_timeout": 60 * 10,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 10
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PublicationEmail", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_PublishPOA.py
+++ b/workflow/workflow_PublishPOA.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PublishPOA workflow
-"""
 
 class workflow_PublishPOA(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PublishPOA(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PublishFinalPOA",
-                    "activity_id": "PublishFinalPOA",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 30,
-                    "schedule_to_close_timeout": 60 * 30,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 30
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PublishFinalPOA", data,
+                        heartbeat_timeout=60 * 30,
+                        schedule_to_close_timeout=60 * 30,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 30,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_PubmedArticleDeposit.py
+++ b/workflow/workflow_PubmedArticleDeposit.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_15
 
 
 class workflow_PubmedArticleDeposit(Workflow):
@@ -34,13 +34,7 @@ class workflow_PubmedArticleDeposit(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "PubmedArticleDeposit", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_15("PubmedArticleDeposit", data),
                 ],
 
             "finish":

--- a/workflow/workflow_PubmedArticleDeposit.py
+++ b/workflow/workflow_PubmedArticleDeposit.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_15
+from workflow.helper import define_workflow_step, define_workflow_step_medium
 
 
 class workflow_PubmedArticleDeposit(Workflow):
@@ -34,7 +34,7 @@ class workflow_PubmedArticleDeposit(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_15("PubmedArticleDeposit", data),
+                    define_workflow_step_medium("PubmedArticleDeposit", data),
                 ],
 
             "finish":

--- a/workflow/workflow_PubmedArticleDeposit.py
+++ b/workflow/workflow_PubmedArticleDeposit.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-PubmedArticleDeposit workflow
-"""
 
 class workflow_PubmedArticleDeposit(Workflow):
 
@@ -29,41 +27,26 @@ class workflow_PubmedArticleDeposit(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "PubmedArticleDeposit",
-                    "activity_id": "PubmedArticleDeposit",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 15,
-                    "schedule_to_close_timeout": 60 * 15,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 15
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "PubmedArticleDeposit", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)
-

--- a/workflow/workflow_S3Monitor.py
+++ b/workflow/workflow_S3Monitor.py
@@ -1,8 +1,6 @@
 from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
 
-"""
-S3Monitor workflow
-"""
 
 class workflow_S3Monitor(Workflow):
 
@@ -29,40 +27,26 @@ class workflow_S3Monitor(Workflow):
             "input": data,
 
             "start":
-            {
-                "requirements": None
-            },
+                {
+                    "requirements": None
+                },
 
             "steps":
-            [
-                {
-                    "activity_type": "PingWorker",
-                    "activity_id": "PingWorker",
-                    "version": "1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 300,
-                    "schedule_to_close_timeout": 300,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 300
-                },
-                {
-                    "activity_type": "S3Monitor",
-                    "activity_id": "S3Monitor",
-                    "version": "1.1",
-                    "input": data,
-                    "control": None,
-                    "heartbeat_timeout": 60 * 25,
-                    "schedule_to_close_timeout": 60 * 25,
-                    "schedule_to_start_timeout": 300,
-                    "start_to_close_timeout": 60 * 25
-                }
-            ],
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "S3Monitor", data,
+                        heartbeat_timeout=60 * 25,
+                        schedule_to_close_timeout=60 * 25,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 25,
+                    ),
+                ],
 
             "finish":
-            {
-                "requirements": None
-            }
+                {
+                    "requirements": None
+                }
         }
 
         self.load_definition(workflow_definition)

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -1,5 +1,6 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import (
+    define_workflow_step, define_workflow_step_short, define_workflow_step_medium)
 
 
 class workflow_SilentCorrectionsIngest(Workflow):
@@ -33,74 +34,21 @@ class workflow_SilentCorrectionsIngest(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step(
-                        "VersionLookup", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "VersionDateLookup", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "ExpandArticle", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_medium("VersionLookup", data),
+                    define_workflow_step_medium("VersionDateLookup", data),
+                    define_workflow_step_medium("ExpandArticle", data),
                     define_workflow_step("SendDashboardProperties", data),
-                    define_workflow_step(
-                        "ApplyVersionNumber", data,
-                        heartbeat_timeout=60 * 10,
-                        schedule_to_close_timeout=60 * 10,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 10,
-                    ),
+                    define_workflow_step_short("ApplyVersionNumber", data),
                     define_workflow_step("ModifyArticleSubjects", data),
-                    define_workflow_step(
-                        "VerifyGlencoe", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "ConvertImagesToJPG", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "DepositIngestAssets", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
-                    define_workflow_step(
-                        "CopyGlencoeStillImages", data,
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                    define_workflow_step_medium("VerifyGlencoe", data),
+                    define_workflow_step_medium("ConvertImagesToJPG", data),
+                    define_workflow_step_medium("DepositIngestAssets", data),
+                    define_workflow_step_medium("CopyGlencoeStillImages", data),
                     define_workflow_step("DepositAssets", data),
                     define_workflow_step("InvalidateCdn", data),
-                    define_workflow_step(
+                    define_workflow_step_medium(
                         "VerifyGlencoe", data,
-                        activity_id="VerifyGlencoeAgain",
-                        heartbeat_timeout=60 * 15,
-                        schedule_to_close_timeout=60 * 15,
-                        schedule_to_start_timeout=60 * 5,
-                        start_to_close_timeout=60 * 15,
-                    ),
+                        activity_id="VerifyGlencoeAgain"),
                     define_workflow_step("IngestToLax", data),
                 ],
 

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-SilentCorrections workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_SilentCorrectionsIngest(Workflow):
@@ -35,183 +32,76 @@ class workflow_SilentCorrectionsIngest(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "VersionLookup",
-                        "activity_id": "VersionLookup",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "VersionDateLookup",
-                        "activity_id": "VersionDateLookup",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "ExpandArticle",
-                        "activity_id": "ExpandArticle",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "SendDashboardProperties",
-                        "activity_id": "SendDashboardProperties",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ApplyVersionNumber",
-                        "activity_id": "ApplyVersionNumber",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 10,
-                        "schedule_to_close_timeout": 60 * 10,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 10
-                    },
-                    {
-                        "activity_type": "ModifyArticleSubjects",
-                        "activity_id": "ModifyArticleSubjects",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoe",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "ConvertImagesToJPG",
-                        "activity_id": "ConvertImagesToJPG",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "DepositIngestAssets",
-                        "activity_id": "DepositIngestAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "CopyGlencoeStillImages",
-                        "activity_id": "CopyGlencoeStillImages",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "DepositAssets",
-                        "activity_id": "DepositAssets",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "InvalidateCdn",
-                        "activity_id": "InvalidateCdn",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "VerifyImageServer",
-                        "activity_id": "VerifyImageServer",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "VerifyGlencoe",
-                        "activity_id": "VerifyGlencoeAgain",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 15,
-                        "schedule_to_close_timeout": 60 * 15,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 15
-                    },
-                    {
-                        "activity_type": "IngestToLax",
-                        "activity_id": "IngestToLax",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step(
+                        "VersionLookup", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "VersionDateLookup", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "ExpandArticle", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step("SendDashboardProperties", data),
+                    define_workflow_step(
+                        "ApplyVersionNumber", data,
+                        heartbeat_timeout=60 * 10,
+                        schedule_to_close_timeout=60 * 10,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 10,
+                    ),
+                    define_workflow_step("ModifyArticleSubjects", data),
+                    define_workflow_step(
+                        "VerifyGlencoe", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "ConvertImagesToJPG", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "DepositIngestAssets", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step(
+                        "CopyGlencoeStillImages", data,
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step("DepositAssets", data),
+                    define_workflow_step("InvalidateCdn", data),
+                    define_workflow_step(
+                        "VerifyGlencoe", data,
+                        activity_id="VerifyGlencoeAgain",
+                        heartbeat_timeout=60 * 15,
+                        schedule_to_close_timeout=60 * 15,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 15,
+                    ),
+                    define_workflow_step("IngestToLax", data),
                 ],
 
             "finish":

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -1,8 +1,5 @@
 from workflow.objects import Workflow
-
-"""
-SilentCorrectionsProcess workflow
-"""
+from workflow.helper import define_workflow_step
 
 
 class workflow_SilentCorrectionsProcess(Workflow):
@@ -35,73 +32,12 @@ class workflow_SilentCorrectionsProcess(Workflow):
 
             "steps":
                 [
-                    {
-                        "activity_type": "PingWorker",
-                        "activity_id": "PingWorker",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 300,
-                        "schedule_to_close_timeout": 300,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 300
-                    },
-                    {
-                        "activity_type": "VerifyLaxResponse",
-                        "activity_id": "VerifyLaxResponse",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ScheduleCrossref",
-                        "activity_id": "ScheduleCrossref",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "ScheduleCrossrefPeerReview",
-                        "activity_id": "ScheduleCrossrefPeerReview",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "IngestDigestToEndpoint",
-                        "activity_id": "IngestDigestToEndpoint",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-                    {
-                        "activity_type": "PublishToLax",
-                        "activity_id": "PublishToLax",
-                        "version": "1",
-                        "input": data,
-                        "control": None,
-                        "heartbeat_timeout": 60 * 5,
-                        "schedule_to_close_timeout": 60 * 5,
-                        "schedule_to_start_timeout": 300,
-                        "start_to_close_timeout": 60 * 5
-                    },
-
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("VerifyLaxResponse", data),
+                    define_workflow_step("ScheduleCrossref", data),
+                    define_workflow_step("ScheduleCrossrefPeerReview", data),
+                    define_workflow_step("IngestDigestToEndpoint", data),
+                    define_workflow_step("PublishToLax", data),
                 ],
 
             "finish":


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/983

An example of definiting a workflow step was merged recently, used in the `IngestDecisionLetter` workflow.

I continued a similar pattern of refactoring for the remaining workflow definitions.

There were many with a standard of 10 or 15 minute timeouts in a specific format, for which I created `define_workflow_step_10()` and `define_workflow_step_15()` to achieve a cleaner result.

There are still some with odd or longer timeout values, which still have these specific timeout values.

Only one worklfow activity step, for `VerifyGlencoe`, do we need to explicitly override the `activity_id` value (as `VerifyGlencoeAgain`, when we repeat the same activity twice in both the regular ingest and the silient correction ingest).

I hope the diff on this is not too hard to read. I carefully copy and pasted items, and I also double-checked each before staging the changes, so I'm fairly sure this will not break anything.