### PR TITLE
Use latest elifetools library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.10.1
 arrow==0.4.4
 requests==2.20.0
 GitPython==3.1.2
-git+https://github.com/elifesciences/elife-tools.git@a5b93afbe4db7852bf1aa12265090d60140fca8e#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@e671697e65dcf428184772b37ac9a940889ff865#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@efb0f8c02b149c9f307e64be23470ae1989f540e#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1c4d2d9755634ef8440dc27fcc074bd56f01fe2c#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@6d352645389acf2b9c8f42bae06f32c456354fb5#egg=elifepubmed


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6136 although not directly related to a fix for XML to JSON output, which will be more directly attributed to `bot-lax-adaptor`, this PR will keep the `elifetools` library up-to-date here too.