### PR TITLE
Refactored starters which have simple console arguments

### DIFF
--- a/starter/objects.py
+++ b/starter/objects.py
@@ -64,9 +64,11 @@ class Starter():
             raise
 
 
-def default_workflow_params():
+def default_workflow_params(settings):
 
     workflow_params = OrderedDict()
+    workflow_params['domain'] = settings.domain
+    workflow_params['task_list'] = settings.default_task_list
     workflow_params['workflow_id'] = None
     workflow_params['workflow_name'] = None
     workflow_params['workflow_version'] = None

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -28,7 +28,8 @@ class Starter():
             else:
                 identity = "starter_%s" % int(random.random() * 1000)
 
-            helper.get_starter_logger(self.settings.setLevel, identity, log_file=LOG_FILE)
+            self.logger = helper.get_starter_logger(
+                self.settings.setLevel, identity, log_file=LOG_FILE)
 
     def connect_to_swf(self):
         """connect to SWF"""

--- a/starter/objects.py
+++ b/starter/objects.py
@@ -2,8 +2,7 @@ import random
 import json
 from collections import OrderedDict
 import boto.swf
-
-import log
+import starter.starter_helper as helper
 
 
 LOG_FILE = "starter.log"
@@ -12,21 +11,24 @@ LOG_FILE = "starter.log"
 class Starter():
 
     # Base class
-    def __init__(self, settings=None, logger=None):
+    def __init__(self, settings=None, logger=None, name=None):
         self.settings = settings
-        self.logger = None
+        self.name = name
+        self.logger = logger
         self.conn = None
 
         # logging
-        if logger:
-            self.logger = logger
-        else:
+        if not self.logger:
             self.instantiate_logger()
 
     def instantiate_logger(self):
         if not self.logger and self.settings:
-            identity = "starter_%s" % int(random.random() * 1000)
-            self.logger = log.logger(LOG_FILE, self.settings.setLevel, identity)
+            if self.name:
+                identity = helper.get_starter_identity(self.name)
+            else:
+                identity = "starter_%s" % int(random.random() * 1000)
+
+            helper.get_starter_logger(self.settings.setLevel, identity, log_file=LOG_FILE)
 
     def connect_to_swf(self):
         """connect to SWF"""

--- a/starter/starter_AdminEmail.py
+++ b/starter/starter_AdminEmail.py
@@ -1,7 +1,4 @@
-import boto.swf
-import log
-import json
-import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
@@ -9,59 +6,41 @@ Amazon SWF Admin Email starter
 """
 
 
-class starter_AdminEmail():
+class starter_AdminEmail(Starter):
 
     def start(self, settings, workflow="AdminEmail"):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        #logFile = None
-        logger = log.logger(logFile, settings.setLevel, identity)
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow()
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id,
-                                      settings.aws_secret_access_key)
-        if workflow:
-            (workflow_id, workflow_name, workflow_version,
-             child_policy, execution_start_to_close_timeout,
-             input) = self.get_workflow_params(workflow)
+    def start_workflow(self):
 
-            logger.info('Starting workflow: %s' % workflow_id)
-            try:
-                response = conn.start_workflow_execution(settings.domain, workflow_id,
-                                                         workflow_name, workflow_version,
-                                                         settings.default_task_list, child_policy,
-                                                         execution_start_to_close_timeout, input)
+        self.connect_to_swf()
 
-                logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
+        workflow_params = get_workflow_params()
 
-            except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-                # There is already a running workflow with that ID, cannot start another
-                message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                           'a running workflow with ID %s' % workflow_id)
-                print(message)
-                logger.info(message)
+        # add domain and task list
+        workflow_params['domain'] = self.settings.domain
+        workflow_params['task_list'] = self.settings.default_task_list
 
-    def get_workflow_params(self, workflow):
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
-        workflow_id = None
-        workflow_name = None
-        workflow_version = None
-        child_policy = None
-        execution_start_to_close_timeout = None
 
-        input = None
-
-        if workflow == "AdminEmail":
-            workflow_id = "AdminEmail"
-            workflow_name = "AdminEmail"
-            workflow_version = "1"
-            child_policy = None
-            execution_start_to_close_timeout = None
-            input = None
-
-        return (workflow_id, workflow_name, workflow_version, child_policy,
-                execution_start_to_close_timeout, input)
+def get_workflow_params():
+    workflow_params = default_workflow_params()
+    workflow_params['workflow_id'] = "AdminEmail"
+    workflow_params['workflow_name'] = "AdminEmail"
+    workflow_params['workflow_version'] = "1"
+    return workflow_params
 
 
 if __name__ == "__main__":
@@ -69,6 +48,6 @@ if __name__ == "__main__":
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    o = starter_AdminEmail()
+    STARTER = starter_AdminEmail(SETTINGS)
 
-    o.start(settings=SETTINGS)
+    STARTER.start_workflow()

--- a/starter/starter_AdminEmail.py
+++ b/starter/starter_AdminEmail.py
@@ -8,6 +8,13 @@ Amazon SWF Admin Email starter
 
 class starter_AdminEmail(Starter):
 
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "AdminEmail"
+        workflow_params['workflow_name'] = "AdminEmail"
+        workflow_params['workflow_version'] = "1"
+        return workflow_params
+
     def start(self, settings, workflow="AdminEmail"):
         """method for backwards compatibility"""
         self.settings = settings
@@ -18,11 +25,7 @@ class starter_AdminEmail(Starter):
 
         self.connect_to_swf()
 
-        workflow_params = get_workflow_params()
-
-        # add domain and task list
-        workflow_params['domain'] = self.settings.domain
-        workflow_params['task_list'] = self.settings.default_task_list
+        workflow_params = self.get_workflow_params()
 
         # start a workflow execution
         self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
@@ -33,14 +36,6 @@ class starter_AdminEmail(Starter):
                 'Exception starting workflow execution for workflow_id %s' %
                 workflow_params.get('workflow_id'))
             self.logger.exception(message)
-
-
-def get_workflow_params():
-    workflow_params = default_workflow_params()
-    workflow_params['workflow_id'] = "AdminEmail"
-    workflow_params['workflow_name'] = "AdminEmail"
-    workflow_params['workflow_version'] = "1"
-    return workflow_params
 
 
 if __name__ == "__main__":

--- a/starter/starter_DepositCrossref.py
+++ b/starter/starter_DepositCrossref.py
@@ -1,7 +1,4 @@
-import boto.swf
-import log
-import json
-import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
@@ -9,46 +6,43 @@ Amazon SWF DepositCrossref starter
 """
 
 
-class starter_DepositCrossref():
+class starter_DepositCrossref(Starter):
+
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "DepositCrossref"
+        workflow_params['workflow_name'] = "DepositCrossref"
+        workflow_params['workflow_version'] = "1"
+        return workflow_params
 
     def start(self, settings):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        #logFile = None
-        logger = log.logger(logFile, settings.setLevel, identity)
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow()
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def start_workflow(self):
 
-        # Start a workflow execution
-        workflow_id = "DepositCrossref"
-        workflow_name = "DepositCrossref"
-        workflow_version = "1"
-        child_policy = None
-        execution_start_to_close_timeout = None
-        input = None
+        self.connect_to_swf()
 
+        workflow_params = self.get_workflow_params()
+
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name,
-                                                     workflow_version, settings.default_task_list,
-                                                     child_policy, execution_start_to_close_timeout,
-                                                     input)
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
-            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                       'a running workflow with ID %s' % workflow_id)
-            print(message)
-            logger.info(message)
 
 if __name__ == "__main__":
 
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    o = starter_DepositCrossref()
+    STARTER = starter_DepositCrossref(SETTINGS)
 
-    o.start(settings=SETTINGS)
+    STARTER.start_workflow()

--- a/starter/starter_DepositCrossrefPeerReview.py
+++ b/starter/starter_DepositCrossrefPeerReview.py
@@ -1,43 +1,37 @@
-import boto.swf
-import log
-import json
-import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 
-class starter_DepositCrossrefPeerReview():
+class starter_DepositCrossrefPeerReview(Starter):
+
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "DepositCrossrefPeerReview"
+        workflow_params['workflow_name'] = "DepositCrossrefPeerReview"
+        workflow_params['workflow_version'] = "1"
+        return workflow_params
 
     def start(self, settings):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        logger = log.logger(logFile, settings.setLevel, identity)
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow()
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def start_workflow(self):
 
-        # Start a workflow execution
-        workflow_id = "DepositCrossrefPeerReview"
-        workflow_name = "DepositCrossrefPeerReview"
-        workflow_version = "1"
-        child_policy = None
-        execution_start_to_close_timeout = None
-        input = None
+        self.connect_to_swf()
 
+        workflow_params = self.get_workflow_params()
+
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name,
-                                                     workflow_version, settings.default_task_list,
-                                                     child_policy, execution_start_to_close_timeout,
-                                                     input)
-
-            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                       'a running workflow with ID %s' % workflow_id)
-            print(message)
-            logger.info(message)
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
 
 if __name__ == "__main__":
@@ -45,6 +39,6 @@ if __name__ == "__main__":
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    o = starter_DepositCrossrefPeerReview()
+    STARTER = starter_DepositCrossrefPeerReview(SETTINGS)
 
-    o.start(settings=SETTINGS)
+    STARTER.start_workflow()

--- a/starter/starter_IngestDecisionLetter.py
+++ b/starter/starter_IngestDecisionLetter.py
@@ -58,8 +58,3 @@ class starter_IngestDecisionLetter(Starter):
                 'Exception starting workflow execution for workflow_id %s' %
                 workflow_params.get('workflow_id'))
             self.logger.exception(message)
-
-
-if __name__ == "__main__":
-    # note: this starter must be started by an S3Notification and not directly from command line
-    pass

--- a/starter/starter_IngestDecisionLetter.py
+++ b/starter/starter_IngestDecisionLetter.py
@@ -1,64 +1,65 @@
-import boto.swf
 import json
 from provider import utils
 from S3utility.s3_notification_info import S3NotificationInfo
+from starter.objects import Starter, default_workflow_params
 import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
 
 
-class starter_IngestDecisionLetter():
-    def __init__(self):
+class starter_IngestDecisionLetter(Starter):
+
+    def __init__(self, settings=None, logger=None):
+        super(starter_IngestDecisionLetter, self).__init__(
+            settings, logger)
         self.const_name = "IngestDecisionLetter"
+        # logging
+        if not self.logger:
+            self.logger = helper.get_starter_logger(
+                self.settings.setLevel, helper.get_starter_identity(self.const_name))
+
+    def get_workflow_params(self, run, info):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "%s_%s" % (self.const_name,
+                                                    info.file_name.replace('/', '_'))
+        workflow_params['workflow_name'] = self.const_name
+        workflow_params['workflow_version'] = "1"
+        workflow_params['execution_start_to_close_timeout'] = str(60 * 15)
+
+        input_data = S3NotificationInfo.to_dict(info)
+        input_data['run'] = run
+        workflow_params['input'] = json.dumps(input_data, default=lambda ob: None)
+
+        return workflow_params
 
     def start(self, settings, run, info):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(run, info)
 
-        # Log
-        logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
+    def start_workflow(self, run, info):
 
         if hasattr(info, 'file_name') is False or info.file_name is None:
             raise NullRequiredDataException("filename is Null. Did not get a filename.")
 
-        input_data = S3NotificationInfo.to_dict(info)
-        input_data['run'] = run
+        self.connect_to_swf()
 
-        workflow_id, \
-        workflow_name, \
-        workflow_version, \
-        child_policy, \
-        execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, input_data,
-                                                         info.file_name.replace('/', '_'),
-                                                         start_to_close_timeout=str(60 * 15))
+        workflow_params = self.get_workflow_params(run, info)
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
-
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name, workflow_version,
-                                                     settings.default_task_list, child_policy,
-                                                     execution_start_to_close_timeout, workflow_input)
-
-            logger.info('got response: \n%s', json.dumps(response, sort_keys=True, indent=4))
-
+            self.start_swf_workflow_execution(workflow_params)
         except NullRequiredDataException as null_exception:
-            logger.exception(null_exception.message)
+            self.logger.exception(null_exception.message)
             raise
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = 'SWFWorkflowExecutionAlreadyStartedError: ' \
-                      'There is already a running workflow with ID %s' % workflow_id
-            logger.info(message)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
 
 if __name__ == "__main__":
-
-    ENV = utils.console_start_env()
-    SETTINGS = utils.get_settings(ENV)
-
-    STARTER_OBJECT = starter_IngestIngestDecisionLetter()
-
     # note: this starter must be started by an S3Notification and not directly from command line
-    RUN = None
-    INFO = None
-    STARTER_OBJECT.start(settings=SETTINGS, run=RUN, info=INFO)
+    pass

--- a/starter/starter_IngestDecisionLetter.py
+++ b/starter/starter_IngestDecisionLetter.py
@@ -1,8 +1,6 @@
 import json
-from provider import utils
 from S3utility.s3_notification_info import S3NotificationInfo
 from starter.objects import Starter, default_workflow_params
-import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
 
 
@@ -10,18 +8,13 @@ class starter_IngestDecisionLetter(Starter):
 
     def __init__(self, settings=None, logger=None):
         super(starter_IngestDecisionLetter, self).__init__(
-            settings, logger)
-        self.const_name = "IngestDecisionLetter"
-        # logging
-        if not self.logger:
-            self.logger = helper.get_starter_logger(
-                self.settings.setLevel, helper.get_starter_identity(self.const_name))
+            settings, logger, "IngestDecisionLetter")
 
     def get_workflow_params(self, run, info):
         workflow_params = default_workflow_params(self.settings)
-        workflow_params['workflow_id'] = "%s_%s" % (self.const_name,
+        workflow_params['workflow_id'] = "%s_%s" % (self.name,
                                                     info.file_name.replace('/', '_'))
-        workflow_params['workflow_name'] = self.const_name
+        workflow_params['workflow_name'] = self.name
         workflow_params['workflow_version'] = "1"
         workflow_params['execution_start_to_close_timeout'] = str(60 * 15)
 

--- a/starter/starter_IngestDigest.py
+++ b/starter/starter_IngestDigest.py
@@ -1,31 +1,20 @@
 import json
-from provider import utils
 from S3utility.s3_notification_info import S3NotificationInfo
 from starter.objects import Starter, default_workflow_params
-import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
-
-"""
-Amazon SWF IngestDigest starter
-"""
 
 
 class starter_IngestDigest(Starter):
 
     def __init__(self, settings=None, logger=None):
         super(starter_IngestDigest, self).__init__(
-            settings, logger)
-        self.const_name = "IngestDigest"
-        # logging
-        if not self.logger:
-            self.logger = helper.get_starter_logger(
-                self.settings.setLevel, helper.get_starter_identity(self.const_name))
+            settings, logger, "IngestDigest")
 
     def get_workflow_params(self, run, info):
         workflow_params = default_workflow_params(self.settings)
-        workflow_params['workflow_id'] = "%s_%s" % (self.const_name,
+        workflow_params['workflow_id'] = "%s_%s" % (self.name,
                                                     info.file_name.replace('/', '_'))
-        workflow_params['workflow_name'] = self.const_name
+        workflow_params['workflow_name'] = self.name
         workflow_params['workflow_version'] = "1"
         workflow_params['execution_start_to_close_timeout'] = str(60 * 15)
 

--- a/starter/starter_IngestDigest.py
+++ b/starter/starter_IngestDigest.py
@@ -62,8 +62,3 @@ class starter_IngestDigest(Starter):
                 'Exception starting workflow execution for workflow_id %s' %
                 workflow_params.get('workflow_id'))
             self.logger.exception(message)
-
-
-if __name__ == "__main__":
-    # note: this starter must be started by an S3Notification and not directly from command line
-    pass

--- a/starter/starter_Ping.py
+++ b/starter/starter_Ping.py
@@ -9,6 +9,13 @@ Amazon SWF Ping workflow starter
 
 class starter_Ping(Starter):
 
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "ping_%s" % int(random.random() * 10000)
+        workflow_params['workflow_name'] = "Ping"
+        workflow_params['workflow_version'] = "1"
+        return workflow_params
+
     def start(self, settings, workflow="Ping"):
         """method for backwards compatibility"""
         self.settings = settings
@@ -19,11 +26,7 @@ class starter_Ping(Starter):
 
         self.connect_to_swf()
 
-        workflow_params = get_workflow_params()
-
-        # add domain and task list
-        workflow_params['domain'] = self.settings.domain
-        workflow_params['task_list'] = self.settings.default_task_list
+        workflow_params = self.get_workflow_params()
 
         # start a workflow execution
         self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
@@ -34,14 +37,6 @@ class starter_Ping(Starter):
                 'Exception starting workflow execution for workflow_id %s' %
                 workflow_params.get('workflow_id'))
             self.logger.exception(message)
-
-
-def get_workflow_params():
-    workflow_params = default_workflow_params()
-    workflow_params['workflow_id'] = "ping_%s" % int(random.random() * 10000)
-    workflow_params['workflow_name'] = "Ping"
-    workflow_params['workflow_version'] = "1"
-    return workflow_params
 
 
 if __name__ == "__main__":

--- a/starter/starter_PublishPOA.py
+++ b/starter/starter_PublishPOA.py
@@ -1,7 +1,4 @@
-import boto.swf
-import log
-import json
-import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
@@ -9,45 +6,44 @@ Amazon SWF PublishPOA starter
 """
 
 
-class starter_PublishPOA():
+class starter_PublishPOA(Starter):
+
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "PublishPOA"
+        workflow_params['workflow_name'] = "PublishPOA"
+        workflow_params['workflow_version'] = "1"
+        workflow_params['execution_start_to_close_timeout'] = str(60 * 35)
+        return workflow_params
 
     def start(self, settings):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        logger = log.logger(logFile, settings.setLevel, identity)
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow()
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def start_workflow(self):
 
-        # Start a workflow execution
-        workflow_id = "PublishPOA"
-        workflow_name = "PublishPOA"
-        workflow_version = "1"
-        child_policy = None
-        execution_start_to_close_timeout = str(60 * 35)
-        input = None
+        self.connect_to_swf()
 
+        workflow_params = self.get_workflow_params()
+
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id,
-                                                     workflow_name, workflow_version,
-                                                     settings.default_task_list, child_policy,
-                                                     execution_start_to_close_timeout, input)
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
-            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                       'a running workflow with ID %s' % workflow_id)
-            print(message)
-            logger.info(message)
 
 if __name__ == "__main__":
 
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    o = starter_PublishPOA()
+    STARTER = starter_PublishPOA(SETTINGS)
 
-    o.start(settings=SETTINGS)
+    STARTER.start_workflow()

--- a/starter/starter_PubmedArticleDeposit.py
+++ b/starter/starter_PubmedArticleDeposit.py
@@ -1,7 +1,4 @@
-import boto.swf
-import log
-import json
-import random
+from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
@@ -9,46 +6,43 @@ Amazon SWF PubmedArticleDeposit starter
 """
 
 
-class starter_PubmedArticleDeposit():
+class starter_PubmedArticleDeposit(Starter):
+
+    def get_workflow_params(self):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params['workflow_id'] = "PubmedArticleDeposit"
+        workflow_params['workflow_name'] = "PubmedArticleDeposit"
+        workflow_params['workflow_version'] = "1"
+        return workflow_params
 
     def start(self, settings):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        logger = log.logger(logFile, settings.setLevel, identity)
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow()
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def start_workflow(self):
 
-        # Start a workflow execution
-        workflow_id = "PubmedArticleDeposit"
-        workflow_name = "PubmedArticleDeposit"
-        workflow_version = "1"
-        child_policy = None
-        execution_start_to_close_timeout = None
-        input = None
+        self.connect_to_swf()
 
+        workflow_params = self.get_workflow_params()
+
+        # start a workflow execution
+        self.logger.info('Starting workflow: %s', workflow_params.get('workflow_id'))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name,
-                                                     workflow_version, settings.default_task_list,
-                                                     child_policy,
-                                                     execution_start_to_close_timeout,
-                                                     input)
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                'Exception starting workflow execution for workflow_id %s' %
+                workflow_params.get('workflow_id'))
+            self.logger.exception(message)
 
-            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                       'a running workflow with ID %s' % workflow_id)
-            print(message)
-            logger.info(message)
 
 if __name__ == "__main__":
 
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
 
-    o = starter_PubmedArticleDeposit()
+    STARTER = starter_PubmedArticleDeposit(SETTINGS)
 
-    o.start(settings=SETTINGS)
+    STARTER.start_workflow()

--- a/tests/starter/test_starter_admin_email.py
+++ b/tests/starter/test_starter_admin_email.py
@@ -1,6 +1,7 @@
 import unittest
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_AdminEmail import starter_AdminEmail
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
 from mock import patch
@@ -8,19 +9,25 @@ from mock import patch
 
 class TestStarterAdminEmail(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_AdminEmail()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_AdminEmail(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
 
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
+
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')
     def test_start_exception(self, fake_conn, fake_start):
         fake_conn.return_value = FakeLayer1()
         fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
-        self.assertIsNone(self.starter.start(settings_mock))
+        self.assertIsNone(self.starter.start_workflow())
 
 
 if __name__ == '__main__':

--- a/tests/starter/test_starter_deposit_crossref.py
+++ b/tests/starter/test_starter_deposit_crossref.py
@@ -1,19 +1,26 @@
 import unittest
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_DepositCrossref import starter_DepositCrossref
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterDepositCrossref(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_DepositCrossref()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_DepositCrossref(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')

--- a/tests/starter/test_starter_deposit_crossref_peer_review.py
+++ b/tests/starter/test_starter_deposit_crossref_peer_review.py
@@ -1,19 +1,26 @@
 import unittest
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_DepositCrossrefPeerReview import starter_DepositCrossrefPeerReview
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterDepositCrossrefPeerReview(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_DepositCrossrefPeerReview()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_DepositCrossrefPeerReview(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')

--- a/tests/starter/test_starter_ingest_decision_letter.py
+++ b/tests/starter/test_starter_ingest_decision_letter.py
@@ -1,28 +1,40 @@
 import unittest
+from mock import patch
 from starter.starter_IngestDecisionLetter import starter_IngestDecisionLetter
 from starter.starter_helper import NullRequiredDataException
 from S3utility.s3_notification_info import S3NotificationInfo
+from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from mock import patch
 from tests.classes_mock import FakeBotoConnection
 
-run_example = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
+RUN_EXAMPLE = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
 
 class TestStarterIngestDecisionLetter(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_IngestDecisionLetter()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_IngestDecisionLetter(settings_mock, logger=self.fake_logger)
 
     def test_ingest_decision_letter_starter_no_article(self):
         self.assertRaises(NullRequiredDataException, self.starter.start,
-                          settings=settings_mock, run=run_example, info=test_data.data_error_lax)
+                          settings=settings_mock, run=RUN_EXAMPLE, info=test_data.data_error_lax)
 
-    @patch('starter.starter_helper.get_starter_logger')
     @patch('boto.swf.layer1.Layer1')
-    def test_ingest_decision_letter_starter(self, fake_boto_conn, fake_logger):
+    def test_ingest_decision_letter_starter(self, fake_boto_conn):
         fake_boto_conn.return_value = FakeBotoConnection()
-        self.starter.start(settings=settings_mock, run=run_example,
-                           info=S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data))
+        self.assertIsNone(self.starter.start(
+            settings=settings_mock,
+            run=RUN_EXAMPLE,
+            info=S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data)))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(self.starter.start_workflow(
+            run=RUN_EXAMPLE,
+            info=S3NotificationInfo.from_dict(test_data.ingest_digest_data)))
 
 
 if __name__ == '__main__':

--- a/tests/starter/test_starter_ingest_digest.py
+++ b/tests/starter/test_starter_ingest_digest.py
@@ -1,28 +1,40 @@
 import unittest
+from mock import patch
 from starter.starter_IngestDigest import starter_IngestDigest
 from starter.starter_helper import NullRequiredDataException
 from S3utility.s3_notification_info import S3NotificationInfo
+from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from mock import patch
 from tests.classes_mock import FakeBotoConnection
 
-run_example = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
+RUN_EXAMPLE = u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda'
+
 
 class TestStarterIngestDigest(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_IngestDigest()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_IngestDigest(settings_mock, logger=self.fake_logger)
 
     def test_ingest_digest_starter_no_article(self):
         self.assertRaises(NullRequiredDataException, self.starter.start,
-                          settings=settings_mock, run=run_example, info=test_data.data_error_lax)
+                          settings=settings_mock, run=RUN_EXAMPLE, info=test_data.data_error_lax)
 
-    @patch('starter.starter_helper.get_starter_logger')
     @patch('boto.swf.layer1.Layer1')
-    def test_ingest_digest_starter(self, fake_boto_conn, fake_logger):
+    def test_ingest_digest_starter(self, fake_boto_conn):
         fake_boto_conn.return_value = FakeBotoConnection()
-        self.starter.start(settings=settings_mock, run=run_example,
-                           info=S3NotificationInfo.from_dict(test_data.ingest_digest_data))
+        self.assertIsNone(self.starter.start(
+            settings=settings_mock,
+            run=RUN_EXAMPLE,
+            info=S3NotificationInfo.from_dict(test_data.ingest_digest_data)))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(self.starter.start_workflow(
+            run=RUN_EXAMPLE,
+            info=S3NotificationInfo.from_dict(test_data.ingest_digest_data)))
 
 
 if __name__ == '__main__':

--- a/tests/starter/test_starter_ping.py
+++ b/tests/starter/test_starter_ping.py
@@ -15,6 +15,11 @@ class TestStarterPing(unittest.TestCase):
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')

--- a/tests/starter/test_starter_publication_email.py
+++ b/tests/starter/test_starter_publication_email.py
@@ -1,19 +1,26 @@
 import unittest
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_PublicationEmail import starter_PublicationEmail
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterPublicationEmail(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_PublicationEmail()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_PublicationEmail(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')

--- a/tests/starter/test_starter_publish_poa.py
+++ b/tests/starter/test_starter_publish_poa.py
@@ -1,19 +1,26 @@
 import unittest
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_PublishPOA import starter_PublishPOA
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterPublishPOA(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_PublishPOA()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_PublishPOA(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')

--- a/tests/starter/test_starter_pubmed_article_deposit.py
+++ b/tests/starter/test_starter_pubmed_article_deposit.py
@@ -1,19 +1,26 @@
 import unittest
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_PubmedArticleDeposit import starter_PubmedArticleDeposit
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterPubmedArticleDeposit(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_PubmedArticleDeposit()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_PubmedArticleDeposit(settings_mock, logger=self.fake_logger)
 
     @patch('boto.swf.layer1.Layer1')
     def test_start(self, fake_conn):
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock))
+
+    @patch('boto.swf.layer1.Layer1')
+    def test_start_workflow(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.assertIsNone(self.starter.start_workflow())
 
     @patch.object(FakeLayer1, 'start_workflow_execution')
     @patch('boto.swf.layer1.Layer1')


### PR DESCRIPTION
Continuing issue https://github.com/elifesciences/elife-bot/issues/992

Refactored `default_workflow_params()` to also set the `domain` and `task_list` value.

These starters are similar because they only gather the `ENV` value from the command line arguments, or are started by an S3 notification message.

For the `PublicationEmail` starter, the `allow_duplicates` value is not used by the activity anymore, so that value in the starter data is removed.

The non-S3 notification starters are fairly simple and similarly changed.

For the S3 notification starters - `IngestDigest` and `IngestDecisionLetter`, there are a few additional features

- retained the custom logging identity value instead of using the default one by overloading `__init__()` of the object
- the `run` and `info` values are passed around for use in the input data
- `NullRequiredDataException` exception catching is kept
- the starter `"__main__"` is not functional since these only start from an S3 notification, so I removed the extra code

I tried my best to not mess up any values, the tests are passing, we can test some of these on the `continuumtest` environment before deploying it to `prod` in case something in the S3 notification ones have a bug.