### PR TITLE
More py27

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -91,7 +91,7 @@ class activity_EmailDigest(Activity):
         return self.ACTIVITY_PERMANENT_FAILURE
 
     def output_path(self, output_dir, file_name):
-        """for python 3 should always return bytes which is what we want"""
+        """for python 3 cast file_name to str so it can be joined with the path value"""
         return os.path.join(output_dir, str(file_name))
 
     def generate_output(self, digest_content):

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -91,11 +91,8 @@ class activity_EmailDigest(Activity):
         return self.ACTIVITY_PERMANENT_FAILURE
 
     def output_path(self, output_dir, file_name):
-        "for python 2 and 3 support, only encode sometimes"
-        try:
-            return os.path.join(output_dir, str(file_name)).encode('utf8')
-        except AttributeError:
-            return os.path.join(output_dir, str(file_name))
+        """for python 3 should always return bytes which is what we want"""
+        return os.path.join(output_dir, str(file_name))
 
     def generate_output(self, digest_content):
         "From the parsed digest content generate the output"

--- a/provider/article.py
+++ b/provider/article.py
@@ -229,12 +229,7 @@ class article(object):
         """
         doi_url = get_doi_url(doi)
         f = {"text": doi_url + " @eLife"}
-        if hasattr(urllib, 'urlencode'):
-            tweet_url = "http://twitter.com/intent/tweet?" + urllib.urlencode(f)
-        else:
-            # python 3
-            tweet_url = "http://twitter.com/intent/tweet?" + urllib.parse.urlencode(f)
-        return tweet_url
+        return "http://twitter.com/intent/tweet?" + urllib.parse.urlencode(f)
 
     def get_lens_url(self, doi):
         """

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -9,7 +9,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import boto.ses
-from provider.utils import unicode_decode, unicode_encode
+from provider.utils import bytes_decode, unicode_encode
 
 
 def ses_connect(settings):
@@ -68,8 +68,8 @@ def encode_filename(file_name):
     """
     if file_name is None:
         return file_name
-    return unicode_encode(unicode_decode(
-        unicodedata.ucd_3_2_0.normalize('NFC', unicode_decode(file_name))))
+    return unicode_encode(bytes_decode(
+        unicodedata.ucd_3_2_0.normalize('NFC', bytes_decode(file_name))))
 
 
 def attachment(file_name,

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -64,19 +64,13 @@ def unicode_decode(string):
 
 
 def base64_encode_string(string):
-    "base64 endcode string for python 2 or 3"
-    if hasattr(base64, 'encodebytes'):
-        # python 3
-        return base64.encodebytes(bytes(string, 'utf8')).decode()
-    return base64.encodestring(string)
+    "base64 endcode string for python 3"
+    return base64.encodebytes(bytes(string, 'utf8')).decode()
 
 
 def base64_decode_string(string):
-    "base64 decode string for python 2 or 3"
-    if hasattr(base64, 'decodebytes'):
-        # python 3
-        return base64.decodebytes(bytes(string, 'utf8')).decode()
-    return base64.decodestring(string)
+    "base64 decode string for python 3"
+    return base64.decodebytes(bytes(string, 'utf8')).decode()
 
 
 def unicode_encode(string):

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -54,13 +54,13 @@ def unquote_plus(string):
     return urllib.parse.unquote_plus(string)
 
 
-def unicode_decode(string):
-    "try to decode from utf8"
+def bytes_decode(bytes_string):
+    "try to decode to utf8"
     try:
-        string = string.decode('utf8')
+        bytes_string = bytes_string.decode('utf8')
     except (UnicodeEncodeError, AttributeError):
         pass
-    return string
+    return bytes_string
 
 
 def base64_encode_string(string):
@@ -77,11 +77,8 @@ def unicode_encode(string):
     """safely encode string as utf8 by catching exceptions"""
     if string is None or isinstance(string, str):
         return string
-    try:
-        string = string.encode('utf8')
-    except (UnicodeDecodeError, TypeError, AttributeError):
-        string = unicode_decode(string)
-    return string
+    # decode bytes to string
+    return bytes_decode(string)
 
 
 def set_datestamp():

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -47,13 +47,11 @@ def volume_from_pub_date(pub_date, start_year=2011):
 
 
 def unquote_plus(string):
-    "unescape plus sign url with python 2 or 3 method"
+    "unescape plus sign url in python 3"
     if not string:
         return string
-    if hasattr(urllib, 'parse'):
-        # python 3
-        return urllib.parse.unquote_plus(string)
-    return urllib.unquote_plus(string)
+    # python 3
+    return urllib.parse.unquote_plus(string)
 
 
 def unicode_decode(string):

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -11,7 +11,7 @@ import boto.sqs
 import newrelic.agent
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider import process
-from provider.utils import unicode_decode
+from provider.utils import bytes_decode
 # this is not an unused import, it is used dynamically
 import starter
 
@@ -57,7 +57,7 @@ def get_queue(settings):
 
 def process_message(settings, logger, message):
     try:
-        message_payload = json.loads(str(unicode_decode(message.get_body())))
+        message_payload = json.loads(str(bytes_decode(message.get_body())))
         name = message_payload.get('workflow_name')
         data = message_payload.get('workflow_data')
         start_workflow(settings, name, data)

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -136,11 +136,7 @@ class FakeStorageContext:
         bucket_name, s3_key = self.get_bucket_and_key(resource)
         src = self.dir + s3_key
         with open(src, 'rb') as fsrc:
-            try:
-                filelike.write(fsrc.read())
-            except TypeError:
-                # python 3
-                filelike.write(fsrc.read().decode())
+            filelike.write(fsrc.read())
 
     def get_resource_as_string(self, origin):
         return '<mock><media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="wmv" mimetype="video" xlink:href="elife-00569-media1.wmv"></media></mock>'

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -49,11 +49,8 @@ class FakeSQSMessage:
         self.dir = directory
 
     def set_body(self, body):
-        try:
-            self.dir.write("fake_sqs_body", body)
-        except TypeError:
-            # python 3, write bytes
-            self.dir.write("fake_sqs_body", bytes(body, 'utf-8'))
+        # write bytes
+        self.dir.write("fake_sqs_body", bytes(body, 'utf-8'))
 
     def get_body(self):
         return self.dir.read("fake_sqs_body")

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -108,7 +108,7 @@ class TestEmailDigest(unittest.TestCase):
             "expected_approve_status": True,
             "expected_email_status": True,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99997',
-            # do not compare output file names due to difference in python 2, 3 and cross plaform
+            "expected_output_dir_files": ['González_99997.docx'],
             "expected_email_count": 2,
             "expected_email_subject": "Subject: =?utf-8?q?Digest=3A_Gonz=C3=A1lez=5F99997?=",
             "expected_email_from": "From: sender@example.org"

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -17,7 +17,7 @@ import tests.test_data as test_case_data
 from tests.activity.classes_mock import FakeStorageContext
 from tests.classes_mock import FakeSMTPServer
 import provider.digest_provider as digest_provider
-from provider.utils import unicode_decode
+from provider.utils import bytes_decode
 
 
 def input_data(file_name_to_change=''):
@@ -320,7 +320,7 @@ class TestPost(unittest.TestCase):
         resp = activity_module.post_as_json(url, payload)
         # make assertions
         self.assertEqual(resp.request.url, expected_url)
-        self.assertEqual(unicode_decode(resp.request.body), expected_body)
+        self.assertEqual(bytes_decode(resp.request.body), expected_body)
 
 
 class TestEmailErrorReport(unittest.TestCase):

--- a/tests/activity/test_activity_send_dashboard_properties.py
+++ b/tests/activity/test_activity_send_dashboard_properties.py
@@ -86,12 +86,8 @@ class TestSendDashboardEvents(unittest.TestCase):
         "test if XML fails to parse, here an incorrect pub_date, will fail"
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_s3_mock.return_value = FakeS3Connection()
-        with open(os.path.join('tests', 'files_source', 'elife-00353-v1_bad_pub_date.xml')) as open_file:
-            try:
-                fake_key = FakeKey(self.directory, 'elife-00353-v1.xml', open_file.read())
-            except TypeError:
-                # python 3
-                fake_key = FakeKey(self.directory, 'elife-00353-v1.xml', bytes(open_file.read(), 'utf-8'))
+        with open(os.path.join('tests', 'files_source', 'elife-00353-v1_bad_pub_date.xml'), 'rb') as open_file:
+            fake_key = FakeKey(self.directory, 'elife-00353-v1.xml', open_file.read())
             fake_get_article_xml_key.return_value = fake_key, test_data.bucket_origin_file_name
 
         result = self.send_dashboard_properties.do_activity(test_data.dashboard_data)

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -123,16 +123,15 @@ class TestListEmailRecipients(unittest.TestCase):
             if name.endswith("35774.docx"):
                 attachment_file = name
         attachments = [attachment_file]
-        # compare two fragments because in Python 2 it wraps with extra quotation marks
-        expected_fragments.append("Content-Disposition: attachment; filename*=")
-        expected_fragments.append("utf-8''Bay%C3%A9s_35774.docx")
-        # create the message
+        # compare attachment in body
+        expected_fragments.append("Content-Disposition: attachment; filename*=utf-8''Bay%C3%A9s_35774.docx")
         email_message = email_provider.simple_message(
             sender, recipient, subject, body, subtype=subtype, attachments=attachments)
         for expected in expected_fragments:
             self.assertTrue(
                 expected in str(email_message),
                 'Fragment %s not found in email %s' % (expected, str(email_message)))
+
 
     def test_get_admin_email_body_foot(self):
         """test simple string Template rendering"""

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -3,7 +3,7 @@
 import glob
 import unittest
 from ddt import ddt, data, unpack
-from provider.utils import base64_encode_string, unicode_decode, unicode_encode
+from provider.utils import base64_encode_string, bytes_decode, unicode_encode
 import provider.email_provider as email_provider
 
 
@@ -69,8 +69,9 @@ class TestListEmailRecipients(unittest.TestCase):
     @data(
         'Bayés_35774.docx',
         u'Bayés_35774.docx',
-        unicode_decode(b'Bay\xc3\xa9s_35774.docx'),
-        unicode_decode(b'Baye\xcc\x81s_35774.docx')
+        b'Bay\xc3\xa9s_35774.docx',
+        bytes_decode(b'Bay\xc3\xa9s_35774.docx'),
+        bytes_decode(b'Baye\xcc\x81s_35774.docx')
     )
     def test_encode_filename(self, filename):
         """the encoded name for the examples will always be the same"""

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -5,14 +5,6 @@ from tests.test_data import glencoe_metadata
 
 class TestGlencoeCheck(unittest.TestCase):
 
-    def items_equal_assertion(self, result, expected):
-        """
-        comparing lists, instead of using assertItemsEqual in python 2, and
-        assertCountEqual in python 3, just rewrite it as as assertEqual
-        as described in the documentation of what it actually does
-        """
-        return self.assertEqual(sorted(result), sorted(expected))
-
     def test_check_msid_long_id(self):
         result = glencoe_check.check_msid("7777777701234")
         self.assertEqual('01234', result)
@@ -27,7 +19,7 @@ class TestGlencoeCheck(unittest.TestCase):
 
     def test_jpg_href_values(self):
         result = glencoe_check.jpg_href_values(glencoe_metadata)
-        self.items_equal_assertion([
+        self.assertCountEqual([
             "http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media2.jpg",
             "http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media1.jpg"],
             result)
@@ -38,7 +30,7 @@ class TestGlencoeCheck(unittest.TestCase):
                             "media_start3": {"no_jpg_href": "value3"},
                             "anything_else": {"jpg_href": "value4"}}
         results = glencoe_check.jpg_href_values(glencoe_metadata)
-        self.items_equal_assertion(["value1", "value2", "value4"], results)
+        self.assertCountEqual(["value1", "value2", "value4"], results)
 
     def test_extend_article_for_end2end(self):
         filename = "elife-01234-media1-v1.jpg"

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -4,7 +4,7 @@ from mock import Mock, patch
 import tests.settings_mock as settings_mock
 from queue_worker import QueueWorker
 from S3utility.s3_notification_info import S3NotificationInfo
-from provider.utils import unicode_decode
+from provider.utils import bytes_decode
 import tests.test_data as test_data
 from tests.classes_mock import FakeFlag, FakeS3Event
 from tests.activity.classes_mock import FakeSQSConn, FakeSQSMessage, FakeSQSQueue
@@ -68,7 +68,7 @@ class TestQueueWorker(unittest.TestCase):
         # invoke queue worker to work
         return_value = self.worker.work(flag)
         # assertions, should have a message in the out_queue
-        out_queue_message = json.loads(unicode_decode(directory.read("fake_sqs_body")))
+        out_queue_message = json.loads(bytes_decode(directory.read("fake_sqs_body")))
         self.assertEqual(out_queue_message, test_data.queue_worker_starter_message)
         self.assertEqual(return_value, None)
 


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/996

This PR includes what I hoped to change in a more in-depth, complicated, removal of additiona Python 2.7 logic. It may not be complete but it is the things I could find as a result of some keyword searching.

It includes:

- in `provider/utils.py` renamed `unicode_decode()` to `bytes_decode()`, which I think is a more accurate name now
- simplfied the unicode encode / decode logic in `provider/utils.py`
- consistent use of `urllib.parse`, including `urllib.parse.unquote_plus()` and `urllib.parse.urlencode()`
- reading binary files in code and test scenarios consistently the same way
- in email digests tests, able to change it to compare the file name and email attachment string, without having to also support what Python 2 was generating
- can use `assertCountEqual()` in `test_glencoe_check.py`

That's about it, give or take.

This is an optional follow-up issue I mentioned on https://github.com/elifesciences/issues/issues/4726