### PR TITLE
Update elifepubmed library, adds more datasets.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==3.1.2
 git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@230de0696fc43913558fbbb16e2a0c44fc04123f#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@e78142e057fb0776e3eb99166a3ee7127f3e7b81#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@7ad319aa398beed0ae5ba3e081d00062091e1ece#egg=elifepubmed
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@cc3b2494357b9c27b2e5f30e3f56f7d3f75b3155#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@46c39d07830789dc89b00de202d14ccd4cd5af76#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@45069c1e6e0cd70b242ea33e715780daa9f8d443#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@f5003c020a9efbc5d3bccb4c20e8586e247e3acb#egg=packagepoa

--- a/tests/activity/pubmed.cfg
+++ b/tests/activity/pubmed.cfg
@@ -6,7 +6,7 @@ pub_date_types: ["pub", "publication", "epub"]
 language: EN
 batch_file_prefix: pubmed-
 # default build parts when parsing article XML, omits the is_poa part which is eLife specific
-build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
+build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'keywords', 'license', 'pub_dates', 'references', 'related_articles', 'research_organisms', 'volume']
 # tags to remove when cleaning the abstract from article XML
 remove_tags: ["xref", "ext-link"]
 author_contrib_types: ["author"]
@@ -20,7 +20,7 @@ abstract_label_types: []
 [elife]
 year_of_first_volume: 2012
 batch_file_prefix: elife-pubmed-
-build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
+build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'references', 'related_articles', 'research_organisms', 'volume']
 split_article_categories: True
 abstract_label_types: ["Editorial note:"]
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-pubmed-xml-generation/issues/33
Re issue https://github.com/elifesciences/elife-pubmed-feed/issues/78

Roll-out of enhancements to the `elifepubmed` library, to include additional datasets as PubMed objects if the data is listed in the article's citation list. Only the datasets with a source name that matches a particular list that PubMed accepts will be included.