### PR TITLE
Remove sys.stderr in glencoe_check provider

### DIFF
--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -14,6 +14,7 @@ activity_VerifyGlencoe.py activity
 class ValidationException(RuntimeError):
     pass
 
+
 class activity_VerifyGlencoe(Activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_VerifyGlencoe, self).__init__(
@@ -48,40 +49,51 @@ class activity_VerifyGlencoe(Activity):
             if expanded_folder is None:
                 raise RuntimeError("No session value for expanded folder")
 
-            expanded_bucket = self.settings.publishing_buckets_prefix + self.settings.expanded_bucket
+            expanded_bucket = (
+                self.settings.publishing_buckets_prefix + self.settings.expanded_bucket)
             self.logger.info("expanded_bucket: " + expanded_bucket)
 
-            xml_filename = lax_provider.get_xml_file_name(self.settings, expanded_folder, expanded_bucket, version)
+            xml_filename = lax_provider.get_xml_file_name(
+                self.settings, expanded_folder, expanded_bucket, version)
             if xml_filename is None:
                 raise RuntimeError("No xml_filename found.")
 
-            xml_origin = "".join((self.settings.storage_provider, "://", expanded_bucket, "/", expanded_folder + '/' +
-                                  xml_filename))
+            xml_origin = "".join(
+                (self.settings.storage_provider, "://", expanded_bucket, "/",
+                 expanded_folder + '/' + xml_filename))
 
             storage = storage_context(self.settings)
             xml_content = storage.get_resource_as_string(xml_origin)
 
             if glencoe_check.has_videos(xml_content):
-                glencoe_check.validate_sources(glencoe_check.metadata(glencoe_check.check_msid(article_id), self.settings))
-                self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
-                                        "Finished Verification. Glencoe is available. Article: " + article_id)
+                glencoe_check.validate_sources(
+                    glencoe_check.metadata(glencoe_check.check_msid(article_id), self.settings))
+                self.emit_monitor_event(
+                    self.settings, article_id, version, run,
+                    self.pretty_name, "end",
+                    "Finished Verification. Glencoe is available. Article: " + article_id)
                 return True
 
-            self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "end",
-                                    "Finished Verification. No Glencoe media tags found in xml. "
-                                    "Article: " + article_id)
+            self.emit_monitor_event(
+                self.settings, article_id, version, run,
+                self.pretty_name, "end",
+                ("Finished Verification. No Glencoe media tags found in xml. "
+                 "Article: " + article_id))
             return True
         except AssertionError as err:
             self.logger.info(err)
-            self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
-                                    "Glencoe video is not available for article " + article_id + '; message: ' + str(err))
+            self.emit_monitor_event(
+                self.settings, article_id, version, run,
+                self.pretty_name, "error",
+                ("Glencoe video is not available for article " + article_id +
+                 '; message: ' + str(err)))
             time.sleep(60)
             return self.ACTIVITY_TEMPORARY_FAILURE
         except Exception as e:
             self.logger.exception(str(e))
-            self.emit_monitor_event(self.settings, article_id, version, run, self.pretty_name, "error",
-                                    "An error occurred when checking for Glencoe video. Article " +
-                                    article_id + '; message: ' + str(e))
+            self.emit_monitor_event(
+                self.settings, article_id, version, run,
+                self.pretty_name, "error",
+                ("An error occurred when checking for Glencoe video. Article " +
+                 article_id + '; message: ' + str(e)))
             return self.ACTIVITY_PERMANENT_FAILURE
-
-

--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -1,14 +1,10 @@
+import time
 import json
 from provider.execution_context import get_session
 import provider.lax_provider as lax_provider
 from provider.storage_provider import storage_context
-import time
 import provider.glencoe_check as glencoe_check
 from activity.objects import Activity
-
-"""
-activity_VerifyGlencoe.py activity
-"""
 
 
 class ValidationException(RuntimeError):
@@ -89,11 +85,11 @@ class activity_VerifyGlencoe(Activity):
                  '; message: ' + str(err)))
             time.sleep(60)
             return self.ACTIVITY_TEMPORARY_FAILURE
-        except Exception as e:
-            self.logger.exception(str(e))
+        except Exception as exception:
+            self.logger.exception(str(exception))
             self.emit_monitor_event(
                 self.settings, article_id, version, run,
                 self.pretty_name, "error",
                 ("An error occurred when checking for Glencoe video. Article " +
-                 article_id + '; message: ' + str(e)))
+                 article_id + '; message: ' + str(exception)))
             return self.ACTIVITY_PERMANENT_FAILURE

--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -62,8 +62,10 @@ class activity_VerifyGlencoe(Activity):
             xml_content = storage.get_resource_as_string(xml_origin)
 
             if glencoe_check.has_videos(xml_content):
-                glencoe_check.validate_sources(
-                    glencoe_check.metadata(glencoe_check.check_msid(article_id), self.settings))
+                gc_data = glencoe_check.metadata(
+                    glencoe_check.check_msid(article_id), self.settings)
+                self.logger.info('gc_data: %s' % json.dumps(gc_data, indent=4))
+                glencoe_check.validate_sources(gc_data)
                 self.emit_monitor_event(
                     self.settings, article_id, version, run,
                     self.pretty_name, "end",

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -31,10 +31,6 @@ glencoe_resp = {
 
 def validate_sources(gc_data):
 
-    sys.stderr.write(json.dumps(gc_data, indent=4))
-    sys.stderr.write('\n')
-    sys.stderr.flush()
-
     sources = {
         'mp4': 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"',
         'webm': 'video/webm; codecs="vp8.0, vorbis"',

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -12,6 +12,46 @@ class TestVerifyGlencoe(unittest.TestCase):
         self.logger = FakeLogger()
         self.verifyglencoe = activity_VerifyGlencoe(settings_mock, self.logger, None, None, None)
 
+    @patch('provider.glencoe_check.validate_sources')
+    @patch('provider.glencoe_check.metadata')
+    @patch('provider.glencoe_check.has_videos')
+    @patch('provider.glencoe_check.check_msid')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch('activity.activity_VerifyGlencoe.storage_context')
+    @patch('activity.activity_VerifyGlencoe.get_session')
+    @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
+    def test_do_acitvity_has_videos(
+            self, fake_emit_monitor, fake_session, fake_storage_context, fake_get_xml_file_name,
+            fake_check_msid, fake_has_videos, fake_metadata, fake_validate_sources):
+        """test for a successful result if has videos"""
+        fake_session.return_value = FakeSession(test_data.session_example)
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "anything.xml"
+        fake_check_msid.return_value = test_data.session_example.get('article_id')
+        fake_metadata.return_value = {}
+        fake_has_videos.return_value = True
+        fake_validate_sources.return_value = True
+        result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
+        self.assertTrue(result)
+
+    @patch('provider.glencoe_check.has_videos')
+    @patch('provider.glencoe_check.check_msid')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch('activity.activity_VerifyGlencoe.storage_context')
+    @patch('activity.activity_VerifyGlencoe.get_session')
+    @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
+    def test_do_acitvity_no_videos(
+            self, fake_emit_monitor, fake_session, fake_storage_context, fake_get_xml_file_name,
+            fake_check_msid, fake_has_videos):
+        """test for a successful result if article does not have videos"""
+        fake_session.return_value = FakeSession(test_data.session_example)
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = "anything.xml"
+        fake_check_msid.return_value = test_data.session_example.get('article_id')
+        fake_has_videos.return_value = False
+        result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
+        self.assertTrue(result)
+
     @patch('time.sleep')
     @patch('provider.lax_provider.get_xml_file_name')
     @patch('activity.activity_VerifyGlencoe.storage_context')

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -61,7 +61,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_emit_monitor.assert_called_with(settings_mock,
                                              test_data.session_example["article_id"],
                                              test_data.session_example["version"],
-                                             test_data.session_example["run"],
+                                             test_data.ExpandArticle_data["run"],
                                              self.verifyglencoe.pretty_name,
                                              "error",
                                              'Glencoe video is not available for article 00353; message: '
@@ -90,7 +90,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_emit_monitor.assert_called_with(settings_mock,
                                              test_data.session_example["article_id"],
                                              test_data.session_example["version"],
-                                             test_data.session_example["run"],
+                                             test_data.ExpandArticle_data["run"],
                                              self.verifyglencoe.pretty_name,
                                              "error",
                                              "An error occurred when checking for Glencoe video. Article 00353; message: "

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -17,8 +17,9 @@ class TestVerifyGlencoe(unittest.TestCase):
     @patch('activity.activity_VerifyGlencoe.get_session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
     @patch('requests.get')
-    def test_do_activity_bad_response_glencoe_404(self, request_mock, fake_emit_monitor, fake_session,
-                                                  fake_storage_context, fake_get_xml_file_name, fake_sleep):
+    def test_do_activity_bad_response_glencoe_404(
+            self, request_mock, fake_emit_monitor, fake_session,
+            fake_storage_context, fake_get_xml_file_name, fake_sleep):
         session_example = {
             'version': '1',
             'article_id': '7777777701234',
@@ -34,14 +35,15 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_get_xml_file_name.return_value = "anything.xml"
         self.verifyglencoe.logger = MagicMock()
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             session_example["article_id"],
-                                             session_example["version"],
-                                             session_example["run"],
-                                             self.verifyglencoe.pretty_name,
-                                             "error",
-                                             "Glencoe video is not available for article 7777777701234; message: "
-                                             "article has no videos - url requested: 10.7554/eLife.01234")
+        fake_emit_monitor.assert_called_with(
+            settings_mock,
+            session_example["article_id"],
+            session_example["version"],
+            session_example["run"],
+            self.verifyglencoe.pretty_name,
+            "error",
+            "Glencoe video is not available for article 7777777701234; message: "
+            "article has no videos - url requested: 10.7554/eLife.01234")
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_TEMPORARY_FAILURE)
 
     @patch('time.sleep')
@@ -50,23 +52,25 @@ class TestVerifyGlencoe(unittest.TestCase):
     @patch('activity.activity_VerifyGlencoe.get_session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
     @patch('requests.get')
-    def test_do_activity_bad_response_glencoe_500(self, request_mock, fake_emit_monitor, fake_session,
-                                                  fake_storage_context, fake_get_xml_file_name, fake_sleep):
+    def test_do_activity_bad_response_glencoe_500(
+            self, request_mock, fake_emit_monitor, fake_session,
+            fake_storage_context, fake_get_xml_file_name, fake_sleep):
         request_mock.return_value = FakeResponse(500, None)
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "anything.xml"
         self.verifyglencoe.logger = MagicMock()
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             test_data.session_example["article_id"],
-                                             test_data.session_example["version"],
-                                             test_data.ExpandArticle_data["run"],
-                                             self.verifyglencoe.pretty_name,
-                                             "error",
-                                             'Glencoe video is not available for article 00353; message: '
-                                             'unhandled status code from Glencoe: 500 - '
-                                             'url requested: 10.7554/eLife.00353')
+        fake_emit_monitor.assert_called_with(
+            settings_mock,
+            test_data.session_example["article_id"],
+            test_data.session_example["version"],
+            test_data.ExpandArticle_data["run"],
+            self.verifyglencoe.pretty_name,
+            "error",
+            'Glencoe video is not available for article 00353; message: '
+            'unhandled status code from Glencoe: 500 - '
+            'url requested: 10.7554/eLife.00353')
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_TEMPORARY_FAILURE)
 
     @patch('provider.glencoe_check.metadata')
@@ -75,8 +79,9 @@ class TestVerifyGlencoe(unittest.TestCase):
     @patch('activity.activity_VerifyGlencoe.storage_context')
     @patch('activity.activity_VerifyGlencoe.get_session')
     @patch.object(activity_VerifyGlencoe, 'emit_monitor_event')
-    def test_do_acitvity_exception(self, fake_emit_monitor, fake_session, fake_storage_context, fake_get_xml_file_name,
-                                   fake_glencoe_check_validate_sources, fake_glencoe_check_metadata):
+    def test_do_acitvity_exception(
+            self, fake_emit_monitor, fake_session, fake_storage_context, fake_get_xml_file_name,
+            fake_glencoe_check_validate_sources, fake_glencoe_check_metadata):
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "anything.xml"
@@ -87,14 +92,15 @@ class TestVerifyGlencoe(unittest.TestCase):
 
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
 
-        fake_emit_monitor.assert_called_with(settings_mock,
-                                             test_data.session_example["article_id"],
-                                             test_data.session_example["version"],
-                                             test_data.ExpandArticle_data["run"],
-                                             self.verifyglencoe.pretty_name,
-                                             "error",
-                                             "An error occurred when checking for Glencoe video. Article 00353; message: "
-                                             "Fake Time out")
+        fake_emit_monitor.assert_called_with(
+            settings_mock,
+            test_data.session_example["article_id"],
+            test_data.session_example["version"],
+            test_data.ExpandArticle_data["run"],
+            self.verifyglencoe.pretty_name,
+            "error",
+            "An error occurred when checking for Glencoe video. Article 00353; message: "
+            "Fake Time out")
 
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_PERMANENT_FAILURE)
 

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -1,7 +1,7 @@
 import unittest
+from mock import patch
 from activity.activity_VerifyGlencoe import activity_VerifyGlencoe
 import tests.activity.settings_mock as settings_mock
-from mock import patch, MagicMock
 from tests.activity.classes_mock import FakeResponse, FakeSession, FakeStorageContext, FakeLogger
 import tests.activity.test_activity_data as test_data
 
@@ -9,7 +9,8 @@ import tests.activity.test_activity_data as test_data
 class TestVerifyGlencoe(unittest.TestCase):
 
     def setUp(self):
-        self.verifyglencoe = activity_VerifyGlencoe(settings_mock, None, None, None, None)
+        self.logger = FakeLogger()
+        self.verifyglencoe = activity_VerifyGlencoe(settings_mock, self.logger, None, None, None)
 
     @patch('time.sleep')
     @patch('provider.lax_provider.get_xml_file_name')
@@ -33,7 +34,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_session.return_value = FakeSession(session_example)
         fake_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "anything.xml"
-        self.verifyglencoe.logger = MagicMock()
+
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
         fake_emit_monitor.assert_called_with(
             settings_mock,
@@ -59,7 +60,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "anything.xml"
-        self.verifyglencoe.logger = MagicMock()
+
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
         fake_emit_monitor.assert_called_with(
             settings_mock,
@@ -85,8 +86,6 @@ class TestVerifyGlencoe(unittest.TestCase):
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = "anything.xml"
-
-        self.verifyglencoe.logger = MagicMock()
 
         fake_glencoe_check_validate_sources.side_effect = Exception("Fake Time out")
 

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -33,6 +33,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         request_mock.return_value = FakeResponse(404, None)
         fake_session.return_value = FakeSession(session_example)
         fake_storage_context.return_value = FakeStorageContext()
+        fake_sleep.return_value = True
         fake_get_xml_file_name.return_value = "anything.xml"
 
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
@@ -59,6 +60,7 @@ class TestVerifyGlencoe(unittest.TestCase):
         request_mock.return_value = FakeResponse(500, None)
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
+        fake_sleep.return_value = True
         fake_get_xml_file_name.return_value = "anything.xml"
 
         result = self.verifyglencoe.do_activity(test_data.ExpandArticle_data)
@@ -85,6 +87,7 @@ class TestVerifyGlencoe(unittest.TestCase):
             fake_glencoe_check_validate_sources, fake_glencoe_check_metadata):
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
+        fake_glencoe_check_metadata.return_value = {}
         fake_get_xml_file_name.return_value = "anything.xml"
 
         fake_glencoe_check_validate_sources.side_effect = Exception("Fake Time out")

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -19,9 +19,13 @@ class TestGlencoeCheck(unittest.TestCase):
 
     def test_jpg_href_values(self):
         result = glencoe_check.jpg_href_values(glencoe_metadata)
-        self.assertCountEqual([
-            "http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media2.jpg",
-            "http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media1.jpg"],
+        self.assertCountEqual(
+            [
+                ("http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/"
+                 "1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media2.jpg"),
+                ("http://static-movie-usa.glencoesoftware.com/jpg/10.7554/114/"
+                 "1245b554bd5cbda4fa4beeba806e659f0624128e/elife-12620-media1.jpg")
+            ],
             result)
 
     def test_simple_jpg_href_values(self):
@@ -35,17 +39,31 @@ class TestGlencoeCheck(unittest.TestCase):
     def test_extend_article_for_end2end(self):
         filename = "elife-01234-media1-v1.jpg"
         article_id = "7777777701234"
-        result  = glencoe_check.force_article_id(filename, article_id)
+        result = glencoe_check.force_article_id(filename, article_id)
         self.assertEqual("elife-7777777701234-media1-v1.jpg", result)
 
     def test_has_videos(self):
         cases = [
-            ('<media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="avi" mimetype="video" xlink:href="elife-00007-media1.avi"></media>', True),
-            ('<media mimetype="video" mime-subtype="mp4" id="fig3video1" xlink:href="elife-00666-fig3-video1.mp4"></media>', True),
-            ('<media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
-            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/><media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
-            ('<media mimetype="application" mime-subtype="xlsx" xlink:href="elife-00666-video1-data1.xlsx"/>', False),
-            (b'<media mimetype="video" mime-subtype="gif" id="video2" xlink:href="elife-00666-video2.gif"></media>', True),
+            ('<media content-type="glencoe play-in-place height-250 width-310" id="media1"'
+             ' mime-subtype="avi" mimetype="video" xlink:href="elife-00007-media1.avi"></media>',
+             True),
+            ('<media mimetype="video" mime-subtype="mp4" id="fig3video1"'
+             ' xlink:href="elife-00666-fig3-video1.mp4"></media>',
+             True),
+            ('<media mimetype="video" mime-subtype="gif" id="video2"'
+             ' xlink:href="elife-00666-video2.gif"></media>',
+             True),
+            ('<media mimetype="application" mime-subtype="xlsx"'
+             ' xlink:href="elife-00666-video1-data1.xlsx"/>'
+             '<media mimetype="video" mime-subtype="gif" id="video2"'
+             ' xlink:href="elife-00666-video2.gif"></media>',
+             True),
+            ('<media mimetype="application" mime-subtype="xlsx"'
+             ' xlink:href="elife-00666-video1-data1.xlsx"/>',
+             False),
+            (b'<media mimetype="video" mime-subtype="gif" id="video2"'
+             b' xlink:href="elife-00666-video2.gif"></media>',
+             True),
         ]
         for xml_str, expected in cases:
             self.assertEqual(glencoe_check.has_videos(xml_str), expected)

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -73,8 +73,10 @@ class TestGlencoeCheckValidateSources(unittest.TestCase):
 
     def test_validate_sources_empty(self):
         gc_data = {}
-        result = glencoe_check.validate_sources(gc_data)
-        self.assertIsNone(result)
+        try:
+            glencoe_check.validate_sources(gc_data)
+        except AssertionError:
+            self.fail("Encountered an unexpected exception.")
 
     def test_validate_sources_good(self):
         """all video sources available is good, does not raise an exception"""
@@ -90,9 +92,10 @@ class TestGlencoeCheckValidateSources(unittest.TestCase):
                 'ogv_href': ''
             }
         }
-        gc_data = {}
-        result = glencoe_check.validate_sources(gc_data)
-        self.assertIsNone(result)
+        try:
+            glencoe_check.validate_sources(gc_data)
+        except AssertionError:
+            self.fail("Encountered an unexpected exception.")
 
     def test_validate_sources_bad(self):
         """not enough video sources for a video raises an exception"""

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -49,3 +49,44 @@ class TestGlencoeCheck(unittest.TestCase):
         ]
         for xml_str, expected in cases:
             self.assertEqual(glencoe_check.has_videos(xml_str), expected)
+
+
+class TestGlencoeCheckValidateSources(unittest.TestCase):
+
+    def test_validate_sources_empty(self):
+        gc_data = {}
+        result = glencoe_check.validate_sources(gc_data)
+        self.assertIsNone(result)
+
+    def test_validate_sources_good(self):
+        """all video sources available is good, does not raise an exception"""
+        gc_data = {
+            'video1': {
+                'mp4_href': '',
+                'webm_href': '',
+                'ogv_href': ''
+            },
+            'video2': {
+                'mp4_href': '',
+                'webm_href': '',
+                'ogv_href': ''
+            }
+        }
+        gc_data = {}
+        result = glencoe_check.validate_sources(gc_data)
+        self.assertIsNone(result)
+
+    def test_validate_sources_bad(self):
+        """not enough video sources for a video raises an exception"""
+        gc_data = {
+            'video1': {
+                'mp4_href': '',
+                'webm_href': '',
+                'ogv_href': ''
+            },
+            'video2': {
+                'mp4_href': '',
+            }
+        }
+        with self.assertRaises(AssertionError):
+            glencoe_check.validate_sources(gc_data)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5595

Some extra code in the `glencoe_check` provider which logs data to `sys.stderr` we do not need in that place. Logging the Glencoe data is moved to the `VerifyGlencoe` activity, the only place that calls `validate_sources()`.

The other changes here are more new test cases and code linting.

The functionality is basically the same, and should have no adverse impact. I will merge it with no code review requested if the tests are green.
