### PR TITLE
multipart/form-data Content-Type for decision letter POST.

### DIFF
--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -126,7 +126,7 @@ class activity_PostDecisionLetterJATS(Activity):
             'decision', doi, jats_content,
             self.settings.typesetter_decision_letter_api_key,
             self.settings.typesetter_decision_letter_account_key)
-        content_type = 'application/xml'
+        content_type = 'multipart/form-data'
         if payload:
             requests_provider.post_to_endpoint(
                 url, payload, self.logger, 'decision letter JATS', params=params, content_type=content_type)


### PR DESCRIPTION
`application/xml` Content-Type header is not working as expected, we can use `multipart/form-data` as a more appropriate value.