### PR TITLE
Also purge digest data from CDN.

### DIFF
--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -15,7 +15,11 @@ class FastlyApi:
         response.raise_for_status()
         return response
 
-KEYS = ['article/{article_id}v{version}', 'article/{article_id}/videos']
+KEYS = [
+    'article/{article_id}v{version}',
+    'article/{article_id}/videos',
+    'digest/{article_id}',
+    ]
 
 def purge(article_id, version, settings):
     responses = []

--- a/tests/provider/test_fastly_provider.py
+++ b/tests/provider/test_fastly_provider.py
@@ -20,6 +20,7 @@ class TestFastlyProvider(unittest.TestCase):
             [
                 'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/article/10627v1',
                 'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/article/10627/videos',
+                'https://api.fastly.com/service/3M35rb7puabccOLrFFxy2/purge/digest/10627',
             ]
         )
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5493

This makes it a standard thing to also purge the digest data from CDN caches at the same time it purges article data.