### PR TITLE
Use DATE_TIME_FORMAT in all the places.

### DIFF
--- a/activity/activity_AdminEmailHistory.py
+++ b/activity/activity_AdminEmailHistory.py
@@ -5,7 +5,7 @@ import time
 from activity.objects import Activity
 
 import provider.swfmeta as swfmetalib
-from provider import email_provider
+from provider import email_provider, utils
 
 """
 AdminEmailHistory activity
@@ -96,8 +96,7 @@ class activity_AdminEmailHistory(Activity):
 
         body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
         body = "A short history of workflow executions\n"
         body += "As at " + datetime_string + "\n"

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -369,8 +369,7 @@ class activity_PackagePOA(Activity):
 
         body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
         activity_status_text = utils.get_activity_status_text(self.activity_status)
 

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -706,8 +706,7 @@ class activity_PubRouterDeposit(Activity):
 
         body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
         activity_status_text = utils.get_activity_status_text(self.activity_status)
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -892,8 +892,7 @@ class activity_PublishFinalPOA(Activity):
 
         body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
         activity_status_text = utils.get_activity_status_text(self.activity_status)
 

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -439,8 +439,7 @@ class activity_PubmedArticleDeposit(Activity):
 
         body = ""
 
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
-        datetime_string = time.strftime(date_format, current_time)
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
         activity_status_text = utils.get_activity_status_text(self.activity_status)
 

--- a/activity/activity_S3Monitor.py
+++ b/activity/activity_S3Monitor.py
@@ -9,6 +9,7 @@ import boto.s3
 from boto.s3.connection import S3Connection
 
 import provider.simpleDB as dblib
+from provider import utils
 
 from activity.objects import Activity
 
@@ -89,7 +90,7 @@ class activity_S3Monitor(Activity):
         # Get extended _runtime values
         if _runtime_timestamp:
             date_attrs = self.get_expanded_date_attributes(
-                base_name='_runtime', date_format="%Y-%m-%dT%H:%M:%S.000Z",
+                base_name='_runtime', date_format=utils.DATE_TIME_FORMAT,
                 timestamp=_runtime_timestamp, date_string=None)
             for k, v in list(date_attrs.items()):
                 base_item_attrs[k] = v
@@ -149,7 +150,7 @@ class activity_S3Monitor(Activity):
             # Example format: 2013-01-26T23:48:28.000Z
             if item_attrs['last_modified']:
                 date_attrs = self.get_expanded_date_attributes(
-                    base_name='last_modified', date_format="%Y-%m-%dT%H:%M:%S.000Z",
+                    base_name='last_modified', date_format=utils.DATE_TIME_FORMAT,
                     timestamp=None, date_string=item_attrs['last_modified'])
                 for k, v in list(date_attrs.items()):
                     item_attrs[k] = v
@@ -174,7 +175,7 @@ class activity_S3Monitor(Activity):
                         item.add_value(k, v)
                 item.save()
 
-    def get_expanded_date_attributes(self, base_name='', date_format="%Y-%m-%dT%H:%M:%S.000Z",
+    def get_expanded_date_attributes(self, base_name='', date_format=utils.DATE_TIME_FORMAT,
                                      timestamp=None, date_string=None):
         """
         Given a base_name as an identifier string, and either a timestamp or a

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -10,6 +10,7 @@ import io
 from ejpcsvparser.utils import entity_to_unicode
 import boto.s3
 from boto.s3.connection import S3Connection
+from provider import utils
 
 """
 EJP data provider
@@ -355,7 +356,7 @@ class EJP(object):
                 try:
                     if item_attrs['last_modified']:
                         # Parse last_modified into a timestamp for easy computations
-                        date_format = "%Y-%m-%dT%H:%M:%S.000Z"
+                        date_format = utils.DATE_TIME_FORMAT
                         date_str = time.strptime(item_attrs['last_modified'], date_format)
                         timestamp = calendar.timegm(date_str)
                         item_attrs['last_modified_timestamp'] = timestamp

--- a/provider/simpleDB.py
+++ b/provider/simpleDB.py
@@ -6,6 +6,7 @@ import boto.sdb
 
 import boto.s3
 from boto.s3.connection import S3Connection
+from provider import utils
 
 """
 SimpleDB S3 data provider
@@ -183,14 +184,12 @@ class SimpleDB(object):
             last_updated_since:       only return items updated since the date provided
         """
 
-        date_format = "%Y-%m-%dT%H:%M:%S.000Z"
-
         domain_name = "S3FileLog"
 
         item_list = []
 
         domain_name_env = self.get_domain_name(domain_name)
-        query = self.elife_get_generic_delivery_S3_query(date_format, domain_name_env,
+        query = self.elife_get_generic_delivery_S3_query(utils.DATE_TIME_FORMAT, domain_name_env,
                                                          bucket_name, last_updated_since)
 
         dom = self.get_domain(domain_name)

--- a/starter/cron_FiveMinute.py
+++ b/starter/cron_FiveMinute.py
@@ -10,6 +10,7 @@ import importlib
 from optparse import OptionParser
 
 import provider.swfmeta as swfmetalib
+from provider import utils
 import starter
 
 """
@@ -37,11 +38,9 @@ class cron_FiveMinute(object):
         self.start_ping_marker(ping_marker_id, settings)
 
         # Check for S3 XML files that were updated since the last run
-        date_format = "%Y-%m-%dT%H:%M:%S.000Z"
-
         # Date conversion
         time_tuple = time.gmtime(last_startTimestamp)
-        last_startDate = time.strftime(date_format, time_tuple)
+        last_startDate = time.strftime(utils.DATE_TIME_FORMAT, time_tuple)
 
         logger.info('last run %s %s' % (ping_marker_id, last_startDate))
 

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -11,6 +11,7 @@ from optparse import OptionParser
 
 import provider.simpleDB as dblib
 import provider.swfmeta as swfmetalib
+from provider import utils
 import starter
 
 """
@@ -42,14 +43,12 @@ class cron_NewS3POA(object):
         self.start_ping_marker(ping_marker_id, settings)
 
         # Check for S3 XML files that were updated since the last run
-        date_format = "%Y-%m-%dT%H:%M:%S.000Z"
-
         # Quick hack - subtract 15 minutes,
         #   the time between S3Monitor running and this cron starter
         last_startTimestamp_minus_15 = last_startTimestamp - (60 * 15)
         time_tuple = time.gmtime(last_startTimestamp_minus_15)
 
-        last_startDate = time.strftime(date_format, time_tuple)
+        last_startDate = time.strftime(utils.DATE_TIME_FORMAT, time_tuple)
 
         logger.info('last run %s' % (last_startDate))
 

--- a/tests/activity/test_activity_s3_monitor.py
+++ b/tests/activity/test_activity_s3_monitor.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch
 from provider.simpleDB import SimpleDB
+from provider import utils
 import activity.activity_S3Monitor as activity_module
 from activity.activity_S3Monitor import activity_S3Monitor as activity_object
 import tests.activity.settings_mock as settings_mock
@@ -61,9 +62,9 @@ class TestS3Monitor(unittest.TestCase):
 
     def test_get_expanded_date_attributes(self):
         base_name = 'last_modified'
-        date_format = '%Y-%m-%dT%H:%M:%S.000Z'
         timestamp = 1359244237
-        date_attrs = self.activity.get_expanded_date_attributes(base_name, date_format, timestamp)
+        date_attrs = self.activity.get_expanded_date_attributes(
+            base_name, utils.DATE_TIME_FORMAT, timestamp)
         self.assertEqual(date_attrs.get('last_modified_timestamp'), timestamp)
         self.assertEqual(date_attrs.get('last_modified_date'), '2013-01-26T23:50:37.000Z')
         self.assertEqual(date_attrs.get('last_modified_year'), '2013')

--- a/tests/provider/test_simpledb.py
+++ b/tests/provider/test_simpledb.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 from provider.simpleDB import SimpleDB
+from provider import utils
 import tests.settings_mock as settings_mock
 from ddt import ddt, data, unpack
 
@@ -81,7 +82,7 @@ class TestSimpleDB(unittest.TestCase):
     def test_elife_get_generic_delivery_s3_query(self, domain_name, bucket_name,
                                                  last_updated_since, expected_query):
         query = self.provider.elife_get_generic_delivery_S3_query(
-            date_format="%Y-%m-%dT%H:%M:%S.000Z",
+            date_format=utils.DATE_TIME_FORMAT,
             domain_name=domain_name,
             bucket_name=bucket_name,
             last_updated_since=last_updated_since)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/1009

Consists of find -> replace of all places `%Y-%m-%dT%H:%M:%S.000Z` was present and replacing it with the constant `DATE_TIME_FORMAT` from `provider/utils.py`.