### PR TITLE
Refactor to use console_start_env() and get_settings()

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -3,13 +3,12 @@ import time
 import datetime
 import importlib
 from collections import OrderedDict
-from argparse import ArgumentParser
 
 from pytz import timezone
 
 import log
 import provider.swfmeta as swfmetalib
-
+from provider import utils
 import newrelic.agent
 
 """
@@ -282,24 +281,9 @@ def start_workflow(settings, starter_name, workflow_id=None):
         starter_object.start(settings=settings)
 
 
-def get_settings(env):
-    import settings as settings_lib
-    return settings_lib.get_settings(env)
-
-
-def console_start():
-    """capture options when running standalone"""
-    parser = ArgumentParser()
-    parser.add_argument("-e", "--env", default="dev", action="store", type=str, dest="env",
-                        help="set the environment to run, either dev or live")
-    args = parser.parse_args()
-    if args.env:
-        return args.env
-
-
 if __name__ == "__main__":
-    ENV = console_start()
-    SETTINGS = get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
     application = newrelic.agent.register_application(timeout=10.0)
     with newrelic.agent.BackgroundTask(application, name='run_cron', group='cron.py'):
         run_cron(settings=SETTINGS)

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -1,4 +1,3 @@
-from optparse import OptionParser
 import boto.sqs
 import log
 import json
@@ -135,16 +134,7 @@ class LaxResponseAdapter:
         output_queue.write(m)
 
 if __name__ == "__main__":
-
-    ENV = None
-
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    ENV = options.env
-    settings_lib = __import__('settings')
-    settings = settings_lib.get_settings(ENV)
-    lax_response_adapter = LaxResponseAdapter(settings, logger)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
+    lax_response_adapter = LaxResponseAdapter(SETTINGS, logger)
     process.monitor_interrupt(lambda flag: lax_response_adapter.listen(flag))

--- a/queue_worker.py
+++ b/queue_worker.py
@@ -1,7 +1,6 @@
 import time
 import json
-from provider import process
-from optparse import OptionParser
+from provider import process, utils
 from S3utility.s3_notification_info import S3NotificationInfo
 from S3utility.s3_sqs_message import S3SQSMessage
 import boto.sqs
@@ -121,13 +120,7 @@ class QueueWorker:
 
 
 if __name__ == "__main__":
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-    settings_lib = __import__('settings')
-    settings = settings_lib.get_settings(ENV)
-    queue_worker = QueueWorker(settings)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
+    queue_worker = QueueWorker(SETTINGS)
     process.monitor_interrupt(lambda flag: queue_worker.work(flag))

--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -5,12 +5,11 @@ import os
 import uuid
 import json
 import importlib
-from optparse import OptionParser
 import log
 import boto.sqs
 import newrelic.agent
 from S3utility.s3_notification_info import S3NotificationInfo
-from provider import process
+from provider import process, utils
 from provider.utils import bytes_decode
 # this is not an unused import, it is used dynamically
 import starter
@@ -126,23 +125,7 @@ workflow_data_processors = {
 }
 
 
-def get_settings(env):
-    import settings as settings_lib
-    return settings_lib.get_settings(env)
-
-
-def console_start():
-    """capture options when running standalone"""
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        env = options.env
-        return env
-
-
 if __name__ == "__main__":
-    ENV = console_start()
-    SETTINGS = get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
     process.monitor_interrupt(lambda flag: main(SETTINGS, flag))

--- a/register.py
+++ b/register.py
@@ -1,13 +1,12 @@
 import json
 import os
 import importlib
-from optparse import OptionParser
 
 import boto.swf
 
 import workflow
 import activity
-
+from provider import utils
 
 """
 Amazon SWF register workflow or activity utility
@@ -128,15 +127,7 @@ def start(settings):
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settings_lib
-    SETTINGS = settings_lib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     start(SETTINGS)

--- a/starter/cron_FiveMinute.py
+++ b/starter/cron_FiveMinute.py
@@ -7,7 +7,6 @@ import boto.swf
 import log
 import time
 import importlib
-from optparse import OptionParser
 
 import provider.swfmeta as swfmetalib
 from provider import utils
@@ -102,17 +101,9 @@ class cron_FiveMinute(object):
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = cron_FiveMinute()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -7,7 +7,6 @@ import boto.swf
 import log
 import time
 import importlib
-from optparse import OptionParser
 
 import provider.simpleDB as dblib
 import provider.swfmeta as swfmetalib
@@ -131,17 +130,9 @@ class cron_NewS3POA(object):
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = cron_NewS3POA()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_AdminEmail.py
+++ b/starter/starter_AdminEmail.py
@@ -7,7 +7,7 @@ import boto.swf
 import log
 import json
 import random
-from optparse import OptionParser
+from provider import utils
 
 """
 Amazon SWF Admin Email starter
@@ -70,17 +70,9 @@ class starter_AdminEmail():
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_AdminEmail()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_DepositCrossref.py
+++ b/starter/starter_DepositCrossref.py
@@ -8,7 +8,7 @@ import log
 import json
 import random
 
-from optparse import OptionParser
+from provider import utils
 
 """
 Amazon SWF DepositCrossref starter
@@ -51,20 +51,9 @@ class starter_DepositCrossref():
 
 if __name__ == "__main__":
 
-    document = None
-
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_DepositCrossref()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_DepositCrossrefPeerReview.py
+++ b/starter/starter_DepositCrossrefPeerReview.py
@@ -8,7 +8,7 @@ import log
 import json
 import random
 
-from optparse import OptionParser
+from provider import utils
 
 
 class starter_DepositCrossrefPeerReview():
@@ -48,18 +48,9 @@ class starter_DepositCrossrefPeerReview():
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_DepositCrossrefPeerReview()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_IngestDecisionLetter.py
+++ b/starter/starter_IngestDecisionLetter.py
@@ -5,7 +5,7 @@ os.sys.path.insert(0, parentdir)
 
 import boto.swf
 import json
-from optparse import OptionParser
+from provider import utils
 from S3utility.s3_notification_info import S3NotificationInfo
 import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
@@ -58,17 +58,8 @@ class starter_IngestDecisionLetter():
 
 if __name__ == "__main__":
 
-    # Add options
-    PARSER = OptionParser()
-    PARSER.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-
-    (OPTIONS, ARGS) = PARSER.parse_args()
-    if OPTIONS.env:
-        ENV = OPTIONS.env
-
-    import settings as settingsLib
-    SETTINGS = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     STARTER_OBJECT = starter_IngestIngestDecisionLetter()
 

--- a/starter/starter_IngestDigest.py
+++ b/starter/starter_IngestDigest.py
@@ -5,7 +5,7 @@ os.sys.path.insert(0, parentdir)
 
 import boto.swf
 import json
-from optparse import OptionParser
+from provider import utils
 from S3utility.s3_notification_info import S3NotificationInfo
 import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
@@ -62,17 +62,8 @@ class starter_IngestDigest():
 
 if __name__ == "__main__":
 
-    # Add options
-    PARSER = OptionParser()
-    PARSER.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-
-    (OPTIONS, ARGS) = PARSER.parse_args()
-    if OPTIONS.env:
-        ENV = OPTIONS.env
-
-    import settings as settingsLib
-    SETTINGS = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     STARTER_OBJECT = starter_IngestDigest()
 

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -7,7 +7,7 @@ import boto.swf
 import log
 import json
 import random
-from optparse import OptionParser
+from provider import utils
 
 """
 Amazon SWF Ping workflow starter
@@ -67,17 +67,9 @@ class starter_Ping():
 
 if __name__ == "__main__":
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_Ping()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_PublicationEmail.py
+++ b/starter/starter_PublicationEmail.py
@@ -7,7 +7,7 @@ import boto.swf
 import log
 import json
 import random
-from optparse import OptionParser
+from provider import utils
 
 """
 Amazon SWF PublicationEmail starter
@@ -57,20 +57,9 @@ class starter_PublicationEmail():
 
 if __name__ == "__main__":
 
-    document = None
-
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_PublicationEmail()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_PublishPOA.py
+++ b/starter/starter_PublishPOA.py
@@ -7,7 +7,7 @@ import boto.swf
 import log
 import json
 import random
-from optparse import OptionParser
+from provider import utils
 
 """
 Amazon SWF PublishPOA starter
@@ -49,20 +49,9 @@ class starter_PublishPOA():
 
 if __name__ == "__main__":
 
-    document = None
-
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_PublishPOA()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/starter/starter_PubmedArticleDeposit.py
+++ b/starter/starter_PubmedArticleDeposit.py
@@ -7,7 +7,7 @@ import boto.swf
 import log
 import json
 import random
-from optparse import OptionParser
+from provider import utils
 
 
 """
@@ -51,20 +51,9 @@ class starter_PubmedArticleDeposit():
 
 if __name__ == "__main__":
 
-    document = None
-
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
     o = starter_PubmedArticleDeposit()
 
-    o.start(settings=settings)
+    o.start(settings=SETTINGS)

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,5 +1,4 @@
 import unittest
-import sys
 import datetime
 from pytz import timezone
 from ddt import ddt, data
@@ -13,19 +12,6 @@ import cron
 class TestCron(unittest.TestCase):
     def setUp(self):
         pass
-
-    def test_console_start(self):
-        env = 'foo'
-        expected = env
-        testargs = ['cron.py', '-e', env]
-        with patch.object(sys, 'argv', testargs):
-            self.assertEqual(cron.console_start(), expected)
-
-    def test_console_start_blank(self):
-        expected = 'dev'
-        testargs = ['cron.py']
-        with patch.object(sys, 'argv', testargs):
-            self.assertEqual(cron.console_start(), expected)
 
     def test_get_current_datetime(self):
         self.assertIsNotNone(cron.get_current_datetime())

--- a/worker.py
+++ b/worker.py
@@ -6,8 +6,7 @@ import os
 import importlib
 import time
 import newrelic.agent
-from provider import process
-from optparse import OptionParser
+from provider import process, utils
 
 import activity
 from activity.objects import Activity
@@ -216,14 +215,7 @@ def signal_fail_workflow(conn, logger, domain, workflow_id, run_id):
 
 if __name__ == "__main__":
 
-    ENV = None
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env", help="set the environment to run, either dev or live")
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
 
-    settings_lib = __import__('settings')
-    settings = settings_lib.get_settings(ENV)
-
-    process.monitor_interrupt(lambda flag: work(settings, flag))
+    process.monitor_interrupt(lambda flag: work(SETTINGS, flag))


### PR DESCRIPTION
Following from PR https://github.com/elifesciences/elife-bot/pull/1012 of decider refactoring, now that `provider/utils.py` has a couple centralised functions to use when starting scripts from the console, these are some places where they are easy to use, including:

- `cron.py` and `queue_workflow_starter.py`, which had duplicates of these functions
- in some other bits that are started as separate processes, including `worker.py`
- many of the starters 

There's room for further refactoring of some starters, for which I added another todo item to issue https://github.com/elifesciences/elife-bot/issues/992 when starters are refactored. Some starters allow for more than just the `-e --env` value when they are run, for which some additional helper functions might be devised in the future.