### PR TITLE
Do not generate PDF covers if article has no subjects

### DIFF
--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -43,7 +43,7 @@ class activity_GeneratePDFCovers(Activity):
                         (article_id, self.name))
                     return self.ACTIVITY_SUCCESS
         except Exception:
-            self.logger.exception("Exception in %s getting data snippet from Lax" % (self.name))
+            self.logger.exception("Exception in data snippet in %s" % (self.name))
             return self.ACTIVITY_PERMANENT_FAILURE
 
         # generate the PDF

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -62,6 +62,21 @@ class TestGeneratePDFCovers(unittest.TestCase):
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
         json.dumps(self.fake_logger.logerror)
 
+    @patch.object(article, 'get_pdf_cover_link')
+    @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
+    def test_do_activity_get_pdf_exception(self, fake_monitor_event, fake_article_pdf_cover_link):
+        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
+                "article_id": "00353",
+                "version": "1"}
+        exception_message = 'Exception for unknown reason'
+        fake_article_pdf_cover_link.side_effect = Exception(exception_message)
+
+        result = self.generatepdfcovers.do_activity(data)
+
+        self.assertEqual(self.fake_logger.logerror[:44], exception_message)
+        self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
+        json.dumps(self.fake_logger.logerror)
+
     @patch('requests.post')
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_success_first_generation(self, fake_monitor_event, fake_request):

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -11,8 +11,19 @@ from tests.activity.classes_mock import FakeLogger, FakeResponse
 class TestGeneratePDFCovers(unittest.TestCase):
     def setUp(self):
         self.fake_logger = FakeLogger()
-        self.generatepdfcovers = activity_GeneratePDFCovers(settings_mock, self.fake_logger, None, None, None)
-        self.article_snippet = {'subjects': [{"id": "neuroscience", "name": "Neuroscience"}]}
+        self.generatepdfcovers = activity_GeneratePDFCovers(
+            settings_mock, self.fake_logger, None, None, None)
+        self.data = {
+            "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
+            "article_id": "00353",
+            "version": "1"}
+        self.article_snippet = {
+            'subjects': [
+                {
+                    "id": "neuroscience",
+                    "name": "Neuroscience"
+                }]
+            }
 
     def test_do_activity_bad_data(self):
         data = None
@@ -26,13 +37,10 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch('requests.post')
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_error_404(self, fake_monitor_event, fake_request, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_request.return_value = FakeResponse(404, {})
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
         self.assertEqual(self.fake_logger.logerror[:20], "PDF cover not found.")
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
@@ -42,15 +50,13 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch('requests.post')
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_error_500(self, fake_monitor_event, fake_request, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_request.return_value = FakeResponse(500, {})
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
-        self.assertEqual(self.fake_logger.logerror[:44], "unhandled status code from PDF cover service")
+        self.assertEqual(
+            self.fake_logger.logerror[:44], "unhandled status code from PDF cover service")
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
         json.dumps(self.fake_logger.logerror)
 
@@ -59,13 +65,10 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_error_wrong_result_from_covers(
             self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_article_pdf_cover_link.return_value = ""
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
         self.assertEqual(self.fake_logger.logerror[:44], "Unexpected result from pdf covers API.")
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
@@ -76,14 +79,11 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_get_pdf_exception(
             self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         exception_message = 'Exception for unknown reason'
         fake_article_pdf_cover_link.side_effect = Exception(exception_message)
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
         self.assertEqual(self.fake_logger.logerror[:44], exception_message)
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
@@ -94,17 +94,17 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_success_first_generation(
             self, fake_monitor_event, fake_request, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
-        fake_request.return_value = FakeResponse(202, {"formats":
-                                                           {"a4":"https://s3.eu-west-2.amazonaws.com/a4/09560",
-                                                            "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
-                                                           }
-                                                       })
+        fake_request.return_value = FakeResponse(
+            202,
+            {
+                "formats": {
+                    "a4": "https://s3.eu-west-2.amazonaws.com/a4/09560",
+                    "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
+                }
+            })
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
 
@@ -113,51 +113,36 @@ class TestGeneratePDFCovers(unittest.TestCase):
     @patch.object(activity_GeneratePDFCovers, 'emit_monitor_event')
     def test_do_activity_success_already_existing(
             self, fake_monitor_event, fake_request, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
-        fake_request.return_value = FakeResponse(200, {"formats":
-                                                           {"a4":"https://s3.eu-west-2.amazonaws.com/a4/09560",
-                                                            "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
-                                                           }
-                                                       })
+        fake_request.return_value = FakeResponse(
+            200,
+            {
+                "formats": {
+                    "a4": "https://s3.eu-west-2.amazonaws.com/a4/09560",
+                    "letter": "https://s3.eu-west-2.amazonaws.com/letter/09560"
+                }
+            })
         fake_snippet.return_value = self.article_snippet
 
-        result = self.generatepdfcovers.do_activity(data)
+        result = self.generatepdfcovers.do_activity(self.data)
 
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
 
     @patch.object(lax_provider, 'article_snippet')
     def test_do_activity_no_lax_snippet(self, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_snippet.return_value = {}
-
-        result = self.generatepdfcovers.do_activity(data)
-
+        result = self.generatepdfcovers.do_activity(self.data)
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
 
     @patch.object(lax_provider, 'article_snippet')
     def test_do_activity_no_subjects(self, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_snippet.return_value = {"status": "poa"}
-
-        result = self.generatepdfcovers.do_activity(data)
-
+        result = self.generatepdfcovers.do_activity(self.data)
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_SUCCESS)
 
     @patch.object(lax_provider, 'article_snippet')
     def test_do_activity_lax_exception(self, fake_snippet):
-        data = {"run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-                "article_id": "00353",
-                "version": "1"}
         fake_snippet.side_effect = Exception('Exception in Lax snippet GET request')
-
-        result = self.generatepdfcovers.do_activity(data)
-
+        result = self.generatepdfcovers.do_activity(self.data)
         self.assertEqual(result, self.generatepdfcovers.ACTIVITY_PERMANENT_FAILURE)
 
 


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/issues/issues/5364

I compared the XML of articles that fail personalised PDF cover generation with articles that work; the ones that fail do not have any `<subj-group subj-group-type="heading">` tags. These values result in a `subjects` key in the article JSON from the RAML API.

I think the personalised covers PDF service uses the eLife API data to determine which background image to use in the PDF file. I haven't seen the logs of the PDF service, but I suspect the error `500` we see has something to do with the missing `subjects` value and/or it cannot locate a `.jpg` file for when subjects do not exist.

Here, I added `lax_provider` as a dependency of the `GeneratePDFCovers` activity.

If there is no `subjects` key in the snippet for this article ID version from Lax, then we do not attempt to generate a PDF for it.

In this situation, and if there is an exception or an error, it only logs this data to the `elife-bot` instance's `worker.log` file, and the error doesn't appear on the publishing dashboard, since we haven't emitted any messages to the queue. I wasn't sure whether this is a good way to go, but it satisfies the basic requirement of not resulting in a `Failed` workflow in SWF if the PDF generation service will fail in this known case.

I also linted and cleaned up the test case scenario file for long lines and duplicated test data.