### PR TITLE
Simplify the imports for two more starters.

### DIFF
--- a/starter/starter_PubmedArticleDeposit.py
+++ b/starter/starter_PubmedArticleDeposit.py
@@ -1,18 +1,13 @@
-import os
-# Add parent directory for imports
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0, parentdir)
-
 import boto.swf
 import log
 import json
 import random
 from provider import utils
 
-
 """
 Amazon SWF PubmedArticleDeposit starter
 """
+
 
 class starter_PubmedArticleDeposit():
 

--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -1,8 +1,3 @@
-import os
-# Add parent directory for imports
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0, parentdir)
-
 import boto.swf
 import json
 from optparse import OptionParser


### PR DESCRIPTION
Next experiment for removing old parent directory imports, as described in issue https://github.com/elifesciences/elife-bot/issues/991.

These are the next two starters we can test out to see if they are compatible.

As I create this PR, I think provided the automated tests are green, I can merge this PR myself without further review. Then I can probalby test this on the `continuumtest` environment today.