### PR TITLE
Do not log decision events in non-debug mode.

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -97,10 +97,10 @@ def decide(settings, flag, debug=False):
 
 
 def trimmed_decision(decision, debug=False):
-    """trim events from a copy of decision prior to logging if not debug"""
+    """trim data from a copy of decision prior to logging if not debug"""
     decision_trimmed = copy.copy(decision)
     if not debug:
-        # set events value to a blank list to reduce logging
+        # removed to limit verbosity
         decision_trimmed['events'] = []
     return decision_trimmed
 

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -66,5 +66,25 @@ class TestDecider(unittest.TestCase):
         self.assertEqual(workflow_object.__class__.__name__, workflow_name)
 
 
+class TestTrimmedDecision(unittest.TestCase):
+
+    def setUp(self):
+        self.decision_json = None
+        with open('tests/test_data/decision.json', 'r') as open_file:
+            self.decision_json = json.loads(open_file.read())
+
+    def test_trimmed_decision(self):
+        decision_trimmed = decider.trimmed_decision(self.decision_json)
+        self.assertEqual(decision_trimmed.get('events'), [])
+        # original is unchanged
+        self.assertEqual(len(self.decision_json.get('events')), 22)
+
+    def test_trimmed_decision_debug(self):
+        decision_trimmed = decider.trimmed_decision(self.decision_json, True)
+        self.assertEqual(len(decision_trimmed.get('events')), 22)
+        # original is unchanged
+        self.assertEqual(len(self.decision_json.get('events')), 22)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/999

So we are not caught with large decider log files, this is a very small change proposed.

When processing a workflow decision, the `decider.py` gets the entire workflow event history from AWS SWF service by following all the paging tokens and puts this data into a dict's `events` value. For a stuck and repeatedly retried workflow, these can reach in the thousands of events, logged every 10 seconds.

In this PR, a separate copy of `decision` is made and its `events` value is set to a blank list `[]` if the decider is not in debug mode. `debug=False` is the default value, and currently there's no way to specify `debug=true`. 

I created the debug flag primarily to signify how there is the potentially to log more decision data, in the future, if we want to expand into that, but based on recent development of this project, we do not normally need to dig into that much detail to determine why a workflow is failing. If we changed how workflow histories are processed, then at that time we could turn on `debug` in some way to figure out why it cannot process a workflow correctly.

I'm open to suggestions to pass the `debug` value in from where the process is started (if you think so), or any other suggestions.

I created an additional issue to cover refactoring, linting, and more test coverage in the future (issue https://github.com/elifesciences/elife-bot/issues/1000).