### PR TITLE
Latest pubmed library, pubmed.cfg test file change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/elifesciences/elife-tools.git@f9ed819e137b8ec96900d8cab59
 git+https://github.com/elifesciences/elife-article.git@a3cc8244d3ddcb45039d8a3d876dfd4673c9975e#egg=elifearticle
 configparser==3.5.0
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1c4d2d9755634ef8440dc27fcc074bd56f01fe2c#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@6d352645389acf2b9c8f42bae06f32c456354fb5#egg=elifepubmed
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@f017802f76c878dfad23eb5432aa02fcb440ea18#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@7dde779b334e7d554174dbed1a78d63603ded293#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@514517f5644cf3eb34514368f252d82acfd861af#egg=packagepoa

--- a/tests/activity/pubmed.cfg
+++ b/tests/activity/pubmed.cfg
@@ -10,7 +10,6 @@ build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'fu
 # tags to remove when cleaning the abstract from article XML
 remove_tags: ["xref", "ext-link"]
 author_contrib_types: ["author"]
-group_author_contrib_types: ["author non-byline", "on-behalf-of"]
 history_date_types: ["received", "accepted"]
 split_article_categories: False
 publication_types: tests/activity/publication_types.yaml


### PR DESCRIPTION
Re bug issue https://github.com/elifesciences/elife-pubmed-feed/issues/28
Deploying code introduced in PR https://github.com/elifesciences/elife-pubmed-xml-generation/pull/44

In this PR the PubMed generation library fix can be deployed. There's a small change to the `pubmed.cfg` file used in test scenarios so it reflects the most up-to-date code logic.