### PR TITLE
Fix S3Monitor workflow activity version call.

### DIFF
--- a/workflow/workflow_S3Monitor.py
+++ b/workflow/workflow_S3Monitor.py
@@ -36,6 +36,7 @@ class workflow_S3Monitor(Workflow):
                     define_workflow_step("PingWorker", data),
                     define_workflow_step(
                         "S3Monitor", data,
+                        version='1.1',
                         heartbeat_timeout=60 * 25,
                         schedule_to_close_timeout=60 * 25,
                         schedule_to_start_timeout=60 * 5,


### PR DESCRIPTION
Bug fix to https://github.com/elifesciences/elife-bot/pull/994. The wrong activity version value was used for `S3Monitor`.