### PR TITLE
Send PubMed deposits by SFTP not by FTP

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -7,7 +7,7 @@ from elifepubmed import generate
 from elifepubmed.conf import config, parse_raw_config
 import provider.article as articlelib
 from provider.sftp import SFTP
-from provider import email_provider, lax_provider, utils
+from provider import article_processing, email_provider, lax_provider, utils
 from provider.storage_provider import storage_context
 from activity.objects import Activity
 
@@ -251,20 +251,6 @@ class activity_PubmedArticleDeposit(Activity):
 
         return status
 
-    def get_filename_from_path(self, filename_path, extension):
-        """
-        Get a filename minus the supplied file extension
-        and without any folder or path
-        """
-        filename = filename_path.split(extension)[0]
-        # Remove path if present
-        try:
-            filename = filename.split(os.sep)[-1]
-        except:
-            pass
-
-        return filename
-
     def sftp_files_to_endpoint(self, from_dir, file_type, sub_dir=None):
         """
         Using the sftp provider module, connect to sftp server and transmit files
@@ -371,7 +357,7 @@ class activity_PubmedArticleDeposit(Activity):
         for xml_file in xml_files:
             resource_dest = (storage_provider + bucket_name + "/" +
                              s3_folder_name + "/" +
-                             self.get_filename_from_path(xml_file, '.xml') + '.xml')
+                             article_processing.file_name_from_name(xml_file))
             storage.set_resource_from_filename(resource_dest, xml_file)
 
     def send_email(self):

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -61,8 +61,7 @@ class activity_PubmedArticleDeposit(Activity):
         """
         Activity, do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         self.make_activity_directories()
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -173,6 +173,12 @@ class exp():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
+
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -447,6 +453,12 @@ class dev():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
+
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -713,6 +725,12 @@ class live():
     PUBMED_FTP_USERNAME = ""
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
+
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
 
     # PMC FTP settings
     PMC_FTP_URI = ""

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -158,6 +158,11 @@ PUBMED_FTP_USERNAME = ""
 PUBMED_FTP_PASSWORD = ""
 PUBMED_FTP_CWD = ""
 
+PUBMED_SFTP_URI = ""
+PUBMED_SFTP_USERNAME = ""
+PUBMED_SFTP_PASSWORD = ""
+PUBMED_SFTP_CWD = ""
+
 # PDF cover
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
 pdf_cover_generator = "https://localhost/personalised-covers/"

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -209,6 +209,14 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             self.activity.logger.logexception,
             'Failed to upload files by SFTP to PubMed: SFTP transfer exception')
 
+
+@ddt
+class TestPubmedParseArticleXml(unittest.TestCase):
+
+    def tearDown(self):
+        helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
+                                       filter_out=['.gitkeep'])
+
     @data(
         {
             "article_xml": 'elife-29353-v1.xml',
@@ -222,7 +230,8 @@ class TestPubmedArticleDeposit(unittest.TestCase):
     )
     def test_parse_article_xml(self, test_data):
         source_doc = "tests/files_source/pubmed/outbox/" + test_data.get('article_xml')
-        article = self.activity.parse_article_xml(source_doc)
+        article = activity_module.parse_article_xml(
+            source_doc, {}, activity_test_data.ExpandArticle_files_dest_folder)
         if test_data.get('expected_article') is None:
             self.assertEqual(article, test_data.get('expected_article'),
                              'failed comparing expected_article')


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5648

The primary reason for this PR is to send PubMed deposits by SFTP, which uses the existing `sftp` provider logic, and adds additional settings for SFTP credentials.

On editing the existing activity code and writing code tests, there were some opportunities for linting, refactoring for a few clearer function calls, and to improve test coverage for the cases where runtime exceptions may be raised.

There is potential for further refactoring, which I described in issue https://github.com/elifesciences/elife-bot/issues/1089, so as to not complicate this switch to SFTP transfers, it can be done in a later PR.

The tests for this code are all passing, and PubMed deposits are a separate, non-critical part of the workflows, so I think it will be safe to merge and deploy without code review.

If I see errors in `prod` I will fix the code and the articles will get deposited to PubMed when it is running again. I anticipate all will be well with no errors.