### PR TITLE
Decision letter receipt

### DIFF
--- a/activity/activity_DecisionLetterReceipt.py
+++ b/activity/activity_DecisionLetterReceipt.py
@@ -1,0 +1,66 @@
+import json
+import time
+from S3utility.s3_notification_info import parse_activity_data
+from provider import email_provider
+from activity.objects import Activity
+
+
+class activity_DecisionLetterReceipt(Activity):
+    "DecisionLetterReceipt activity"
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_DecisionLetterReceipt, self).__init__(
+            settings, logger, conn, token, activity_task)
+
+        self.name = "DecisionLetterReceipt"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = ("Send email as a receipt of a successful decision letter workflow")
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        # parse data
+        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+
+        # send email
+        try:
+            self.email_receipt(real_filename)
+        except:
+            self.logger.exception(
+                "Exception raised sending email in %s for file %s." %
+                (self.name, real_filename))
+            return self.ACTIVITY_TEMPORARY_FAILURE
+
+        return self.ACTIVITY_SUCCESS
+
+    def email_receipt(self, filename):
+        "send an email receipt"
+        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
+        body = email_provider.simple_email_body(datetime_string)
+        subject = receipt_email_subject(filename)
+        sender_email = self.settings.decision_letter_sender_email
+
+        recipient_email_list = email_provider.list_email_recipients(
+            self.settings.decision_letter_validate_error_recipient_email)
+
+        connection = email_provider.smtp_connect(self.settings, self.logger)
+        # send the emails
+        for recipient in recipient_email_list:
+            # create the email
+            email_message = email_provider.message(subject, sender_email, recipient)
+            email_provider.add_text(email_message, body)
+            # send the email
+            email_provider.smtp_send(connection, sender_email, recipient,
+                                     email_message, self.logger)
+        return True
+
+
+def receipt_email_subject(filename):
+    "email subject for a receipt email"
+    return u'Decision letter workflow completed! file: {filename}'.format(filename=filename)

--- a/register.py
+++ b/register.py
@@ -107,6 +107,7 @@ def start(settings):
     activity_names.append("PostDigestJATS")
     activity_names.append("ValidateDecisionLetterInput")
     activity_names.append("GenerateDecisionLetterJATS")
+    activity_names.append("DecisionLetterReceipt")
     activity_names.append("DepositDecisionLetterIngestAssets")
 
     for activity_name in activity_names:

--- a/tests/activity/test_activity_decision_letter_receipt.py
+++ b/tests/activity/test_activity_decision_letter_receipt.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+
+import os
+import glob
+import unittest
+from mock import patch
+from ddt import ddt, data
+import activity.activity_DecisionLetterReceipt as activity_module
+from activity.activity_DecisionLetterReceipt import (
+    activity_DecisionLetterReceipt as activity_object)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+import tests.test_data as test_case_data
+from tests.classes_mock import FakeSMTPServer
+
+
+def input_data(file_name_to_change=''):
+    activity_data = test_case_data.ingest_decision_letter_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestDecisionLetterReceipt(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, self.fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    @data(
+        {
+            "comment": 'decision letter zip file example',
+            "filename": 'elife-39122.zip',
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_email_count": 1,
+            "expected_email_subject": (
+                "Subject: Decision letter workflow completed! file: elife-39122.zip"),
+            "expected_email_from": "From: sender@example.org"
+        },
+    )
+    def test_do_activity(self, test_data, fake_email_smtp_connect):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+        # check result
+        self.assertEqual(
+            result, test_data.get("expected_result"),
+            ('failed in {comment}, got {result}, filename {filename}').format(
+                comment=test_data.get("comment"),
+                result=result,
+                filename=filename_used))
+        # check assertions on email files and contents
+        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files = glob.glob(email_files_filter)
+        if "expected_email_count" in test_data:
+            self.assertEqual(len(email_files), test_data.get("expected_email_count"))
+            # can look at the first email for the subject and sender
+            first_email_content = None
+            with open(email_files[0]) as open_file:
+                first_email_content = open_file.read()
+            if first_email_content:
+                if test_data.get("expected_email_subject"):
+                    self.assertTrue(test_data.get("expected_email_subject") in first_email_content)
+                if test_data.get("expected_email_from"):
+                    self.assertTrue(test_data.get("expected_email_from") in first_email_content)
+
+    @patch.object(activity_module.email_provider, 'simple_email_body')
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    def test_do_activity_exception(self, fake_email_smtp_connect, fake_email_body):
+        filename = 'elife-39122.zip'
+        expected_result = activity_object.ACTIVITY_TEMPORARY_FAILURE
+        expected_email_count = 0
+        expected_exception_log_message = (
+            'Exception raised sending email in DecisionLetterReceipt for file elife-39122.zip.')
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        fake_email_body.side_effect = Exception('Some exception')
+        # do the activity
+        result = self.activity.do_activity(input_data(filename))
+        # check result
+        self.assertEqual(result, expected_result)
+        # check assertions on emails
+        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files = glob.glob(email_files_filter)
+        self.assertEqual(len(email_files), expected_email_count)
+        self.assertEqual(self.fake_logger.logexception, expected_exception_log_message)

--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -37,6 +37,7 @@ class workflow_IngestDecisionLetter(Workflow):
                     define_workflow_step("GenerateDecisionLetterJATS", data),
                     define_workflow_step("DepositDecisionLetterIngestAssets", data),
                     define_workflow_step("PostDecisionLetterJATS", data),
+                    define_workflow_step("DecisionLetterReceipt", data),
                 ],
 
             "finish":


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/970

I'll consider this mildly blocked by PR https://github.com/elifesciences/elife-bot/pull/1040, so this next activity can be added to the workflow without causing a merge conflict.

Todo: 
- [x] Add this new activity to the `IngestDecisionLetter` worklfow

A very simple email sent to the recipients who would also be receiving validation error emails. The file name is in the email subject line.

The email body is currently empty, there being not much in particular I can think is required to include right now. In future maybe we can include the DOI and/or the full JATS produced for this decision letter content. I think just sending an email to denote the end of a successful workflow will be enough to get started using this new workflow.