### PR TITLE
Fix renaming files with two file extension parts.

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -173,8 +173,12 @@ def get_videos(files):
 
 
 def file_parts(filename):
+    """
+    prefix is part before the first dot
+    extension is all the parts after the first dot
+    """
     prefix = filename.split('.')[0]
-    extension = filename.split('.')[-1]
+    extension = '.'.join(filename.split('.')[1:]).lstrip('.')
     return prefix, extension
 
 

--- a/tests/activity/test_activity_apply_version_number.py
+++ b/tests/activity/test_activity_apply_version_number.py
@@ -145,9 +145,13 @@ class MyTestCase(unittest.TestCase):
         self.assertDictEqual(result, expected)
 
     @unpack
-    @data({'file': u'elife-15224.xml', 'version': '1', 'expected': u'elife-15224-v1.xml'},
-          {'file': u'elife-15224-v1.xml', 'version': '1', 'expected': u'elife-15224-v1.xml'},
-          {'file': u'elife-15224-v1.xml', 'version': '2', 'expected': u'elife-15224-v2.xml'})
+    @data(
+        {'file': u'elife-15224.xml', 'version': '1', 'expected': u'elife-15224-v1.xml'},
+        {'file': u'elife-code1.tar.gz', 'version': '1', 'expected': u'elife-code1-v1.tar.gz'},
+        {'file': u'elife-15224-v1.xml', 'version': '1', 'expected': u'elife-15224-v1.xml'},
+        {'file': u'elife-15224-v1.xml', 'version': '2', 'expected': u'elife-15224-v2.xml'},
+        {'file': u'elife-code1-v1.tar.gz', 'version': '2', 'expected': u'elife-code1-v2.tar.gz'}
+        )
     def test_new_filename(self, file, version, expected):
         result = self.applyversionnumber.new_filename(file, version)
         self.assertEqual(result, expected)

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -312,11 +312,15 @@ class TestArticleStructure(unittest.TestCase):
         result = article_structure.is_video_file(filename)
         self.assertTrue(result)
 
-    @data(u'elife-15224-fig1-figsupp1.tif')
-    def test_file_parts(self, filename):
+    @data(
+        (u'elife-15224-fig1-figsupp1.tif', u'elife-15224-fig1-figsupp1', u'tif'),
+        (u'elife-code1.tar.gz', u'elife-code1', u'tar.gz'),
+    )
+    @unpack
+    def test_file_parts(self, filename, expected_prefix, expected_extension):
         prefix, extension = article_structure.file_parts(filename)
-        self.assertEqual(prefix, u'elife-15224-fig1-figsupp1')
-        self.assertEqual(extension, u'tif')
+        self.assertEqual(prefix, expected_prefix)
+        self.assertEqual(extension, expected_extension)
 
     def test_get_videos(self):
         files = [u'elife-13273-fig1-v1.tif', u'elife-13273-fig2-figsupp1-v1.tif', u'elife-13273-fig2-figsupp2-v1.tif', u'elife-13273-fig2-figsupp3-v1.tif', u'elife-13273-fig2-v1.tif', u'elife-13273-fig3-data1-v1.xlsx', u'elife-13273-fig3-figsupp1-v1.tif', u'elife-13273-fig3-figsupp2-v1.tif', u'elife-13273-fig3-figsupp3-v1.tif', u'elife-13273-fig3-figsupp4-v1.tif', u'elife-13273-fig3-figsupp5-v1.tif', u'elife-13273-fig3-v1.tif', u'elife-13273-fig4-figsupp1-v1.tif', u'elife-13273-fig4-v1.tif', u'elife-13273-fig5-data1-v1.xlsx', u'elife-13273-fig5-figsupp1-v1.tif', u'elife-13273-fig5-v1.tif', u'elife-13273-fig6-data1-v1.xlsx', u'elife-13273-fig6-data2-v1.xlsx', u'elife-13273-fig6-figsupp1-v1.tif', u'elife-13273-fig6-figsupp2-v1.tif', u'elife-13273-fig6-v1.tif', u'elife-13273-fig7-v1.tif', u'elife-13273-fig8-v1.tif', u'elife-13273-fig9-v1.tif', u'elife-13273-figures-v1.pdf', u'elife-13273-media1.mp4', u'elife-13273-v1.pdf', u'elife-13273-v1.xml']


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/issues/issues/5453

A file with name like `elife-00666-code1.tar.gz` when renamed by the `ApplyVersionNumber` activity it drops the `tar` portion of the file extension.

This retains all the dotted parts of the file extension as well as satisfies existing test cases.

I will self-merge this PR if green.