### PR TITLE
Destroy image on exception in imageresize provider, plus tests.

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -9,6 +9,7 @@ def resize(format, filep, info, logger):
     try:
 
         with Image(file=filep, resolution=96) as tiff:
+            image = None
             image_format = format.get('format')
             if image_format is not None:
                 image = tiff.convert(image_format)
@@ -43,6 +44,9 @@ def resize(format, filep, info, logger):
     except Exception as e:
         message = "error resizing image %s" % info.filename
         logger.error(message, exc_info=True)
+        # free up memory
+        if image:
+            image.destroy()
         raise RuntimeError("%s (%s)" % (message, str(e)))
 
     filename = info.filename

--- a/tests/provider/test_imageresize.py
+++ b/tests/provider/test_imageresize.py
@@ -1,4 +1,6 @@
 import unittest
+from mock import patch
+import wand
 import provider.imageresize as resizer
 import provider.article_structure as article_structure
 from tests.activity.classes_mock import FakeLogger
@@ -12,17 +14,53 @@ FORMATS = {
         }}
 
 
+def image_spec_info(file_name, format_spec='Original'):
+    info = article_structure.ArticleInfo(file_name)
+    format_spec = FORMATS.get(format_spec)
+    return info, format_spec
+
+
 class TestImageresize(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_logger = FakeLogger()
 
     def test_resize(self):
         file_name = 'tests/files_source/elife-00353-fig1-v1.tif'
-        info = article_structure.ArticleInfo(file_name)
-        format_spec = FORMATS.get('Original')
+        info, format_spec = image_spec_info(file_name)
         new_file_name = None
         image_buffer = None
         expected_file_name = 'tests/files_source/elife-00353-fig1-v1.jpg'
         with open(file_name, 'rb') as open_file:
             new_file_name, image_buffer = resizer.resize(
-                format_spec, open_file, info, FakeLogger())
+                format_spec, open_file, info, self.fake_logger)
         self.assertEqual(new_file_name, expected_file_name)
         self.assertIsNotNone(image_buffer)
+
+    @patch.object(wand.image.Image, 'convert')
+    def test_resize_exception_in_convert(self, fake_convert):
+        fake_convert.side_effect = Exception('An exception')
+        file_name = 'tests/files_source/elife-00353-fig1-v1.tif'
+        info, format_spec = image_spec_info(file_name)
+
+        with self.assertRaises(RuntimeError):
+            with open(file_name, 'rb') as open_file:
+                resizer.resize(
+                    format_spec, open_file, info, self.fake_logger)
+        self.assertEqual(
+            self.fake_logger.logerror,
+            'error resizing image tests/files_source/elife-00353-fig1-v1')
+
+    @patch.object(wand.image.Image, 'save')
+    def test_resize_exception_in_save(self, fake_save):
+        fake_save.side_effect = Exception('An exception')
+        file_name = 'tests/files_source/elife-00353-fig1-v1.tif'
+        info, format_spec = image_spec_info(file_name)
+
+        with self.assertRaises(RuntimeError):
+            with open(file_name, 'rb') as open_file:
+                resizer.resize(
+                    format_spec, open_file, info, self.fake_logger)
+        self.assertEqual(
+            self.fake_logger.logerror,
+            'error resizing image tests/files_source/elife-00353-fig1-v1')


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/1067.

It looked like a good idea to call `image.destroy()` if any exception is raised when resizing an image. There could be other reasons for why image resizing fails beyond `CorruptImageError` and we do not want the in-memory image object to remain afterward.

I also expanded and refactored the tests to cover the exception code.

There's many lines of the `provider/imageresize.py` provider that are not covered in the test scenarios, but I didn't add any additional tests here. They include the logic for resizing by width, height, and all the file renaming logic. We used to use these when we resized image into multiple sizes, but right now we only reformat `.tif` to `.jpg` with no changes to the dimensions.