### PR TITLE
Success in PDF covers if stated assertion fails.

### DIFF
--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -62,7 +62,7 @@ class activity_GeneratePDFCovers(Activity):
             self.logger.error(error_message)
             self.emit_monitor_event(self.settings, article_id, version, run,
                                     self.pretty_name, "error", error_message)
-            return self.ACTIVITY_PERMANENT_FAILURE
+            return self.ACTIVITY_SUCCESS
 
         except Exception as e:
             error_message = str(e)

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -31,7 +31,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         result = self.generatepdfcovers.do_activity(data)
 
         self.assertEqual(self.fake_logger.logerror[:20], "PDF cover not found.")
-        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
+        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
         json.dumps(self.fake_logger.logerror)
 
     @patch('requests.post')
@@ -45,7 +45,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         result = self.generatepdfcovers.do_activity(data)
 
         self.assertEqual(self.fake_logger.logerror[:44], "unhandled status code from PDF cover service")
-        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
+        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
         json.dumps(self.fake_logger.logerror)
 
     @patch.object(article, 'get_pdf_cover_link')
@@ -59,6 +59,21 @@ class TestGeneratePDFCovers(unittest.TestCase):
         result = self.generatepdfcovers.do_activity(data)
 
         self.assertEqual(self.fake_logger.logerror[:44], "Unexpected result from pdf covers API.")
+        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
+        json.dumps(self.fake_logger.logerror)
+
+    @patch.object(article, 'get_pdf_cover_link')
+    @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
+    def test_do_activity_get_pdf_exception(self, fake_monitor_event, fake_article_pdf_cover_link):
+        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
+                "article_id": "00353",
+                "version": "1"}
+        exception_message = 'Exception for unknown reason'
+        fake_article_pdf_cover_link.side_effect = Exception(exception_message)
+
+        result = self.generatepdfcovers.do_activity(data)
+
+        self.assertEqual(self.fake_logger.logerror[:44], exception_message)
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
         json.dumps(self.fake_logger.logerror)
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5364

There are some cases where a personalised cover PDF will not be created, sometimes resulting in a status `500` from the service call. This results in a failed workflow. It doesn't really cause too much trouble if the activity is the last one in a workflow, but it is hard to determine why the workflow failed without having to dig deeply into the list of activities to see if it failed earlier on, in where it archives the article to a `.zip` file, for example.

Code change here is a small improvement to not fail if an error `500` happens. The exception is still logged to file. If an exception beyond the assertions on the status code value happens (something that is not defined in the code) it will still result in a failed workflow. This might be due to anything in the process that does not end in an HTTP response from the service.