### PR TITLE
Fix starter import in cron_NewS3POA.

### DIFF
--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -5,6 +5,7 @@ import importlib
 import provider.simpleDB as dblib
 import provider.swfmeta as swfmetalib
 from provider import utils
+import starter
 
 """
 Cron job to check for new article S3 POA and start workflows


### PR DESCRIPTION
There was a problem with the old `eval` method of loading a `PackagePOA` starter by the `cron_NewS3POA` script, due to too aggresive pruning of the imports. `import starter` seems to be required still using this old method.

An updated PoA cron process is coming soon, which also no longer uses `eval`, but for now this needs to be fixed for current operations.