### PR TITLE
PublicationEmail start to close timeout 20 min.

### DIFF
--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_short
+from workflow.helper import define_workflow_step
 
 
 class workflow_PublicationEmail(Workflow):
@@ -34,7 +34,13 @@ class workflow_PublicationEmail(Workflow):
             "steps":
                 [
                     define_workflow_step("PingWorker", data),
-                    define_workflow_step_short("PublicationEmail", data),
+                    define_workflow_step(
+                        "PublicationEmail", data,
+                        heartbeat_timeout=60 * 20,
+                        schedule_to_close_timeout=60 * 20,
+                        schedule_to_start_timeout=60 * 5,
+                        start_to_close_timeout=60 * 20,
+                    ),
                 ],
 
             "finish":


### PR DESCRIPTION
When many articles are processed to send emails to authors upon publication, it is reaching the current 10 minute timeout after sending around 200 emails. The code change in this PR is a short-term temporary fix, extending the timeout to 20 minutes, which should allow the sending of 400 emails a day using the current method of sending once per day in a batch format.

Re issue https://github.com/elifesciences/issues/issues/6255 describes the observed timeout and suggestions for the simple immediate fix (in this PR), and describes additional potential changes to make the procedure better in the near future.