### PR TITLE
More flexible arguments parsing.

### DIFF
--- a/provider/utils.py
+++ b/provider/utils.py
@@ -117,7 +117,7 @@ def console_start_env():
     parser = ArgumentParser()
     parser.add_argument("-e", "--env", default="dev", action="store", type=str, dest="env",
                         help="set the environment to run, either dev or live")
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
     return args.env
 
 

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -125,6 +125,12 @@ class TestConsoleStart(unittest.TestCase):
         with patch.object(sys, 'argv', testargs):
             self.assertEqual(utils.console_start_env(), expected)
 
+    def test_console_unrecognized_arguments(self):
+        env = 'foo'
+        expected = env
+        testargs = ['cron.py', '-e', env, '0']
+        with patch.object(sys, 'argv', testargs):
+            self.assertEqual(utils.console_start_env(), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Final (hopefully) bug fix to PR https://github.com/elifesciences/elife-bot/pull/1012

In `end2end` testing (and in a `prod` situation if code were yet deployed), the `decider.py` gracefully shuts down and does not come back.

I think I tracked this down to how systemctl is starting multiple processes. It invokes something like,

`/opt/elife-bot/venv/bin/python decider.py -e end2end 0`

where `0` is the process number (as well as `1`, `2`, etc.).

The problem being when trying to run this, the recent switch over from `OptionParser` over to `ArgumentParser`, the `0` is not allowed, resulting in

```
usage: decider.py [-h] [-e ENV]
decider.py: error: unrecognized arguments: 0
```

Here I am switching it over to use `parse_known_args()`, which seems to be more lenient.

I will merge and deploy this now to get `end2end` and `ci` running again.

@giorgiosironi, I wonder if the number on the processes needs to be there in the running of these? It won't hurt after this PR is merged though I think.