### PR TITLE
Email body refactoring for sending simple error and success emails

### DIFF
--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -211,8 +211,8 @@ class activity_CreateDigestMediumPost(Activity):
         "email the success notification to the recipients"
         success = True
 
-        current_time = time.gmtime()
-        body = success_email_body(current_time)
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(article_id)
         sender_email = self.settings.digest_sender_email
 
@@ -243,16 +243,3 @@ def post_medium_content(medium_content, digest_config, logger):
 def success_email_subject(article_id):
     "the email subject"
     return u'Medium post created for Digest: {msid:0>5}'.format(msid=str(article_id))
-
-
-def success_email_body(current_time):
-    """
-    Format the body of the email
-    """
-    body = ""
-    date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-    datetime_string = time.strftime(date_format, current_time)
-    body += "As at " + datetime_string + "\n"
-    body += "\n"
-    body += "\n\nSincerely\n\neLife bot"
-    return body

--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -3,8 +3,7 @@ import json
 import time
 from digestparser import medium_post
 from provider.article_processing import download_jats
-import provider.digest_provider as digest_provider
-import provider.email_provider as email_provider
+from provider import digest_provider, email_provider, utils
 from activity.objects import Activity
 
 
@@ -211,7 +210,7 @@ class activity_CreateDigestMediumPost(Activity):
         "email the success notification to the recipients"
         success = True
 
-        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(article_id)
         sender_email = self.settings.digest_sender_email

--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -211,7 +211,7 @@ class activity_CreateDigestMediumPost(Activity):
         "email the success notification to the recipients"
         success = True
 
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
         body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(article_id)
         sender_email = self.settings.digest_sender_email

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -118,7 +118,7 @@ class activity_EmailDigest(Activity):
         "email the digest as an attachment to the recipients"
         success = True
 
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
         body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(digest_content)
         sender_email = self.settings.digest_sender_email

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -4,7 +4,7 @@ import time
 from digestparser import output
 import digestparser.utils as digest_utils
 from S3utility.s3_notification_info import parse_activity_data
-from provider import digest_provider, download_helper, email_provider
+from provider import digest_provider, download_helper, email_provider, utils
 from activity.objects import Activity
 
 
@@ -118,7 +118,7 @@ class activity_EmailDigest(Activity):
         "email the digest as an attachment to the recipients"
         success = True
 
-        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(digest_content)
         sender_email = self.settings.digest_sender_email

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -118,8 +118,8 @@ class activity_EmailDigest(Activity):
         "email the digest as an attachment to the recipients"
         success = True
 
-        current_time = time.gmtime()
-        body = success_email_body(current_time)
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body = email_provider.simple_email_body(datetime_string)
         subject = success_email_subject(digest_content)
         sender_email = self.settings.digest_sender_email
 
@@ -162,16 +162,3 @@ def success_email_subject(digest_content):
         msid = None
     return u'Digest: {author}_{msid:0>5}'.format(
         author=digest_content.author, msid=str(msid))
-
-
-def success_email_body(current_time):
-    """
-    Format the body of the email
-    """
-    body = ""
-    date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-    datetime_string = time.strftime(date_format, current_time)
-    body += "As at " + datetime_string + "\n"
-    body += "\n"
-    body += "\n\nSincerely\n\neLife bot"
-    return body

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -137,7 +137,7 @@ class activity_PostDigestJATS(Activity):
 
     def send_email(self, digest_content, jats_content):
         """send an email after digest JATS is posted to endpoint"""
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
         body_content = success_email_body_content(digest_content, jats_content)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = success_email_subject(digest_content)
@@ -157,7 +157,7 @@ class activity_PostDigestJATS(Activity):
 
     def email_error_report(self, digest_content, jats_content, error_messages):
         """send an email on error"""
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
         body_content = error_email_body_content(digest_content, jats_content, error_messages)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = error_email_subject(digest_content)

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -156,8 +156,9 @@ class activity_PostDigestJATS(Activity):
 
     def email_error_report(self, digest_content, jats_content, error_messages):
         """send an email on error"""
-        current_time = time.gmtime()
-        body = error_email_body(current_time, digest_content, jats_content, error_messages)
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body_content = error_email_body_content(digest_content, jats_content, error_messages)
+        body = email_provider.simple_email_body(datetime_string, body_content)
         subject = error_email_subject(digest_content)
         sender_email = self.settings.digest_sender_email
 
@@ -260,18 +261,13 @@ def error_email_subject(digest_content):
         author=digest_content.author)
 
 
-def error_email_body(current_time, digest_content, jats_content, error_messages):
-    """body of an error email"""
-    body = ""
+def error_email_body_content(digest_content, jats_content, error_messages):
+    """body content of an error email"""
+    content = ""
     if error_messages:
-        body += str(error_messages)
-        body += "\n\nMore details about the error may be found in the worker.log file\n\n"
+        content += str(error_messages)
+        content += "\n\nMore details about the error may be found in the worker.log file\n\n"
     if hasattr(digest_content, "doi"):
-        body += "Article DOI: %s\n\n" % digest_content.doi
-    body += "JATS content: %s\n\n" % jats_content
-    date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-    datetime_string = time.strftime(date_format, current_time)
-    body += "\nAs at " + datetime_string + "\n"
-    body += "\n"
-    body += "\n\nSincerely\n\neLife bot"
-    return body
+        content += "Article DOI: %s\n\n" % digest_content.doi
+    content += "JATS content: %s\n\n" % jats_content
+    return content

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -6,7 +6,7 @@ import requests
 import digestparser.utils as digest_utils
 from elifetools.utils import doi_uri_to_doi
 from S3utility.s3_notification_info import parse_activity_data
-from provider import digest_provider, download_helper, email_provider
+from provider import digest_provider, download_helper, email_provider, utils
 from activity.objects import Activity
 
 
@@ -137,7 +137,7 @@ class activity_PostDigestJATS(Activity):
 
     def send_email(self, digest_content, jats_content):
         """send an email after digest JATS is posted to endpoint"""
-        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body_content = success_email_body_content(digest_content, jats_content)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = success_email_subject(digest_content)
@@ -157,7 +157,7 @@ class activity_PostDigestJATS(Activity):
 
     def email_error_report(self, digest_content, jats_content, error_messages):
         """send an email on error"""
-        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body_content = error_email_body_content(digest_content, jats_content, error_messages)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = error_email_subject(digest_content)

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -137,8 +137,9 @@ class activity_PostDigestJATS(Activity):
 
     def send_email(self, digest_content, jats_content):
         """send an email after digest JATS is posted to endpoint"""
-        current_time = time.gmtime()
-        body = success_email_body(current_time, digest_content, jats_content)
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body_content = success_email_body_content(digest_content, jats_content)
+        body = email_provider.simple_email_body(datetime_string, body_content)
         subject = success_email_subject(digest_content)
         sender_email = self.settings.digest_sender_email
 
@@ -239,17 +240,11 @@ def success_email_subject(digest_content):
         author=digest_content.author)
 
 
-def success_email_body(current_time, digest_content, jats_content):
+def success_email_body_content(digest_content, jats_content):
     """
-    Format the body of the email
+    Format the body content of the email
     """
-    body = "JATS content for article %s:\n\n%s\n\n" % (digest_content.doi, jats_content)
-    date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-    datetime_string = time.strftime(date_format, current_time)
-    body += "As at " + datetime_string + "\n"
-    body += "\n"
-    body += "\n\nSincerely\n\neLife bot"
-    return body
+    return "JATS content for article %s:\n\n%s\n\n" % (digest_content.doi, jats_content)
 
 
 def error_email_subject(digest_content):

--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -104,7 +104,7 @@ class activity_ValidateDecisionLetterInput(Activity):
     def email_error_report(self, filename, error_messages):
         "send an email on error"
         datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
-        body = email_provider.error_email_body(datetime_string, error_messages)
+        body = email_provider.simple_email_body(datetime_string, error_messages)
         subject = error_email_subject(filename)
         sender_email = self.settings.decision_letter_sender_email
 

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -83,8 +83,8 @@ class activity_ValidateDigestInput(Activity):
 
     def email_error_report(self, filename, error_messages):
         "send an email on error"
-        current_time = time.gmtime()
-        body = error_email_body(current_time, error_messages)
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body = email_provider.simple_email_body(datetime_string, error_messages)
         subject = error_email_subject(filename)
         sender_email = self.settings.digest_sender_email
 
@@ -106,16 +106,3 @@ class activity_ValidateDigestInput(Activity):
 def error_email_subject(filename):
     "email subject for an error email"
     return u'Error processing digest file: {filename}'.format(filename=filename)
-
-
-def error_email_body(current_time, error_messages):
-    "body of an error email"
-    body = ""
-    if error_messages:
-        body += str(error_messages)
-    date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-    datetime_string = time.strftime(date_format, current_time)
-    body += "\nAs at " + datetime_string + "\n"
-    body += "\n"
-    body += "\n\nSincerely\n\neLife bot"
-    return body

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -2,7 +2,7 @@ import os
 import json
 import time
 from S3utility.s3_notification_info import parse_activity_data
-from provider import digest_provider, download_helper, email_provider
+from provider import digest_provider, download_helper, email_provider, utils
 from activity.objects import Activity
 
 
@@ -83,7 +83,7 @@ class activity_ValidateDigestInput(Activity):
 
     def email_error_report(self, filename, error_messages):
         "send an email on error"
-        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string, error_messages)
         subject = error_email_subject(filename)
         sender_email = self.settings.digest_sender_email

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -83,7 +83,7 @@ class activity_ValidateDigestInput(Activity):
 
     def email_error_report(self, filename, error_messages):
         "send an email on error"
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        datetime_string = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime())
         body = email_provider.simple_email_body(datetime_string, error_messages)
         subject = error_email_subject(filename)
         sender_email = self.settings.digest_sender_email

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -258,13 +258,13 @@ def get_admin_email_body_foot(activity_id, workflow_id, datetime_string, domain)
     return ''
 
 
-def error_email_body(datetime_string, error_messages):
-    """body of an error email"""
+def simple_email_body(datetime_string, body_content):
+    """body of a simple success or error email"""
     string_template = None
-    with open('template/error_email_body.txt', 'r') as open_file:
+    with open('template/simple_email_body.txt', 'r') as open_file:
         string_template = Template(open_file.read())
     if string_template:
         return string_template.safe_substitute(
-            error_messages=error_messages,
+            body_content=body_content,
             datetime_string=datetime_string)
     return ''

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -258,7 +258,7 @@ def get_admin_email_body_foot(activity_id, workflow_id, datetime_string, domain)
     return ''
 
 
-def simple_email_body(datetime_string, body_content):
+def simple_email_body(datetime_string, body_content=''):
     """body of a simple success or error email"""
     string_template = None
     with open('template/simple_email_body.txt', 'r') as open_file:

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -3,8 +3,11 @@ import urllib
 import base64
 import arrow
 
+
 S3_DATE_FORMAT = '%Y%m%d%H%M%S'
 PUB_DATE_FORMAT = "%Y-%m-%d"
+DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000Z"
+
 
 def pad_msid(msid):
     return '{:05d}'.format(int(msid))

--- a/template/simple_email_body.txt
+++ b/template/simple_email_body.txt
@@ -1,4 +1,4 @@
-$error_messages
+$body_content
 
 As at $datetime_string
 

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -386,25 +386,18 @@ class TestEmailSubject(unittest.TestCase):
 
 class TestEmailBody(unittest.TestCase):
 
-    def test_success_email_body(self):
+    def test_success_email_body_content(self):
         """email body line with correct, unicode data"""
         digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
         digest_content.text = [u'<i>First</i> paragraph.', u'<b>First</b> > second, nö?.']
         jats_content = digest_provider.digest_jats(digest_content)
-        current_time = time.gmtime(1)
 
         expected = u'''JATS content for article 10.7554/eLife.99999:
 
 <p><italic>First</italic> paragraph.</p><p><bold>First</bold> &gt; second, nö?.</p>
 
-As at 1970-01-01T00:00:01.000Z
-
-
-
-Sincerely
-
-eLife bot'''
-        body = activity_module.success_email_body(current_time, digest_content, jats_content)
+'''
+        body = activity_module.success_email_body_content(digest_content, jats_content)
         self.assertEqual(body, expected)
 
     def test_error_email_body_content(self):

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -407,13 +407,12 @@ eLife bot'''
         body = activity_module.success_email_body(current_time, digest_content, jats_content)
         self.assertEqual(body, expected)
 
-    def test_error_email_body(self):
+    def test_error_email_body_content(self):
         """email error body"""
         error_message = "Exception blah blah blah"
         digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
         digest_content.text = [u'<i>First</i> paragraph.', u'<b>First</b> > second, nö?.']
         jats_content = digest_provider.digest_jats(digest_content)
-        current_time = time.gmtime(1)
 
         expected = u'''Exception blah blah blah
 
@@ -423,16 +422,9 @@ Article DOI: 10.7554/eLife.99999
 
 JATS content: <p><italic>First</italic> paragraph.</p><p><bold>First</bold> &gt; second, nö?.</p>
 
-
-As at 1970-01-01T00:00:01.000Z
-
-
-
-Sincerely
-
-eLife bot'''
-        body = activity_module.error_email_body(
-            current_time, digest_content, jats_content, error_message)
+'''
+        body = activity_module.error_email_body_content(
+            digest_content, jats_content, error_message)
         self.assertEqual(body, expected)
 
 


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/1004

After starting in on this refactoring issue, I noticed with a small change the previously named `error_email_body()` in `provider/email_provider.py` would be better renamed as `simple_email_body()`, which I've done here. As a result, it is more suited to formatting both simple success and error emails.

Similar code in other activities is refactored to use `simple_email_body()`. If the email body content contains more than error messages, the body content is formatted separately, but now using fewer lines of code and is more specific to the particular activity data.

To note / a question: when searching for places to refactor, there are a few other email body functions around that we may want to also turn into templates. Examples are in `PackagePoA`, `PublishFinalPOA`, `PubmedArticleDeposit`, `PubRouterDeposit`, and a little in `PublicationEmail`. These would possibly be better as jinja2 templates, but it may be possible to just use string replace templates. @giorgiosironi what do you think in terms of priority whether all the email body formatting were in templates, would this be worthwhile for now or in the future?