### PR TITLE
Decision letter assets activity

### DIFF
--- a/activity/activity_DepositDecisionLetterIngestAssets.py
+++ b/activity/activity_DepositDecisionLetterIngestAssets.py
@@ -1,0 +1,129 @@
+import os
+import json
+from S3utility.s3_notification_info import parse_activity_data
+from provider.storage_provider import storage_context
+from provider import download_helper, letterparser_provider
+from activity.objects import Activity
+
+"""
+DepositDecisionLetterIngestAssets.py activity
+"""
+
+
+class activity_DepositDecisionLetterIngestAssets(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_DepositDecisionLetterIngestAssets, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "DepositDecisionLetterIngestAssets"
+        self.pretty_name = "Deposit Decision Letter Ingest Assets"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Deposit Assets for a Decision Letter to the output bucket"
+
+        # Track some values
+        self.input_file = None
+        self.articles = None
+        self.asset_file_names = None
+        self.dest_resource = None
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
+        }
+
+        # Track the success of some steps
+        self.statuses = {
+            "unzip": None,
+            "build": None,
+            "valid": None,
+            "upload": None,
+        }
+
+        # Load the config
+        self.letterparser_config = letterparser_provider.letterparser_config(self.settings)
+
+    def do_activity(self, data=None):
+        "do the work"
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        # Create output directories
+        self.make_activity_directories()
+
+        # output bucket
+        output_bucket_name = self.settings.decision_letter_output_bucket
+
+        # parse the activity data
+        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+
+        # Download from S3
+        self.input_file = download_helper.download_file_from_s3(
+            self.settings, real_filename, bucket_name, bucket_folder,
+            self.directories.get("INPUT_DIR"))
+
+        # zip file to articles and assets
+        self.articles, self.asset_file_names, statuses, error_messages = (
+            letterparser_provider.process_zip(
+                self.input_file,
+                config=self.letterparser_config,
+                temp_dir=self.directories.get("TEMP_DIR"),
+                logger=self.logger))
+
+        self.set_statuses(statuses)
+
+        # check if there are any assets if not return True
+        if not self.asset_file_names:
+            self.logger.info("%s file %s has no assets to deposit" % (self.name, self.input_file))
+            return self.ACTIVITY_SUCCESS
+
+        # S3 bucket folder name
+        manuscript = letterparser_provider.manuscript_from_articles(self.articles)
+        bucket_folder_name = letterparser_provider.output_bucket_folder_name(
+            self.settings, manuscript)
+
+        self.logger.info(
+            "%s asset file names from %s: %s" % (self.name, self.input_file, self.asset_file_names))
+
+        # deposit assets to the bucket
+        try:
+            self.deposit_assets_to_bucket(
+                output_bucket_name, bucket_folder_name, self.asset_file_names)
+        except:
+            self.logger.exception('%s failed to upload an asset to the bucket' % self.name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        self.statuses['upload'] = True
+        self.log_statuses(self.input_file)
+        return self.ACTIVITY_SUCCESS
+
+    def set_statuses(self, statuses):
+        """copy statuses values to self.statuses"""
+        for status, value in statuses.items():
+            self.statuses[status] = value
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s" % (self.name, str(input_file), self.statuses))
+
+    def asset_dest_resource(self, bucket_name, folder_name, asset_file_name):
+        "concatenate the S3 bucket object path we copy the file to"
+        file_name = asset_file_name.split(os.sep)[-1]
+        storage_provider = self.settings.storage_provider + "://"
+        dest_resource = storage_provider + bucket_name + "/" + folder_name + "/" + file_name
+        return dest_resource
+
+    def deposit_assets_to_bucket(self, output_bucket, bucket_folder_name, asset_file_names):
+        "deposit the assets to the output bucket"
+        for asset_file_name in asset_file_names:
+            dest_resource = self.asset_dest_resource(
+                output_bucket, bucket_folder_name, asset_file_name)
+            storage = storage_context(self.settings)
+            self.logger.info("Depositing asset %s to S3 key %s" % (asset_file_name, dest_resource))
+            # set the bucket object resource from the local file
+            storage.set_resource_from_filename(dest_resource, asset_file_name)
+            self.logger.info("Deposited asset %s to S3" % asset_file_name)

--- a/register.py
+++ b/register.py
@@ -109,6 +109,7 @@ def start(settings):
     activity_names.append("PostDigestJATS")
     activity_names.append("ValidateDecisionLetterInput")
     activity_names.append("GenerateDecisionLetterJATS")
+    activity_names.append("DepositDecisionLetterIngestAssets")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_deposit_decision_letter_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_decision_letter_ingest_assets.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from ddt import ddt, data
+from provider import digest_provider, download_helper
+from activity.activity_DepositDecisionLetterIngestAssets import (
+    activity_DepositDecisionLetterIngestAssets as activity_object)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeStorageContext
+import tests.activity.test_activity_data as testdata
+import tests.activity.helpers as helpers
+
+
+def input_data(file_name_to_change=''):
+    activity_data = test_case_data.ingest_decision_letter_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestDepositDecisionLetterIngestAssets(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, self.fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+        # clean out the bucket destination folder
+        helpers.delete_files_in_folder(testdata.ExpandArticle_files_dest_folder,
+                                       filter_out=['.gitkeep'])
+
+    @patch.object(download_helper, 'storage_context')
+    @patch.object(digest_provider, 'storage_context')
+    @patch('activity.activity_DepositDecisionLetterIngestAssets.storage_context')
+    @data(
+        {
+            "comment": 'decision letter zip file example',
+            "filename": 'elife-39122.zip',
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_asset_file_names": ['elife-39122-sa2-fig1.jpg', 'elife-39122-sa2-fig2.jpg'],
+            "expected_file_list": ['elife-39122-sa2-fig1.jpg', 'elife-39122-sa2-fig2.jpg'],
+        },
+    )
+    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
+                         fake_download_storage_context):
+        # copy XML files into the input directory using the storage context
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_provider_storage_context.return_value = FakeStorageContext()
+        fake_download_storage_context.return_value = FakeStorageContext()
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        # check asset file name values
+        if self.activity.asset_file_names:
+            asset_file_names = [
+                file_name.split(os.sep)[-1] for file_name in self.activity.asset_file_names]
+        self.assertEqual(sorted(asset_file_names), test_data.get("expected_asset_file_names"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+
+        # Check destination folder as a list
+        files = sorted(os.listdir(testdata.ExpandArticle_files_dest_folder))
+        compare_files = [file_name for file_name in files if file_name != '.gitkeep']
+        self.assertEqual(compare_files, test_data.get("expected_file_list"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/activity/test_activity_deposit_decision_letter_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_decision_letter_ingest_assets.py
@@ -4,7 +4,7 @@ import os
 import unittest
 from mock import patch
 from ddt import ddt, data
-from provider import digest_provider, download_helper
+from provider import download_helper
 from activity.activity_DepositDecisionLetterIngestAssets import (
     activity_DepositDecisionLetterIngestAssets as activity_object)
 import tests.activity.settings_mock as settings_mock
@@ -36,7 +36,6 @@ class TestDepositDecisionLetterIngestAssets(unittest.TestCase):
                                        filter_out=['.gitkeep'])
 
     @patch.object(download_helper, 'storage_context')
-    @patch.object(digest_provider, 'storage_context')
     @patch('activity.activity_DepositDecisionLetterIngestAssets.storage_context')
     @data(
         {
@@ -47,11 +46,9 @@ class TestDepositDecisionLetterIngestAssets(unittest.TestCase):
             "expected_file_list": ['elife-39122-sa2-fig1.jpg', 'elife-39122-sa2-fig2.jpg'],
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_provider_storage_context,
-                         fake_download_storage_context):
+    def test_do_activity(self, test_data, fake_storage_context, fake_download_storage_context):
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
-        fake_provider_storage_context.return_value = FakeStorageContext()
         fake_download_storage_context.return_value = FakeStorageContext()
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))

--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -35,6 +35,7 @@ class workflow_IngestDecisionLetter(Workflow):
                     define_workflow_step("PingWorker", data),
                     define_workflow_step("ValidateDecisionLetterInput", data),
                     define_workflow_step("GenerateDecisionLetterJATS", data),
+                    define_workflow_step("DepositDecisionLetterIngestAssets", data),
                 ],
 
             "finish":


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/968

New activity named `DepositDecisionLetterIngestAssets`. It unzips the decision letter zip file, and saves each asset file to the output bucket into the specific subfolder for the article.

It is added to the `IngestDecisionLetter`.