### PR TITLE
Article structure provider changes for chem and scheme fig file name parsing

### DIFF
--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -83,13 +83,17 @@ class ArticleInfo(object):
                 child_name = self.extra_info[1]
             final_name = self.extra_info[-1]
             # determine the file_type based on the extra file parts
-            if parent_name.startswith('resp') and child_name.startswith('fig'):
+            if parent_name.startswith('resp') and final_name.startswith('fig'):
                 self.file_type = "Figure"
-            elif parent_name.startswith('sa') and child_name.startswith('fig'):
+            elif parent_name.startswith('sa') and final_name.startswith('fig'):
                 self.file_type = "Figure"
-            elif parent_name.startswith('app') and child_name.startswith('fig'):
+            elif parent_name.startswith('app') and final_name.startswith('fig'):
                 self.file_type = "Figure"
-            elif parent_name.startswith('box') and child_name.startswith('fig'):
+            elif parent_name.startswith('box') and final_name.startswith('fig'):
+                self.file_type = "Figure"
+            elif parent_name.startswith('chem') and final_name.startswith('fig'):
+                self.file_type = "Figure"
+            elif parent_name.startswith('scheme') and final_name.startswith('fig'):
                 self.file_type = "Figure"
             elif final_name.startswith('video') or final_name.startswith('code'):
                 self.file_type = 'Other'

--- a/provider/article_structure.py
+++ b/provider/article_structure.py
@@ -2,7 +2,7 @@ import re
 import datetime
 
 
-class ArticleInfo(object):
+class ArticleInfo():
     """
     Determine useful information about an article file from its filename
     see https://github.com/elifesciences/ppp-project/blob/master/file_naming_spec.md
@@ -110,21 +110,19 @@ class ArticleInfo(object):
         match = re.search(r'.*?-.*?-.*?-.*?-(.*?)\..*', filename)
         if match is None:
             return None
-        else:
-            try:
-                raw_update_date = match.group(1)
-                updated_date = datetime.datetime.strptime(raw_update_date, "%Y%m%d%H%M%S")
-                return updated_date.strftime('%Y-%m-%dT%H:%M:%SZ')
-            except:
-                return None
+        try:
+            raw_update_date = match.group(1)
+            updated_date = datetime.datetime.strptime(raw_update_date, "%Y%m%d%H%M%S")
+            return updated_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+        except:
+            return None
 
     def get_version_from_zip_filename(self):
         filename = self.full_filename
         match = re.search(r'-v([0-9]+?)[\.|-]', filename)
         if match is None:
             return None
-        else:
-            return match.group(1)
+        return match.group(1)
 
 
 def article_figure(filename):

--- a/tests/provider/test_article_structure.py
+++ b/tests/provider/test_article_structure.py
@@ -173,11 +173,14 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-supp99-v1.xml', 'expected': 'Other'},
         {'input': 'elife-00666-sa1-fig1-v1.tif', 'expected': 'Figure'},
         {'input': 'elife-00666-sa2-video1.mp4', 'expected': 'Other'},
-          )
+        {'input': 'elife-00666-chem1-fig1-v1.tif', 'expected': 'Figure'},
+        {'input': 'elife-00666-scheme1-fig1-v1.tif', 'expected': 'Figure'},
+        {'input': 'elife-00666-app1-scheme1-fig1-v1.tif', 'expected': 'Figure'},
+    )
     def test_get_file_type_from_zip_filename(self, input, expected):
         self.articleinfo = ArticleInfo(input)
         result = self.articleinfo.file_type
-        self.assertEqual(result, expected)
+        self.assertEqual(result, expected, 'failed on input %s, expected %s' % (input, expected))
 
     @unpack
     @data(
@@ -220,8 +223,10 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-video1.mp4', 'expected': False},
         {'input': 'elife-00666-video1-data1-v1.xlsx', 'expected': False},
         {'input': 'elife-00666-supp1-v1.tif', 'expected': False},
-        {'input': 'elife-00666-sa1-fig1-v1.tif', 'expected': True}
-          )
+        {'input': 'elife-00666-sa1-fig1-v1.tif', 'expected': True},
+        {'input': 'elife-00666-chem1-fig1-v1.tif', 'expected': True},
+        {'input': 'elife-00666-scheme1-fig1-v1.tif', 'expected': True},
+    )
     def test_article_figure(self, input, expected):
         self.assertEqual(article_structure.article_figure(input), expected)
 
@@ -230,7 +235,7 @@ class TestArticleStructure(unittest.TestCase):
         {'input': 'elife-00666-app1-fig1-v1.tif', 'expected': False},
         {'input': 'elife-00666-fig1-v1.tif', 'expected': False},
         {'input': 'elife-00666-inf1-v1.tif', 'expected': True},
-          )
+    )
     def test_inline_figure(self, input, expected):
         self.assertEqual(article_structure.inline_figure(input), expected, "Case %s" % input)
 
@@ -238,12 +243,14 @@ class TestArticleStructure(unittest.TestCase):
         files = ['elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-fig2-figsupp2-v10.tif',
                  'elife-00666-inf001-v1.tif',
+                 'elife-00666-chem1-v1.tif',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-07398-media1.jpg']
         expected = ['elife-00666-fig2-figsupp2-v1.tif',
                     'elife-00666-fig2-figsupp2-v10.tif',
                     'elife-00666-inf001-v1.tif',
+                    'elife-00666-chem1-v1.tif',
                     'elife-00666-table3-data1-v1.xlsx']
 
         self.assertListEqual(article_structure.get_original_files(files), expected)
@@ -265,12 +272,14 @@ class TestArticleStructure(unittest.TestCase):
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-inf001-v1.tif',
+                 'elife-00666-chem1-fig1-v1.tif',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',
                  'elife-9204580859652100230-fig2-data1-v1.xls']
         expected = ['elife-00666-app1-fig1-figsupp1-v1.tif',
-                    'elife-00666-fig2-figsupp2-v1.tif']
+                    'elife-00666-fig2-figsupp2-v1.tif',
+                    'elife-00666-chem1-fig1-v1.tif']
         self.assertListEqual(article_structure.get_figures_for_iiif(files), expected)
 
     def test_get_inline_figures_for_iiif(self):
@@ -278,6 +287,7 @@ class TestArticleStructure(unittest.TestCase):
         files = ['elife-00666-app1-fig1-figsupp1-v1.tif',
                  'elife-00666-fig2-figsupp2-v1.tif',
                  'elife-00666-inf001-v1.tif',
+                 'elife-00666-chem1-v1.tif',
                  'elife-00666-table3-data1-v1.xlsx',
                  'elife-07702-vor-r4.zip',
                  'elife-6148691793723703318-fig10-v1.gif',


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6256

In the latest article `00666` kitchen sink XML there are some file names not yet supported in the `elife-bot` article_structure provider for `chem` and `scheme` images.

The functional change in this PR is to identify these image file names as a `Figure` type when evaluating article file names.

There are also a couple articles with files like this in appendices, which are also now supported, plus a change to the file name part detection logic to match these more consistently.

Test coverage is the same, but I also did some linting while this provider code and its tests are being edited here, it is a small additional improvement at the same time.

I think there's little for someone else to review here so I will merge it myself with no review if the tests remain green.

There should be no backwards compatibility issues to adding support for the new file names, and the extensive tests give me confidence it will not introduce any new errors.