### PR TITLE
Letter parser only 1 article is enough to be valid.

### DIFF
--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -13,16 +13,16 @@ IDENTITY = "process_%s" % os.getpid()
 LOGGER = log.logger("letterparser_provider.log", 'INFO', IDENTITY, loggerName=__name__)
 
 
-ARTICLES_MIN_COUNT = 2
+ARTICLES_MIN_COUNT = 1
 
 ARTICLE_TITLE_MAP = [
     OrderedDict([
         ('snippet', 'decision letter'),
-        ('min_count', 1)
+        ('min_count', 0)
     ]),
     OrderedDict([
         ('snippet', 'author response'),
-        ('min_count', 1)
+        ('min_count', 0)
     ])
 ]
 

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -75,11 +75,11 @@ class TestValidateArticles(unittest.TestCase):
         self.assertTrue(len(error_messages) > 0)
 
     def test_validate_articles_count(self):
-        """test one article which is not enough"""
-        articles = [Article()]
+        """test one article which is enough"""
+        articles = [Article('10.7554/eLife.99999.sa1')]
         valid, error_messages = letterparser_provider.validate_articles(articles)
-        self.assertFalse(valid)
-        self.assertTrue(len(error_messages) > 0)
+        self.assertTrue(valid)
+        self.assertTrue(len(error_messages) == 0)
 
     def test_validate_articles_doi(self):
         """test article missing a DOI"""
@@ -92,8 +92,8 @@ class TestValidateArticles(unittest.TestCase):
         """test two articles without titles"""
         articles = [Article('10.7554/eLife.99999.sa1'), Article('10.7554/eLife.99999.sa2')]
         valid, error_messages = letterparser_provider.validate_articles(articles)
-        self.assertFalse(valid)
-        self.assertTrue(len(error_messages) > 0)
+        self.assertTrue(valid)
+        self.assertTrue(len(error_messages) == 0)
 
 
 class TestProcessZip(unittest.TestCase):


### PR DESCRIPTION
Re comment on issue https://github.com/elifesciences/issues/issues/5428

Relax the rules around how many decision letter aritcles are required to be valid, we will allow just one article as enough, for situations where there is only a Decision Letter and no Author Response.