### PR TITLE
Remove py27 testing and fixes for latest libraries

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -1,7 +1,6 @@
 import os
 import json
 import time
-from elifetools.utils import unicode_value
 from digestparser import output
 import digestparser.utils as digest_utils
 from S3utility.s3_notification_info import parse_activity_data
@@ -95,9 +94,9 @@ class activity_EmailDigest(Activity):
     def output_path(self, output_dir, file_name):
         "for python 2 and 3 support, only encode sometimes"
         try:
-            return os.path.join(output_dir, unicode_value(file_name)).encode('utf8')
+            return os.path.join(output_dir, str(file_name)).encode('utf8')
         except AttributeError:
-            return os.path.join(output_dir, unicode_value(file_name))
+            return os.path.join(output_dir, str(file_name))
 
     def generate_output(self, digest_content):
         "From the parsed digest content generate the output"
@@ -106,7 +105,7 @@ class activity_EmailDigest(Activity):
         file_name = output_file_name(digest_content, self.digest_config)
         self.logger.info('EmailDigest output file_name: %s', file_name)
         full_file_name = self.output_path(
-            self.directories.get("OUTPUT_DIR"), unicode_value(file_name))
+            self.directories.get("OUTPUT_DIR"), str(file_name))
         self.logger.info('EmailDigest output full_file_name: %s', full_file_name)
         try:
             output_file = output.digest_docx(digest_content, full_file_name)
@@ -163,7 +162,7 @@ def success_email_subject(digest_content):
     except AttributeError:
         msid = None
     return u'Digest: {author}_{msid:0>5}'.format(
-        author=digest_utils.unicode_decode(digest_content.author), msid=str(msid))
+        author=digest_content.author, msid=str(msid))
 
 
 def success_email_body(current_time):

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -235,7 +235,7 @@ def success_email_subject(digest_content):
         return u''
     return u'Digest JATS posted for article {msid:0>5}, author {author}'.format(
         msid=str(digest_provider.get_digest_msid(digest_content)),
-        author=digest_utils.unicode_decode(digest_content.author))
+        author=digest_content.author)
 
 
 def success_email_body(current_time, digest_content, jats_content):
@@ -257,7 +257,7 @@ def error_email_subject(digest_content):
         return u''
     return u'Error in digest JATS post for article {msid:0>5}, author {author}'.format(
         msid=str(digest_provider.get_digest_msid(digest_content)),
-        author=digest_utils.unicode_decode(digest_content.author))
+        author=digest_content.author)
 
 
 def error_email_body(current_time, digest_content, jats_content, error_messages):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ boto==2.48.0
 Jinja2==2.10.1
 arrow==0.4.4
 requests==2.20.0
-git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@53afe11590971788a64fb4790ea96a0967280e1b#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@0339bc8d13e92621898561740231e8d8d69e3f87#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@814bcf15dacfbbb0000ba592f7c3b1b047ee99bf#egg=elifepubmed
-git+https://github.com/elifesciences/ejp-csv-parser.git@9fdfa6a37c00b6134f8a2a46c784b0b11b19c654#egg=ejpcsvparser
-git+https://github.com/elifesciences/jats-generator.git@ea0d4d90a28198eb2953cc982da85392fbfee360#egg=jatsgenerator
-git+https://github.com/elifesciences/package-poa.git@2649777a020661e507de4087d447f50ca8c2fe57#egg=packagepoa
+git+https://github.com/elifesciences/elife-tools.git@1ca1de40c9747a2ba25559ec5c5f52f00c1fd85e#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@158d5d9484aeb22bfb5109a79db3615f8fbe8ab0#egg=elifearticle
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@b0779aaa92b7d5db820064a18cf382bbc6b324d1#egg=elifecrossref
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@d0edbc89910628da9b793daadb305c39ddb60370#egg=elifepubmed
+git+https://github.com/elifesciences/ejp-csv-parser.git@4a458be95d4177d19d53b8e4e8d70705dc6b07a1#egg=ejpcsvparser
+git+https://github.com/elifesciences/jats-generator.git@54864941d8cdd5f0aaddaa99bcd829d505f0b7ce#egg=jatsgenerator
+git+https://github.com/elifesciences/package-poa.git@f9c74b0503a3b776f59e551a9095838cef595cac#egg=packagepoa
 docker==4.0.2
 git+https://github.com/elifesciences/decision-letter-parser.git@711e70d279644c38e80f4df9fe8dc5a2169344c8#egg=letterparser
 PyYAML==4.2b2
@@ -29,7 +29,7 @@ pyFunctional==1.2.0
 func_timeout==4.3.0
 # versions of python-docx>=0.8.9 have issues installing on python 3.5.2 (xenial default)
 python-docx==0.8.10
-git+https://github.com/elifesciences/digest-parser.git@cd3a47af45db64a1731cc5ae9d0647ec3511a120#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@04edbe9ac980e33125a4654b93280e42ac174db9#egg=digestparser
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium
 psutil==5.4.6
 pytz==2019.2

--- a/tests/activity/test_activity_validate_digest_input.py
+++ b/tests/activity/test_activity_validate_digest_input.py
@@ -6,7 +6,6 @@ import email
 import unittest
 from mock import patch
 from ddt import ddt, data
-from elifetools.utils import unicode_value
 import activity.activity_ValidateDigestInput as activity_module
 from activity.activity_ValidateDigestInput import activity_ValidateDigestInput as activity_object
 import tests.activity.settings_mock as settings_mock
@@ -160,7 +159,7 @@ class TestValidateDigestInput(unittest.TestCase):
                     self.assertTrue(test_data.get("expected_email_from") in first_email_content)
                 if test_data.get("expected_email_body"):
                     body = body_from_multipart_email_string(first_email_content)
-                    self.assertTrue(test_data.get("expected_email_body") in unicode_value(body))
+                    self.assertTrue(test_data.get("expected_email_body") in str(body))
 
 
 class TestEmailSubject(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35,py36
+envlist = py35,py36
 [testenv]
 passenv = HOME MAGICK_HOME
 deps = -rrequirements.txt


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/995

Here I updated all the libraries this project depends on to the latest commits, which include a few changes regarding dropping `py27` support.

Code changes I did the minimal changes required to get the tests to pass.

I split refactoring and cleaning up the code for Python 2.7 specific code to a separate issue (https://github.com/elifesciences/elife-bot/issues/996) so it doesn't get in the way of compatibility and getting this PR merged.