### PR TITLE
Remove unused PubMed FTP credentials.

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -167,12 +167,6 @@ class exp():
     letterparser_config_file = 'letterparser.cfg'
     letterparser_config_section = 'elife'
 
-    # PubMed FTP settings
-    PUBMED_FTP_URI = ""
-    PUBMED_FTP_USERNAME = ""
-    PUBMED_FTP_PASSWORD = ""
-    PUBMED_FTP_CWD = ""
-
     # PubMed SFTP settings
     PUBMED_SFTP_URI = ""
     PUBMED_SFTP_USERNAME = ""
@@ -447,12 +441,6 @@ class dev():
     letterparser_config_file = 'letterparser.cfg'
     letterparser_config_section = 'elife'
 
-    # PubMed FTP settings
-    PUBMED_FTP_URI = ""
-    PUBMED_FTP_USERNAME = ""
-    PUBMED_FTP_PASSWORD = ""
-    PUBMED_FTP_CWD = ""
-
     # PubMed SFTP settings
     PUBMED_SFTP_URI = ""
     PUBMED_SFTP_USERNAME = ""
@@ -719,12 +707,6 @@ class live():
     # Decision letter parser
     letterparser_config_file = 'letterparser.cfg'
     letterparser_config_section = 'elife'
-
-    # PubMed FTP settings
-    PUBMED_FTP_URI = ""
-    PUBMED_FTP_USERNAME = ""
-    PUBMED_FTP_PASSWORD = ""
-    PUBMED_FTP_CWD = ""
 
     # PubMed SFTP settings
     PUBMED_SFTP_URI = ""

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -153,11 +153,6 @@ git_repo_name = 'elife-article-xml-ci'
 git_repo_path = '/articles/'
 github_token = '1234567890abcdef'
 
-PUBMED_FTP_URI = ""
-PUBMED_FTP_USERNAME = ""
-PUBMED_FTP_PASSWORD = ""
-PUBMED_FTP_CWD = ""
-
 PUBMED_SFTP_URI = ""
 PUBMED_SFTP_USERNAME = ""
 PUBMED_SFTP_PASSWORD = ""


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5648

The final step now we send PubMed deposits by SFTP, and FTP will no longer be supported beyond August, 2020, we can remove these old, now unused, credentials.