### PR TITLE
Decision letter POST Content-Type

### DIFF
--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -126,7 +126,7 @@ class activity_PostDecisionLetterJATS(Activity):
             'decision', doi, jats_content,
             self.settings.typesetter_decision_letter_api_key,
             self.settings.typesetter_decision_letter_account_key)
-        content_type = 'multipart/form-data'
+        content_type = 'application/x-www-form-urlencoded'
         if payload:
             requests_provider.post_to_endpoint(
                 url, payload, self.logger, 'decision letter JATS', params=params, content_type=content_type)

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -56,8 +56,9 @@ def post_to_endpoint(url, payload, logger, identifier,
     if resp.status_code != 200:
         response_error_message = (
             ("Error posting %s to endpoint %s: status_code: %s\nrequest headers: %s" +
-             "\nresponse headers: %s\nresponse: %s") %
-            (identifier, url, resp.status_code, resp.request.headers, resp.headers, resp.content))
+             "\nrequest body: %s\nresponse headers: %s\nresponse: %s") %
+            (identifier, url, resp.status_code, resp.request.headers,
+             resp.request.body, resp.headers, resp.content))
         full_error_message = (
             "%s\npayload: %s" %
             (response_error_message, payload))
@@ -65,9 +66,9 @@ def post_to_endpoint(url, payload, logger, identifier,
         raise HTTPError(response_error_message)
     logger.info(
         ("Success posting %s to endpoint %s: status_code: %s\nrequest headers: %s" +
-         "\nresponse headers: %s\nresponse: %s\npayload: %s") %
+         "\nrequest body: %s\nresponse headers: %s\nresponse: %s\npayload: %s") %
         (identifier, url, resp.status_code, resp.request.headers,
-         resp.headers, resp.content, payload))
+         resp.request.body, resp.headers, resp.content, payload))
 
 
 def success_email_subject_doi(identity, doi):

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -43,7 +43,7 @@ def post_as_json(url, payload):
 
 
 def post_to_endpoint(url, payload, logger, identifier,
-                     params=None, content_type='multipart/form-data'):
+                     params=None, content_type='application/x-www-form-urlencoded'):
     """issue the POST"""
     headers = {'Content-Type': content_type}
     try:

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -188,6 +188,7 @@ def fake_clean_tmp_dir():
 class FakeRequest:
     def __init__(self):
         self.headers = {}
+        self.body = None
 
 
 class FakeResponse:

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -80,6 +80,7 @@ class TestPostDecisionLetterJats(unittest.TestCase):
             'POST was not successful, details: Error posting decision letter JATS to endpoint'
             ' https://typesetter/decisionLetter: status_code: 500\n'
             'request headers: {}\n'
+            'request body: None\n'
             'response headers: {}\n'
             'response: None'))
 

--- a/tests/provider/test_requests_provider.py
+++ b/tests/provider/test_requests_provider.py
@@ -143,7 +143,7 @@ class TestRequestsProviderPost(unittest.TestCase):
         self.assertEqual(
             self.fake_logger.logerror,
             ('Error posting test to endpoint : status_code: 404\nrequest headers: {}\n' +
-             'response headers: {}\nresponse: None\npayload: {}'))
+             'request body: None\nresponse headers: {}\nresponse: None\npayload: {}'))
 
     @patch('requests.post')
     def test_post_to_endpoint_exception(self, post_mock):


### PR DESCRIPTION
It looks like `application/x-www-form-urlencoded` as a `Content-Type` of a `POST` is going to be a better default and value to use for decision letter data.

This value was already changed back to this for digest POST requests.

Also log the request body to the log file to see if it will illustrate the unicode character urlencode values.