### PR TITLE
Declare image earlier in imageresize so always exists.

### DIFF
--- a/provider/imageresize.py
+++ b/provider/imageresize.py
@@ -6,10 +6,10 @@ from wand.image import Image
 def resize(format, filep, info, logger):
 
     image_buffer = None
+    image = None
     try:
 
         with Image(file=filep, resolution=96) as tiff:
-            image = None
             image_format = format.get('format')
             if image_format is not None:
                 image = tiff.convert(image_format)

--- a/tests/provider/test_imageresize.py
+++ b/tests/provider/test_imageresize.py
@@ -1,4 +1,5 @@
 import unittest
+import io
 from mock import patch
 import wand
 import provider.imageresize as resizer
@@ -61,6 +62,21 @@ class TestImageresize(unittest.TestCase):
             with open(file_name, 'rb') as open_file:
                 resizer.resize(
                     format_spec, open_file, info, self.fake_logger)
+        self.assertEqual(
+            self.fake_logger.logerror,
+            'error resizing image tests/files_source/elife-00353-fig1-v1')
+
+    @patch.object(wand.image.Image, 'save')
+    def test_resize_exception_bad_file(self, fake_save):
+        fake_save.side_effect = Exception('An exception')
+        file_name = 'tests/files_source/elife-00353-fig1-v1.tif'
+        info, format_spec = image_spec_info(file_name)
+        # create a bad file that wand.Image will not open
+        in_memory_file = io.BytesIO(b'junk')
+
+        with self.assertRaises(RuntimeError):
+            resizer.resize(
+                format_spec, in_memory_file, info, self.fake_logger)
         self.assertEqual(
             self.fake_logger.logerror,
             'error resizing image tests/files_source/elife-00353-fig1-v1')


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5543 where an image file conversion raised exception.

I suspected the `image` would potentially not exist in the case of certain exceptions, and it should have been declared earlier. Due to what looks like an EPS file, it results in the exception:

`UnboundLocalError: local variable 'image' referenced before assignment`

Here, declare `image` before anything really happens, it should (conceivably) always exist when  an exception is raised.