### PR TITLE
Send email after first FTP exception in PMCDeposit

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -125,6 +125,10 @@ class exp():
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
 
+    # PMC or FTP sending error email settings
+    ftp_deposit_error_sender_email = "sender@example.org"
+    ftp_deposit_error_recipient_email = ["e@example.org", "life@example.org"]
+
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
 
@@ -400,6 +404,10 @@ class dev():
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
 
+    # PMC or FTP sending error email settings
+    ftp_deposit_error_sender_email = "sender@example.org"
+    ftp_deposit_error_recipient_email = ["e@example.org", "life@example.org"]
+
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'
 
@@ -671,6 +679,10 @@ class live():
     typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
     decision_letter_jats_error_recipient_email = "error@example.org"
+
+    # PMC or FTP sending error email settings
+    ftp_deposit_error_sender_email = "sender@example.org"
+    ftp_deposit_error_recipient_email = ["e@example.org", "life@example.org"]
 
     # journal preview
     journal_preview_base_url = 'https://preview--journal.example.org'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -65,6 +65,9 @@ typesetter_digest_endpoint = 'https://typesetter/updateDigest'
 typesetter_digest_api_key = 'typesetter_api_key'
 typesetter_digest_account_key = '1'
 
+ftp_deposit_error_sender_email = "sender@example.org"
+ftp_deposit_error_recipient_email = ["e@example.org", "life@example.org"]
+
 journal_preview_base_url = 'https://preview'
 
 features_publication_recipient_email = "features_team@example.org"

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -6,7 +6,8 @@ from ddt import ddt, data, unpack
 import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger, FakeStorageContext, FakeFTP
+from tests.classes_mock import FakeSMTPServer
+from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext, FakeFTP
 import tests.activity.test_activity_data as activity_test_data
 import tests.activity.helpers as helpers
 
@@ -119,13 +120,18 @@ class TestPMCDeposit(unittest.TestCase):
 
         self.assertEqual(False, success)
 
+    @patch.object(activity_module.email_provider, 'smtp_connect')
+    @patch('activity.activity_PMCDeposit.get_session')
     @patch.object(FakeStorageContext, 'list_resources')
     @patch.object(activity_PMCDeposit, 'ftp_to_endpoint')
     @patch('activity.activity_PMCDeposit.storage_context')
     def test_do_activity_ftp_to_endpoint_exception(
-            self, fake_storage_context, fake_ftp_to_endpoint, fake_list_resources):
+            self, fake_storage_context, fake_ftp_to_endpoint, fake_list_resources,
+            fake_session, fake_email_smtp_connect):
 
         test_data = self.do_activity_passes[1]
+        fake_session.return_value = FakeSession({})
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
 
         fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
         fake_list_resources.return_value = test_data["pmc_zip_key_names"]


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6205

In order to make `PMCDeposit` sending FTP timeouts more visible and easier to monitor, the code here will send a simple email including the exception message for the first time an exception is encountered. It sets a value for the `ftp_exception` session attribute when the email is sent, so the email is not sent an additional time for the same workflow execution.

I considered to increment the `ftp_exception` session value each time an exception is reached (although an email would only send once) but counting how many exceptions is not part of the requirements of this feature, so it will just set the value to `1` each time an exception is raised in the attempts to send by FTP as a flag only.