### PR TITLE
Fix to mocks in IngestDigestToEndpoint tests.

### DIFF
--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -316,21 +316,27 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
     @patch.object(lax_provider, 'article_highest_version')
     @patch.object(lax_provider, 'article_first_by_status')
     @patch.object(activity_object, 'emit_monitor_event')
+    @patch.object(article_processing, 'download_article_xml')
+    @patch.object(digest_provider, 'image_file_name_from_s3')
     @patch.object(digest_provider, 'download_docx_from_s3')
     @patch.object(digest_provider, 'storage_context')
     @patch('activity.activity_IngestDigestToEndpoint.get_session')
     def test_do_activity_bad_download(self, fake_session, fake_storage_context, fake_download,
-                                      fake_emit, fake_first, fake_highest_version,
+                                      fake_image, fake_download_article_xml, fake_emit,
+                                      fake_first, fake_highest_version,
                                       fake_email_smtp_connect):
         "test unable to download a digest docx file"
         fake_emit.return_value = True
-        fake_session.return_value = FakeSession({})
+        session_test_data = session_data({})
+        fake_session.return_value = FakeSession(session_test_data)
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
         fake_first.return_value = True
         fake_highest_version.return_value = 1
         named_fake_storage_context = FakeStorageContext()
         named_fake_storage_context.resource_exists = lambda return_true: True
         fake_storage_context.return_value = named_fake_storage_context
+        fake_image.return_value = True
+        fake_download_article_xml.return_value = True
         fake_download.return_value = None
         session_test_data = session_data({})
         fake_session.return_value = FakeSession(session_test_data)


### PR DESCRIPTION
When running tests I noticed `test_activity_ingest_digest_to_endpoint.py` tests seemed to be really slow. I tracked it down to this particular test case, and when mocking some additional function calls (mirroring some other test cases of this activity) it is much improved, knocking total time for running tests from about 154 seconds down to 58 seconds for me.