### PR TITLE
Default decision letter XML as non-pretty output.

### DIFF
--- a/activity/activity_GenerateDecisionLetterJATS.py
+++ b/activity/activity_GenerateDecisionLetterJATS.py
@@ -77,9 +77,7 @@ class activity_GenerateDecisionLetterJATS(Activity):
         self.xml_string, statuses = letterparser_provider.process_articles_to_xml(
             self.articles,
             self.directories.get("TEMP_DIR"),
-            self.logger,
-            pretty=True,
-            indent="")
+            self.logger)
 
         self.set_statuses(statuses)
 

--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -76,9 +76,7 @@ class activity_ValidateDecisionLetterInput(Activity):
         self.xml_string, statuses = letterparser_provider.process_articles_to_xml(
             self.articles,
             self.directories.get("TEMP_DIR"),
-            self.logger,
-            pretty=True,
-            indent="")
+            self.logger)
 
         self.set_statuses(statuses)
 

--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -56,7 +56,7 @@ def process_zip(file_name, config, temp_dir, logger=LOGGER):
     return articles, asset_file_names, statuses, error_messages
 
 
-def process_articles_to_xml(articles, temp_dir, logger=LOGGER, pretty=True, indent=""):
+def process_articles_to_xml(articles, temp_dir, logger=LOGGER, pretty=False, indent=""):
     """convert decision letter Article objects to XML"""
     statuses = {}
     # Generate XML from articles


### PR DESCRIPTION
On further review of sample data going to the decision letter API endpoint, and after some discussion, we will get a cleaner result if the XML produced is non-pretty XML. This means all the content is on one line.

Here I've set `pretty=False` as the default value in all cases in `letterparser_provider.py`, and then the activites invoking it relies on that default value of `False`.

@giorgiosironi so you're aware of this change as it related to some earlier discussions about indents and pretty XML in a recently merged PR on this project (https://github.com/elifesciences/elife-bot/pull/1024).