### PR TITLE
Add BCC recipient to publication emails.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -297,7 +297,8 @@ class activity_PublicationEmail(Activity):
                 # Good, we can send emails
                 for recipient_author in recipient_authors:
                     result = self.send_email(
-                        email_type, article.doi_id, recipient_author, article, authors)
+                        email_type, article.doi_id, recipient_author, article, authors,
+                        self.settings.ses_bcc_recipient_email)
                     if result is False:
                         self.log_cannot_find_authors(article.doi)
 
@@ -352,7 +353,7 @@ class activity_PublicationEmail(Activity):
 
         return merged_list
 
-    def send_email(self, email_type, elife_id, author, article, authors):
+    def send_email(self, email_type, elife_id, author, article, authors, bcc=None):
         """
         Given the email type and author,
         send the email
@@ -397,14 +398,15 @@ class activity_PublicationEmail(Activity):
                 article=article,
                 authors=authors,
                 doi_id=elife_id,
-                subtype="html")
+                subtype="html",
+                bcc=bcc)
 
             return True
         except Exception:
             self.logger.exception("An error has occurred on send_email method")
 
     def send_author_email(self, email_type, author, headers, article, authors, doi_id,
-                          subtype="html"):
+                          subtype="html", bcc=None):
         """
         Format the email body and send the email by SMTP
         Only call this to send actual emails!
@@ -418,7 +420,7 @@ class activity_PublicationEmail(Activity):
 
         message = email_provider.simple_message(
             headers["sender_email"], str(author.get('e_mail')), headers["subject"], body,
-            subtype=headers["format"], logger=self.logger)
+            subtype=headers["format"], logger=self.logger, bcc=bcc)
 
         email_provider.smtp_send_messages(
             self.settings, messages=[message], logger=self.logger)

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -99,12 +99,14 @@ def add_text(message, text, subtype='plain', charset='utf-8'):
     message.attach(MIMEText(text, subtype, charset))
 
 
-def message(subject, sender, recipient):
+def message(subject, sender, recipient, bcc=None):
     "create an email message to later attach things to"
     message = MIMEMultipart()
     message['Subject'] = subject
     message['From'] = sender
     message['To'] = recipient
+    if bcc:
+        message['BCC'] = bcc
     return message
 
 
@@ -145,7 +147,7 @@ def smtp_send_messages(settings, messages, logger=None):
 
 
 def simple_message(sender, recipient, subject, body, subtype='plain',
-                   charset='utf-8', attachments=None, logger=None):
+                   charset='utf-8', attachments=None, logger=None, bcc=None):
     """set values of a message
 
     :param sender: email address of the sender
@@ -156,9 +158,10 @@ def simple_message(sender, recipient, subject, body, subtype='plain',
     :param charset: charset for the body text
     :param attachments: optional list of email attachments, each a file system path to the file
     :param logger: optional log.logger object
+    :param bcc: optional email address to BCC to
     :returns: MIMEMultipart email message object
     """
-    email_message = message(subject, sender, recipient)
+    email_message = message(subject, sender, recipient, bcc)
     add_text(email_message, body, subtype, charset)
     if attachments:
         for attachment in attachments:
@@ -167,7 +170,7 @@ def simple_message(sender, recipient, subject, body, subtype='plain',
 
 
 def simple_messages(sender, recipients, subject, body, subtype='plain',
-                   charset='utf-8', attachments=None, logger=None):
+                   charset='utf-8', attachments=None, logger=None, bcc=None):
     """list of simple messages for a list of recipients
 
     :param sender: email address of the sender
@@ -178,13 +181,14 @@ def simple_messages(sender, recipients, subject, body, subtype='plain',
     :param charset: charset for the body text
     :param attachments: optional list of email attachments, each a file system path to the file
     :param logger: optional log.logger object
+    :param bcc: optional email address to BCC to
     :returns: list of MIMEMultipart email message objects
     """
     messages = []
     for recipient in recipients:
         messages.append(simple_message(
             sender, recipient, subject, body, subtype=subtype, 
-            charset=charset, attachments=attachments, logger=logger))
+            charset=charset, attachments=attachments, logger=logger, bcc=bcc))
     return messages
 
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -58,6 +58,7 @@ class exp():
     ses_region = "eu-west-1"
     ses_sender_email = "sender@example.com"
     ses_admin_email = "admin@example.com"
+    ses_bcc_recipient_email = ""
 
     # SMTP settings
     smtp_host = 'localhost'
@@ -337,6 +338,7 @@ class dev():
     ses_region = "us-east-1"
     ses_sender_email = "sender@example.com"
     ses_admin_email = "admin@example.com"
+    ses_bcc_recipient_email = ""
 
     # SMTP settings
     smtp_host = 'localhost'
@@ -613,6 +615,7 @@ class live():
     ses_region = "us-east-1"
     ses_sender_email = "sender@example.com"
     ses_admin_email = "admin@example.com"
+    ses_bcc_recipient_email = ""
 
     # SMTP settings
     smtp_host = 'localhost'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -32,6 +32,7 @@ ses_sender_email = ""
 ses_poa_sender_email = ""
 ses_poa_recipient_email = ""
 ses_admin_email = ""
+ses_bcc_recipient_email = ""
 templates_bucket = ""
 ppp_cdn_bucket = 'ppd_cdn_bucket'
 digest_cdn_bucket = 'ppd_cdn_bucket/digests'

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -89,6 +89,7 @@ class TestListEmailRecipients(unittest.TestCase):
     def test_simple_message(self, subtype, expected_content_type):
         sender = 'sender@example.org'
         recipient = 'recipient@example.org'
+        bcc_recipient = 'bcc_recipient@example.org'
         subject = 'Email subject'
         body = '<p>Email body</p>'
         expected_fragments = []
@@ -97,6 +98,7 @@ class TestListEmailRecipients(unittest.TestCase):
         expected_fragments.append('Subject: %s' % subject)
         expected_fragments.append('From: %s' % sender)
         expected_fragments.append('To: %s' % recipient)
+        expected_fragments.append('BCC: %s' % bcc_recipient)
         expected_fragments.append(expected_content_type)
         expected_fragments.append('MIME-Version: 1.0')
         expected_fragments.append('Content-Transfer-Encoding: base64')
@@ -104,7 +106,7 @@ class TestListEmailRecipients(unittest.TestCase):
         expected_fragments.append(base64_encode_string(body))
         # create the message
         email_message = email_provider.simple_message(
-            sender, recipient, subject, body, subtype=subtype)
+            sender, recipient, subject, body, subtype=subtype, bcc=bcc_recipient)
         for expected in expected_fragments:
             self.assertTrue(
                 expected in str(email_message),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6268

The ability to add `BCC` headers to email messages created using `email_provider.py`. Then, in `PublicationEmail` activity, add a BCC recipient, if there is one specified in the `ses_bcc_recipient_email` value in `settings.py`. If it is blank then no BCC will be added.