### PR TITLE
Extended checking of decision letter input zip file

### DIFF
--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -8,6 +8,7 @@ from elifetools import parseJATS as parser
 from letterparser import generate, parse, zip_lib
 from letterparser.conf import raw_config, parse_raw_config
 from letterparser.utils import manuscript_from_file_name
+from provider.article_processing import file_name_from_name
 import log
 
 
@@ -47,21 +48,24 @@ def parse_file(file_name, config):
 def check_input(file_name):
     """check the input zip file complies with the expected naming and structure"""
     error_messages = []
+    short_file_name = None
+    if file_name:
+        short_file_name = file_name_from_name(file_name)
     # check file_name exists
     if not file_name:
-        error_messages.append('File %s does not exist' % file_name)
+        error_messages.append('File %s does not exist' % short_file_name)
     # check file name
     if file_name and not file_name.endswith('.zip'):
-        error_messages.append('File %s name does not end in .zip' % file_name)
+        error_messages.append('File %s name does not end in .zip' % short_file_name)
     # check file is a valid zip
     if file_name and not zipfile.is_zipfile(file_name):
-        error_messages.append('File %s is not a valid zip file' % file_name)
+        error_messages.append('File %s is not a valid zip file' % short_file_name)
     # profile the zip using letterparser library to check for .docx file
     zip_docx_info = None
     if file_name and zipfile.is_zipfile(file_name):
         zip_docx_info, zip_asset_infos = zip_lib.profile_zip(file_name)
         if not zip_docx_info:
-            error_messages.append('Could not find .docx file in zip file %s' % file_name)
+            error_messages.append('Could not find .docx file in zip file %s' % short_file_name)
         # provide additional hint whether a docx file is in a subfolder
         with zipfile.ZipFile(file_name, 'r') as open_zipfile:
             for zipfile_info in open_zipfile.infolist():
@@ -72,12 +76,12 @@ def check_input(file_name):
                         and '/' in zipfile_file):
                     error_messages.append(
                         'Note: .docx file %s may be in a subfolder in zip file %s' %
-                        (zipfile_file, file_name))
+                        (zipfile_file, short_file_name))
     # check manuscript can be extracted from the docx file name
     if zip_docx_info and not manuscript_from_file_name(zip_docx_info.filename):
         error_messages.append(
             'Cannot get manuscript ID from %s inside %s' %
-            (zip_docx_info.filename, file_name))
+            (zip_docx_info.filename, short_file_name))
 
     return error_messages
 

--- a/tests/activity/test_activity_validate_decision_letter_input.py
+++ b/tests/activity/test_activity_validate_decision_letter_input.py
@@ -51,6 +51,7 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
             "comment": 'decision letter zip file example',
             "filename": 'elife-39122.zip',
             "expected_result": True,
+            "expected_check_input_status": True,
             "expected_unzip_status": True,
             "expected_build_status": True,
             "expected_valid_status": True,
@@ -64,16 +65,17 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
             "comment": 'file does not exist example',
             "filename": '',
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
-            "expected_unzip_status": False,
-            "expected_build_status": False,
-            "expected_valid_status": False,
-            "expected_generate_status": False,
-            "expected_output_status": False,
+            "expected_check_input_status": False,
+            "expected_unzip_status": None,
+            "expected_build_status": None,
+            "expected_valid_status": None,
+            "expected_generate_status": None,
+            "expected_output_status": None,
             "expected_email_status": True,
             "expected_email_count": 1,
             "expected_email_subject": "Error processing decision letter file: ",
             "expected_email_from": "From: sender@example.org",
-            "expected_email_body": "Unable to unzip decision letter"
+            "expected_email_body": "File None does not exist"
         },
     )
     def test_do_activity(self, test_data, fake_download_storage_context, fake_email_smtp_connect):
@@ -95,6 +97,7 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
 
         # check assertions on status values
         status_map = OrderedDict([
+            ("check_input", "expected_check_input_status"),
             ("unzip", "expected_unzip_status"),
             ("build", "expected_build_status"),
             ("valid", "expected_valid_status"),


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-bot/issues/1072

Re issue https://github.com/elifesciences/issues/issues/5559

As described in the issue, when the first activity of an `IngestDecisionLetter` workflow runs (the activity being `ValidateDecisionLetterInput`), check the zip file input more in depth and provide easier to understand error messages in the error email about any deficiencies.