### PR TITLE
Revert "Send PubMed deposits by SFTP not by FTP"

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -173,12 +173,6 @@ class exp():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
-    # PubMed SFTP settings
-    PUBMED_SFTP_URI = ""
-    PUBMED_SFTP_USERNAME = ""
-    PUBMED_SFTP_PASSWORD = ""
-    PUBMED_SFTP_CWD = ""
-
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -453,12 +447,6 @@ class dev():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
-    # PubMed SFTP settings
-    PUBMED_SFTP_URI = ""
-    PUBMED_SFTP_USERNAME = ""
-    PUBMED_SFTP_PASSWORD = ""
-    PUBMED_SFTP_CWD = ""
-
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -725,12 +713,6 @@ class live():
     PUBMED_FTP_USERNAME = ""
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
-
-    # PubMed SFTP settings
-    PUBMED_SFTP_URI = ""
-    PUBMED_SFTP_USERNAME = ""
-    PUBMED_SFTP_PASSWORD = ""
-    PUBMED_SFTP_CWD = ""
 
     # PMC FTP settings
     PMC_FTP_URI = ""

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -158,11 +158,6 @@ PUBMED_FTP_USERNAME = ""
 PUBMED_FTP_PASSWORD = ""
 PUBMED_FTP_CWD = ""
 
-PUBMED_SFTP_URI = ""
-PUBMED_SFTP_USERNAME = ""
-PUBMED_SFTP_PASSWORD = ""
-PUBMED_SFTP_CWD = ""
-
 # PDF cover
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
 pdf_cover_generator = "https://localhost/personalised-covers/"

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -1,11 +1,10 @@
 import unittest
 import os
-from collections import OrderedDict
 from ddt import ddt, data
 from mock import patch
 import activity.activity_PubmedArticleDeposit as activity_module
 from activity.activity_PubmedArticleDeposit import activity_PubmedArticleDeposit
-from provider import lax_provider, sftp
+from provider import lax_provider
 from tests.classes_mock import FakeSMTPServer
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger
@@ -34,24 +33,21 @@ class TestPubmedArticleDeposit(unittest.TestCase):
     @patch.object(activity_PubmedArticleDeposit, 'clean_tmp_dir')
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch.object(lax_provider, 'article_versions')
-    @patch.object(activity_PubmedArticleDeposit, 'sftp_files_to_endpoint')
+    @patch.object(activity_PubmedArticleDeposit, 'ftp_files_to_endpoint')
     @patch('activity.activity_PubmedArticleDeposit.storage_context')
     @patch.object(FakeStorageContext, 'list_resources')
     @data(
         {
             "comment": 'example PoA file will have an aheadofprint',
             "outbox_filenames": ['elife-29353-v1.xml', 'not_an_xml_file.pdf'],
-            "sftp_files_return_value": True,
+            "ftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_ftp_status": True,
+            "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
                 (b'<ArticleTitle>An evolutionary young defense metabolite influences the root' +
@@ -66,17 +62,14 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         {
             "comment": 'example VoR file will have a Replaces tag',
             "outbox_filenames": ['elife-15747-v2.xml'],
-            "sftp_files_return_value": True,
+            "ftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_ftp_status": True,
+            "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
                 b'<Replaces IdType="doi">10.7554/eLife.15747</Replaces>',
@@ -90,49 +83,40 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         {
             "comment": 'test for if the article is published False (not published yet)',
             "outbox_filenames": ['elife-15747-v2.xml'],
-            "sftp_files_return_value": True,
+            "ftp_files_return_value": True,
             "article_versions_data": [],
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', False),
-                ('approve', False),
-                ('upload', None),
-                ('publish', None),
-                ('outbox', None),
-                ('activity', True),
-            ]),
+            "expected_approve_status": False,
+            "expected_generate_status": False,
+            "expected_publish_status": None,
+            "expected_ftp_status": None,
+            "expected_activity_status": True,
             "expected_file_count": 0
         },
         {
             "comment": 'test for if FTP status is False',
             "outbox_filenames": ['elife-15747-v2.xml'],
-            "sftp_files_return_value": False,
+            "ftp_files_return_value": False,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": activity_PubmedArticleDeposit.ACTIVITY_PERMANENT_FAILURE,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', False),
-                ('publish', False),
-                ('outbox', None),
-                ('activity', False),
-            ]),
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": False,
+            "expected_ftp_status": False,
+            "expected_activity_status": False,
             "expected_file_count": 1,
         },
         {
             "comment": 'test for if the XML file has no version it will use lax data',
             "outbox_filenames": ['elife-15747.xml'],
-            "sftp_files_return_value": True,
+            "ftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_ftp_status": True,
+            "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
                 b'<Replaces IdType="doi">10.7554/eLife.15747</Replaces>'
@@ -140,7 +124,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         },
     )
     def test_do_activity(self, test_data, fake_list_resources, fake_storage_context,
-                         fake_sftp_files_to_endpoint, fake_article_versions,
+                         fake_ftp_files_to_endpoint, fake_article_versions,
                          fake_email_smtp_connect, fake_clean_tmp_dir):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         fake_clean_tmp_dir.return_value = None
@@ -150,22 +134,20 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         # lax data overrides
         fake_article_versions.return_value = 200, test_data.get("article_versions_data")
         # ftp
-        fake_sftp_files_to_endpoint.return_value = test_data.get("sftp_files_return_value")
+        fake_ftp_files_to_endpoint.return_value = test_data.get("ftp_files_return_value")
         # do the activity
         result = self.activity.do_activity()
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"),
                          'failed in {comment}'.format(comment=test_data.get("comment")))
-        # check statuses assertions
-        for status_name in test_data.get("expected_statuses"):
-            status_value = self.activity.statuses.get(status_name)
-            expected = test_data.get("expected_statuses").get(status_name)
-            self.assertEqual(
-                status_value, expected,
-                '{expected} {status_name} status not equal to {status_value} in {comment}'.format(
-                    expected=expected, status_name=status_name, status_value=status_value,
-                    comment=test_data.get("comment")))
-
+        self.assertEqual(self.activity.approve_status, test_data.get("expected_approve_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.generate_status, test_data.get("expected_generate_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.publish_status, test_data.get("expected_publish_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(self.activity.activity_status, test_data.get("expected_activity_status"),
+                         'failed in {comment}'.format(comment=test_data.get("comment")))
         # check the outbox_s3_key_names values
         self.assertEqual(self.activity.outbox_s3_key_names,
                          [self.activity.outbox_folder + '/' + filename
@@ -189,52 +171,6 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         # clean directory after each test
         self.activity.clean_tmp_dir()
 
-    @patch.object(activity_PubmedArticleDeposit, 'sftp_files_to_endpoint')
-    @patch.object(activity_PubmedArticleDeposit, 'approve_for_publishing')
-    @patch.object(activity_PubmedArticleDeposit, 'generate_pubmed_xml')
-    @patch.object(activity_PubmedArticleDeposit, 'download_files_from_s3_outbox')
-    @patch.object(activity_PubmedArticleDeposit, 'get_outbox_s3_key_names')
-    def test_do_activity_upload_exception(self, fake_get, fake_download, fake_generate,
-                                          fake_approve, fake_sftp_files_to_endpoint):
-        fake_get.return_value = True
-        fake_download.return_value = True
-        fake_generate.return_value = True
-        fake_approve.return_value = True
-        fake_sftp_files_to_endpoint.side_effect = Exception('SFTP upload exception')
-        # do the activity
-        self.activity.do_activity()
-        # check assertions
-        self.assertIsNone(self.activity.statuses.get('upload'))
-        self.assertEqual(self.activity.logger.logexception, 'SFTP upload exception')
-
-    @patch.object(sftp.SFTP, 'sftp_connect')
-    def test_sftp_files_connection_exception(self, fake_sftp_connect):
-        fake_sftp_connect.side_effect = Exception('SFTP connect exception')
-        with self.assertRaises(Exception):
-            self.activity.sftp_files_to_endpoint('', '')
-        self.assertEqual(
-            self.activity.logger.logexception,
-            'Failed to connect to SFTP endpoint : SFTP connect exception')
-
-    @patch.object(sftp.SFTP, 'sftp_to_endpoint')
-    @patch.object(sftp.SFTP, 'sftp_connect')
-    def test_sftp_files_transfer_exception(self, fake_sftp_connect, fake_sftp_to_endpoint):
-        fake_sftp_connect.return_value = True
-        fake_sftp_to_endpoint.side_effect = Exception('SFTP transfer exception')
-        with self.assertRaises(Exception):
-            self.activity.sftp_files_to_endpoint('', '')
-        self.assertEqual(
-            self.activity.logger.logexception,
-            'Failed to upload files by SFTP to PubMed: SFTP transfer exception')
-
-
-@ddt
-class TestPubmedParseArticleXml(unittest.TestCase):
-
-    def tearDown(self):
-        helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
-                                       filter_out=['.gitkeep'])
-
     @data(
         {
             "article_xml": 'elife-29353-v1.xml',
@@ -248,8 +184,7 @@ class TestPubmedParseArticleXml(unittest.TestCase):
     )
     def test_parse_article_xml(self, test_data):
         source_doc = "tests/files_source/pubmed/outbox/" + test_data.get('article_xml')
-        article = activity_module.parse_article_xml(
-            source_doc, {}, activity_test_data.ExpandArticle_files_dest_folder)
+        article = self.activity.parse_article_xml(source_doc)
         if test_data.get('expected_article') is None:
             self.assertEqual(article, test_data.get('expected_article'),
                              'failed comparing expected_article')


### PR DESCRIPTION
Reverts elifesciences/elife-bot#1090

Due to a failed test in `end2end`, which looks like it expects PubMed to send files by FTP, I think it is good to revert the change in the code to continuing using FTP for PubMed deposits until the `end2end` testing can be discussed and resolved.

It will keep the `develop` branch of this project to be deployable if needed, and allow new work to be continued.