### PR TITLE
Turn off sending to GoOA in cron.py

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -206,12 +206,12 @@ def conditional_starts(current_datetime):
             ]))
 
         # GoOA / CAS deposits once per day 21:45 UTC
-        if current_time.tm_hour == 21:
-            conditional_start_list.append(OrderedDict([
-                ("starter_name", "starter_PubRouterDeposit"),
-                ("workflow_id", "PubRouterDeposit_GoOA"),
-                ("start_seconds", 60 * 31)
-            ]))
+        # if current_time.tm_hour == 21:
+        #    conditional_start_list.append(OrderedDict([
+        #        ("starter_name", "starter_PubRouterDeposit"),
+        #        ("workflow_id", "PubRouterDeposit_GoOA"),
+        #        ("start_seconds", 60 * 31)
+        #    ]))
 
         conditional_start_list.append(OrderedDict([
             ("starter_name", "starter_PubmedArticleDeposit"),

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -322,13 +322,11 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 21:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
-                "starter_PubRouterDeposit",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
-                "PubRouterDeposit_GoOA",
                 "PubmedArticleDeposit",
                 "AdminEmail",
             ]


### PR DESCRIPTION
Due to temporary connection issues do not send to GoOA on a daily basis until we can try again.