### PR TITLE
Exclude CSV files from being deleted in PackagePOA

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -134,6 +134,14 @@ class activity_PackagePOA(Activity):
 
         return result
 
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = ['CSV', 'CSV_TMP']
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)
+
     def get_pub_date(self, doi_id):
         # Get the date for the first version
         date_struct = None


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6064

For debugging purposes, in the `PackagePOA` it will be useful to retain the CSV files in the temporary directories for inspection after the activity is completed, done here by overriding `clean_tmp_dir()` method of the activity object, and relying on the pre-defined list of subdirectory names already defined in `PackagePOA`.

Existing tests already cover this new bit of code, and I'll test on `continuumtest` environment prior to deployed to `prod` environment just to be safe.