### PR TITLE
Software Heritage deposit workflow stub

### DIFF
--- a/register.py
+++ b/register.py
@@ -40,6 +40,7 @@ def start(settings):
     workflow_names.append("PostPerfectPublication")
     workflow_names.append("IngestDigest")
     workflow_names.append("IngestDecisionLetter")
+    workflow_names.append("SoftwareHeritageDeposit")
 
     for workflow_name in workflow_names:
         # Import the workflow libraries

--- a/starter/starter_SoftwareHeritageDeposit.py
+++ b/starter/starter_SoftwareHeritageDeposit.py
@@ -1,0 +1,63 @@
+import json
+import uuid
+from starter.objects import Starter, default_workflow_params
+from starter.starter_helper import NullRequiredDataException
+
+
+class starter_SoftwareHeritageDeposit(Starter):
+    def __init__(self, settings=None, logger=None):
+        super(starter_SoftwareHeritageDeposit, self).__init__(
+            settings, logger, "SoftwareHeritageDeposit"
+        )
+
+    def get_workflow_params(self, run, info):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s" % (self.name, str(info.get("doi_id")))
+        workflow_params["workflow_name"] = self.name
+        workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 15)
+
+        input_data = info
+        input_data["run"] = run
+        workflow_params["input"] = json.dumps(input_data, default=lambda ob: None)
+
+        return workflow_params
+
+    def start(self, settings, run, info):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(run, info)
+
+    def start_workflow(self, run=None, info=None):
+
+        if run is None:
+            run = str(uuid.uuid4())
+
+        if not info:
+            raise NullRequiredDataException(
+                "Did not get info in starter %s" % self.name
+            )
+        for info_key in ["doi_id", "download_url"]:
+            if info.get(info_key) is None or str(info.get(info_key)) == "":
+                raise NullRequiredDataException(
+                    "Did not get a %s in starter %s" % (info_key, self.name)
+                )
+
+        self.connect_to_swf()
+
+        workflow_params = self.get_workflow_params(run, info)
+
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except NullRequiredDataException as null_exception:
+            self.logger.exception(null_exception.message)
+            raise
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)

--- a/tests/starter/test_starter_software_heritage_deposit.py
+++ b/tests/starter/test_starter_software_heritage_deposit.py
@@ -1,0 +1,76 @@
+import copy
+import unittest
+from mock import patch
+from starter.starter_SoftwareHeritageDeposit import starter_SoftwareHeritageDeposit
+from starter.starter_helper import NullRequiredDataException
+from tests.activity.classes_mock import FakeLogger
+import tests.settings_mock as settings_mock
+from tests.classes_mock import FakeBotoConnection
+
+
+RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
+
+INFO_EXAMPLE = {
+    "doi_id": "00666",
+    "download_url": "https://example.org/api/projects/1/snapshots/1/archive",
+}
+
+
+class TestStarterSoftwareHeritageDeposit(unittest.TestCase):
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.starter = starter_SoftwareHeritageDeposit(
+            settings_mock, logger=self.fake_logger
+        )
+
+    def test_software_heritage_deposit_starter_no_info(self):
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            run=RUN_EXAMPLE,
+            info={},
+        )
+
+    def test_software_heritage_deposit_starter_info_missing_doi_id(self):
+        info = copy.copy(INFO_EXAMPLE)
+        del info["doi_id"]
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            run=RUN_EXAMPLE,
+            info=info,
+        )
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_ingest_decision_letter_starter_no_run_argument(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(
+            self.starter.start(
+                settings=settings_mock,
+                run=None,
+                info=INFO_EXAMPLE,
+            )
+        )
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_ingest_decision_letter_starter(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(
+            self.starter.start(
+                settings=settings_mock,
+                run=RUN_EXAMPLE,
+                info=INFO_EXAMPLE,
+            )
+        )
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_workflow(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(
+            self.starter.start_workflow(
+                run=RUN_EXAMPLE,
+                info=INFO_EXAMPLE,
+            )
+        )

--- a/tests/workflow/test_workflow_software_heritage_deposit.py
+++ b/tests/workflow/test_workflow_software_heritage_deposit.py
@@ -1,0 +1,13 @@
+import unittest
+import tests.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+from workflow.workflow_SoftwareHeritageDeposit import workflow_SoftwareHeritageDeposit
+
+
+class TestWorkflowSoftwareHeritageDeposit(unittest.TestCase):
+    def setUp(self):
+        self.workflow = workflow_SoftwareHeritageDeposit(
+            settings_mock, FakeLogger(), None, None, None, None)
+
+    def test_init(self):
+        self.assertEqual(self.workflow.name, 'SoftwareHeritageDeposit')

--- a/workflow/workflow_SoftwareHeritageDeposit.py
+++ b/workflow/workflow_SoftwareHeritageDeposit.py
@@ -1,0 +1,44 @@
+from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
+
+
+class workflow_SoftwareHeritageDeposit(Workflow):
+    def __init__(self, settings, logger, conn=None, token=None, decision=None,
+                 maximum_page_size=100):
+        super(workflow_SoftwareHeritageDeposit, self).__init__(
+            settings, logger, conn, token, decision, maximum_page_size)
+
+        # SWF Defaults
+        self.name = "SoftwareHeritageDeposit"
+        self.version = "1"
+        self.description = "Deposit article data to Software Heritage repository"
+        self.default_execution_start_to_close_timeout = 60 * 15
+        self.default_task_start_to_close_timeout = 30
+
+        # Get the input from the JSON decision response
+        data = self.get_input()
+
+        # JSON format workflow definition, for now - may be from common YAML definition
+        workflow_definition = {
+            "name": self.name,
+            "version": self.version,
+            "task_list": self.settings.default_task_list,
+            "input": data,
+
+            "start":
+                {
+                    "requirements": None
+                },
+
+            "steps":
+                [
+                    define_workflow_step("PingWorker", data),
+                ],
+
+            "finish":
+                {
+                    "requirements": None
+                }
+        }
+
+        self.load_definition(workflow_definition)

--- a/workflow/workflow_SoftwareHeritageDeposit.py
+++ b/workflow/workflow_SoftwareHeritageDeposit.py
@@ -3,10 +3,18 @@ from workflow.helper import define_workflow_step
 
 
 class workflow_SoftwareHeritageDeposit(Workflow):
-    def __init__(self, settings, logger, conn=None, token=None, decision=None,
-                 maximum_page_size=100):
+    def __init__(
+        self,
+        settings,
+        logger,
+        conn=None,
+        token=None,
+        decision=None,
+        maximum_page_size=100,
+    ):
         super(workflow_SoftwareHeritageDeposit, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size)
+            settings, logger, conn, token, decision, maximum_page_size
+        )
 
         # SWF Defaults
         self.name = "SoftwareHeritageDeposit"
@@ -24,21 +32,11 @@ class workflow_SoftwareHeritageDeposit(Workflow):
             "version": self.version,
             "task_list": self.settings.default_task_list,
             "input": data,
-
-            "start":
-                {
-                    "requirements": None
-                },
-
-            "steps":
-                [
-                    define_workflow_step("PingWorker", data),
-                ],
-
-            "finish":
-                {
-                    "requirements": None
-                }
+            "start": {"requirements": None},
+            "steps": [
+                define_workflow_step("PingWorker", data),
+            ],
+            "finish": {"requirements": None},
         }
 
         self.load_definition(workflow_definition)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6415

To develop a new downstream recipient depositing workflow for Software Heritage, a simple first step is to create a stub workflow and starter. The workflow defined in this stub does only a `PingWorker` activity.

Unit tests are included.

If green, it should be safe to merge this, deploy, and manually trigger a `SoftwareHeritageDeposit` workflow to test all the parts are working for real.

Then, additional code can be added incrementally for this new workflow.