### PR TITLE
Add BCC address to list of email recipients.

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -1,4 +1,5 @@
 "provider for sending email"
+import copy
 import os
 import smtplib
 import unicodedata
@@ -117,10 +118,11 @@ def ses_send(connection, sender, recipient, message):
 
 def smtp_send(connection, sender, recipient, message, logger=None):
     "send a MIMEMultipart email to the recipient from sender by SMTP"
-    # strip the BCC header from the message, if present, prior to sending
-    message.__delitem__('BCC')
+    # strip the BCC header from a copy of the message, if present, prior to sending
+    message_to_send = copy.copy(message)
+    message_to_send.__delitem__('BCC')
     try:
-        connection.sendmail(sender, recipient, message.as_string())
+        connection.sendmail(sender, recipient, message_to_send.as_string())
     except smtplib.SMTPSenderRefused:
         if logger:
             logger.error('error in smtp_send: %s ', traceback.format_exc())

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -130,6 +130,11 @@ def smtp_send_message(connection, email_message, logger=None):
     """send the email message using the connection"""
     sender = email_message.get('From')
     recipient = email_message.get('To')
+    # if there is a BCC address, add them to the recipient list
+    if email_message.get('BCC'):
+        if isinstance(recipient, str):
+            recipient = [recipient]
+        recipient.append(email_message.get('BCC'))
     return smtp_send(connection, sender, recipient, email_message, logger)
 
 

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -118,7 +118,7 @@ def ses_send(connection, sender, recipient, message):
 def smtp_send(connection, sender, recipient, message, logger=None):
     "send a MIMEMultipart email to the recipient from sender by SMTP"
     # strip the BCC header from the message, if present, prior to sending
-    message.pop('BCC', None)
+    message.__delitem__('BCC')
     try:
         connection.sendmail(sender, recipient, message.as_string())
     except smtplib.SMTPSenderRefused:

--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -117,6 +117,8 @@ def ses_send(connection, sender, recipient, message):
 
 def smtp_send(connection, sender, recipient, message, logger=None):
     "send a MIMEMultipart email to the recipient from sender by SMTP"
+    # strip the BCC header from the message, if present, prior to sending
+    message.pop('BCC', None)
     try:
         connection.sendmail(sender, recipient, message.as_string())
     except smtplib.SMTPSenderRefused:


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6268

A small change, tested it manually on the real SMTP server. It does consider if the `To` value is a `str` or `list`, but it currently would only understand one `BCC` recipient (not a list of `BCC` recipients).

Hopefully looks ok @lsh-0? I feel like another set of eyes in case it can be improved.