### PR TITLE
Use latest letterparser, to fix xref tag rewrites.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/elifesciences/ejp-csv-parser.git@4a458be95d4177d19d53b8e4
 git+https://github.com/elifesciences/jats-generator.git@59e64e99b657d0942c376edd14f72c8c15a67e14#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@f9c74b0503a3b776f59e551a9095838cef595cac#egg=packagepoa
 docker==4.0.2
-git+https://github.com/elifesciences/decision-letter-parser.git@f889cb019e9b72b9fbf853d6e642e8690d907512#egg=letterparser
+git+https://github.com/elifesciences/decision-letter-parser.git@306294901d78ae80ca1975e51661c4734bfd9d6f#egg=letterparser
 PyYAML==4.2b2
 Wand==0.5.1
 paramiko==2.4.2


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5512

A parsing bug using the `letterparser` library for decision letter parsing, I will deploy the fix using the latest library `sha`.