### PR TITLE
Check once only if article has no email recipients

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -282,10 +282,8 @@ class activity_PublicationEmail(Activity):
 
             # Get the article author data
             authors = self.article_authors_by_article_type(article)
-            if not authors:
-                self.log_cannot_find_authors(article.doi)
 
-            # Send an email to each author
+            # process the recipient data, adding Feature article recipients if applicable
             recipient_authors = choose_recipient_authors(
                 authors=authors,
                 article_type=article.article_type,


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5796

A bug fix for when a Feature article has no authors, it was prematurely adding it to the list of articles to not remove from the outbox, leaving it there to be sending emails the next day. It only affected Feature articles that are sent to internal recipients in this case. The fix here is only check once whether the article has no recipients after all the recipient email collection procedures is complete.