### PR TITLE
Content-Type header in requests provider POST.

### DIFF
--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -126,9 +126,10 @@ class activity_PostDecisionLetterJATS(Activity):
             'decision', doi, jats_content,
             self.settings.typesetter_decision_letter_api_key,
             self.settings.typesetter_decision_letter_account_key)
+        content_type = 'application/xml'
         if payload:
             requests_provider.post_to_endpoint(
-                url, payload, self.logger, 'decision letter JATS', params=params)
+                url, payload, self.logger, 'decision letter JATS', params=params, content_type=content_type)
 
     def send_email(self, doi, jats_content):
         """send an email after JATS is posted to endpoint"""

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -136,9 +136,10 @@ class activity_PostDigestJATS(Activity):
             'digest', doi, jats_content,
             self.settings.typesetter_digest_api_key,
             self.settings.typesetter_digest_account_key)
+        content_type = 'application/xml'
         if payload:
             requests_provider.post_to_endpoint(
-                url, payload, self.logger, 'digest JATS', params=params)
+                url, payload, self.logger, 'digest JATS', params=params, content_type=content_type)
 
     def send_email(self, digest_content, jats_content):
         """send an email after digest JATS is posted to endpoint"""

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -32,9 +32,9 @@ def post_as_params(url, payload):
     return requests.post(url, params=payload)
 
 
-def post_as_data(url, payload, params=None):
+def post_as_data(url, payload, params=None, headers=None):
     """post the payload as form data"""
-    return requests.post(url, data=payload, params=params)
+    return requests.post(url, data=payload, params=params, headers=headers)
 
 
 def post_as_json(url, payload):
@@ -42,10 +42,12 @@ def post_as_json(url, payload):
     return requests.post(url, json=payload)
 
 
-def post_to_endpoint(url, payload, logger, identifier, params=None):
+def post_to_endpoint(url, payload, logger, identifier,
+                     params=None, content_type='multipart/form-data'):
     """issue the POST"""
+    headers = {'Content-Type': content_type}
     try:
-        resp = post_as_data(url, payload, params=params)
+        resp = post_as_data(url, payload, params=params, headers=headers)
     except:
         logger.exception('Exception in post_to_endpoint')
         raise

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -80,10 +80,12 @@ class TestRequestsProviderPostAs(unittest.TestCase):
         url = 'http://localhost/'
         api_key = 'key'
         account_key = '1'
+        content_type = 'application/xml'
         params = OrderedDict([
             ("apiKey", api_key),
             ("accountKey", account_key)
         ])
+        headers = {'Content-Type': content_type}
         payload = OrderedDict([
             ("type", "digest"),
             ("content", '<p>"98%"β</p>')
@@ -91,10 +93,11 @@ class TestRequestsProviderPostAs(unittest.TestCase):
         expected_url = '%s?apiKey=%s&accountKey=%s' % (url, api_key, account_key)
         expected_body = 'type=digest&content=%3Cp%3E%2298%25%22%CE%B2%3C%2Fp%3E'
         # populate the fake request
-        resp = requests_provider.post_as_data(url, payload, params)
+        resp = requests_provider.post_as_data(url, payload, params, headers)
         # make assertions
         self.assertEqual(resp.request.url, expected_url)
         self.assertEqual(resp.request.body, expected_body)
+        self.assertEqual(resp.request.headers.get('Content-Type'), content_type)
 
     @patch('requests.adapters.HTTPAdapter.get_connection')
     def test_post_as_json(self, fake_connection):


### PR DESCRIPTION
Ability to change the `Content-Type` header of a `POST` issued by the `requests_provider.py` provider. 

Set the default value to `multipart/form-data`, however for the two activities that rely on it (which POST a digest or POST a decision letter to an endpoint) there they explicity set the value to `application/xml`, which we've agreed with the Typesetters is an acceptable value.

This change it to help the intact transmission of UTF-8 endcode characters in the data.