### PR TITLE
Escape chars in email headers prior to json loads.

### DIFF
--- a/provider/templates.py
+++ b/provider/templates.py
@@ -297,6 +297,8 @@ class Templates(object):
 
             jinja_env = self.get_jinja_env()
             tmpl = self.get_jinja_template(jinja_env, template_name)
+            # fix special characters in subject
+            article = article_title_char_escape(article)
             headers_str = tmpl.render(author=author, article=article)
             headers = json.loads(headers_str)
             # Add the email format as specified
@@ -383,3 +385,16 @@ def email_body(templates_object, email_type, recipient,
             logger.info(log_info)
             logger.exception(str(exception))
     return body
+
+
+def json_char_escape(string):
+    return string.replace('\\', '\\\\').replace('"', '\\"')
+
+
+def article_title_char_escape(article):
+    """escape characters in article object article_title for JSON parsing"""
+    if hasattr(article, 'article_title'):
+        article.article_title = json_char_escape(article.article_title)
+    if isinstance(article, dict) and 'article_title' in article:
+        article['article_title'] = json_char_escape(article['article_title'])
+    return article


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/4185

There were some recent changes to the `PublicationEmail` activity, and I also found the older issue above, where backslash characters caused errors when building email headers from the templates.

In this PR, I've added a specific fix to escape `\` and `"` characters in an article's `article_title` as an improvement to this. These are two known, possibly common, characters that may appear in an article title. They also proved to cause a `json.decoder.JSONDecodeError` exception when the JSON string from rendering the email header template file has a character that is not valid JSON. The character replacements fix the potential string to JSON loading problem.

Test cases are added for some specific examples.

I didn't do any linting or try to increase test coverage, which looks like a potential future task, since these files are still a little messy. I wanted to keep this PR simple and not more confusing with a bunch of linting changes.