### PR TITLE
Remove unused code from cron_FiveMinute.py

### DIFF
--- a/starter/cron_FiveMinute.py
+++ b/starter/cron_FiveMinute.py
@@ -63,35 +63,6 @@ class cron_FiveMinute(object):
                        'a running workflow with ID %s' % workflow_id)
             print(message)
 
-    def get_starter_module(self, starter_name, logger=None):
-        """
-        Given an starter_name, and if the starter module is already
-        imported, load the module and return it
-        """
-        full_path = "starter." + starter_name + "." + starter_name + "()"
-        f = None
-
-        try:
-            f = eval(full_path)
-        except:
-            if logger:
-                logger.exception('')
-
-        return f
-
-    def import_starter_module(self, starter_name, logger=None):
-        """
-        Given an starter name as starter_name,
-        attempt to lazy load the module when needed
-        """
-        try:
-            module_name = "starter." + starter_name
-            importlib.import_module(module_name)
-            return True
-        except ImportError:
-            if logger:
-                logger.exception('')
-            return False
 
 if __name__ == "__main__":
 

--- a/tests/starter/test_cron_five_minute.py
+++ b/tests/starter/test_cron_five_minute.py
@@ -23,18 +23,6 @@ class TestCronFiveMinute(unittest.TestCase):
         fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
         self.assertIsNone(self.starter.start(settings_mock))
 
-    def test_get_starter_module_failure(self):
-        "for coverage test failure"
-        starter_name = 'not_a_starter'
-        module_object = self.starter.get_starter_module(starter_name, FakeLogger())
-        self.assertIsNone(module_object)
-
-    def test_import_starter_module_failure(self):
-        "for coverage test import failure"
-        starter_name = 'not_a_starter'
-        return_value = self.starter.import_starter_module(starter_name, FakeLogger())
-        self.assertFalse(return_value)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It was odd in bug fix PR https://github.com/elifesciences/elife-bot/pull/1030 where the new PoA file cron script was unable to import the starter class it wanted, since in `starter/cron_FiveMinute.py` was starting workflows fine.

On closer inspection, `cron_FiveMinute.py` doesn't actually import any starters, even though the code is there.

This PR removes the code that is not run anyway, to simplify things, prior to more extensive starter refactoring.