### PR TITLE
Set existing digest published date if not set.

### DIFF
--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -67,13 +67,24 @@ class activity_PublishDigest(Activity):
                 return self.ACTIVITY_SUCCESS
 
             # set the stage attribute if is not published
+            put_digest = False
             if existing_digest_json.get("stage") != "published":
                 self.digest_content = digest_provider.set_stage(existing_digest_json, 'published')
                 self.logger.info("Set Digest stage value of %s to published" % article_id)
-                # set the published date
                 if not self.digest_content.get("published"):
                     self.digest_content["published"] = digest_provider.published_date_from_lax(
                         self.settings, digest_id)
+                put_digest = True
+            if not existing_digest_json.get("published"):
+                # if published of the existing digest is not set, set it to the date published
+                if not self.digest_content:
+                    self.digest_content = existing_digest_json
+                # set the published date
+                self.digest_content["published"] = digest_provider.published_date_from_lax(
+                    self.settings, digest_id)
+                put_digest = True
+
+            if put_digest:
                 put_response = digest_provider.put_digest_to_endpoint(
                     self.logger, digest_id, self.digest_content, self.settings)
                 self.statuses["put"] = True

--- a/tests/activity/test_activity_publish_digest.py
+++ b/tests/activity/test_activity_publish_digest.py
@@ -87,6 +87,19 @@ class TestPublishDigest(unittest.TestCase):
             "expected_published_date": "2015-12-29T00:00:00Z"
         },
         {
+            "comment": "published digest with no date, put it to the endpoint",
+            "article_id": "99999",
+            "status": "vor",
+            "existing_digest_json": digest_data_no_published(),
+            "put_response": FakeResponse(204, None),
+            "stage": "published",
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+            "expected_stage": "published",
+            "expected_approve_status": True,
+            "expected_put_status": True,
+            "expected_published_date": "2015-12-29T00:00:00Z"
+        },
+        {
             "comment": "fail to put a digest",
             "article_id": "99999",
             "status": "vor",


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5852

If a digest was PUT for the first time as a result of an article silent correction workflow, the `published` attribute is `null`. This code change will populate it with the article's published date and issue a PUT to the endpoint to set the value there.