### PR TITLE
Do not set bcc on email message, pass when sent.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -420,10 +420,10 @@ class activity_PublicationEmail(Activity):
 
         message = email_provider.simple_message(
             headers["sender_email"], str(author.get('e_mail')), headers["subject"], body,
-            subtype=headers["format"], logger=self.logger, bcc=bcc)
+            subtype=headers["format"], logger=self.logger)
 
         email_provider.smtp_send_messages(
-            self.settings, messages=[message], logger=self.logger)
+            self.settings, messages=[message], logger=self.logger, bcc=bcc)
         self.logger.info('Email sending details: article %s, email %s, to %s' %
                          (doi_id, headers["email_type"], str(author.get('e_mail'))))
 

--- a/tests/provider/test_email_provider.py
+++ b/tests/provider/test_email_provider.py
@@ -89,7 +89,6 @@ class TestListEmailRecipients(unittest.TestCase):
     def test_simple_message(self, subtype, expected_content_type):
         sender = 'sender@example.org'
         recipient = 'recipient@example.org'
-        bcc_recipient = 'bcc_recipient@example.org'
         subject = 'Email subject'
         body = '<p>Email body</p>'
         expected_fragments = []
@@ -98,7 +97,7 @@ class TestListEmailRecipients(unittest.TestCase):
         expected_fragments.append('Subject: %s' % subject)
         expected_fragments.append('From: %s' % sender)
         expected_fragments.append('To: %s' % recipient)
-        expected_fragments.append('BCC: %s' % bcc_recipient)
+
         expected_fragments.append(expected_content_type)
         expected_fragments.append('MIME-Version: 1.0')
         expected_fragments.append('Content-Transfer-Encoding: base64')
@@ -106,7 +105,7 @@ class TestListEmailRecipients(unittest.TestCase):
         expected_fragments.append(base64_encode_string(body))
         # create the message
         email_message = email_provider.simple_message(
-            sender, recipient, subject, body, subtype=subtype, bcc=bcc_recipient)
+            sender, recipient, subject, body, subtype=subtype)
         for expected in expected_fragments:
             self.assertTrue(
                 expected in str(email_message),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6268

A re-do of PR https://github.com/elifesciences/elife-bot/pull/1168 which I will close.

Testing of email BCC recipients and an implementation in the previous PR didn't sit right with me; since `BCC` is not a valid email message header, and now there is more clarification of how to implement BCC, the email message itself shouldn't have a `BCC` header set. Then we don't have to remove it from the headers prior to sending the email message.

To make a BCC recipient work, we pass it in at the time of sending the message, where it can then be added to the list of email recipients. It will not be present in the message headers.

The BCC feature was recently added and was only used by the `PublicationEmail` activity, so refactoring the function arguments should have little backwards compatibility problems.