### PR TITLE
Use the latest elife libraries in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,15 @@ Jinja2==2.10.1
 arrow==0.4.4
 requests==2.20.0
 GitPython==3.1.2
-git+https://github.com/elifesciences/elife-tools.git@045a279275d78464533f84aad4d539e8ba44ff05#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@0944c90ce641fea09706d70059a4db3bbec8cec4#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@2e4e99e791db45d1b0f912adffc4fc431b1585de#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@05e9c1e80bdc99583f1317e3a0219afd7c437e89#egg=elifepubmed
-git+https://github.com/elifesciences/ejp-csv-parser.git@7ecae0064e6ae34267ecfd587bf274cb5b612691#egg=ejpcsvparser
-git+https://github.com/elifesciences/jats-generator.git@2181152e49ace9d38bc821f4a2337176ea291e2c#egg=jatsgenerator
+git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@230de0696fc43913558fbbb16e2a0c44fc04123f#egg=elifearticle
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@32185ac1c5754616b65b8bc8c0732995ccdead02#egg=elifecrossref
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@7ad319aa398beed0ae5ba3e081d00062091e1ece#egg=elifepubmed
+git+https://github.com/elifesciences/ejp-csv-parser.git@46c39d07830789dc89b00de202d14ccd4cd5af76#egg=ejpcsvparser
+git+https://github.com/elifesciences/jats-generator.git@45069c1e6e0cd70b242ea33e715780daa9f8d443#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@f5003c020a9efbc5d3bccb4c20e8586e247e3acb#egg=packagepoa
 docker==4.0.2
-git+https://github.com/elifesciences/decision-letter-parser.git@a44f3ea7ae76ef705d3e2936682dadcb05381694#egg=letterparser
+git+https://github.com/elifesciences/decision-letter-parser.git@aed2cecaec9f0ee5ce661bd2982b85cb9b8fef43#egg=letterparser
 PyYAML==4.2b2
 Wand==0.5.1
 paramiko==2.4.2
@@ -30,7 +30,7 @@ pyFunctional==1.2.0
 func_timeout==4.3.0
 # versions of python-docx>=0.8.9 have issues installing on python 3.5.2 (xenial default)
 python-docx==0.8.10
-git+https://github.com/elifesciences/digest-parser.git@e2b2ca1fb97fc4ba91b301d79b94533cf2c86a27#egg=digestparser
+git+https://github.com/elifesciences/digest-parser.git@502ef1f7365769365b3a56569d4a739f89371074#egg=digestparser
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium
 psutil==5.6.6
 pytz==2019.2


### PR DESCRIPTION
I was expecting the small changes to the `elifetools` library for structured abstracts support would be compatible with all the other libraries which depend on it, but rather than assume this fact, I've updated and tested them all to be sure. Here are the all the latest library versions which, at least according to the existing test scenarios, seems to be compatible.