### PR TITLE
Latest elifepubmed, bug fix to Group tag pruning.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/elifesciences/elife-tools.git@cf81b77f8b16970bf0f60ea47f8
 git+https://github.com/elifesciences/elife-article.git@a3cc8244d3ddcb45039d8a3d876dfd4673c9975e#egg=elifearticle
 configparser==3.5.0
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1c4d2d9755634ef8440dc27fcc074bd56f01fe2c#egg=elifecrossref
-git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@22b0d59a3c56a39bbf6570729cda5fdf64b89e58#egg=elifepubmed
+git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@89319ae311f8a599c0adec3d75d5e35a865c1123#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@7dde779b334e7d554174dbed1a78d63603ded293#egg=jatsgenerator
 git+https://github.com/elifesciences/package-poa.git@514517f5644cf3eb34514368f252d82acfd861af#egg=packagepoa


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6500

Deploying bug fix in PR https://github.com/elifesciences/elife-pubmed-xml-generation/pull/47

A bug where PubMed deposit `<Group>` tag is not removed when there is more than one group having no individuals in that group.