### PR TITLE
Log last_modified of S3 CSV files in PackagePOA.

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -71,8 +71,7 @@ class activity_PackagePOA(Activity):
         """
         Activity, do the work
         """
-        if self.logger:
-            self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
 
         # Create output directories
         self.make_activity_directories()
@@ -234,19 +233,21 @@ class activity_PackagePOA(Activity):
             storage = storage_context(self.settings)
             storage_provider = self.settings.storage_provider + "://"
             orig_resource = storage_provider + bucket_name + "/"
-            storage_resource_origin = orig_resource + s3_key_name
             try:
                 storage_resource_origin = orig_resource + s3_key_name
             except TypeError:
-                if self.logger:
-                    self.logger.info(
-                        'PackagePoA unable to download CSV file for {file_type}'.format(
-                            file_type=file_type
-                        ))
+                self.logger.info(
+                    'PackagePoA unable to download CSV file for {file_type}'.format(
+                        file_type=file_type
+                    ))
                 continue
             filename_plus_path = os.path.join(self.directories.get("CSV"), filename)
             with open(filename_plus_path, 'wb') as open_file:
                 storage.get_resource_to_file(storage_resource_origin, open_file)
+            # log last modified date if available
+            s3_key = storage.get_resource_as_key(storage_resource_origin)
+            self.logger.info('CSV file %s last_modified: %s' % (
+                storage_resource_origin, getattr(s3_key, 'last_modified', '[unknown]')))
 
     def jatsgenerator_config(self, config_section):
         "parse the config values from the jatsgenerator config"

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -45,6 +45,10 @@ class S3StorageContext:
         key.key = s3_key
         return key.exists()
 
+    def get_resource_as_key(self, resource):
+        bucket, s3_key = self.s3_storage_objects(resource)
+        return bucket.get_key(s3_key)
+
     def get_resource_to_file(self, resource, file):
         bucket, s3_key = self.s3_storage_objects(resource)
         key = Key(bucket)

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -129,6 +129,13 @@ class FakeStorageContext:
         s3_key = match.group(3)
         return bucket_name, s3_key
 
+    def get_resource_as_key(self, resource):
+        bucket, s3_key = self.get_bucket_and_key(resource)
+        attributes = {
+            'last_modified': '2021-01-01T00:00:01.000Z'
+        }
+        return FakeKey(None, s3_key, **attributes)
+
     def resource_exists(self, resource):
         "check if a key exists"
         bucket, s3_key = self.get_bucket_and_key(resource)
@@ -206,19 +213,21 @@ class FakeResponse:
 
 class FakeKey:
 
-    def __init__(self, directory, destination=None, source=None, key=None):
+    def __init__(self, directory=None, destination=None, source=None, **kwargs):
         self.d = directory
         if destination is None:
             destination = data.bucket_origin_file_name
         if source is None:
             source = data.xml_content_for_xml_key
 
-        if destination and source:
+        if directory and destination and source:
             self.d.write(destination, source)
 
         self.destination = destination
-        if key:
-            self.key = key
+
+        # set object attributes from remaining keyword arguments
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def get_contents_as_string(self):
         return self.d.read(self.destination)

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -252,7 +252,7 @@ class TestPackagePOA(unittest.TestCase):
         # check logging of CSV file S3 object last_modified date
         if test_data.get('expected_activity_status'):
             loginfo_message = (
-                'CSV object '
+                'CSV file '
                 's3://ejp_bucket/ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'
                 ' last_modified: 2021-01-01T00:00:01.000Z')
             self.assertTrue(
@@ -360,7 +360,7 @@ class TestPackagePOA(unittest.TestCase):
         self.poa.download_latest_csv()
         # make assertions
         loginfo_message = (
-            'CSV object '
+            'CSV file '
             's3://ejp_bucket/ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'
             ' last_modified: 2021-01-01T00:00:01.000Z')
         self.assertTrue(loginfo_message in self.logger.loginfo)

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -249,6 +249,15 @@ class TestPackagePOA(unittest.TestCase):
             self.boolean_assertion(len(outbox_files(test_outbox_folder)),
                                    test_data.get('expected_outbox_count'),
                                    test_data.get('scenario'))
+        # check logging of CSV file S3 object last_modified date
+        if test_data.get('expected_activity_status'):
+            loginfo_message = (
+                'CSV object '
+                's3://ejp_bucket/ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'
+                ' last_modified: 2021-01-01T00:00:01.000Z')
+            self.assertTrue(
+                loginfo_message in self.logger.loginfo,
+                'failed in scenario %s' % test_data.get('scenario'))
 
     def boolean_assertion(self, value, expected, scenario=None):
         "shorthand for checking and displaying output for equality assertions"
@@ -335,6 +344,42 @@ class TestPackagePOA(unittest.TestCase):
         self.assertEqual(
             self.poa.logger.logexception,
             'Exception in build_xml_to_disk for article_id 12717: An exception')
+
+    @patch('activity.activity_PackagePOA.storage_context')
+    @patch('provider.ejp.EJP.ejp_bucket_file_list')
+    def test_download_latest_csv(self, fake_ejp_bucket_file_list, fake_storage_context):
+        "test downloading CSV files from bucket storage"
+        # make directories first
+        self.poa.make_activity_directories()
+        # mock other methods
+        fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
+        bucket_list_file = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
+        with open(bucket_list_file, 'rb') as open_file:
+            fake_ejp_bucket_file_list.return_value = json.loads(open_file.read().decode())
+        # download the CSV files
+        self.poa.download_latest_csv()
+        # make assertions
+        loginfo_message = (
+            'CSV object '
+            's3://ejp_bucket/ejp_query_tool_query_id_POA_Author_2019_06_10_eLife.csv'
+            ' last_modified: 2021-01-01T00:00:01.000Z')
+        self.assertTrue(loginfo_message in self.logger.loginfo)
+
+    @patch('activity.activity_PackagePOA.storage_context')
+    @patch('provider.ejp.EJP.find_latest_s3_file_name')
+    def test_download_latest_csv_ejp_exception(self, fake_ejp_s3_file_name, fake_storage_context):
+        "test exception if CSV file cannot be found using ejp provider"
+        # make directories first
+        self.poa.make_activity_directories()
+        # mock other methods
+        fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
+        fake_ejp_s3_file_name.return_value = None
+        # download the CSV files
+        self.poa.download_latest_csv()
+        # make assertions
+        loginfo_message = (
+            'PackagePoA unable to download CSV file for poa_author')
+        self.assertTrue(loginfo_message in self.logger.loginfo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6064

In order to debug more easily if there is a CSV file data caching issue, log the `last_modified` attribute of the S3 object for each CSV file downloaded when running a `PackagePOA` activity.

The testing mock objects needed a little change to allow for reusing the `FakeKey` in this case and all other existing test cases.

There are two new test cases added, one specifically for the CSV downloading when it is successful, and one for an existing exception that was not covered yet in tests.

If this PR tests are green, I will proceed to merge and test on the testing environment prior to deploying it to prod.