### PR TITLE
elifecrossref library to include Crossmark data.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests==2.20.0
 GitPython==3.1.2
 git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@230de0696fc43913558fbbb16e2a0c44fc04123f#egg=elifearticle
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@32185ac1c5754616b65b8bc8c0732995ccdead02#egg=elifecrossref
+git+https://github.com/elifesciences/elife-crossref-xml-generation.git@e78142e057fb0776e3eb99166a3ee7127f3e7b81#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@7ad319aa398beed0ae5ba3e081d00062091e1ece#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@46c39d07830789dc89b00de202d14ccd4cd5af76#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@45069c1e6e0cd70b242ea33e715780daa9f8d443#egg=jatsgenerator


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-crossref-feed/issues/145

The `elifecrossref` library is updated now so it includes Crossmark data in the deposits, if the `crossref.cfg` file has `crossmark: true`, and all the other data pre-requisites are available. Right now it only adds actual Crossmark data for articles of type `correction` and `retraction`, to link the data in Crossref between the correction/retraction article and the research article it is correcting.