### PR TITLE
Add workflow run session to PMCDeposit workflows.

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -6,6 +6,7 @@ import glob
 from elifetools import parseJATS as parser
 import provider.s3lib as s3lib
 from provider.article_structure import ArticleInfo
+from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from provider import article_processing
 from provider.ftp import FTP
@@ -53,6 +54,9 @@ class activity_PMCDeposit(Activity):
         Activity, do the work
         """
         self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+
+        run = data['run']
+        session = get_session(self.settings, data, run)
 
         # Data passed to this activity
         self.document = data["data"]["document"]

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 import boto.swf
 import json
 import time
@@ -301,8 +302,9 @@ class activity_PubRouterDeposit(Activity):
         data['document'] = zip_file_name
         data['folder'] = folder
         input_json = {}
+        input_json['run'] = str(uuid.uuid4())
         input_json['data'] = data
-        input = json.dumps(input_json)
+        workflow_input = json.dumps(input_json)
 
         # Connect to SWF
         conn = boto.swf.layer1.Layer1(self.settings.aws_access_key_id,
@@ -314,7 +316,8 @@ class activity_PubRouterDeposit(Activity):
                                                      workflow_name, workflow_version,
                                                      self.settings.default_task_list,
                                                      child_policy,
-                                                     execution_start_to_close_timeout, input)
+                                                     execution_start_to_close_timeout,
+                                                     workflow_input)
             starter_status = True
         except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
             # There is already a running workflow with that ID, cannot start another

--- a/starter/starter_PMCDeposit.py
+++ b/starter/starter_PMCDeposit.py
@@ -1,3 +1,4 @@
+import uuid
 import boto.swf
 import log
 import json
@@ -53,7 +54,11 @@ class starter_PMCDeposit():
                 workflow_version = "1"
                 child_policy = None
                 execution_start_to_close_timeout = None
-                input = '{"data": ' + json.dumps(doc) + '}'
+
+                input_json = {}
+                input_json['run'] = str(uuid.uuid4())
+                input_json['data'] = doc
+                workflow_input = json.dumps(input_json)
 
                 try:
                     response = conn.start_workflow_execution(settings.domain, workflow_id,
@@ -61,7 +66,7 @@ class starter_PMCDeposit():
                                                              settings.default_task_list,
                                                              child_policy,
                                                              execution_start_to_close_timeout,
-                                                             input)
+                                                             workflow_input)
 
                     logger.info('got response: \n%s' %
                                 json.dumps(response, sort_keys=True, indent=4))

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -24,7 +24,9 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.do_activity_passes.append({
             "scenario": "zip file was not downloaded",
-            "input_data": {"data": {"document": "does_not_exist.zip"}},
+            "input_data": {
+                "data": {"document": "does_not_exist.zip"},
+                "run": "test-uuid"},
             "pmc_zip_key_names": [],
             "expected_zip_filename": None,
             "expected_result": self.activity.ACTIVITY_TEMPORARY_FAILURE,
@@ -32,7 +34,9 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.do_activity_passes.append({
             "scenario": "no previous PMC zip file",
-            "input_data": {"data": {"document": "elife-19405-vor-v1-20160802113816.zip"}},
+            "input_data": {
+                "data": {"document": "elife-19405-vor-v1-20160802113816.zip"},
+                "run": "test-uuid"},
             "pmc_zip_key_names": [],
             "expected_zip_filename": "elife-05-19405.zip",
             "expected_result": True,
@@ -41,7 +45,9 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.do_activity_passes.append({
             "scenario": "one previous PMC zip file",
-            "input_data": {"data": {"document": "elife-19405-vor-v1-20160802113816.zip"}},
+            "input_data": {
+                "data": {"document": "elife-19405-vor-v1-20160802113816.zip"},
+                "run": "test-uuid"},
             "pmc_zip_key_names": ["pmc/zip/elife-05-19405.zip"],
             "expected_zip_filename": "elife-05-19405.r1.zip",
             "expected_result": True,
@@ -50,7 +56,9 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.do_activity_passes.append({
             "scenario": "two previous PMC zip file revisions present",
-            "input_data": {"data": {"document": "elife-19405-vor-v1-20160802113816.zip"}},
+            "input_data": {
+                "data": {"document": "elife-19405-vor-v1-20160802113816.zip"},
+                "run": "test-uuid"},
             "pmc_zip_key_names": ["pmc/zip/elife-05-19405.zip", "pmc/zip/elife-05-19405.r1.zip"],
             "expected_zip_filename": "elife-05-19405.r2.zip",
             "expected_result": True,


### PR DESCRIPTION
First part of issue https://github.com/elifesciences/issues/issues/6205, generate a `uuid` as a run value to store session data for the `PMCDeposit` workflows.

A subsequent PR will include some logic to set data and send an email in the case of a `PMCDeposit` timeout.