### PR TITLE
Change data key names in SoftwareHeritageDeposit.

### DIFF
--- a/starter/starter_SoftwareHeritageDeposit.py
+++ b/starter/starter_SoftwareHeritageDeposit.py
@@ -38,7 +38,7 @@ class starter_SoftwareHeritageDeposit(Starter):
             raise NullRequiredDataException(
                 "Did not get info in starter %s" % self.name
             )
-        for info_key in ["doi_id", "download_url"]:
+        for info_key in ["article_id", "input_file"]:
             if info.get(info_key) is None or str(info.get(info_key)) == "":
                 raise NullRequiredDataException(
                     "Did not get a %s in starter %s" % (info_key, self.name)

--- a/tests/starter/test_starter_software_heritage_deposit.py
+++ b/tests/starter/test_starter_software_heritage_deposit.py
@@ -11,8 +11,8 @@ from tests.classes_mock import FakeBotoConnection
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
 
 INFO_EXAMPLE = {
-    "doi_id": "00666",
-    "download_url": "https://example.org/api/projects/1/snapshots/1/archive",
+    "article_id": "00666",
+    "input_file": "https://example.org/api/projects/1/snapshots/1/archive",
 }
 
 
@@ -32,9 +32,9 @@ class TestStarterSoftwareHeritageDeposit(unittest.TestCase):
             info={},
         )
 
-    def test_software_heritage_deposit_starter_info_missing_doi_id(self):
+    def test_software_heritage_deposit_starter_info_missing_article_id(self):
         info = copy.copy(INFO_EXAMPLE)
-        del info["doi_id"]
+        del info["article_id"]
         self.assertRaises(
             NullRequiredDataException,
             self.starter.start,


### PR DESCRIPTION
After testing a manually started workflow, there was a mismatch between the data variable names used in the workflow starter very early in the development process, to later on these names were changed or disregarded.

In the starter, instead of `doi_id` use `article_id`, and instead of `download_url` use `input_file`.