### PR TITLE
Improve logging and exception handling in PMCDeposit activity

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -3,12 +3,12 @@ import json
 import zipfile
 import re
 import glob
+from elifetools import parseJATS as parser
 import provider.s3lib as s3lib
 from provider.article_structure import ArticleInfo
 from provider.storage_provider import storage_context
 from provider import article_processing
 from provider.ftp import FTP
-from elifetools import parseJATS as parser
 from activity.objects import Activity
 
 
@@ -95,11 +95,12 @@ class activity_PMCDeposit(Activity):
         (verified, renamed_list, not_renamed_list) = article_processing.verify_rename_files(
             file_name_map)
 
-        self.logger.info("verified " + self.directories.get("INPUT_DIR") + ": " + str(verified))
-        self.logger.info(file_name_map)
-
-        if len(not_renamed_list) > 0:
-            self.logger.info("not renamed " + str(not_renamed_list))
+        self.logger.info("verified %s: %s" % (self.directories.get("INPUT_DIR"), verified))
+        self.logger.info("file_name_map: %s" % file_name_map)
+        if renamed_list:
+            self.logger.info("renamed: %s" % renamed_list)
+        if not_renamed_list:
+            self.logger.info("not renamed: %s" % not_renamed_list)
 
         # Convert the XML
         article_processing.convert_xml(article_xml_file(xml_search_folders), file_name_map)
@@ -248,6 +249,7 @@ def get_journal(document):
     if document:
         info = ArticleInfo(article_processing.file_name_from_name(document))
         return info.journal
+    return None
 
 
 def article_xml_file(folders):

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -164,6 +164,7 @@ class activity_PMCDeposit(Activity):
                 sub_dir_list=[self.settings.PMC_FTP_CWD])
         except Exception as exception:
             self.logger.exception("Exception in transfer of files by FTP: %s" % exception)
+            ftp_provider.ftp_disconnect(ftp_instance)
             raise
 
         try:

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -147,10 +147,13 @@ class TestFtpToEndpoint(unittest.TestCase):
             str(self.activity.logger.logexception),
             ('Exception connecting to FTP server: An exception'))
 
+    @patch.object(activity_module.FTP, 'ftp_disconnect')
     @patch.object(activity_module.FTP, 'ftp_to_endpoint')
     @patch.object(activity_module.FTP, 'ftp_connect')
-    def test_ftp_to_endpoint_transfer_exception(self, fake_ftp_connect, fake_ftp_to_endpoint):
+    def test_ftp_to_endpoint_transfer_exception(
+            self, fake_ftp_connect, fake_ftp_to_endpoint, fake_ftp_disconnect):
         fake_ftp_connect.return_value = True
+        fake_ftp_disconnect.return_value = True
         fake_ftp_to_endpoint.side_effect = Exception('An exception')
         with self.assertRaises(Exception):
             self.activity.ftp_to_endpoint(self.test_data_dir)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5872

On the rare ocassion when an FTP transfer to PMC failed, we didn't have enough evidence in the log files to determine a more precise reason why it failed. Were we unable to connect to their FTP server? Was there a connection timeout during transfer of the file? Did the remote FTP server run out of disk space?

The changes here should give us more details about what may have happened during a failed FTP transfer to PMC.

If an exception is raised during transfer, it will try to disconnect before the activity is finished.

Test scenarios are included for each type of exception.

If an exception is raised, the activity will retry, until the workflow ultimately reaches a timeout.

A little bit of code linting is included here too.
