### PR TITLE
Do not send silent correction articles to PubMed.

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -126,12 +126,12 @@ def choose_outboxes(status, outbox_map, first_by_status, run_type=None):
     if run_type != "silent-correction":
         if first_by_status:
             outbox_list.append(outbox_map.get("publication_email"))
+        outbox_list.append(outbox_map.get("pubmed"))
 
     if status == "poa":
-        outbox_list.append(outbox_map.get("pubmed"))
+        pass
 
     elif status == "vor":
-        outbox_list.append(outbox_map.get("pubmed"))
         outbox_list.append(outbox_map.get("pmc"))
         outbox_list.append(outbox_map.get("pub_router"))
         outbox_list.append(outbox_map.get("cengage"))

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -60,6 +60,7 @@ class TestScheduleDownstream(unittest.TestCase):
         """first vor version"""
         outbox_list = activity_module.choose_outboxes("vor", activity_module.outbox_map(), True)
         self.assertTrue("pmc/outbox/" in outbox_list)
+        self.assertTrue("pubmed/outbox/" in outbox_list)
         self.assertTrue("publication_email/outbox/" in outbox_list)
         self.assertTrue("pub_router/outbox/" in outbox_list)
 
@@ -67,6 +68,7 @@ class TestScheduleDownstream(unittest.TestCase):
         """vor but not the first vor"""
         outbox_list = activity_module.choose_outboxes("vor", activity_module.outbox_map(), False)
         self.assertTrue("pmc/outbox/" in outbox_list)
+        self.assertTrue("pubmed/outbox/" in outbox_list)
         self.assertTrue("pub_router/outbox/" in outbox_list)
         # do not send publication_email
         self.assertFalse("publication_email/outbox/" in outbox_list)
@@ -77,6 +79,8 @@ class TestScheduleDownstream(unittest.TestCase):
         self.assertTrue("pmc/outbox/" in outbox_list)
         # do not send publication_email
         self.assertFalse("publication_email/outbox/" in outbox_list)
+        # do not send to pubmed
+        self.assertFalse("pubmed/outbox/" in outbox_list)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/elife-pubmed-feed/issues/76

Production wishes not to send articles from a silent correction workflow to PubMed.