### PR TITLE
PackagePOA, start at twenty minutes past the hour.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -118,11 +118,15 @@ def conditional_starts(current_datetime):
                 ("start_seconds", 60 * 31)
             ]))
 
-    elif current_time.tm_min >= 15 and current_time.tm_min <= 29:
+    elif current_time.tm_min >= 15 and current_time.tm_min <= 19:
         # Jobs to start at quarter past the hour
         LOGGER.info("Quarter past the hour")
 
-        # POA Packaging at UK local time, hourly between 6:15 and 15:15
+    elif current_time.tm_min >= 20 and current_time.tm_min <= 29:
+        # Jobs to start at 20 minutes past the hour
+        LOGGER.info("Twenty minutes past the hour")
+
+        # POA Packaging at UK local time, hourly between 6:20 and 15:20
         if (local_current_time.tm_hour >= 6
                 and local_current_time.tm_hour <= 15):
             conditional_start_list.append(OrderedDict([

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@6d352645389
 git+https://github.com/elifesciences/ejp-csv-parser.git@46c39d07830789dc89b00de202d14ccd4cd5af76#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@45069c1e6e0cd70b242ea33e715780daa9f8d443#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@f5003c020a9efbc5d3bccb4c20e8586e247e3acb#egg=packagepoa
+six==1.13.0
 docker==4.0.2
 git+https://github.com/elifesciences/decision-letter-parser.git@ae9fe68c11b78ad44f03af8d75049bb3474ce657#egg=letterparser
 PyYAML==4.2b2

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -170,8 +170,8 @@ class TestConditionalStarts(unittest.TestCase):
 
     @data(
         {
-            "comment": "06:15 UTC",
-            "date_time": "1970-01-01 06:15:00 UTC",
+            "comment": "06:20 UTC",
+            "date_time": "1970-01-01 06:20:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
                 "cron_NewS3POA",
@@ -182,7 +182,7 @@ class TestConditionalStarts(unittest.TestCase):
             ]
         },
     )
-    def test_conditional_starts_06_15_utc(self, test_data):
+    def test_conditional_starts_06_20_utc(self, test_data):
         self.conditional_start_test_run(test_data)
 
     @data(


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6138

For better stability if the files exported from EJP arrive a little late, move the `PackagePOA` workflows to start at `:20` past the hour, instead of `:15` past.