### PR TITLE
No indent for decision letter XML output.

### DIFF
--- a/activity/activity_GenerateDecisionLetterJATS.py
+++ b/activity/activity_GenerateDecisionLetterJATS.py
@@ -79,7 +79,7 @@ class activity_GenerateDecisionLetterJATS(Activity):
             self.directories.get("TEMP_DIR"),
             self.logger,
             pretty=True,
-            indent="    ")
+            indent="")
 
         self.set_statuses(statuses)
 

--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -78,7 +78,7 @@ class activity_ValidateDecisionLetterInput(Activity):
             self.directories.get("TEMP_DIR"),
             self.logger,
             pretty=True,
-            indent="    ")
+            indent="")
 
         self.set_statuses(statuses)
 

--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -56,7 +56,7 @@ def process_zip(file_name, config, temp_dir, logger=LOGGER):
     return articles, asset_file_names, statuses, error_messages
 
 
-def process_articles_to_xml(articles, temp_dir, logger=LOGGER, pretty=True, indent="    "):
+def process_articles_to_xml(articles, temp_dir, logger=LOGGER, pretty=True, indent=""):
     """convert decision letter Article objects to XML"""
     statuses = {}
     # Generate XML from articles


### PR DESCRIPTION
I tested generating decision letter output again after fixing the bucket names, and it worked; the output bucket contained a `.xml` file.

I downloaded it to check and see all looked well, and then I realised it was _too_ pretty.

I remember now the best output to produce is pretty XML -- which is a new line for each tag -- but do not indent, otherwise we get extra whitespace before every tag.