### PR TITLE
letterparser library and pandoc version upgrade.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/elifesciences/ejp-csv-parser.git@4a458be95d4177d19d53b8e4
 git+https://github.com/elifesciences/jats-generator.git@59e64e99b657d0942c376edd14f72c8c15a67e14#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@f9c74b0503a3b776f59e551a9095838cef595cac#egg=packagepoa
 docker==4.0.2
-git+https://github.com/elifesciences/decision-letter-parser.git@d4b1f5a6b7b5ea0b4fb9949d47279d876236c261#egg=letterparser
+git+https://github.com/elifesciences/decision-letter-parser.git@f35fa4a82f0cc7d060c72edf26c96c2226e16e28#egg=letterparser
 PyYAML==4.2b2
 Wand==0.5.1
 paramiko==2.4.2

--- a/tests/activity/letterparser.cfg
+++ b/tests/activity/letterparser.cfg
@@ -8,6 +8,7 @@ video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+# docker_image populated by https://alfred.elifesciences.org/job/process/job/process-mirror-pandoc/
 docker_image: elifesciences/pandoc:2.9.1.1
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/tests/activity/letterparser.cfg
+++ b/tests/activity/letterparser.cfg
@@ -1,13 +1,13 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
-docker_image: pandoc/core:2.7
+docker_image: pandoc/core:2.9.1.1
 fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
-docker_image: elifesciences/pandoc:2.7
+docker_image: elifesciences/pandoc:2.9.1.1
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -19,13 +19,14 @@ class TestLetterParserProvider(unittest.TestCase):
     def test_letterparser_config(self):
         """test reading the letterparser config file"""
         config = letterparser_provider.letterparser_config(settings_mock)
-        self.assertEqual(config.get("docker_image"), "elifesciences/pandoc:2.7")
+        self.assertEqual(config.get("docker_image"), "elifesciences/pandoc:2.9.1.1")
 
     def test_parse_file(self):
         """test parsing docx file with pandoc which may be called via Docker"""
         # blank config will use pandoc executable if present, otherwise via Docker image default
         expected = (
-            '<p><bold>Preamble<break /></bold></p>\n'
+            '<p><bold>Preamble\n'
+            '</bold></p>\n'
             '<p>Preamble ....</p>\n'
             '<p><bold>Decision letter</bold></p>\n'
             '<p>Decision letter ....</p>\n'


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/issues/issues/5429 to use the latest `letterparser` library and upgrade the version of `pandoc` used.

Blocked by Docker hub tag `elifesciences/pandoc:2.9.1.1` to exist first, which until then, this PR may fail testing.