### PR TITLE
Starter object and refactor Ping starter

### DIFF
--- a/starter/objects.py
+++ b/starter/objects.py
@@ -64,7 +64,7 @@ class Starter():
             raise
 
 
-def get_workflow_params(workflow):
+def default_workflow_params():
 
     workflow_params = OrderedDict()
     workflow_params['workflow_id'] = None
@@ -73,10 +73,5 @@ def get_workflow_params(workflow):
     workflow_params['child_policy'] = None
     workflow_params['execution_start_to_close_timeout'] = None
     workflow_params['input'] = None
-
-    if workflow == "Ping":
-        workflow_params['workflow_id'] = "ping_%s" % int(random.random() * 10000)
-        workflow_params['workflow_name'] = "Ping"
-        workflow_params['input'] = "1"
 
     return workflow_params

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -1,5 +1,6 @@
 import random
 import json
+from collections import OrderedDict
 import boto.swf
 
 import log
@@ -61,3 +62,21 @@ class Starter():
             print(message)
             self.logger.info(message)
             raise
+
+
+def get_workflow_params(workflow):
+
+    workflow_params = OrderedDict()
+    workflow_params['workflow_id'] = None
+    workflow_params['workflow_name'] = None
+    workflow_params['workflow_version'] = None
+    workflow_params['child_policy'] = None
+    workflow_params['execution_start_to_close_timeout'] = None
+    workflow_params['input'] = None
+
+    if workflow == "Ping":
+        workflow_params['workflow_id'] = "ping_%s" % int(random.random() * 10000)
+        workflow_params['workflow_name'] = "Ping"
+        workflow_params['input'] = "1"
+
+    return workflow_params

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -1,0 +1,19 @@
+import random
+import log
+
+
+LOG_FILE = "starter.log"
+
+
+class Starter():
+
+    # Base class
+    def __init__(self, settings, logger=None):
+        self.settings = settings
+
+        # logging
+        if logger:
+            self.logger = logger
+        else:
+            identity = "starter_%s" % int(random.random() * 1000)
+            self.logger = log.logger(LOG_FILE, settings.setLevel, identity)

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -1,4 +1,6 @@
 import random
+import boto.swf
+
 import log
 
 
@@ -10,6 +12,7 @@ class Starter():
     # Base class
     def __init__(self, settings, logger=None):
         self.settings = settings
+        self.conn = None
 
         # logging
         if logger:
@@ -17,3 +20,10 @@ class Starter():
         else:
             identity = "starter_%s" % int(random.random() * 1000)
             self.logger = log.logger(LOG_FILE, settings.setLevel, identity)
+
+    def connect_to_swf(self):
+        """connect to SWF"""
+        # Simple connect
+        self.conn = boto.swf.layer1.Layer1(
+            self.settings.aws_access_key_id,
+            self.settings.aws_secret_access_key)

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -10,16 +10,21 @@ LOG_FILE = "starter.log"
 class Starter():
 
     # Base class
-    def __init__(self, settings, logger=None):
+    def __init__(self, settings=None, logger=None):
         self.settings = settings
+        self.logger = None
         self.conn = None
 
         # logging
         if logger:
             self.logger = logger
         else:
+            self.instantiate_logger()
+
+    def instantiate_logger(self):
+        if not self.logger and self.settings:
             identity = "starter_%s" % int(random.random() * 1000)
-            self.logger = log.logger(LOG_FILE, settings.setLevel, identity)
+            self.logger = log.logger(LOG_FILE, self.settings.setLevel, identity)
 
     def connect_to_swf(self):
         """connect to SWF"""

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -30,8 +30,10 @@ class starter_Ping(Starter):
                 response = self.conn.start_workflow_execution(
                     self.settings.domain, workflow_id,
                     workflow_name, workflow_version,
-                    self.settings.default_task_list, child_policy,
-                    execution_start_to_close_timeout, workflow_input)
+                    task_list=self.settings.default_task_list,
+                    child_policy=child_policy,
+                    execution_start_to_close_timeout=execution_start_to_close_timeout,
+                    input=workflow_input)
 
                 self.logger.info(
                     'got response: \n%s', json.dumps(response, sort_keys=True, indent=4))

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -1,6 +1,4 @@
-import random
-from collections import OrderedDict
-from starter.objects import Starter
+from starter.objects import Starter, get_workflow_params
 from provider import utils
 
 """
@@ -21,21 +19,14 @@ class starter_Ping(Starter):
         self.connect_to_swf()
 
         if workflow:
-            (workflow_id, workflow_name, workflow_version, child_policy,
-             execution_start_to_close_timeout, workflow_input) = self.get_workflow_params(workflow)
+            workflow_params = get_workflow_params(workflow)
 
-            # temporary workflow_params var
-            workflow_params = OrderedDict()
+            # add domain and task list
             workflow_params['domain'] = self.settings.domain
-            workflow_params['workflow_id'] = workflow_id
-            workflow_params['workflow_name'] = workflow_name
-            workflow_params['workflow_version'] = workflow_version
             workflow_params['task_list'] = self.settings.default_task_list
-            workflow_params['child_policy'] = child_policy
-            workflow_params['execution_start_to_close_timeout'] = execution_start_to_close_timeout
-            workflow_params['input'] = workflow_input
 
-            self.logger.info('Starting workflow: %s', workflow_id)
+            # start a workflow execution
+            self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
             try:
                 self.start_swf_workflow_execution(workflow_params)
             except:
@@ -43,27 +34,6 @@ class starter_Ping(Starter):
                     'Exception starting workflow execution for workflow_id %s' %
                     workflow_params.get('workflow_id'))
                 self.logger.exception(message)
-
-    def get_workflow_params(self, workflow):
-
-        workflow_id = None
-        workflow_name = None
-        workflow_version = None
-        child_policy = None
-        execution_start_to_close_timeout = None
-
-        workflow_input = None
-
-        if workflow == "Ping":
-            workflow_id = "ping_%s" % int(random.random() * 10000)
-            workflow_name = "Ping"
-            workflow_version = "1"
-            child_policy = None
-            execution_start_to_close_timeout = None
-            workflow_input = None
-
-        return (workflow_id, workflow_name, workflow_version, child_policy,
-                execution_start_to_close_timeout, workflow_input)
 
 
 if __name__ == "__main__":

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    STARTER_OBJECT = starter_Ping(SETTINGS)
+    STARTER = starter_Ping(SETTINGS)
 
-    STARTER_OBJECT.start_workflow()
+    STARTER.start_workflow()

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -1,4 +1,5 @@
-from starter.objects import Starter, get_workflow_params
+import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
@@ -12,28 +13,35 @@ class starter_Ping(Starter):
         """method for backwards compatibility"""
         self.settings = settings
         self.instantiate_logger()
-        self.start_workflow(workflow)
+        self.start_workflow()
 
-    def start_workflow(self, workflow="Ping"):
+    def start_workflow(self):
 
         self.connect_to_swf()
 
-        if workflow:
-            workflow_params = get_workflow_params(workflow)
+        workflow_params = get_workflow_params()
 
-            # add domain and task list
-            workflow_params['domain'] = self.settings.domain
-            workflow_params['task_list'] = self.settings.default_task_list
+        # add domain and task list
+        workflow_params['domain'] = self.settings.domain
+        workflow_params['task_list'] = self.settings.default_task_list
 
-            # start a workflow execution
-            self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
-            try:
-                self.start_swf_workflow_execution(workflow_params)
-            except:
-                message = (
-                    'Exception starting workflow execution for workflow_id %s' %
-                    workflow_params.get('workflow_id'))
-                self.logger.exception(message)
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
+
+
+def get_workflow_params():
+    workflow_params = default_workflow_params()
+    workflow_params['workflow_id'] = "ping_%s" % int(random.random() * 10000)
+    workflow_params['workflow_name'] = "Ping"
+    workflow_params['workflow_version'] = "1"
+    return workflow_params
 
 
 if __name__ == "__main__":

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -13,10 +13,7 @@ class starter_Ping(Starter):
 
     def start(self, workflow="Ping"):
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(
-            self.settings.aws_access_key_id,
-            self.settings.aws_secret_access_key)
+        self.connect_to_swf()
 
         if workflow:
             (workflow_id, workflow_name, workflow_version, child_policy,
@@ -24,7 +21,7 @@ class starter_Ping(Starter):
 
             self.logger.info('Starting workflow: %s', workflow_id)
             try:
-                response = conn.start_workflow_execution(
+                response = self.conn.start_workflow_execution(
                     self.settings.domain, workflow_id,
                     workflow_name, workflow_version,
                     self.settings.default_task_list, child_policy,

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -11,7 +11,13 @@ Amazon SWF Ping workflow starter
 
 class starter_Ping(Starter):
 
-    def start(self, workflow="Ping"):
+    def start(self, settings, workflow="Ping"):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(workflow)
+
+    def start_workflow(self, workflow="Ping"):
 
         self.connect_to_swf()
 
@@ -66,4 +72,4 @@ if __name__ == "__main__":
 
     STARTER_OBJECT = starter_Ping(SETTINGS)
 
-    STARTER_OBJECT.start()
+    STARTER_OBJECT.start_workflow()

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -7,7 +7,7 @@ class FakeBotoConnection:
     def __init__(self):
         self.start_called = None
 
-    def start_workflow_execution(self, *args):
+    def start_workflow_execution(self, *args, **kwargs):
         self.start_called = True
 
 

--- a/tests/starter/test_starter_ping.py
+++ b/tests/starter/test_starter_ping.py
@@ -15,14 +15,14 @@ class TestStarterPing(unittest.TestCase):
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
-        self.assertIsNone(self.starter.start())
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')
     def test_start_exception(self, fake_conn, fake_start):
         fake_conn.return_value = FakeLayer1()
         fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
-        self.assertIsNone(self.starter.start())
+        self.assertIsNone(self.starter.start_workflow())
 
 
 if __name__ == '__main__':

--- a/tests/starter/test_starter_ping.py
+++ b/tests/starter/test_starter_ping.py
@@ -1,6 +1,7 @@
 import unittest
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_Ping import starter_Ping
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
 from mock import patch
@@ -8,19 +9,20 @@ from mock import patch
 
 class TestStarterPing(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_Ping()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_Ping(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
-        self.assertIsNone(self.starter.start(settings_mock))
+        self.assertIsNone(self.starter.start())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')
     def test_start_exception(self, fake_conn, fake_start):
         fake_conn.return_value = FakeLayer1()
         fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
-        self.assertIsNone(self.starter.start(settings_mock))
+        self.assertIsNone(self.starter.start())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In regards to issue https://github.com/elifesciences/elife-bot/issues/992.

As a first attempt to refactor some of the starter logic, I selected the `Ping` workflow starter as a simple example.

To a new module, `starter/objects.py`, I created a base `Starter()` object, from which the Ping starter now inherits. The base `Starter` holds the logic for starting a workflow execution and to catch exceptions there.

In `starter_Ping.py`, I kept a method named `start()` for backwards compatibility. Other parts of the exisitng code depends on this method, which now invokes the new `start_workflow()` method anyway.

The `workflow_params` are set and collected in an `OrderedDict()` rather than having lots of separate property values floating around.

I wanted to keep the first PR on the starter refactoring to be as simple as possible, and this is it! I think this can gradually be applied to other starters and the code can be modified to account for different workflow parameters and logic in different circumstances as they are refactored.

