### PR TITLE
Revert "Revert "Send PubMed deposits by SFTP not by FTP""

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -1,25 +1,17 @@
 import os
-import boto.swf
 import json
-import importlib
 import time
-import arrow
 import glob
 import re
-import requests
-from collections import namedtuple
-
-import provider.article as articlelib
-from provider.ftp import FTP
-from provider import email_provider, lax_provider, utils
-from provider.storage_provider import storage_context
+from collections import OrderedDict
 from elifepubmed import generate
 from elifepubmed.conf import config, parse_raw_config
+import provider.article as articlelib
+from provider.sftp import SFTP
+from provider import article_processing, email_provider, lax_provider, utils
+from provider.storage_provider import storage_context
 from activity.objects import Activity
 
-"""
-PubmedArticleDeposit activity
-"""
 
 class activity_PubmedArticleDeposit(Activity):
 
@@ -53,12 +45,14 @@ class activity_PubmedArticleDeposit(Activity):
         self.published_folder = "pubmed/published"
 
         # Track the success of some steps
-        self.activity_status = None
-        self.generate_status = None
-        self.approve_status = None
-        self.ftp_status = None
-        self.outbox_status = None
-        self.publish_status = None
+        self.statuses = OrderedDict([
+            ('generate', None),
+            ('approve', None),
+            ('upload', None),
+            ('publish', None),
+            ('outbox', None),
+            ('activity', None),
+        ])
 
         self.outbox_s3_key_names = None
 
@@ -66,15 +60,11 @@ class activity_PubmedArticleDeposit(Activity):
         self.article_published_file_names = []
         self.article_not_published_file_names = []
 
-        # Load the config
-        self.pubmed_config = self.elifepubmed_config(self.settings.elifepubmed_config_section)
-
     def do_activity(self, data=None):
         """
         Activity, do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         self.make_activity_directories()
 
@@ -85,46 +75,50 @@ class activity_PubmedArticleDeposit(Activity):
         self.download_files_from_s3_outbox()
 
         # Generate pubmed XML
-        self.generate_status = self.generate_pubmed_xml()
+        self.statuses['generate'] = self.generate_pubmed_xml()
 
         # Approve files for publishing
-        self.approve_status = self.approve_for_publishing()
+        self.statuses['approve'] = self.approve_for_publishing()
 
-        if self.approve_status is True:
+        if self.statuses.get('approve'):
             # Publish files
-            self.ftp_status = self.ftp_files_to_endpoint(
-                from_dir=self.directories.get("TMP_DIR"),
-                file_type="/*.xml")
+            try:
+                self.statuses['upload'] = self.sftp_files_to_endpoint(
+                    from_dir=self.directories.get("TMP_DIR"),
+                    file_type="/*.xml")
+            except Exception as exception:
+                self.logger.exception(str(exception))
+                return self.ACTIVITY_PERMANENT_FAILURE
 
-        if self.ftp_status is True:
+        if self.statuses.get('upload'):
             # Clean up outbox
             print("Moving files from outbox folder to published folder")
             self.clean_outbox()
             self.upload_pubmed_xml_to_s3()
-            self.outbox_status = True
-            self.publish_status = True
-        elif self.ftp_status is False:
-            self.publish_status = False
+            self.statuses['outbox'] = True
+            self.statuses['publish'] = True
+        elif self.statuses.get('upload') is False:
+            self.statuses['publish'] = False
 
         # Set the activity status of this activity based on successes
-        if self.publish_status is not False:
-            self.activity_status = True
+        if self.statuses.get('publish') in (None, True):
+            self.statuses['activity'] = True
         else:
-            self.activity_status = False
+            self.statuses['activity'] = False
 
         # Send email
         # Only if there were files approved for publishing
-        if len(self.article_published_file_names) > 0:
+        if self.article_published_file_names:
             self.send_email()
 
         # Clean up disk
         self.clean_tmp_dir()
 
         # return a value based on the activity_status
-        if self.activity_status is True:
+        if self.statuses.get('activity') is True:
             return True
-        else:
-            return self.ACTIVITY_PERMANENT_FAILURE
+
+        return self.ACTIVITY_PERMANENT_FAILURE
 
     def download_files_from_s3_outbox(self):
         """
@@ -150,33 +144,6 @@ class activity_PubmedArticleDeposit(Activity):
                 with open(filename_plus_path, 'wb') as open_file:
                     storage_resource_origin = orig_resource + '/' + name
                     storage.get_resource_to_file(storage_resource_origin, open_file)
-
-
-    def elifepubmed_config(self, config_section):
-        "parse the config values from the elifepubmed config"
-        config.read(self.settings.elifepubmed_config_file)
-        raw_config = config[config_section]
-        return parse_raw_config(raw_config)
-
-    def parse_article_xml(self, xml_file):
-        """
-        Given an article XML files, parse it into an article object
-        """
-        article = None
-        generate.TMP_DIR = self.directories.get("TMP_DIR")
-        try:
-            # Convert the XML file to article objects
-            article_list = generate.build_articles(
-                article_xmls=[xml_file],
-                build_parts=self.pubmed_config.get('build_parts'),
-                remove_tags=self.pubmed_config.get('remove_tags'))
-            # take the first article from the list
-            if article_list:
-                article = article_list[0]
-        except:
-            article = None
-
-        return article
 
     def get_article_version_from_lax(self, article_id):
         """
@@ -214,7 +181,8 @@ class activity_PubmedArticleDeposit(Activity):
         for xml_file in article_xml_files:
             generate_status = True
 
-            article = self.parse_article_xml(xml_file)
+            article = parse_article_xml(xml_file, elifepubmed_config(
+                self.settings), self.directories.get("TMP_DIR"))
 
             if article is None:
                 self.article_not_published_file_names.append(xml_file)
@@ -249,7 +217,7 @@ class activity_PubmedArticleDeposit(Activity):
 
         # Check for empty directory
         xml_files = glob.glob(self.directories.get("TMP_DIR") + "/*.xml")
-        if len(xml_files) <= 0:
+        if not xml_files:
             status = False
         else:
             # Default until full sets of files checker is built
@@ -257,47 +225,32 @@ class activity_PubmedArticleDeposit(Activity):
 
         return status
 
-    def get_filename_from_path(self, f, extension):
+    def sftp_files_to_endpoint(self, from_dir, file_type, sub_dir=None):
         """
-        Get a filename minus the supplied file extension
-        and without any folder or path
+        Using the sftp provider module, connect to sftp server and transmit files
         """
-        filename = f.split(extension)[0]
-        # Remove path if present
-        try:
-            filename = filename.split(os.sep)[-1]
-        except:
-            pass
+        uploadfiles = glob.glob(from_dir + file_type)
 
-        return filename
-
-    def ftp_files_to_endpoint(self, from_dir, file_type):
-        """
-        FTP files to endpoint
-        as specified by the file_type to use in the glob
-        e.g. "/*.zip"
-        """
-        ftp_status = None
+        sftp = SFTP(logger=self.logger)
         try:
-            ftp_provider = FTP()
-            ftp_instance = ftp_provider.ftp_connect(
-                uri=self.settings.PUBMED_FTP_URI,
-                username=self.settings.PUBMED_FTP_USERNAME,
-                password=self.settings.PUBMED_FTP_PASSWORD
-            )
-            # collect the list of files
-            zipfiles = glob.glob(from_dir + file_type)
-            # transfer them by FTP to the endpoint
-            ftp_provider.ftp_to_endpoint(
-                ftp_instance=ftp_instance,
-                uploadfiles=zipfiles,
-                sub_dir_list=[self.settings.PUBMED_FTP_CWD])
-            # disconnect the FTP connection
-            ftp_provider.ftp_disconnect(ftp_instance)
-            ftp_status = True
-        except:
-            ftp_status = False
-        return ftp_status
+            sftp_client = sftp.sftp_connect(
+                self.settings.PUBMED_SFTP_URI,
+                self.settings.PUBMED_SFTP_USERNAME,
+                self.settings.PUBMED_SFTP_PASSWORD)
+        except Exception as exception:
+            self.logger.exception(
+                'Failed to connect to SFTP endpoint %s: %s' % (
+                    self.settings.PUBMED_SFTP_URI, str(exception)))
+            raise
+
+        try:
+            sftp.sftp_to_endpoint(
+                sftp_client, uploadfiles, self.settings.PUBMED_SFTP_CWD, sub_dir)
+        except Exception as exception:
+            self.logger.exception('Failed to upload files by SFTP to PubMed: %s' % str(exception))
+            raise
+
+        return True
 
     def get_outbox_s3_key_names(self, force=None):
         """
@@ -339,9 +292,6 @@ class activity_PubmedArticleDeposit(Activity):
         """
         Clean out the S3 outbox folder
         """
-        # Save the list of outbox contents to report on later
-        outbox_s3_key_names = self.get_outbox_s3_key_names()
-
         # Move only the published files from the S3 outbox to the published folder
         bucket_name = self.publish_bucket
         to_folder = self.get_to_folder_name()
@@ -381,7 +331,7 @@ class activity_PubmedArticleDeposit(Activity):
         for xml_file in xml_files:
             resource_dest = (storage_provider + bucket_name + "/" +
                              s3_folder_name + "/" +
-                             self.get_filename_from_path(xml_file, '.xml') + '.xml')
+                             article_processing.file_name_from_name(xml_file))
             storage.set_resource_from_filename(resource_dest, xml_file)
 
     def send_email(self):
@@ -417,7 +367,7 @@ class activity_PubmedArticleDeposit(Activity):
         date_format = '%Y-%m-%d %H:%M'
         datetime_string = time.strftime(date_format, current_time)
 
-        activity_status_text = utils.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.statuses.get('activity'))
 
         # Count the files moved from the outbox, the files that were processed
         files_count = 0
@@ -441,7 +391,7 @@ class activity_PubmedArticleDeposit(Activity):
 
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
 
-        activity_status_text = utils.get_activity_status_text(self.activity_status)
+        activity_status_text = utils.get_activity_status_text(self.statuses.get('activity'))
 
         # Bulk of body
         body += self.name + " status:" + "\n"
@@ -449,12 +399,12 @@ class activity_PubmedArticleDeposit(Activity):
         body += activity_status_text + "\n"
         body += "\n"
 
-        body += "activity_status: " + str(self.activity_status) + "\n"
-        body += "generate_status: " + str(self.generate_status) + "\n"
-        body += "approve_status: " + str(self.approve_status) + "\n"
-        body += "ftp_status: " + str(self.ftp_status) + "\n"
-        body += "publish_status: " + str(self.publish_status) + "\n"
-        body += "outbox_status: " + str(self.outbox_status) + "\n"
+        body += "activity_status: " + str(self.statuses.get('activity')) + "\n"
+        body += "generate_status: " + str(self.statuses.get('generate')) + "\n"
+        body += "approve_status: " + str(self.statuses.get('approve')) + "\n"
+        body += "upload_status: " + str(self.statuses.get('upload')) + "\n"
+        body += "publish_status: " + str(self.statuses.get('publish')) + "\n"
+        body += "outbox_status: " + str(self.statuses.get('outbox')) + "\n"
 
         body += "\n"
         body += "Outbox files: " + "\n"
@@ -470,14 +420,14 @@ class activity_PubmedArticleDeposit(Activity):
             body += "No files in outbox." + "\n"
 
         # Report on published files
-        if len(self.article_published_file_names) > 0:
+        if self.article_published_file_names:
             body += "\n"
             body += "Published files included in pubmed XML: " + "\n"
             for name in self.article_published_file_names:
                 body += name.split(os.sep)[-1] + "\n"
 
         # Report on not published files
-        if len(self.article_not_published_file_names) > 0:
+        if self.article_not_published_file_names:
             body += "\n"
             body += "Files in pubmed outbox not yet published: " + "\n"
             for name in self.article_not_published_file_names:
@@ -496,3 +446,31 @@ class activity_PubmedArticleDeposit(Activity):
         body += "\n\nSincerely\n\neLife bot"
 
         return body
+
+
+def elifepubmed_config(settings):
+    "parse the config values from the elifepubmed config"
+    config.read(settings.elifepubmed_config_file)
+    raw_config = config[settings.elifepubmed_config_section]
+    return parse_raw_config(raw_config)
+
+
+def parse_article_xml(xml_file, pubmed_config, tmp_dir):
+    """
+    Given an article XML files, parse it into an article object
+    """
+    article = None
+    generate.TMP_DIR = tmp_dir
+    try:
+        # Convert the XML file to article objects
+        article_list = generate.build_articles(
+            article_xmls=[xml_file],
+            build_parts=pubmed_config.get('build_parts'),
+            remove_tags=pubmed_config.get('remove_tags'))
+        # take the first article from the list
+        if article_list:
+            article = article_list[0]
+    except:
+        article = None
+
+    return article

--- a/settings-example.py
+++ b/settings-example.py
@@ -173,6 +173,12 @@ class exp():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
+
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -447,6 +453,12 @@ class dev():
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
 
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
+
     # PMC FTP settings
     PMC_FTP_URI = ""
     PMC_FTP_USERNAME = ""
@@ -713,6 +725,12 @@ class live():
     PUBMED_FTP_USERNAME = ""
     PUBMED_FTP_PASSWORD = ""
     PUBMED_FTP_CWD = ""
+
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
 
     # PMC FTP settings
     PMC_FTP_URI = ""

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -158,6 +158,11 @@ PUBMED_FTP_USERNAME = ""
 PUBMED_FTP_PASSWORD = ""
 PUBMED_FTP_CWD = ""
 
+PUBMED_SFTP_URI = ""
+PUBMED_SFTP_USERNAME = ""
+PUBMED_SFTP_PASSWORD = ""
+PUBMED_SFTP_CWD = ""
+
 # PDF cover
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
 pdf_cover_generator = "https://localhost/personalised-covers/"


### PR DESCRIPTION
Reverts elifesciences/elife-bot#1091

Revert the reversion, to reintroduce the original code to submit PubMed deposits by SFTP. This is best not to be merged until we are more confident end2end tests can pass.