### PR TITLE
PoA libraries, adds article type id 8 support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@ beautifulsoup4==4.7.1
 lxml==4.6.2
 python-slugify==1.2.4
 git+https://github.com/elifesciences/elife-tools.git@f9ed819e137b8ec96900d8cab59f4a8c9911ce45#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@efb0f8c02b149c9f307e64be23470ae1989f540e#egg=elifearticle
+git+https://github.com/elifesciences/elife-article.git@a3cc8244d3ddcb45039d8a3d876dfd4673c9975e#egg=elifearticle
 configparser==3.5.0
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1c4d2d9755634ef8440dc27fcc074bd56f01fe2c#egg=elifecrossref
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@6d352645389acf2b9c8f42bae06f32c456354fb5#egg=elifepubmed
-git+https://github.com/elifesciences/ejp-csv-parser.git@b3d0d740c789ed8df07b379d0bd2e041b5713035#egg=ejpcsvparser
-git+https://github.com/elifesciences/jats-generator.git@da53da99954a6661bc09c13794771639fcfe3e13#egg=jatsgenerator
-git+https://github.com/elifesciences/package-poa.git@f5003c020a9efbc5d3bccb4c20e8586e247e3acb#egg=packagepoa
+git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser
+git+https://github.com/elifesciences/jats-generator.git@7dde779b334e7d554174dbed1a78d63603ded293#egg=jatsgenerator
+git+https://github.com/elifesciences/package-poa.git@514517f5644cf3eb34514368f252d82acfd861af#egg=packagepoa
 six==1.13.0
 docker==4.0.2
 pypandoc==1.4


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6389

The https://github.com/elifesciences/ejp-csv-parser library is modified to add support for generating PoA XML for article type id `8` data.

Here, that library as well as other PoA-related libraries are updated in requirements so we can make full use of this feature.