### PR TITLE
Clean up imports in starter_AdminEmail.

### DIFF
--- a/starter/starter_AdminEmail.py
+++ b/starter/starter_AdminEmail.py
@@ -1,8 +1,3 @@
-import os
-# Add parent directory for imports
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0, parentdir)
-
 import boto.swf
 import log
 import json
@@ -12,6 +7,7 @@ from provider import utils
 """
 Amazon SWF Admin Email starter
 """
+
 
 class starter_AdminEmail():
 


### PR DESCRIPTION
A first experiment towards issue https://github.com/elifesciences/elife-bot/issues/991

`AdminEmail` workflow is old, we considered to remove it, but haven't yet. The `cron.py` starts one every four hours, it gets some metadata from SWF, and sends an email with some stats. 

It has no effect on other workflows, so it looks like a good place to remove old parent directory imports.

If this continues to run after deploying to `prod`, we can remove it from another one or two starters that are lower priority, like for `SilentCorrectionIngest` and `PubmedArticleDeposit`, which are triggered by the SQS queue listener. 