### PR TITLE
Post decision letter JATS activity

### DIFF
--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -13,7 +13,7 @@ class activity_PostDecisionLetterJATS(Activity):
         super(activity_PostDecisionLetterJATS, self).__init__(
             settings, logger, conn, token, activity_task)
 
-        self.name = "PostDigestJATS"
+        self.name = "PostDecisionLetterJATS"
         self.pretty_name = "POST decision letter JATS content to API endpoint"
         self.version = "1"
         self.default_task_heartbeat_timeout = 30

--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -128,9 +128,9 @@ class activity_PostDecisionLetterJATS(Activity):
     def send_email(self, doi, jats_content):
         """send an email after JATS is posted to endpoint"""
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
-        body_content = success_email_body_content(doi, jats_content)
+        body_content = requests_provider.success_email_body_content(doi, jats_content)
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = success_email_subject(doi)
+        subject = requests_provider.success_email_subject_doi('Decision letter ', doi)
         sender_email = self.settings.decision_letter_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
@@ -148,9 +148,9 @@ class activity_PostDecisionLetterJATS(Activity):
     def email_error_report(self, doi, jats_content, error_messages):
         """send an email on error"""
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
-        body_content = error_email_body_content(doi, jats_content, error_messages)
+        body_content = requests_provider.error_email_body_content(doi, jats_content, error_messages)
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = error_email_subject(doi)
+        subject = requests_provider.error_email_subject_doi('decision letter', doi)
         sender_email = self.settings.decision_letter_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
@@ -164,34 +164,3 @@ class activity_PostDecisionLetterJATS(Activity):
         self.logger.info('Email sending details: %s' % str(details))
 
         return True
-
-
-def success_email_subject(doi):
-    """email subject for a success email"""
-    return u'Decision letter JATS posted for article {doi}'.format(
-        doi=str(doi))
-
-
-def success_email_body_content(doi, jats_content):
-    """
-    Format the body content of the email
-    """
-    return "JATS content for article %s:\n\n%s\n\n" % (doi, jats_content)
-
-
-def error_email_subject(doi):
-    """email subject for an error email"""
-    return u'Error in decision letter JATS post for article {doi}'.format(
-        doi=str(doi))
-
-
-def error_email_body_content(doi, jats_content, error_messages):
-    """body content of an error email"""
-    content = ""
-    if error_messages:
-        content += str(error_messages)
-        content += "\n\nMore details about the error may be found in the worker.log file\n\n"
-    if doi:
-        content += "Article DOI: %s\n\n" % doi
-    content += "JATS content: %s\n\n" % jats_content
-    return content

--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -119,11 +119,16 @@ class activity_PostDecisionLetterJATS(Activity):
     def post_jats(self, doi, jats_content):
         """prepare and POST jats to API endpoint"""
         url = self.settings.typesetter_decision_letter_endpoint
+        params = requests_provider.jats_post_params(
+            self.settings.typesetter_decision_letter_api_key,
+            self.settings.typesetter_decision_letter_account_key)
         payload = requests_provider.jats_post_payload(
-            'decision', doi, jats_content, self.settings.typesetter_decision_letter_api_key)
+            'decision', doi, jats_content,
+            self.settings.typesetter_decision_letter_api_key,
+            self.settings.typesetter_decision_letter_account_key)
         if payload:
             requests_provider.post_to_endpoint(
-                url, payload, self.logger, 'decision letter JATS')
+                url, payload, self.logger, 'decision letter JATS', params=params)
 
     def send_email(self, doi, jats_content):
         """send an email after JATS is posted to endpoint"""

--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -1,0 +1,234 @@
+import os
+import json
+import time
+from collections import OrderedDict
+import requests
+from provider import download_helper, email_provider, letterparser_provider, utils
+from provider.execution_context import get_session
+from activity.objects import Activity
+
+
+class activity_PostDecisionLetterJATS(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_PostDecisionLetterJATS, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "PostDigestJATS"
+        self.pretty_name = "POST decision letter JATS content to API endpoint"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = self.pretty_name
+
+        # Track some values
+        self.xml_file = None
+        self.doi = None
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
+        }
+
+        # Track the success of some steps
+        self.statuses = {
+            "post": None,
+            "email": None,
+            "error_email": None
+        }
+
+        # Load the config
+        self.letterparser_config = letterparser_provider.letterparser_config(self.settings)
+
+    def do_activity(self, data=None):
+        if self.logger:
+            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        self.make_activity_directories()
+
+        # session
+        run = data['run']
+        session = get_session(self.settings, data, run)
+
+        bucket_folder_name = session.get_value('bucket_folder_name')
+        xml_file_name = session.get_value('xml_file_name')
+        output_bucket_name = self.settings.decision_letter_output_bucket
+
+        # check for session data
+        if not bucket_folder_name or not xml_file_name:
+            self.logger.error('Missing session data in %s.' % self.name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # check if there is an endpoint in the settings specified
+        if not hasattr(self.settings, "typesetter_decision_letter_endpoint"):
+            self.logger.error("No typesetter endpoint in settings, skipping %s." % self.name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+        if not self.settings.typesetter_decision_letter_endpoint:
+            self.logger.error("Typesetter endpoint in settings is blank, skipping %s." % self.name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # download XML from S3 bucket
+        self.xml_file = download_helper.download_file_from_s3(
+            self.settings, xml_file_name, output_bucket_name, bucket_folder_name,
+            self.directories.get("INPUT_DIR"))
+
+        # get doi from the xml string
+        xml_string = None
+        try:
+            with open(self.xml_file, 'r') as open_file:
+                xml_string = open_file.read()
+            self.doi = letterparser_provider.article_doi_from_xml(xml_string)
+        except:
+            self.logger.exception(
+                "Failed to get doi from xml_string in %s for xml_file %s" %
+                (self.name, self.xml_file))
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # POST to API endpoint
+        try:
+            post_jats_return_value = self.post_jats(self.doi, xml_string)
+            if post_jats_return_value is True:
+                self.statuses["post"] = True
+                post_jats_error_message = ""
+            else:
+                self.statuses["post"] = False
+                post_jats_error_message = str(post_jats_return_value)
+            # send email
+            if self.statuses.get("post"):
+                self.statuses["email"] = self.send_email(self.doi, xml_string)
+            else:
+                # post was not a success, send error email
+                error_message = "POST was not successful, details: %s" % post_jats_error_message
+                self.statuses["error_email"] = self.email_error_report(
+                    self.doi, xml_string, error_message)
+                return self.ACTIVITY_PERMANENT_FAILURE
+        except Exception as exception:
+            # exception, send error email
+            self.statuses["error_email"] = self.email_error_report(
+                self.doi, xml_string, str(exception))
+            self.logger.exception("Exception raised in do_activity. Details: %s" % str(exception))
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        self.logger.info(
+            "%s for real_filename %s statuses: %s" % (self.name, str(self.xml_file), self.statuses))
+
+        return self.ACTIVITY_SUCCESS
+
+    def post_jats(self, doi, jats_content):
+        """prepare and POST jats to API endpoint"""
+        url = self.settings.typesetter_decision_letter_endpoint
+        payload = post_payload(doi, jats_content, self.settings.typesetter_decision_letter_api_key)
+        if payload:
+            return post_jats_to_endpoint(url, payload, self.logger)
+        return None
+
+    def send_email(self, doi, jats_content):
+        """send an email after digest JATS is posted to endpoint"""
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
+        body_content = success_email_body_content(doi, jats_content)
+        body = email_provider.simple_email_body(datetime_string, body_content)
+        subject = success_email_subject(doi)
+        sender_email = self.settings.digest_sender_email
+
+        recipient_email_list = email_provider.list_email_recipients(
+            self.settings.digest_jats_recipient_email)
+
+        messages = email_provider.simple_messages(
+            sender_email, recipient_email_list, subject, body, logger=self.logger)
+        self.logger.info('Formatted %d email messages in %s' % (len(messages), self.name))
+
+        details = email_provider.smtp_send_messages(self.settings, messages, self.logger)
+        self.logger.info('Email sending details: %s' % str(details))
+
+        return True
+
+    def email_error_report(self, doi, jats_content, error_messages):
+        """send an email on error"""
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
+        body_content = error_email_body_content(doi, jats_content, error_messages)
+        body = email_provider.simple_email_body(datetime_string, body_content)
+        subject = error_email_subject(doi)
+        sender_email = self.settings.digest_sender_email
+
+        recipient_email_list = email_provider.list_email_recipients(
+            self.settings.digest_jats_error_recipient_email)
+
+        messages = email_provider.simple_messages(
+            sender_email, recipient_email_list, subject, body, logger=self.logger)
+        self.logger.info('Formatted %d error email messages in %s' % (len(messages), self.name))
+
+        details = email_provider.smtp_send_messages(self.settings, messages, self.logger)
+        self.logger.info('Email sending details: %s' % str(details))
+
+        return True
+
+
+def post_payload(doi, jats_content, api_key):
+    """compile the POST data payload"""
+    account_key = 1
+    content_type = "decision"
+    payload = OrderedDict()
+    payload["apiKey"] = api_key
+    payload["accountKey"] = account_key
+    payload["doi"] = doi
+    payload["type"] = content_type
+    payload["content"] = jats_content
+    return payload
+
+
+def post_jats_to_endpoint(url, payload, logger):
+    """issue the POST"""
+    resp = post_as_data(url, payload)
+    # Check for good HTTP status code
+    if resp.status_code != 200:
+        response_error_message = (
+            "Error posting decision letter JATS to endpoint %s: status_code: %s\nresponse: %s" %
+            (url, resp.status_code, resp.content))
+        full_error_message = (
+            "%s\npayload: %s" %
+            (response_error_message, payload))
+        logger.error(full_error_message)
+        return response_error_message
+    logger.info(
+        ("Success posting decision letter JATS to endpoint %s: status_code: %s\nresponse: %s" +
+         " \npayload: %s") %
+        (url, resp.status_code, resp.content, payload))
+    return True
+
+
+def post_as_data(url, payload):
+    """post the payload as form data"""
+    return requests.post(url, data=payload)
+
+
+def success_email_subject(doi):
+    """email subject for a success email"""
+    return u'Decision letter JATS posted for article {doi}'.format(
+        doi=str(doi))
+
+
+def success_email_body_content(doi, jats_content):
+    """
+    Format the body content of the email
+    """
+    return "JATS content for article %s:\n\n%s\n\n" % (doi, jats_content)
+
+
+def error_email_subject(doi):
+    """email subject for an error email"""
+    return u'Error in decision letter JATS post for article {doi}'.format(
+        doi=str(doi))
+
+
+def error_email_body_content(doi, jats_content, error_messages):
+    """body content of an error email"""
+    content = ""
+    if error_messages:
+        content += str(error_messages)
+        content += "\n\nMore details about the error may be found in the worker.log file\n\n"
+    if doi:
+        content += "Article DOI: %s\n\n" % doi
+    content += "JATS content: %s\n\n" % jats_content
+    return content

--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -125,15 +125,15 @@ class activity_PostDecisionLetterJATS(Activity):
         return None
 
     def send_email(self, doi, jats_content):
-        """send an email after digest JATS is posted to endpoint"""
+        """send an email after JATS is posted to endpoint"""
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body_content = success_email_body_content(doi, jats_content)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = success_email_subject(doi)
-        sender_email = self.settings.digest_sender_email
+        sender_email = self.settings.decision_letter_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_jats_recipient_email)
+            self.settings.decision_letter_jats_recipient_email)
 
         messages = email_provider.simple_messages(
             sender_email, recipient_email_list, subject, body, logger=self.logger)
@@ -150,10 +150,10 @@ class activity_PostDecisionLetterJATS(Activity):
         body_content = error_email_body_content(doi, jats_content, error_messages)
         body = email_provider.simple_email_body(datetime_string, body_content)
         subject = error_email_subject(doi)
-        sender_email = self.settings.digest_sender_email
+        sender_email = self.settings.decision_letter_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.digest_jats_error_recipient_email)
+            self.settings.decision_letter_jats_error_recipient_email)
 
         messages = email_provider.simple_messages(
             sender_email, recipient_email_list, subject, body, logger=self.logger)

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -128,11 +128,17 @@ class activity_PostDigestJATS(Activity):
     def post_jats(self, digest, jats_content):
         """prepare and POST jats to API endpoint"""
         url = self.settings.typesetter_digest_endpoint
+        params = requests_provider.jats_post_params(
+            self.settings.typesetter_digest_api_key,
+            self.settings.typesetter_digest_account_key)
         doi = doi_uri_to_doi(digest.doi)
         payload = requests_provider.jats_post_payload(
-            'digest', doi, jats_content, self.settings.typesetter_digest_api_key)
+            'digest', doi, jats_content,
+            self.settings.typesetter_digest_api_key,
+            self.settings.typesetter_digest_account_key)
         if payload:
-            requests_provider.post_to_endpoint(url, payload, self.logger, 'digest JATS')
+            requests_provider.post_to_endpoint(
+                url, payload, self.logger, 'digest JATS', params=params)
 
     def send_email(self, digest_content, jats_content):
         """send an email after digest JATS is posted to endpoint"""

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -176,26 +176,6 @@ class activity_PostDigestJATS(Activity):
         return True
 
 
-def get_as_params(url, payload):
-    """transmit the payload as a GET with URL parameters"""
-    return requests.get(url, params=payload)
-
-
-def post_as_params(url, payload):
-    """post the payload as URL parameters"""
-    return requests.post(url, params=payload)
-
-
-def post_as_data(url, payload):
-    """post the payload as form data"""
-    return requests.post(url, data=payload)
-
-
-def post_as_json(url, payload):
-    """post the payload as JSON data"""
-    return requests.post(url, json=payload)
-
-
 def success_email_subject(digest_content):
     """email subject for a success email"""
     if not digest_content:

--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -3,6 +3,7 @@
 import os
 from collections import OrderedDict
 import docker
+from elifetools import parseJATS as parser
 from letterparser import generate, parse, zip_lib
 from letterparser.conf import raw_config, parse_raw_config
 import log
@@ -151,6 +152,18 @@ def manuscript_from_articles(articles):
     if articles:
         return articles[0].manuscript
     return None
+
+
+def article_doi_from_xml(xml_string):
+    """get main article DOI from XML string"""
+    doi = None
+    xml = parser.parse_xml(xml_string)
+    article_ids = parser.article_id_list(xml)
+    if article_ids:
+        first_article_id = article_ids[0]
+        article_id = first_article_id.get('value')
+        doi = '.'.join(article_id.split('.')[0:-1])
+    return doi
 
 
 def output_bucket_folder_name(settings, manuscript):

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import requests
+from requests.exceptions import HTTPError
 
 
 def jats_post_payload(content_type, doi, jats_content, api_key):
@@ -36,7 +37,12 @@ def post_as_json(url, payload):
 
 def post_to_endpoint(url, payload, logger, identifier):
     """issue the POST"""
-    resp = post_as_data(url, payload)
+    try:
+        resp = post_as_data(url, payload)
+    except:
+        logger.exception('Exception in post_to_endpoint')
+        raise
+    
     # Check for good HTTP status code
     if resp.status_code != 200:
         response_error_message = (
@@ -46,9 +52,8 @@ def post_to_endpoint(url, payload, logger, identifier):
             "%s\npayload: %s" %
             (response_error_message, payload))
         logger.error(full_error_message)
-        return response_error_message
+        raise HTTPError(response_error_message)
     logger.info(
         ("Success posting %s to endpoint %s: status_code: %s\nresponse: %s" +
          " \npayload: %s") %
         (identifier, url, resp.status_code, resp.content, payload))
-    return True

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -1,0 +1,39 @@
+from collections import OrderedDict
+import requests
+
+
+def jats_post_payload(content_type, doi, jats_content, api_key):
+    """compile the POST data payload"""
+    account_key = 1
+    payload = OrderedDict()
+    payload["apiKey"] = api_key
+    payload["accountKey"] = account_key
+    payload["doi"] = doi
+    payload["type"] = content_type
+    payload["content"] = jats_content
+    return payload
+
+
+def post_as_data(url, payload):
+    """post the payload as form data"""
+    return requests.post(url, data=payload)
+
+
+def post_to_endpoint(url, payload, logger, identifier):
+    """issue the POST"""
+    resp = post_as_data(url, payload)
+    # Check for good HTTP status code
+    if resp.status_code != 200:
+        response_error_message = (
+            "Error posting %s to endpoint %s: status_code: %s\nresponse: %s" %
+            (identifier, url, resp.status_code, resp.content))
+        full_error_message = (
+            "%s\npayload: %s" %
+            (response_error_message, payload))
+        logger.error(full_error_message)
+        return response_error_message
+    logger.info(
+        ("Success posting %s to endpoint %s: status_code: %s\nresponse: %s" +
+         " \npayload: %s") %
+        (identifier, url, resp.status_code, resp.content, payload))
+    return True

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -3,9 +3,16 @@ import requests
 from requests.exceptions import HTTPError
 
 
-def jats_post_payload(content_type, doi, jats_content, api_key):
+def jats_post_params(api_key, account_key):
+    """the full endpoint URL to authenticate via URL parameters"""
+    params = OrderedDict()
+    params["apiKey"] = api_key
+    params["accountKey"] = account_key
+    return params
+
+
+def jats_post_payload(content_type, doi, jats_content, api_key, account_key):
     """compile the POST data payload"""
-    account_key = 1
     payload = OrderedDict()
     payload["apiKey"] = api_key
     payload["accountKey"] = account_key
@@ -25,9 +32,9 @@ def post_as_params(url, payload):
     return requests.post(url, params=payload)
 
 
-def post_as_data(url, payload):
+def post_as_data(url, payload, params=None):
     """post the payload as form data"""
-    return requests.post(url, data=payload)
+    return requests.post(url, data=payload, params=params)
 
 
 def post_as_json(url, payload):
@@ -35,10 +42,10 @@ def post_as_json(url, payload):
     return requests.post(url, json=payload)
 
 
-def post_to_endpoint(url, payload, logger, identifier):
+def post_to_endpoint(url, payload, logger, identifier, params=None):
     """issue the POST"""
     try:
-        resp = post_as_data(url, payload)
+        resp = post_as_data(url, payload, params=params)
     except:
         logger.exception('Exception in post_to_endpoint')
         raise

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -14,9 +14,24 @@ def jats_post_payload(content_type, doi, jats_content, api_key):
     return payload
 
 
+def get_as_params(url, payload):
+    """transmit the payload as a GET with URL parameters"""
+    return requests.get(url, params=payload)
+
+
+def post_as_params(url, payload):
+    """post the payload as URL parameters"""
+    return requests.post(url, params=payload)
+
+
 def post_as_data(url, payload):
     """post the payload as form data"""
     return requests.post(url, data=payload)
+
+
+def post_as_json(url, payload):
+    """post the payload as JSON data"""
+    return requests.post(url, json=payload)
 
 
 def post_to_endpoint(url, payload, logger, identifier):

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -42,7 +42,7 @@ def post_to_endpoint(url, payload, logger, identifier):
     except:
         logger.exception('Exception in post_to_endpoint')
         raise
-    
+
     # Check for good HTTP status code
     if resp.status_code != 200:
         response_error_message = (
@@ -57,3 +57,52 @@ def post_to_endpoint(url, payload, logger, identifier):
         ("Success posting %s to endpoint %s: status_code: %s\nresponse: %s" +
          " \npayload: %s") %
         (identifier, url, resp.status_code, resp.content, payload))
+
+
+def success_email_subject_doi(identity, doi):
+    """email subject for a success email"""
+    return u'{identity}JATS posted for article {doi}'.format(
+        identity=identity,
+        doi=str(doi))
+
+
+def success_email_subject_msid_author(identity, msid, author):
+    """email subject for a success email with msid and author values"""
+    return u'{identity}JATS posted for article {msid:0>5}, author {author}'.format(
+        identity=identity,
+        msid=str(msid),
+        author=author)
+
+
+def success_email_body_content(doi, jats_content):
+    """
+    Format the body content of the email
+    """
+    return "JATS content for article %s:\n\n%s\n\n" % (doi, jats_content)
+
+
+def error_email_subject_doi(identity, doi):
+    """email subject for an error email"""
+    return u'Error in {identity} JATS post for article {doi}'.format(
+        identity=identity,
+        doi=str(doi))
+
+
+def error_email_subject_msid_author(identity, msid, author):
+    """email subject for an error email with msid and author values"""
+    return u'Error in {identity} JATS post for article {msid:0>5}, author {author}'.format(
+        identity=identity,
+        msid=str(msid),
+        author=author)
+
+
+def error_email_body_content(doi, jats_content, error_messages):
+    """body content of an error email"""
+    content = ""
+    if error_messages:
+        content += str(error_messages)
+        content += "\n\nMore details about the error may be found in the worker.log file\n\n"
+    if doi:
+        content += "Article DOI: %s\n\n" % doi
+    content += "JATS content: %s\n\n" % jats_content
+    return content

--- a/register.py
+++ b/register.py
@@ -107,6 +107,7 @@ def start(settings):
     activity_names.append("PostDigestJATS")
     activity_names.append("ValidateDecisionLetterInput")
     activity_names.append("GenerateDecisionLetterJATS")
+    activity_names.append("PostDecisionLetterJATS")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/settings-example.py
+++ b/settings-example.py
@@ -118,6 +118,8 @@ class exp():
     decision_letter_output_bucket = 'exp-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
+    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_api_key = 'typesetter_api_key'
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
@@ -380,6 +382,8 @@ class dev():
     decision_letter_output_bucket = 'dev-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
+    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_api_key = 'typesetter_api_key'
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
@@ -639,6 +643,8 @@ class live():
     decision_letter_output_bucket = 'prod-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
+    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_api_key = 'typesetter_api_key'
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'

--- a/settings-example.py
+++ b/settings-example.py
@@ -111,6 +111,7 @@ class exp():
     # digest typesetter endpoint
     typesetter_digest_endpoint = 'https://typesetter/updateDigest'
     typesetter_digest_api_key = 'typesetter_api_key'
+    typesetter_digest_account_key = '1'
 
     # decision letter
     decision_letter_sender_email = 'sender@example.org'
@@ -120,6 +121,7 @@ class exp():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
 
@@ -377,6 +379,7 @@ class dev():
     # digest typesetter endpoint
     typesetter_digest_endpoint = 'https://typesetter/updateDigest'
     typesetter_digest_api_key = 'typesetter_api_key'
+    typesetter_digest_account_key = '1'
 
     # decision letter
     decision_letter_sender_email = 'sender@example.org'
@@ -386,6 +389,7 @@ class dev():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
 
@@ -640,6 +644,7 @@ class live():
     # digest typesetter endpoint
     typesetter_digest_endpoint = 'https://typesetter/updateDigest'
     typesetter_digest_api_key = 'typesetter_api_key'
+    typesetter_digest_account_key = '1'
 
     # decision letter
     decision_letter_sender_email = 'sender@example.org'
@@ -649,6 +654,7 @@ class live():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -120,6 +120,8 @@ class exp():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
+    decision_letter_jats_error_recipient_email = "error@example.org"
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
@@ -384,6 +386,8 @@ class dev():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
+    decision_letter_jats_error_recipient_email = "error@example.org"
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
@@ -645,6 +649,8 @@ class live():
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
     typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
+    decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
+    decision_letter_jats_error_recipient_email = "error@example.org"
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -63,6 +63,7 @@ digest_auth_key = 'digest_auth_key'
 
 typesetter_digest_endpoint = 'https://typesetter/updateDigest'
 typesetter_digest_api_key = 'typesetter_api_key'
+typesetter_digest_account_key = '1'
 
 journal_preview_base_url = 'https://preview'
 
@@ -185,5 +186,6 @@ decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
 
 typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
 typesetter_decision_letter_api_key = 'typesetter_api_key'
+typesetter_decision_letter_account_key = '1'
 decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
 decision_letter_jats_error_recipient_email = "error@example.org"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -182,3 +182,6 @@ decision_letter_validate_error_recipient_email = 'error@example.org'
 decision_letter_output_bucket = 'dev-elife-bot-decision-letter-output'
 decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
 decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
+
+typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+typesetter_decision_letter_api_key = 'typesetter_api_key'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -185,3 +185,5 @@ decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
 
 typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
 typesetter_decision_letter_api_key = 'typesetter_api_key'
+decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
+decision_letter_jats_error_recipient_email = "error@example.org"

--- a/tests/activity/test_activity_generate_decision_letter_jats.py
+++ b/tests/activity/test_activity_generate_decision_letter_jats.py
@@ -48,7 +48,7 @@ class TestGenerateDecisionLetterJATS(unittest.TestCase):
         # activity storage context
         fake_storage_context.return_value = FakeStorageContext()
         # mock the session
-        fake_session = FakeSession(activity_input_data)
+        fake_session = FakeSession({})
         mock_session.return_value = fake_session
         # do the activity
         result = self.activity.do_activity(activity_input_data)
@@ -73,6 +73,10 @@ class TestGenerateDecisionLetterJATS(unittest.TestCase):
             self.activity.xml_bucket_resource,
             's3://dev-elife-bot-decision-letter-output/elife39122/elife-39122.xml')
 
+        # check session values
+        self.assertEqual(fake_session.get_value('bucket_folder_name'), 'elife39122')
+        self.assertEqual(fake_session.get_value('xml_file_name'), 'elife-39122.xml')
+
     @patch.object(FakeStorageContext, 'set_resource_from_string')
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_module, 'storage_context')
@@ -82,10 +86,14 @@ class TestGenerateDecisionLetterJATS(unittest.TestCase):
         activity_input_data = input_data('elife-39122.zip')
         fake_download_storage_context.return_value = FakeStorageContext()
         fake_storage_context.return_value = FakeStorageContext()
-        fake_session = FakeSession(activity_input_data)
+        fake_session = FakeSession({})
         mock_session.return_value = fake_session
         # mock the exception
         fake_set_resource.side_effect = Exception()
         # do the activity
         result = self.activity.do_activity(activity_input_data)
         self.assertEqual(result, activity_object.ACTIVITY_PERMANENT_FAILURE)
+
+        # check session values will be empty
+        self.assertEqual(fake_session.get_value('bucket_folder_name'), None)
+        self.assertEqual(fake_session.get_value('xml_file_name'), None)

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -80,7 +80,7 @@ class TestPostDecisionLetterJats(unittest.TestCase):
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch.object(activity_module.download_helper, 'storage_context')
-    @patch.object(activity_module, 'post_jats_to_endpoint')
+    @patch.object(activity_module.requests_provider, 'post_to_endpoint')
     def test_do_activity_post_exception(self, fake_post_jats, fake_download_storage_context,
                                       fake_email_smtp_connect, mock_session):
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -111,7 +111,8 @@ class TestPostDecisionLetterJats(unittest.TestCase):
 
         # check assertions
         self.assertEqual(result, expected_result)
-        self.assertEqual(self.fake_logger.logerror, 'Missing session data in PostDigestJATS.')
+        self.assertEqual(
+            self.fake_logger.logerror, 'Missing session data in PostDecisionLetterJATS.')
 
 
 class TestPostDecisionLetterBadSettings(unittest.TestCase):
@@ -138,7 +139,7 @@ class TestPostDecisionLetterBadSettings(unittest.TestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(
             self.fake_logger.logerror,
-            'No typesetter endpoint in settings, skipping PostDigestJATS.')
+            'No typesetter endpoint in settings, skipping PostDecisionLetterJATS.')
 
     @patch.object(activity_module, 'get_session')
     def test_do_activity_blank_endpoint(self, mock_session):
@@ -158,4 +159,4 @@ class TestPostDecisionLetterBadSettings(unittest.TestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(
             self.fake_logger.logerror,
-            'Typesetter endpoint in settings is blank, skipping PostDigestJATS.')
+            'Typesetter endpoint in settings is blank, skipping PostDecisionLetterJATS.')

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -63,7 +63,7 @@ class TestPostDecisionLetterJats(unittest.TestCase):
     @patch('requests.post')
     @patch.object(activity_module.download_helper, 'storage_context')
     def test_do_activity_post_failed(self, fake_download_storage_context,
-                         requests_method_mock, fake_email_smtp_connect, mock_session):
+                                     requests_method_mock, fake_email_smtp_connect, mock_session):
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
         fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
@@ -76,13 +76,17 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         result = self.activity.do_activity(self.input_data)
         # check assertions
         self.assertEqual(result, expected_result)
+        self.assertTrue(self.activity.post_error_message.startswith(
+            'POST was not successful, details: Error posting decision letter JATS to endpoint'
+            ' https://typesetter/decisionLetter: status_code: 500\n'
+            'response: None'))
 
     @patch.object(activity_module, 'get_session')
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch.object(activity_module.download_helper, 'storage_context')
     @patch.object(activity_module.requests_provider, 'post_to_endpoint')
     def test_do_activity_post_exception(self, fake_post_jats, fake_download_storage_context,
-                                      fake_email_smtp_connect, mock_session):
+                                        fake_email_smtp_connect, mock_session):
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
         fake_download_storage_context.return_value = FakeStorageContext()
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -1,0 +1,161 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+import activity.activity_PostDecisionLetterJATS as activity_module
+from activity.activity_PostDecisionLetterJATS import (
+    activity_PostDecisionLetterJATS as activity_object)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeResponse
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeSession, FakeStorageContext
+from tests.classes_mock import FakeSMTPServer
+
+
+SESSION_DATA = {
+    'bucket_folder_name': 'elife39122',
+    'xml_file_name': 'elife-39122.xml',
+}
+
+
+def input_data(file_name_to_change=''):
+    activity_data = test_case_data.ingest_decision_letter_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+class TestPostDecisionLetterJats(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, self.fake_logger, None, None, None)
+        self.input_data = input_data('elife-39122.zip')
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch('requests.post')
+    @patch.object(activity_module.download_helper, 'storage_context')
+    def test_do_activity(self, fake_download_storage_context,
+                         requests_method_mock, fake_email_smtp_connect, mock_session):
+        expected_result = activity_object.ACTIVITY_SUCCESS
+        fake_download_storage_context.return_value = FakeStorageContext()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        # mock the session
+        fake_session = FakeSession(SESSION_DATA)
+        mock_session.return_value = fake_session
+        # POST response
+        requests_method_mock.return_value = FakeResponse(200, None)
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+        # check assertions
+        self.assertEqual(result, expected_result)
+        xml_file_name = self.activity.xml_file.split(os.sep)[-1]
+        self.assertEqual(xml_file_name, 'elife-39122.xml')
+        self.assertEqual(self.activity.doi, '10.7554/eLife.39122')
+
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch('requests.post')
+    @patch.object(activity_module.download_helper, 'storage_context')
+    def test_do_activity_post_failed(self, fake_download_storage_context,
+                         requests_method_mock, fake_email_smtp_connect, mock_session):
+        expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
+        fake_download_storage_context.return_value = FakeStorageContext()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        # mock the session
+        fake_session = FakeSession(SESSION_DATA)
+        mock_session.return_value = fake_session
+        # POST response
+        requests_method_mock.return_value = FakeResponse(500, None)
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+        # check assertions
+        self.assertEqual(result, expected_result)
+
+    @patch.object(activity_module, 'get_session')
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch.object(activity_module.download_helper, 'storage_context')
+    @patch.object(activity_module, 'post_jats_to_endpoint')
+    def test_do_activity_post_exception(self, fake_post_jats, fake_download_storage_context,
+                                      fake_email_smtp_connect, mock_session):
+        expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
+        fake_download_storage_context.return_value = FakeStorageContext()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        # mock the session
+        fake_session = FakeSession(SESSION_DATA)
+        mock_session.return_value = fake_session
+        # exception in post
+        fake_post_jats.side_effect = Exception("Something went wrong!")
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, expected_result)
+        self.assertTrue(self.activity.statuses.get('error_email'))
+        self.assertEqual(
+            self.fake_logger.logexception,
+            'Exception raised in do_activity. Details: Something went wrong!')
+
+    @patch.object(activity_module, 'get_session')
+    def test_do_activity_bad_session(self, mock_session):
+        expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
+        # mock the session
+        fake_session = FakeSession({})
+        mock_session.return_value = fake_session
+
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+
+        # check assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.fake_logger.logerror, 'Missing session data in PostDigestJATS.')
+
+
+class TestPostDecisionLetterBadSettings(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, self.fake_logger, None, None, None)
+        self.input_data = input_data('elife-39122.zip')
+
+    @patch.object(activity_module, 'get_session')
+    def test_do_activity_missing_endpoint(self, mock_session):
+        expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
+        # mock the session
+        fake_session = FakeSession(SESSION_DATA)
+        mock_session.return_value = fake_session
+
+        # remove the setting value
+        del self.activity.settings.typesetter_decision_letter_endpoint
+
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+
+        # check assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.fake_logger.logerror,
+            'No typesetter endpoint in settings, skipping PostDigestJATS.')
+
+    @patch.object(activity_module, 'get_session')
+    def test_do_activity_blank_endpoint(self, mock_session):
+        expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
+
+        # mock the session
+        fake_session = FakeSession(SESSION_DATA)
+        mock_session.return_value = fake_session
+
+        # remove the setting value
+        self.activity.settings.typesetter_decision_letter_endpoint = None
+
+        # do the activity
+        result = self.activity.do_activity(self.input_data)
+
+        # check assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.fake_logger.logerror,
+            'Typesetter endpoint in settings is blank, skipping PostDigestJATS.')

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -6,7 +6,6 @@ from ddt import ddt, data
 from digestparser.objects import Digest
 import activity.activity_PostDigestJATS as activity_module
 from activity.activity_PostDigestJATS import activity_PostDigestJATS as activity_object
-import tests.activity.helpers as helpers
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeResponse
 import tests.test_data as test_case_data
@@ -223,81 +222,6 @@ class TestEmailErrorReport(unittest.TestCase):
         settings_mock.typesetter_digest_endpoint = ""
         result = self.activity.email_error_report(digest_content, jats_content, error_messages)
         self.assertEqual(result, True)
-
-
-class TestEmailSubject(unittest.TestCase):
-
-    def test_success_email_subject(self):
-        """email subject line with correct, unicode data"""
-        digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
-        expected = u'Digest JATS posted for article 99999, author Nö'
-        subject = activity_module.success_email_subject(digest_content)
-        self.assertEqual(subject, expected)
-
-    def test_success_email_subject_no_doi(self):
-        """email subject line when no doi attribute"""
-        digest_content = Digest()
-        expected = u'Digest JATS posted for article 0None, author None'
-        file_name = activity_module.success_email_subject(digest_content)
-        self.assertEqual(file_name, expected)
-
-    def test_success_email_subject_bad_object(self):
-        """email subject line when digest is None"""
-        digest_content = None
-        expected = u''
-        subject = activity_module.success_email_subject(digest_content)
-        self.assertEqual(subject, expected)
-
-    def test_error_email_subject(self):
-        """error email subject"""
-        digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
-        expected = u'Error in digest JATS post for article 99999, author Nö'
-        subject = activity_module.error_email_subject(digest_content)
-        self.assertEqual(subject, expected)
-
-    def test_error_email_subject_bad_object(self):
-        """error email subject line when digest is None"""
-        digest_content = None
-        expected = u''
-        subject = activity_module.error_email_subject(digest_content)
-        self.assertEqual(subject, expected)
-
-
-class TestEmailBody(unittest.TestCase):
-
-    def test_success_email_body_content(self):
-        """email body line with correct, unicode data"""
-        digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
-        digest_content.text = [u'<i>First</i> paragraph.', u'<b>First</b> > second, nö?.']
-        jats_content = digest_provider.digest_jats(digest_content)
-
-        expected = u'''JATS content for article 10.7554/eLife.99999:
-
-<p><italic>First</italic> paragraph.</p><p><bold>First</bold> &gt; second, nö?.</p>
-
-'''
-        body = activity_module.success_email_body_content(digest_content, jats_content)
-        self.assertEqual(body, expected)
-
-    def test_error_email_body_content(self):
-        """email error body"""
-        error_message = "Exception blah blah blah"
-        digest_content = helpers.create_digest(u'Nö', '10.7554/eLife.99999')
-        digest_content.text = [u'<i>First</i> paragraph.', u'<b>First</b> > second, nö?.']
-        jats_content = digest_provider.digest_jats(digest_content)
-
-        expected = u'''Exception blah blah blah
-
-More details about the error may be found in the worker.log file
-
-Article DOI: 10.7554/eLife.99999
-
-JATS content: <p><italic>First</italic> paragraph.</p><p><bold>First</bold> &gt; second, nö?.</p>
-
-'''
-        body = activity_module.error_email_body_content(
-            digest_content, jats_content, error_message)
-        self.assertEqual(body, expected)
 
 
 if __name__ == '__main__':

--- a/tests/activity/test_activity_post_digest_jats.py
+++ b/tests/activity/test_activity_post_digest_jats.py
@@ -1,23 +1,18 @@
 # coding=utf-8
 
-import os
 import unittest
-import time
-from collections import OrderedDict
 from mock import patch
 from ddt import ddt, data
 from digestparser.objects import Digest
 import activity.activity_PostDigestJATS as activity_module
 from activity.activity_PostDigestJATS import activity_PostDigestJATS as activity_object
-from tests import read_fixture
 import tests.activity.helpers as helpers
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger, FakeResponse, fake_get_tmp_dir
+from tests.activity.classes_mock import FakeLogger, FakeResponse
 import tests.test_data as test_case_data
 from tests.activity.classes_mock import FakeStorageContext
 from tests.classes_mock import FakeSMTPServer
 import provider.digest_provider as digest_provider
-from provider.utils import bytes_decode
 
 
 def input_data(file_name_to_change=''):
@@ -205,76 +200,6 @@ class TestPostDigestJatsNoEndpoint(unittest.TestCase):
         activity.settings.typesetter_digest_endpoint = ""
         result = activity.do_activity()
         self.assertEqual(result, activity_object.ACTIVITY_SUCCESS)
-
-
-class TestPost(unittest.TestCase):
-
-    def setUp(self):
-        self.fake_logger = FakeLogger()
-
-    @patch('requests.adapters.HTTPAdapter.get_connection')
-    def test_get_as_params(self, fake_connection):
-        """"test get data as params only"""
-        url = 'http://localhost/'
-        payload = OrderedDict([
-            ("type", "digest"),
-            ("content", '<p>"98%"β</p>')
-            ])
-        expected_url = url + '?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
-        expected_body = None
-        # populate the fake request
-        resp = activity_module.get_as_params(url, payload)
-        # make assertions
-        self.assertEqual(resp.request.url, expected_url)
-        self.assertEqual(resp.request.body, expected_body)
-
-    @patch('requests.adapters.HTTPAdapter.get_connection')
-    def test_post_as_params(self, fake_connection):
-        """"test posting data as params only"""
-        url = 'http://localhost/'
-        payload = OrderedDict([
-            ("type", "digest"),
-            ("content", '<p>"98%"β</p>')
-            ])
-        expected_url = url + '?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
-        expected_body = None
-        # populate the fake request
-        resp = activity_module.post_as_params(url, payload)
-        # make assertions
-        self.assertEqual(resp.request.url, expected_url)
-        self.assertEqual(resp.request.body, expected_body)
-
-    @patch('requests.adapters.HTTPAdapter.get_connection')
-    def test_post_as_data(self, fake_connection):
-        """"test posting data as data only"""
-        url = 'http://localhost/'
-        payload = OrderedDict([
-            ("type", "digest"),
-            ("content", '<p>"98%"β</p>')
-            ])
-        expected_url = url
-        expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
-        # populate the fake request
-        resp = activity_module.post_as_data(url, payload)
-        # make assertions
-        self.assertEqual(resp.request.url, expected_url)
-        self.assertEqual(resp.request.body, expected_body)
-
-    @patch('requests.adapters.HTTPAdapter.get_connection')
-    def test_post_as_json(self, fake_connection):
-        """test posting data as data only"""
-        url = 'http://localhost/'
-        payload = OrderedDict([
-            ("type", "digest"),
-            ("content", '<p>"98%"β</p>')
-            ])
-        expected_url = url
-        expected_body = '{"type": "digest", "content": "<p>\\"98%\\"\\u03b2</p>"}'
-        # populate the fake request
-        resp = activity_module.post_as_json(url, payload)
-        # make assertions
-        self.assertEqual(resp.request.url, expected_url)
-        self.assertEqual(bytes_decode(resp.request.body), expected_body)
 
 
 class TestEmailErrorReport(unittest.TestCase):

--- a/tests/files_source/elife39122/elife-39122.xml
+++ b/tests/files_source/elife39122/elife-39122.xml
@@ -1,0 +1,949 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+<sub-article article-type="decision-letter" id="sa1">
+<front-stub>
+<article-id pub-id-type="doi">10.7554/eLife.39122.sa1</article-id>
+<title-group>
+<article-title>Decision letter</article-title>
+</title-group>
+</front-stub>
+<body>
+<boxed-text>
+<p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+</boxed-text>
+<p>
+Thank you for submitting your article &quot;Ligand-dependent electrostatic control of anion access to the pore of the calcium-activated chloride channel TMEM16A&quot; for consideration by 
+<italic>eLife</italic>
+. Your article has been reviewed by three peer reviewers, and the evaluation has been overseen by a Reviewing Editor and Richard Aldrich as the Senior Editor. The following individuals involved in review of your submission have agreed to reveal their identity: Criss Hartzell (Reviewer#1) and Alessio Accardi (Reviewer #2).
+</p>
+<p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
+<p>Summary:</p>
+<p>
+Lam and Dutzler discover that the negatively charged residues that form the Ca
+<sup>2+</sup>
+-binding sites act as an electrostatic barrier for the flow of anions once the pore has adopted the open conformation, thus acting as an additional activation gate in the absence of Ca
+<sup>2+</sup>
+. By introducing mutations in the Ca
+<sup>2+</sup>
+-sites in constitutively active mutants of TMEM16A and measuring their I-V relations at various Ca
+<sup>2+</sup>
+concentrations, the authors show that the binding of calcium reduces the two innermost energy barriers of an open channel through an electrostatic mechanism, allowing ions to flow. In the absence of Ca
+<sup>2+</sup>
+, the constitutively active mutants display pronounced outward rectification due to this electrostatic effect. Overall, these studies highlight a novel mechanism of regulation of ion permeation by a ligand. Nevertheless, the reviewers raise several concerns that should be addressed in the revised version.
+</p>
+<p>Essential revisions:</p>
+<p>
+1) I am not sure that I understand the permeation model. Why do the electrostatics of Ca
+<sup>2+</sup>
+ affect only inward and not outward current? The energy profile in Figure 1D could not lead to rectification, because the height of each energy barrier is the same whether the ion is coming from the inside or the outside. Outward rectification requires an energy well between the barriers 
+<italic>h</italic>
+ and 
+<italic>β</italic>
+ so that the height of 
+<italic>β</italic>
+ is greater from the out&gt;in than the in&gt;out direction. It would seem that the depth of this well would be significant considering the degree of rectification observed.
+</p>
+<p>
+2) Furthermore, the second paragraph of the subsection “Data analysis” states that 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ and 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ are voltage-independent, but Figure 1G seems to show that 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ is voltage-dependent. The statement in the next paragraph is rather inscrutable, as is the subsequent explanation about why the &quot;decay&quot; was omitted from the fits. What does &quot;inaccurate estimation of 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+&quot; mean? It would be useful to know how the conclusions are affected by changing 
+<italic>n</italic>
+ in Equation 2. And why is 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ not shown beyond Figure 1?
+</p>
+<p>
+3) Even though the G644P and Q649A mutations increase the baseline open probability of the channel, it is unclear whether the protein with any of these mutations still undergoes some gating-associated conformational changes. If this were the case, some of the effects of Ca
+<sup>2+</sup>
+-binding on the rectification of the mutant channels could arise from these conformational changes rather than the simple electrostatic influence of the site and the bound Ca
+<sup>2+</sup>
+ ions. To test for this possibility, the authors could use Mg
+<sup>2+</sup>
+ instead of Ca
+<sup>2+</sup>
+, as it is reported to compete with Ca
+<sup>2+</sup>
+ without activating the channel. The authors should test whether the presence of internal magnesium in the context of either of the constitutively active mutants has the same effect as Ca
+<sup>2+</sup>
+, as expected from their proposed mechanism. Although it is not necessary, I think it would be also interesting to test whether a trivalent cation could also bind and have a larger effect than Ca
+<sup>2+</sup>
+.
+</p>
+<p>4) Large portions of the data shown depend on the use of a permeation model for analysis, together with the use of several equations for permeation and electrostatics. I think these play such a central role in the manuscript that it would make the reading easier if some of these models and equations were described with more detail in the main text, rather than the Materials and methods section.</p>
+</body>
+</sub-article>
+<sub-article article-type="reply" id="sa2">
+<front-stub>
+<article-id pub-id-type="doi">10.7554/eLife.39122.sa2</article-id>
+<title-group>
+<article-title>Author response</article-title>
+</title-group>
+</front-stub>
+<body>
+<disp-quote content-type="editor-comment">
+<p>Essential revisions:</p>
+<p>
+1) I am not sure that I understand the permeation model. Why do the electrostatics of Ca
+<sup>2+</sup>
+ affect only inward and not outward current? The energy profile in Figure 1D could not lead to rectification, because the height of each energy barrier is the same whether the ion is coming from the inside or the outside. Outward rectification requires an energy well between the barriers h and β so that the height of β is greater from the out&gt;in than the in&gt;out direction. It would seem that the depth of this well would be significant considering the degree of rectification observed.
+</p>
+</disp-quote>
+<fig id="sa2fig1">
+<label>Author response image 1.</label>
+<caption>
+<title>
+Model calculations based on the energy profile of G644P at zero Ca
+<sup>2+</sup>
+ (top) and a WT-like channel with a totally symmetric energy profile (bottom).
+</title>
+<p>
+Left, Ion occupancy in the model channel relative to that at the outermost wells (p
+<sub>n</sub>
+ or p
+<sub>0</sub>
+) as a function of voltage at the indicated locations. Right, Shape of the I-V relation at steady state. At zero voltage, the relative occupancy is 1 for all cases because our model assumes no binding affinity when no voltage gradient is present. The curves on the left panels were calculated using
+<disp-formula id="sa2equ1">
+<mml:math alttext="\frac{p_{1}}{\text{vc}} = \phi + \frac{J}{\text{vc}\beta_{V}}" display="block" id="sa2m1">
+<mml:mrow>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>p</mml:mi>
+<mml:mn>1</mml:mn>
+</mml:msub>
+<mml:mtext mathvariant="normal">vc</mml:mtext>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:mi>ϕ</mml:mi>
+<mml:mo>+</mml:mo>
+<mml:mfrac>
+<mml:mi>J</mml:mi>
+<mml:mrow>
+<mml:mtext mathvariant="normal">vc</mml:mtext>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mrow>
+</mml:mfrac>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+<disp-formula id="sa2equ2">
+<mml:math alttext="\frac{p_{n - 1}}{\text{vc}} = \phi^{n - 1} + \frac{J}{\text{vc}\beta_{V}}\left( \phi^{n - 2} + \frac{1}{\sigma_{h}}\left( \frac{1 - \phi^{n - 2}}{1 - \phi} \right) \right)" display="block" id="sa2m2">
+<mml:mrow>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>p</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>1</mml:mn>
+</mml:mrow>
+</mml:msub>
+<mml:mtext mathvariant="normal">vc</mml:mtext>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>1</mml:mn>
+</mml:mrow>
+</mml:msup>
+<mml:mo>+</mml:mo>
+<mml:mfrac>
+<mml:mi>J</mml:mi>
+<mml:mrow>
+<mml:mtext mathvariant="normal">vc</mml:mtext>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mrow>
+</mml:mfrac>
+<mml:mrow>
+<mml:mo form="prefix" stretchy="true">(</mml:mo>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>2</mml:mn>
+</mml:mrow>
+</mml:msup>
+<mml:mo>+</mml:mo>
+<mml:mfrac>
+<mml:mn>1</mml:mn>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+</mml:mfrac>
+<mml:mrow>
+<mml:mo form="prefix" stretchy="true">(</mml:mo>
+<mml:mfrac>
+<mml:mrow>
+<mml:mn>1</mml:mn>
+<mml:mo>−</mml:mo>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>2</mml:mn>
+</mml:mrow>
+</mml:msup>
+</mml:mrow>
+<mml:mrow>
+<mml:mn>1</mml:mn>
+<mml:mo>−</mml:mo>
+<mml:mi>ϕ</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+<mml:mo form="postfix" stretchy="true">)</mml:mo>
+</mml:mrow>
+<mml:mo form="postfix" stretchy="true">)</mml:mo>
+</mml:mrow>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+and those on the right panels using
+<disp-formula id="sa2equ3">
+<mml:math alttext="I = zFJ" display="block" id="sa2m3">
+<mml:mrow>
+<mml:mi>I</mml:mi>
+<mml:mo>=</mml:mo>
+<mml:mi>z</mml:mi>
+<mml:mi>F</mml:mi>
+<mml:mi>J</mml:mi>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+where
+<disp-formula id="sa2equ4">
+<mml:math alttext="J = \frac{\beta_{V}\text{vc}\left( 1 - \phi^{n} \right)}{\phi^{n - 1} + \frac{1}{\sigma_{h}}\phi\left( \frac{1 - \phi^{n - 2}}{1 - \phi} \right) + \frac{1}{\sigma_{\beta}}}" display="block" id="sa2m4">
+<mml:mrow>
+<mml:mi>J</mml:mi>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:mrow>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+<mml:mtext mathvariant="normal">vc</mml:mtext>
+<mml:mrow>
+<mml:mo form="prefix" stretchy="true">(</mml:mo>
+<mml:mn>1</mml:mn>
+<mml:mo>−</mml:mo>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mi>n</mml:mi>
+</mml:msup>
+<mml:mo form="postfix" stretchy="true">)</mml:mo>
+</mml:mrow>
+</mml:mrow>
+<mml:mrow>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>1</mml:mn>
+</mml:mrow>
+</mml:msup>
+<mml:mo>+</mml:mo>
+<mml:mfrac>
+<mml:mn>1</mml:mn>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+</mml:mfrac>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mo form="prefix" stretchy="true">(</mml:mo>
+<mml:mfrac>
+<mml:mrow>
+<mml:mn>1</mml:mn>
+<mml:mo>−</mml:mo>
+<mml:msup>
+<mml:mi>ϕ</mml:mi>
+<mml:mrow>
+<mml:mi>n</mml:mi>
+<mml:mo>−</mml:mo>
+<mml:mn>2</mml:mn>
+</mml:mrow>
+</mml:msup>
+</mml:mrow>
+<mml:mrow>
+<mml:mn>1</mml:mn>
+<mml:mo>−</mml:mo>
+<mml:mi>ϕ</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+<mml:mo form="postfix" stretchy="true">)</mml:mo>
+</mml:mrow>
+<mml:mo>+</mml:mo>
+<mml:mfrac>
+<mml:mn>1</mml:mn>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:mfrac>
+</mml:mrow>
+</mml:mfrac>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+<disp-formula id="sa2equ5">
+<mml:math alttext="\phi = e^{- \frac{\text{zFV}}{\text{nRT}}}" display="block" id="sa2m5">
+<mml:mrow>
+<mml:mi>ϕ</mml:mi>
+<mml:mo>=</mml:mo>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mrow>
+<mml:mo>−</mml:mo>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mtext mathvariant="normal">nRT</mml:mtext>
+</mml:mfrac>
+</mml:mrow>
+</mml:msup>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+<disp-formula id="sa2equ6">
+<mml:math alttext="\beta_{V} = \beta_{0}e^{\frac{\text{zFV}}{2nRT}}" display="block" id="sa2m6">
+<mml:mrow>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+<mml:mo>=</mml:mo>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mrow>
+<mml:mn>2</mml:mn>
+<mml:mi>n</mml:mi>
+<mml:mi>R</mml:mi>
+<mml:mi>T</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+</mml:msup>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+under symmetrical ionic conditions. The number of barriers 
+<inline-formula>
+<mml:math alttext="n" display="inline" id="sa2m7">
+<mml:mi>n</mml:mi>
+</mml:math>
+</inline-formula>
+ is 3 in this model. This has been determined to describe the conduction properties of mutants in our previous study (Paulino et al., 2017). 
+<inline-formula>
+<mml:math alttext="\beta_{V}" display="inline" id="sa2m8">
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ is the voltage-dependent rate constant of the outermost barrier. The rate constant of the innermost barrier is defined as 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}\beta_{V}" display="inline" id="sa2m9">
+<mml:mrow>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mrow>
+</mml:math>
+</inline-formula>
+ and that of the middle barrier as 
+<inline-formula>
+<mml:math alttext="\sigma_{h}\beta_{V}" display="inline" id="sa2m10">
+<mml:mrow>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mrow>
+</mml:math>
+</inline-formula>
+ where both fitted parameters 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ and 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ are independent of voltage. 
+<inline-formula>
+<mml:math alttext="p_{i}" display="inline" id="sa2m11">
+<mml:msub>
+<mml:mi>p</mml:mi>
+<mml:mi>i</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+’s are the probabilities of occupying the i
+<sup>th</sup>
+ wells (from 
+<inline-formula>
+<mml:math alttext="p_{0}" display="inline" id="sa2m12">
+<mml:msub>
+<mml:mi>p</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ to 
+<inline-formula>
+<mml:math alttext="p_{n}" display="inline" id="sa2m13">
+<mml:msub>
+<mml:mi>p</mml:mi>
+<mml:mi>n</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+). 
+<italic>v</italic>
+ is a proportionality factor that has a dimension of volume and may be interpreted as the hypothetical volume for outermost well at the channel entrance. 
+<inline-formula>
+<mml:math alttext="V" display="inline" id="sa2m14">
+<mml:mi>V</mml:mi>
+</mml:math>
+</inline-formula>
+ is the membrane potential, 
+<inline-formula>
+<mml:math alttext="z" display="inline" id="sa2m15">
+<mml:mi>z</mml:mi>
+</mml:math>
+</inline-formula>
+ is the valence of the ion, and 
+<inline-formula>
+<mml:math alttext="R" display="inline" id="sa2m16">
+<mml:mi>R</mml:mi>
+</mml:math>
+</inline-formula>
+, 
+<inline-formula>
+<mml:math alttext="T" display="inline" id="sa2m17">
+<mml:mi>T</mml:mi>
+</mml:math>
+</inline-formula>
+ and 
+<inline-formula>
+<mml:math alttext="F" display="inline" id="sa2m18">
+<mml:mi>F</mml:mi>
+</mml:math>
+</inline-formula>
+ have their usual meanings.
+</p>
+</caption>
+<graphic mimetype="image" xlink:href="elife-39122-sa2-fig1.jpg"/>
+</fig>
+<p>
+In our analysis, we rely on a simple rate theory model proposed by Peter Läuger (Lauger, 1973). We have explained this model in detail in our previous manuscript published in 
+<italic>eLife</italic>
+, to which this work refers to (Paulino et al., 2017). In this model, ions surmount energy barriers in a pore that does not contain deep energy wells and that cannot be saturated. We think that such model is appropriate for our analysis since we have not found evidence for tight ion binding sites in our structures and we have measured a K
+<sub>M</sub>
+ of chloride conduction between 300-400 mM, thus underlining that there is no saturation in the applied conditions (Paulino et al., 2017). The energy profile displayed in Figure 1D or Figure 1—figure supplement 1 represents the potential of mean force for permeation in the absence of an applied electric field, where, in symmetric ion concentrations, the system is at equilibrium and there is no net flux in either direction. Upon application of a potential difference, the model predicts ionic currents. In such case, rectification is a consequence of the asymmetric free energy profile. The location of the barrier maximum governs the shape of the I-V relation, which becomes increasingly outwardly rectifying when the barrier maximum moves closer to the inner end. We note that the I-V relation is a function of both occupancy and rate of barrier crossing. Unlike the pseudo-ohmic cases, in case of low symmetric barriers, where the total occupancy remains approximately constant, ion depletion occurs in cases of an increased intracellular barrier at negative voltages where the channel is less conductive while ion accumulation occurs at positive voltages (
+<xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref>
+. Both behaviors likely account for the resulting outward rectification and the general reduction in ion conductance. The latter corresponds to an effect that also affects the outward current (as indicated by the reduction of current at positive voltages in the I-V profiles in 
+<xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref>
+.
+</p>
+<disp-quote content-type="editor-comment">
+<p>
+2) Furthermore, the second paragraph of the subsection “Data analysis” states that σ
+<sub>h</sub>
+ and σ
+<sub>β</sub>
+ are voltage-independent, but Figure 1G seems to show that σ
+<sub>β</sub>
+ is voltage-dependent.
+</p>
+</disp-quote>
+<p>
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ and 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ are both not intrinsically voltage-dependent as they denote the ratio of the rate constants in the case of a linear voltage drop (also see equation above). In Figure 1G they are only voltage-dependent because they change as a function of calcium binding and calcium binding itself is voltage-dependent. We have added the following sentences to our manuscript:
+</p>
+<p>
+“
+<inline-formula>
+<mml:math alttext="\sigma_{h}" display="inline" id="sa2m19">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ and 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m20">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ are respectively the rate of barrier crossing at the middle and the innermost barriers relative to that at the outermost barrier (
+<inline-formula>
+<mml:math alttext="\beta" display="inline" id="sa2m21">
+<mml:mi>β</mml:mi>
+</mml:math>
+</inline-formula>
+),
+</p>
+<p>
+<disp-formula id="sa2equ7">
+<mml:math alttext="\sigma_{h} = \frac{h_{V}}{\beta_{V}} = \frac{h_{0}e^{\frac{\text{zFV}}{2nRT}}}{\beta_{0}e^{\frac{\text{zFV}}{2nRT}}} = \frac{h_{0}}{\beta_{0}}" display="block" id="sa2m22">
+<mml:mrow>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>h</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:mrow>
+<mml:msub>
+<mml:mi>h</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mrow>
+<mml:mn>2</mml:mn>
+<mml:mi>n</mml:mi>
+<mml:mi>R</mml:mi>
+<mml:mi>T</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+</mml:msup>
+</mml:mrow>
+<mml:mrow>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mrow>
+<mml:mn>2</mml:mn>
+<mml:mi>n</mml:mi>
+<mml:mi>R</mml:mi>
+<mml:mi>T</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+</mml:msup>
+</mml:mrow>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>h</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+</mml:mfrac>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+<disp-formula id="sa2equ8">
+<mml:math alttext="\sigma_{\beta} = \frac{\delta_{V}}{\beta_{V}} = \frac{\delta_{0}e^{\frac{\text{zFV}}{2nRT}}}{\beta_{0}e^{\frac{\text{zFV}}{2nRT}}} = \frac{\delta_{0}}{\beta_{0}}" display="block" id="sa2m23">
+<mml:mrow>
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>δ</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mi>V</mml:mi>
+</mml:msub>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:mrow>
+<mml:msub>
+<mml:mi>δ</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mrow>
+<mml:mn>2</mml:mn>
+<mml:mi>n</mml:mi>
+<mml:mi>R</mml:mi>
+<mml:mi>T</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+</mml:msup>
+</mml:mrow>
+<mml:mrow>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msup>
+<mml:mi>e</mml:mi>
+<mml:mfrac>
+<mml:mtext mathvariant="normal">zFV</mml:mtext>
+<mml:mrow>
+<mml:mn>2</mml:mn>
+<mml:mi>n</mml:mi>
+<mml:mi>R</mml:mi>
+<mml:mi>T</mml:mi>
+</mml:mrow>
+</mml:mfrac>
+</mml:msup>
+</mml:mrow>
+</mml:mfrac>
+<mml:mo>=</mml:mo>
+<mml:mfrac>
+<mml:msub>
+<mml:mi>δ</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+<mml:msub>
+<mml:mi>β</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+</mml:mfrac>
+</mml:mrow>
+</mml:math>
+</disp-formula>
+where 
+<inline-formula>
+<mml:math alttext="h_{0}" display="inline" id="sa2m24">
+<mml:msub>
+<mml:mi>h</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ is the rate of barrier crossing at the middle barrier and 
+<inline-formula>
+<mml:math alttext="\delta_{0}" display="inline" id="sa2m25">
+<mml:msub>
+<mml:mi>δ</mml:mi>
+<mml:mn>0</mml:mn>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ at the innermost barrier in the absence of voltage. Thus, for a linear voltage drop as is the case in our model, 
+<inline-formula>
+<mml:math alttext="\sigma_{h}" display="inline" id="sa2m26">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ and 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m27">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ are intrinsically voltage-independent and represent the relative rates when 
+<inline-formula>
+<mml:math alttext="V" display="inline" id="sa2m28">
+<mml:mi>V</mml:mi>
+</mml:math>
+</inline-formula>
+ = 0. 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m29">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ appears to be voltage-dependent in Figure 1G because 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m30">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ is a function of Ca
+<sup>2+</sup>
+ binding whose EC
+<sub>50</sub>
+ exhibits voltage dependence.”
+</p>
+<disp-quote content-type="editor-comment">
+<p>
+The statement in the next paragraph is rather inscrutable, as is the subsequent explanation about why the &quot;decay&quot; was omitted from the fits. What does &quot;inaccurate estimation of σ
+<sub>β</sub>
+&quot; mean? It would be useful to know how the conclusions are affected by changing n in Equation 2.
+</p>
+</disp-quote>
+<p>We have added the following sentences:</p>
+<p>
+We note that the decay phase in general does not follow the same trend as the high affinity phase and occurs an order of magnitude above the concentration range where activation takes place (
+<xref ref-type="fig" rid="sa2fig2">Author response image 2.</xref>
+. The decay might be related to additional processes conferred by Ca
+<sup>2+</sup>
+ not intrinsic to its high affinity binding, as we have observed in a previous study (Lim et al., 2016). As we are interested in the effect of calcium binding to the high affinity transmembrane site, the low affinity phase becomes irrelevant and was therefore omitted from analysis. Since the same treatment was applied consistently, this does not affect the outcome of the analysis. The number of barrier 
+<italic>n</italic>
+ is kept equal to that determined for the WT channel in our previous manuscript. This energy profile presents a minimal model required for a phenomenological description of ion permeation across a narrow neck region with two flanking barriers that account for the entry of ions into the neck whose heights are modulated by long-range electrostatics. It is reasonable to assume that the barrier heights are affected by the introduction of mutations, whereas the overall architecture of the energy profile remains similar.
+</p>
+<p>
+“We have previously shown that the model describes the behavior of WT best when the number of barriers 
+<inline-formula>
+<mml:math alttext="n" display="inline" id="sa2m31">
+<mml:mi>n</mml:mi>
+</mml:math>
+</inline-formula>
+ equals 3 (Paulino et al., 2017b), which was used as a fixed parameter. This leaves 
+<inline-formula>
+<mml:math alttext="\sigma_{h}" display="inline" id="sa2m32">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>h</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+, 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m33">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ and the amplitude factor 
+<inline-formula>
+<mml:math alttext="A" display="inline" id="sa2m34">
+<mml:mi>A</mml:mi>
+</mml:math>
+</inline-formula>
+ as the only free parameters to be fitted.”
+</p>
+<p>
+“We observed for mutants G644P/E654Q, G644P/E654R, G644P/E654Q/E705Q and G644P/E654R/E705Q a low affinity decay of 
+<inline-formula>
+<mml:math alttext="\sigma_{\beta}" display="inline" id="sa2m35">
+<mml:msub>
+<mml:mi>σ</mml:mi>
+<mml:mi>β</mml:mi>
+</mml:msub>
+</mml:math>
+</inline-formula>
+ at high Ca
+<sup>2+</sup>
+ concentrations (Figure 3A, B, D, E). Since this decay might be related to processes not intrinsic to the transmembrane binding site (Lim et al., 2016), only the high affinity phase was analyzed.”
+</p>
+<fig id="sa2fig2">
+<label>Author response image 2.</label>
+<caption>
+<title>
+Relationship between experimental 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ and RI (I
+<sub>-100/+120</sub>
+) for the G644P family of constructs.
+</title>
+<p>Horizontal error bars indicate S.E.M and vertical error bars indicate the 95% confidence interval.</p>
+</caption>
+<graphic mimetype="image" xlink:href="elife-39122-sa2-fig2.jpg"/>
+</fig>
+<disp-quote content-type="editor-comment">
+<p>
+And why is σ
+<sub>h</sub>
+ not shown beyond Figure 1?
+</p>
+</disp-quote>
+<disp-quote content-type="editor-comment">
+<p>
+3) Even though the G644P and Q649A mutations increase the baseline open probability of the channel, it is unclear whether the protein with any of these mutations still undergoes some gating-associated conformational changes. If this were the case, some of the effects of Ca
+<sup>2+</sup>
+-binding on the rectification of the mutant channels could arise from these conformational changes rather than the simple electrostatic influence of the site and the bound Ca
+<sup>2+</sup>
+ ions. To test for this possibility, the authors could use Mg
+<sup>2+</sup>
+ instead of Ca
+<sup>2+</sup>
+, as it is reported to compete with Ca
+<sup>2+</sup>
+ without activating the channel. The authors should test whether the presence of internal magnesium in the context of either of the constitutively active mutants has the same effect as Ca
+<sup>2+</sup>
+, as expected from their proposed mechanism. Although it is not necessary, I think it would be also interesting to test whether a trivalent cation could also bind and have a larger effect than Ca
+<sup>2+</sup>
+.
+</p>
+</disp-quote>
+<p>
+We have selected 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ for most of our graphs since it was determined with higher precision than 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+. As shown in Figure 1E, the 95% confidence interval of 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ is much wider than that of 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+, indicating that the best-fit value of 
+<italic>
+σ
+<sub>h</sub>
+</italic>
+ is less well defined. In addition, the value of 
+<italic>
+σ
+<sub>β</sub>
+</italic>
+ increases monotonically (and almost linearly for the experimental range) with the rectification index (I
+<sub>-100/+120</sub>
+) (
+<xref ref-type="fig" rid="sa2fig2">Author response image 2.</xref>
+, which allows a straightforward comparison with the I-V data.
+</p>
+<p>We agree that gating-associated conformational changes may still exist. However, since for our analysis we characterize instantaneous currents following a voltage jump prior to any conformational changes, the I-V relations correspond to the open populations of the channel.</p>
+<p>
+In our revised version, we have now investigated the effect of Mg
+<sup>2+</sup>
+ binding on the conductance. For that purpose, we have recorded data at varying Mg
+<sup>2+</sup>
+ concentration in the absence of Ca
+<sup>2+</sup>
+. Consistent with previous observations by Chen and colleagues (Ni et al., 2014), we found that Mg
+<sup>2+</sup>
+ binds with an apparent affinity of around 1-2 mM. Although Mg
+<sup>2+</sup>
+ addition does not lead to activation of WT, its binding to the mutant G644P lowers the energy barrier for anion conduction at the intracellular part of the pore, consistent with the presence of a single Mg
+<sup>2+</sup>
+ ion in the site (as judged by the remaining rectification at high Mg
+<sup>2+</sup>
+ concentration). This result thus further confirms our proposed mechanism on the influence of divalent cations in the transmembrane binding site on the energetics of anion conduction in the open channel. In another set of experiments, we have also investigated the effect of the trivalent metal ion Gd
+<sup>3+</sup>
+ and found that the application of this ion at high µM concentrations exerts an even stronger effect than Ca
+<sup>2+</sup>
+, leading to slight inward rectification of currents. This behavior is consistent with a larger increase in the positive charge density after the binding of two Gd
+<sup>3+</sup>
+ ions. However, in this case the effect was not completely reversible upon washout indicating an unmeasurably slow off-rate for one of the bound ions. It should also be noted that in the case of Gd
+<sup>3+</sup>
+, we could not buffer residual Ca
+<sup>2+</sup>
+ in the solutions by addition of EGTA and we can thus not exclude the presence of traces of Ca
+<sup>2+</sup>
+ in the solutions. In light of our new data, we have added another subsection to our manuscript “The effect of the competitive antagonist Mg
+<sup>2+</sup>
+, and the trivalent cation Gd
+<sup>3+</sup>
+ on conduction”) and an additional accompanying figure (see the new Figure 2 and Figure 2—figure supplements 1 and 2).
+</p>
+<disp-quote content-type="editor-comment">
+<p>4) Large portions of the data shown depend on the use of a permeation model for analysis, together with the use of several equations for permeation and electrostatics. I think these play such a central role in the manuscript that it would make the reading easier if some of these models and equations were described with more detail in the main text, rather than the Materials and methods section.</p>
+</disp-quote>
+<p>We have added two sentences to the Results where we discuss general features of the model and extended its description in the methods. However, we have already explained the same model in great detail in our preceding study, which the current manuscript is referring to, and think that the link to this previous study would help interested readers to gain in-depth insight. We also think that a more extended description of the model in the main part of the manuscript might distract readers from the main findings of the work.</p>
+<p>The following sentences were added to the Results section:</p>
+<p>
+“The diffusion path does not contain deep energy wells and the model does not account for saturation of the pore, which is generally consistent with the high K
+<sub>M</sub>
+ for chloride conduction.”
+</p>
+<p>“The rectification is a consequence of both pore occupancy and the rate of barrier crossing at the applied potential.”</p>
+</body>
+</sub-article>
+</root>

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -139,3 +139,11 @@ class TestManuscriptFromArticles(unittest.TestCase):
 
     def test_manuscript_from_articles_none(self):
         self.assertEqual(letterparser_provider.manuscript_from_articles(None), None)
+
+
+class TestArticleDoiFromXml(unittest.TestCase):
+
+    def test_article_doi_from_xml(self):
+        xml_string = '<article-id>10.7554/eLife.39122.sa1'
+        self.assertEqual(
+            letterparser_provider.article_doi_from_xml(xml_string), '10.7554/eLife.39122')

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -1,0 +1,48 @@
+import unittest
+from collections import OrderedDict
+from mock import patch
+from provider import requests_provider
+from tests.activity.classes_mock import FakeLogger, FakeResponse
+
+
+class TestRequestsProvider(unittest.TestCase):
+
+    def test_jats_post_payload(self):
+        content_type = 'decision'
+        doi = '10.7554/eLife.00666'
+        content = {}
+        api_key = 'key'
+        expected = OrderedDict([
+            ('apiKey', api_key),
+            ('accountKey', 1),
+            ('doi', doi),
+            ('type', content_type),
+            ('content', {})
+        ])
+        result = requests_provider.jats_post_payload(content_type, doi, content, api_key)
+        self.assertEqual(result, expected)
+
+
+class TestRequestsProviderPost(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+
+    @patch('requests.post')
+    def test_post_to_endpoint_200(self, post_mock):
+        post_mock.return_value = FakeResponse(200, {})
+        url = ''
+        payload = {}
+        identifier = 'test'
+        result = requests_provider.post_to_endpoint(url, payload, self.fake_logger, identifier)
+        self.assertTrue(result)
+
+    @patch('requests.post')
+    def test_post_to_endpoint_404(self, post_mock):
+        post_mock.return_value = FakeResponse(404, {})
+        url = ''
+        payload = {}
+        identifier = 'test'
+        result = requests_provider.post_to_endpoint(url, payload, self.fake_logger, identifier)
+        self.assertEqual(
+            result, 'Error posting test to endpoint : status_code: 404\nresponse: None')

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -2,6 +2,7 @@ import unittest
 from collections import OrderedDict
 from mock import patch
 from provider import requests_provider
+from provider.utils import bytes_decode
 from tests.activity.classes_mock import FakeLogger, FakeResponse
 
 
@@ -21,6 +22,73 @@ class TestRequestsProvider(unittest.TestCase):
         ])
         result = requests_provider.jats_post_payload(content_type, doi, content, api_key)
         self.assertEqual(result, expected)
+
+
+class TestRequestsProviderPostAs(unittest.TestCase):
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_get_as_params(self, fake_connection):
+        """"test get data as params only"""
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = url + '?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        expected_body = None
+        # populate the fake request
+        resp = requests_provider.get_as_params(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_params(self, fake_connection):
+        """"test posting data as params only"""
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = url + '?type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        expected_body = None
+        # populate the fake request
+        resp = requests_provider.post_as_params(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_data(self, fake_connection):
+        """"test posting data as data only"""
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = url
+        expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
+        # populate the fake request
+        resp = requests_provider.post_as_data(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(resp.request.body, expected_body)
+
+    @patch('requests.adapters.HTTPAdapter.get_connection')
+    def test_post_as_json(self, fake_connection):
+        """test posting data as data only"""
+        url = 'http://localhost/'
+        payload = OrderedDict([
+            ("type", "digest"),
+            ("content", '<p>"98%"β</p>')
+            ])
+        expected_url = url
+        expected_body = '{"type": "digest", "content": "<p>\\"98%\\"\\u03b2</p>"}'
+        # populate the fake request
+        resp = requests_provider.post_as_json(url, payload)
+        # make assertions
+        self.assertEqual(resp.request.url, expected_url)
+        self.assertEqual(bytes_decode(resp.request.body), expected_body)
 
 
 class TestRequestsProviderPost(unittest.TestCase):

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -11,19 +11,32 @@ import tests.activity.helpers as helpers
 
 class TestRequestsProvider(unittest.TestCase):
 
+    def test_jats_post_params(self):
+        api_key = 'key'
+        account_key = '1'
+        expected = OrderedDict([
+            ('apiKey', api_key),
+            ('accountKey', account_key),
+        ])
+        result = requests_provider.jats_post_params(api_key, account_key)
+        self.assertEqual(result, expected)
+
     def test_jats_post_payload(self):
         content_type = 'decision'
         doi = '10.7554/eLife.00666'
         content = {}
         api_key = 'key'
+        account_key = '1'
+
         expected = OrderedDict([
             ('apiKey', api_key),
-            ('accountKey', 1),
+            ('accountKey', account_key),
             ('doi', doi),
             ('type', content_type),
             ('content', {})
         ])
-        result = requests_provider.jats_post_payload(content_type, doi, content, api_key)
+        result = requests_provider.jats_post_payload(
+            content_type, doi, content, api_key, account_key)
         self.assertEqual(result, expected)
 
 
@@ -65,14 +78,20 @@ class TestRequestsProviderPostAs(unittest.TestCase):
     def test_post_as_data(self, fake_connection):
         """"test posting data as data only"""
         url = 'http://localhost/'
+        api_key = 'key'
+        account_key = '1'
+        params = OrderedDict([
+            ("apiKey", api_key),
+            ("accountKey", account_key)
+        ])
         payload = OrderedDict([
             ("type", "digest"),
             ("content", '<p>"98%"β</p>')
             ])
-        expected_url = url
+        expected_url = '%s?apiKey=%s&accountKey=%s' % (url, api_key, account_key)
         expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
         # populate the fake request
-        resp = requests_provider.post_as_data(url, payload)
+        resp = requests_provider.post_as_data(url, payload, params)
         # make assertions
         self.assertEqual(resp.request.url, expected_url)
         self.assertEqual(resp.request.body, expected_body)

--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -35,6 +35,7 @@ class workflow_IngestDecisionLetter(Workflow):
                     define_workflow_step("PingWorker", data),
                     define_workflow_step("ValidateDecisionLetterInput", data),
                     define_workflow_step("GenerateDecisionLetterJATS", data),
+                    define_workflow_step("PostDecisionLetterJATS", data),
                 ],
 
             "finish":


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/969

Blocked by a future PR to add new settings before this PR can be merged.

The simple story about this new activity is 
- it will download the decision letter JATS XML from a bucket, the object's location is already saved in a workflow's session data,
- it extracts a DOI from the XML,
- it issues a `POST` to an endpoint
- it sends success or error emails depending on the response of the `POST`

There is still some testing underway with the real endpoint, but it shouldn't alter how the logic looks as presented here.

Test coverage is fairly good, but I'm sure there's room for improvement and comments!
