### PR TITLE
XML processing instructions in xmlio rewriting.

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -129,13 +129,16 @@ class activity_ApplyVersionNumber(Activity):
         local_xml_filename = path.join(self.get_tmp_dir(), xml_filename)
 
         xmlio.register_xmlns()
-        root, doctype_dict = xmlio.parse(local_xml_filename, return_doctype_dict=True)
+        root, doctype_dict, processing_instructions = xmlio.parse(
+            local_xml_filename, return_doctype_dict=True, return_processing_instructions=True)
 
         # Convert xlink href values
         total = xmlio.convert_xlink_href(root, file_name_map)
 
         # Start the file output
-        reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)
+        reparsed_string = xmlio.output(
+            root, type=None, doctype_dict=doctype_dict,
+            processing_instructions=processing_instructions)
         f = open(local_xml_filename, 'wb')
         f.write(reparsed_string)
         f.close()

--- a/activity/activity_ModifyArticleSubjects.py
+++ b/activity/activity_ModifyArticleSubjects.py
@@ -252,13 +252,16 @@ class activity_ModifyArticleSubjects(Activity):
     def rewrite_xml_file(self, article_xml_file, subject_group_type, subjects):
         xmlio.register_xmlns()
 
-        root, doctype_dict = xmlio.parse(article_xml_file, return_doctype_dict=True)
+        root, doctype_dict, processing_instructions = xmlio.parse(
+            article_xml_file, return_doctype_dict=True, return_processing_instructions=True)
 
         # Modify subject values
         total = xmlio.rewrite_subject_group(root, subjects, subject_group_type)
 
         # Start the file output
-        reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)
+        reparsed_string = xmlio.output(
+            root, type=None, doctype_dict=doctype_dict,
+            processing_instructions=processing_instructions)
         with open(article_xml_file, 'wb') as open_file:
             open_file.write(reparsed_string)
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -226,7 +226,8 @@ class activity_PublishFinalPOA(Activity):
         # Register namespaces
         xmlio.register_xmlns()
 
-        root, doctype_dict = xmlio.parse(xml_file, return_doctype_dict=True)
+        root, doctype_dict, processing_instructions = xmlio.parse(
+            xml_file, return_doctype_dict=True, return_processing_instructions=True)
 
         soup = self.article_soup(xml_file)
 
@@ -264,7 +265,9 @@ class activity_PublishFinalPOA(Activity):
 
 
         # Start the file output
-        reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)
+        reparsed_string = xmlio.output(
+            root, type=None, doctype_dict=doctype_dict,
+            processing_instructions=processing_instructions)
 
         # Remove extra whitespace here for PoA articles to clean up and one VoR file too
         reparsed_string = reparsed_string.replace(b"\n", b'').replace(b"\t", b'')

--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -78,14 +78,21 @@ def convert_xml(xml_file, file_name_map):
     # Register namespaces
     xmlio.register_xmlns()
 
-    root, doctype_dict = xmlio.parse(xml_file, return_doctype_dict=True)
+    root, doctype_dict, processing_instructions = xmlio.parse(
+        xml_file,
+        return_doctype_dict=True,
+        return_processing_instructions=True)
 
     # Convert xlink href values
     total = xmlio.convert_xlink_href(root, file_name_map)
     # TODO - compare whether all file names were converted
 
     # Start the file output
-    reparsed_string = xmlio.output(root, type=None, doctype_dict=doctype_dict)
+    reparsed_string = xmlio.output(
+        root,
+        type=None,
+        doctype_dict=doctype_dict,
+        processing_instructions=processing_instructions)
 
     f = open(xml_file, 'wb')
     f.write(reparsed_string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto==2.48.0
 Jinja2==2.10.1
 arrow==0.4.4
 requests==2.20.0
-git+https://github.com/elifesciences/elife-tools.git@ccc610adf7d658642399d49d1f5906057487606b#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@5a984b40e51ca6c42d9e2a429bdb385110fd072e#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@bdd5d40ff289e53fd7ff9ab88ab5a68b7b467064#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@e6ab6af02b24e7a12f8e7fcbef628f653160a251#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@0c43fa3c6368d25589ed58f888bd5cd95e1565a1#egg=elifepubmed

--- a/tests/provider/test_article_processing.py
+++ b/tests/provider/test_article_processing.py
@@ -65,6 +65,24 @@ class TestArticleProcessing(unittest.TestCase):
             xml_content = fp.read()
             self.assertTrue(expected_xml_contains in xml_content)
 
+    def test_convert_xml_extra_xml(self):
+        xml_file = 'tests/test_data/xml_sample_with_directive.xml'
+        file_name_map = {}
+
+        with open(xml_file, 'rb') as open_file:
+            expected = open_file.read()
+            path = self.directory.write(xml_file, expected)
+
+        xml_file_path = path
+
+        article_processing.convert_xml(
+            xml_file=xml_file_path,
+            file_name_map=file_name_map)
+
+        with open(xml_file_path, 'rb') as open_file:
+            xml_string = open_file.read()
+            self.assertEqual(xml_string, expected)
+
     def test_verify_rename_files(self):
         verified, renamed_list, not_renamed_list = article_processing.verify_rename_files(
             self.file_name_map_19405)

--- a/tests/test_data/xml_sample_with_directive.xml
+++ b/tests/test_data/xml_sample_with_directive.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN"  "JATS-archivearticle1.dtd"><?covid-19-tdm ?><article article-type="research-article" dtd-version="1.1"/>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5509

XML processing instruction data was no retained when XML is parsed, and not included in output when XML is rewritten using the `elifetools` `xmlio.py` module function.

I updated `elifetools` to support input and output of these processing instruction nodes.

Here the values are collected and added back using the `article_processing` provider. I've also now updated three activities that call `xmlio.parse()` and `xmlio.output()` to also support processing instructions.