### PR TITLE
Email digest docx file even for silent workflows.

### DIFF
--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -76,13 +76,9 @@ class activity_EmailDigest(Activity):
         # Approve files for emailing
         self.approve_status, error_messages = digest_provider.validate_digest(self.digest)
 
-        silent = digest_provider.silent_digest(real_filename)
-
-        if not silent and self.approve_status is True and self.generate_status is True:
+        if self.approve_status is True and self.generate_status is True:
             # Email file
             self.email_status = self.email_digest(self.digest, output_file)
-        elif silent:
-            self.logger.info('EmailDigest silent deposit of real_filename: %s', real_filename)
 
         # return a value based on the activity_status
         if self.activity_status is True:

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -106,11 +106,13 @@ class TestEmailDigest(unittest.TestCase):
             "expected_build_status": True,
             "expected_generate_status": True,
             "expected_approve_status": True,
-            "expected_email_status": None,
+            "expected_email_status": True,
             "expected_digest_doi": u'https://doi.org/10.7554/eLife.99999',
             "expected_digest_image_file": u'IMAGE 99999.jpeg',
             "expected_output_dir_files": ['Anonymous_99999.docx'],
-            "expected_email_count": 0
+            "expected_email_count": 2,
+            "expected_email_subject": "Subject: Digest: Anonymous_99999",
+            "expected_email_from": "From: sender@example.org",
         },
     )
     def test_do_activity(self, test_data, fake_storage_context, fake_download_storage_context,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6438

We will send an email containing the digest `.docx` file as an attachment every time the `IngestDigest` workflow is run, even when it is a `silent` workflow. These emails are currently only going to internal recipients, so we do not need to block sending of the email any more, which was previously also going to third-party recipients.

The digest is now deposited to an API endpoint, and in the case of a silent workflow it is not sent to the API endpoint.