### PR TITLE
Log request and response headers for a POST.

### DIFF
--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -55,17 +55,19 @@ def post_to_endpoint(url, payload, logger, identifier,
     # Check for good HTTP status code
     if resp.status_code != 200:
         response_error_message = (
-            "Error posting %s to endpoint %s: status_code: %s\nresponse: %s" %
-            (identifier, url, resp.status_code, resp.content))
+            ("Error posting %s to endpoint %s: status_code: %s\nrequest headers: %s" +
+             "\nresponse headers: %s\nresponse: %s") %
+            (identifier, url, resp.status_code, resp.request.headers, resp.headers, resp.content))
         full_error_message = (
             "%s\npayload: %s" %
             (response_error_message, payload))
         logger.error(full_error_message)
         raise HTTPError(response_error_message)
     logger.info(
-        ("Success posting %s to endpoint %s: status_code: %s\nresponse: %s" +
-         " \npayload: %s") %
-        (identifier, url, resp.status_code, resp.content, payload))
+        ("Success posting %s to endpoint %s: status_code: %s\nrequest headers: %s" +
+         "\nresponse headers: %s\nresponse: %s\npayload: %s") %
+        (identifier, url, resp.status_code, resp.request.headers,
+         resp.headers, resp.content, payload))
 
 
 def success_email_subject_doi(identity, doi):

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -184,15 +184,24 @@ def fake_clean_tmp_dir():
     tmp_dir = fake_get_tmp_dir()
     shutil.rmtree(tmp_dir)
 
+
+class FakeRequest:
+    def __init__(self):
+        self.headers = {}
+
+
 class FakeResponse:
     def __init__(self, status_code, response_json=None, text=""):
         self.status_code = status_code
         self.response_json = response_json
         self.content = None
         self.text = text
+        self.request = FakeRequest()
+        self.headers = {}
 
     def json(self):
         return self.response_json
+
 
 class FakeKey:
 

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -79,6 +79,8 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         self.assertTrue(self.activity.post_error_message.startswith(
             'POST was not successful, details: Error posting decision letter JATS to endpoint'
             ' https://typesetter/decisionLetter: status_code: 500\n'
+            'request headers: {}\n'
+            'response headers: {}\n'
             'response: None'))
 
     @patch.object(activity_module, 'get_session')

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -142,7 +142,8 @@ class TestRequestsProviderPost(unittest.TestCase):
             requests_provider.post_to_endpoint(url, payload, self.fake_logger, identifier)
         self.assertEqual(
             self.fake_logger.logerror,
-            'Error posting test to endpoint : status_code: 404\nresponse: None\npayload: {}')
+            ('Error posting test to endpoint : status_code: 404\nrequest headers: {}\n' +
+             'response headers: {}\nresponse: None\npayload: {}'))
 
     @patch('requests.post')
     def test_post_to_endpoint_exception(self, post_mock):


### PR DESCRIPTION
To assist in troubleshooting a `POST` request of decision letter content, add the request headers and response headers to the log file when issuing in the `POST`.