### PR TITLE
Do not take authors from XML for feature articles.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -323,7 +323,13 @@ class activity_PublicationEmail(Activity):
     def article_authors(self, doi_id, article):
         """get a merged list of authors from CSV for the doi_id and from the article object"""
         article_authors = self.get_authors(doi_id)
-        xml_authors = authors_from_xml(article)
+
+        # do not get email addresses from the XML for feature articles
+        if is_feature_article(article):
+            xml_authors = []
+        else:
+            xml_authors = authors_from_xml(article)
+
         all_authors = self.merge_recipients(article_authors, xml_authors)
         return all_authors
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -506,6 +506,73 @@ class TestPublicationEmail(unittest.TestCase):
         self.assertEqual(approved_articles[0].doi, research_article_doi)
 
 
+class TestArticleAuthors(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_PublicationEmail(settings_mock, fake_logger, None, None, None)
+        self.article_xml_authors = [
+            {
+                'surname': 'Author',
+                'given-names': 'Article',
+                'email': ['article_xml_author@example.org'],
+                'corresp': True,
+            }
+        ]
+        self.article_csv_authors = [
+            {
+                'surname': 'Author',
+                'given-names': 'CSV',
+                'email': ['article_csv_author@example.org'],
+            }
+        ]
+
+    @patch.object(activity_PublicationEmail, 'get_authors')
+    def test_article_authors(self, fake_get_authors):
+        "test getting authors for a research article"
+        fake_get_authors.return_value = self.article_csv_authors
+        doi_id = 3
+        display_channel = 'Research Article'
+        expected = [
+            {
+                'surname': 'Author',
+                'given-names': 'CSV',
+                'email': ['article_csv_author@example.org']
+            },
+            OrderedDict([
+                ('e_mail', 'article_xml_author@example.org'),
+                ('first_nm', 'Article'),
+                ('last_nm', 'Author')]),
+        ]
+
+        article_object = article()
+        article_object.authors = self.article_xml_authors
+        article_object.display_channel = display_channel
+
+        all_authors = self.activity.article_authors(doi_id, article_object)
+        self.assertEqual(all_authors, expected)
+
+    @patch.object(activity_PublicationEmail, 'get_authors')
+    def test_article_authors_feature_article(self, fake_get_authors):
+        "test getting authors for a feature article"
+        fake_get_authors.return_value = self.article_csv_authors
+        doi_id = 3
+        display_channel = 'Feature Article'
+        expected = [
+            {
+                'surname': 'Author',
+                'given-names': 'CSV',
+                'email': ['article_csv_author@example.org']
+            },
+        ]
+
+        article_object = article()
+        article_object.authors = self.article_xml_authors
+        article_object.display_channel = display_channel
+
+        all_authors = self.activity.article_authors(doi_id, article_object)
+        self.assertEqual(all_authors, expected)
+
+
 @ddt
 class TestChooseRecipientAuthors(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6192

To fix an unintended side-effect from PR https://github.com/elifesciences/elife-bot/pull/1076, when a `Feature Article` is evaluated for who receives an email upon publication, the email was additionally sent to the corresponding author in the article XML, whereas before we only sent that email to internal recipients first.

This PR will make it so only for non-Feature articles do we try and extract corresponding author email addresses from the article XML when sending emails in the `PublicationEmail` activity.

