### PR TITLE
New download_helper, refactor from digest provider.

### DIFF
--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -3,7 +3,7 @@ import json
 from S3utility.s3_notification_info import parse_activity_data
 from provider.storage_provider import storage_context
 from provider.utils import unicode_encode
-import provider.digest_provider as digest_provider
+from provider import digest_provider, download_helper
 from activity.objects import Activity
 
 
@@ -42,7 +42,7 @@ class activity_CopyDigestToOutbox(Activity):
         # parse the data with the digest_provider
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
         # Download from S3
-        input_file = digest_provider.download_digest_from_s3(
+        input_file = download_helper.download_file_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder,
             self.directories.get("INPUT_DIR"))
         # Parse input and build digest

--- a/activity/activity_DepositDigestIngestAssets.py
+++ b/activity/activity_DepositDigestIngestAssets.py
@@ -2,7 +2,7 @@ import os
 import json
 from S3utility.s3_notification_info import parse_activity_data
 from provider.storage_provider import storage_context
-import provider.digest_provider as digest_provider
+from provider import digest_provider, download_helper
 import provider.utils as utils
 from activity.objects import Activity
 
@@ -50,7 +50,7 @@ class activity_DepositDigestIngestAssets(Activity):
         # parse the data with the digest_provider
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
         # Download from S3
-        self.input_file = digest_provider.download_digest_from_s3(
+        self.input_file = download_helper.download_file_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder,
             self.directories.get("INPUT_DIR"))
         # Parse input and build digest

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -4,8 +4,7 @@ import time
 from digestparser import output
 import digestparser.utils as digest_utils
 from S3utility.s3_notification_info import parse_activity_data
-import provider.digest_provider as digest_provider
-import provider.email_provider as email_provider
+from provider import digest_provider, download_helper, email_provider
 from activity.objects import Activity
 
 
@@ -60,7 +59,7 @@ class activity_EmailDigest(Activity):
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
 
         # Download from S3
-        self.input_file = digest_provider.download_digest_from_s3(
+        self.input_file = download_helper.download_file_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder,
             self.directories.get("INPUT_DIR"))
 

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -6,7 +6,7 @@ import requests
 import digestparser.utils as digest_utils
 from elifetools.utils import doi_uri_to_doi
 from S3utility.s3_notification_info import parse_activity_data
-from provider import digest_provider, email_provider
+from provider import digest_provider, download_helper, email_provider
 from activity.objects import Activity
 
 
@@ -73,7 +73,7 @@ class activity_PostDigestJATS(Activity):
             return self.ACTIVITY_SUCCESS
 
         # Download from S3
-        self.input_file = digest_provider.download_digest_from_s3(
+        self.input_file = download_helper.download_file_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder,
             self.directories.get("INPUT_DIR"))
 

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -2,8 +2,7 @@ import os
 import json
 import time
 from S3utility.s3_notification_info import parse_activity_data
-import provider.digest_provider as digest_provider
-import provider.email_provider as email_provider
+from provider import digest_provider, download_helper, email_provider
 from activity.objects import Activity
 
 
@@ -57,7 +56,7 @@ class activity_ValidateDigestInput(Activity):
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)
 
         # Download from S3
-        self.input_file = digest_provider.download_digest_from_s3(
+        self.input_file = download_helper.download_file_from_s3(
             self.settings, real_filename, bucket_name, bucket_folder,
             self.directories.get("INPUT_DIR"))
 

--- a/provider/download_helper.py
+++ b/provider/download_helper.py
@@ -1,0 +1,37 @@
+import os
+from provider.storage_provider import storage_context
+
+
+def file_resource_origin(storage_provider, filename, bucket_name, bucket_folder):
+    "concatenate the origin of a bucket file for the storage provider"
+    if not filename or not bucket_name or bucket_folder is None:
+        return None
+    storage_provider_prefix = storage_provider + "://"
+    orig_resource = storage_provider_prefix + bucket_name + "/" + bucket_folder
+    return orig_resource + '/' + filename
+
+
+def download_file(storage, filename, resource_origin, to_dir):
+    "download the filename from a bucket or storage to the to_dir"
+    if not resource_origin:
+        return None
+    filename_plus_path = to_dir + os.sep + filename
+    with open(filename_plus_path, 'wb') as open_file:
+        storage.get_resource_to_file(resource_origin, open_file)
+    return filename_plus_path
+
+
+def download_file_from_s3(settings, filename, bucket_name, bucket_folder, to_dir):
+    "Connect to the S3 bucket and download the input"
+    resource_origin = file_resource_origin(
+        storage_provider=settings.storage_provider,
+        filename=filename,
+        bucket_name=bucket_name,
+        bucket_folder=bucket_folder
+        )
+    return download_file(
+        storage=storage_context(settings),
+        filename=filename,
+        resource_origin=resource_origin,
+        to_dir=to_dir,
+        )

--- a/tests/activity/test_activity_copy_digest_to_outbox.py
+++ b/tests/activity/test_activity_copy_digest_to_outbox.py
@@ -5,7 +5,7 @@ import unittest
 from mock import patch
 from ddt import ddt, data
 from digestparser.objects import Digest
-import provider.digest_provider as digest_provider
+from provider import digest_provider, download_helper
 from activity.activity_CopyDigestToOutbox import activity_CopyDigestToOutbox as activity_object
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
@@ -44,6 +44,7 @@ class TestCopyDigestToOutbox(unittest.TestCase):
         helpers.delete_files_in_folder(testdata.ExpandArticle_files_dest_folder,
                                        filter_out=['.gitkeep'])
 
+    @patch.object(download_helper, 'storage_context')
     @patch.object(digest_provider, 'storage_context')
     @patch('activity.activity_CopyDigestToOutbox.storage_context')
     @data(
@@ -77,12 +78,14 @@ class TestCopyDigestToOutbox(unittest.TestCase):
             "expected_file_list": []
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context):
+    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
+                         fake_download_storage_context):
         # copy files into the input directory using the storage context
         named_fake_storage_context = FakeStorageContext()
         named_fake_storage_context.resources = test_data.get('bucket_resources')
         fake_storage_context.return_value = named_fake_storage_context
         fake_provider_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         # populate the fake resources
         populate_outbox(test_data.get('bucket_resources'))
         # do the activity

--- a/tests/activity/test_activity_deposit_digest_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_digest_ingest_assets.py
@@ -4,7 +4,7 @@ import os
 import unittest
 from mock import patch
 from ddt import ddt, data
-import provider.digest_provider as digest_provider
+from provider import digest_provider, download_helper
 from activity.activity_DepositDigestIngestAssets import (
     activity_DepositDigestIngestAssets as activity_object)
 import tests.activity.settings_mock as settings_mock
@@ -36,6 +36,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         helpers.delete_files_in_folder(testdata.ExpandArticle_files_dest_folder,
                                        filter_out=['.gitkeep'])
 
+    @patch.object(download_helper, 'storage_context')
     @patch.object(digest_provider, 'storage_context')
     @patch('activity.activity_DepositDigestIngestAssets.storage_context')
     @data(
@@ -76,10 +77,12 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
             "expected_file_list": []
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context):
+    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
+                         fake_download_storage_context):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_provider_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))
 

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -40,6 +40,7 @@ class TestEmailDigest(unittest.TestCase):
         self.activity.clean_tmp_dir()
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @data(
         {
@@ -127,9 +128,11 @@ class TestEmailDigest(unittest.TestCase):
             "expected_email_count": 0
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_email_smtp_connect):
+    def test_do_activity(self, test_data, fake_storage_context, fake_download_storage_context,
+                         fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -39,6 +39,7 @@ class TestPostDigestJats(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('requests.post')
+    @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @data(
         {
@@ -121,10 +122,11 @@ class TestPostDigestJats(unittest.TestCase):
             "expected_email_status": None
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, requests_method_mock,
-                         fake_email_smtp_connect):
+    def test_do_activity(self, test_data, fake_storage_context, fake_download_storage_context,
+                         requests_method_mock, fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # POST response
         requests_method_mock.return_value = FakeResponse(test_data.get("post_status_code"), None)
@@ -158,11 +160,13 @@ class TestPostDigestJats(unittest.TestCase):
                              'failed in {comment}'.format(comment=test_data.get("comment")))
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @patch.object(digest_provider, 'digest_jats')
     def test_do_activity_jats_failure(self, fake_digest_jats, fake_storage_context,
-                                      fake_email_smtp_connect):
+                                      fake_download_storage_context, fake_email_smtp_connect):
         fake_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         activity_data = input_data("DIGEST+99999.zip")
         fake_digest_jats.return_value = None
@@ -170,11 +174,13 @@ class TestPostDigestJats(unittest.TestCase):
         self.assertEqual(result, activity_object.ACTIVITY_SUCCESS)
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @patch.object(activity_module, 'post_payload')
     def test_do_activity_post_failure(self, fake_post_jats, fake_storage_context,
-                                      fake_email_smtp_connect):
+                                      fake_download_storage_context, fake_email_smtp_connect):
         fake_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         activity_data = input_data("DIGEST+99999.zip")
         fake_post_jats.side_effect = Exception("Something went wrong!")

--- a/tests/activity/test_activity_validate_digest_input.py
+++ b/tests/activity/test_activity_validate_digest_input.py
@@ -43,6 +43,7 @@ class TestValidateDigestInput(unittest.TestCase):
         self.activity.clean_tmp_dir()
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.digest_provider, 'storage_context')
     @data(
         {
@@ -107,9 +108,11 @@ class TestValidateDigestInput(unittest.TestCase):
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.35774',
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_email_smtp_connect):
+    def test_do_activity(self, test_data, fake_storage_context, fake_download_storage_context,
+                         fake_email_smtp_connect):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))


### PR DESCRIPTION
I was starting in on logic for decision letter parsing (https://github.com/elifesciences/elife-bot/issues/966), based on how digest workflows work.

There was code in the `digest_provider.py` for downloading the zip files from the S3 bucket that could be reused.

Here I moved it over to a new module, `download_helper.py`, and refactored all the existing digest activities to use it.

Rather than mixing this into a PR with new decision letter workflow code, I created this smaller PR first.