### PR TITLE
Remove DecisionLetterReceipt activity from workflow.

### DIFF
--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -37,7 +37,6 @@ class workflow_IngestDecisionLetter(Workflow):
                     define_workflow_step("GenerateDecisionLetterJATS", data),
                     define_workflow_step("DepositDecisionLetterIngestAssets", data),
                     define_workflow_step("PostDecisionLetterJATS", data),
-                    define_workflow_step("DecisionLetterReceipt", data),
                 ],
 
             "finish":


### PR DESCRIPTION
There are duplicate emails sent as a result of a successfully ingested decision letter zip file, so we can skip this additional email receipt activity.