### PR TITLE
Bug fix logging formatting in decider.py

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -97,7 +97,7 @@ def invoke_do_workflow(workflow_name, workflow_object, logger):
 
     # Print the result to the log
     if success:
-        logger.info('%s success %s', (workflow_name, success))
+        logger.info('%s success %s' % (workflow_name, success))
 
 
 def trimmed_decision(decision, debug=False):


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1012

Somehow a `log.info()` with two string formatting parameters was changed to have a `,` instead of `%`, which causes a `TypeError`. Tests didn't catch it. I ran minimal decider and worker and executed a ping workflow on dev environment to troubleshoot, after `end2end` tests failed.