### PR TITLE
Refactor FTPArticle to use the ftp provider.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -97,7 +97,13 @@ class FakeFTP:
     def ftp_connect(self, **kwargs):
         return self.ftp_instance
 
+    def ftp_cwd_mkd(self, ftp_instance, sub_dir):
+        pass
+
     def ftp_to_endpoint(self, **kwargs):
+        pass
+
+    def ftp_upload(self, ftp_instance, filename):
         pass
 
     def ftp_disconnect(self, ftp_instance=None):

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -7,7 +7,7 @@ from ddt import ddt, data, unpack
 import activity.activity_FTPArticle as activity_module
 from activity.activity_FTPArticle import activity_FTPArticle
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger
+from tests.activity.classes_mock import FakeFTP, FakeLogger
 
 
 @ddt
@@ -22,7 +22,7 @@ class TestFTPArticle(unittest.TestCase):
     @patch.object(activity_FTPArticle, "repackage_archive_zip_to_pmc_zip")
     @patch.object(activity_FTPArticle, "download_archive_zip_from_s3")
     @patch.object(activity_FTPArticle, "download_pmc_zip_from_s3")
-    @patch.object(activity_FTPArticle, "ftp_to_endpoint")
+    @patch('activity.activity_FTPArticle.FTP')
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
     @data(
         ('HEFCE', True, None, 'hefce_ftp.localhost', 'hefce_sftp.localhost', True),
@@ -40,11 +40,11 @@ class TestFTPArticle(unittest.TestCase):
     @unpack
     def test_do_activity(self, workflow, pmc_zip_return_value, archive_zip_return_value,
                          expected_ftp_uri, expected_sftp_uri, expected_result,
-                         fake_sftp_to_endpoint, fake_ftp_to_endpoint,
+                         fake_sftp_to_endpoint, fake_ftp,
                          fake_download_pmc_zip_from_s3, fake_download_archive_zip_from_s3,
                          fake_repackage_pmc_zip):
         fake_sftp_to_endpoint = MagicMock()
-        fake_ftp_to_endpoint = MagicMock()
+        fake_ftp.return_value = FakeFTP()
         fake_download_pmc_zip_from_s3.return_value = pmc_zip_return_value
         fake_download_archive_zip_from_s3.return_value = archive_zip_return_value
         fake_repackage_pmc_zip.return_value = True
@@ -58,21 +58,19 @@ class TestFTPArticle(unittest.TestCase):
         self.assertEqual(self.activity.FTP_URI, expected_ftp_uri)
         self.assertEqual(self.activity.SFTP_URI, expected_sftp_uri)
 
-    @patch.object(activity_FTPArticle, "download_archive_zip_from_s3")
     @patch.object(activity_FTPArticle, "download_pmc_zip_from_s3")
-    @patch.object(activity_FTPArticle, "ftp_to_endpoint")
+    @patch('activity.activity_FTPArticle.FTP')
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
     @data(
         ('HEFCE', 'non_numeric_raises_exception', False),
     )
     @unpack
     def test_do_activity_failure(self, workflow, elife_id, expected_result,
-                                 fake_sftp_to_endpoint, fake_ftp_to_endpoint,
-                                 fake_download_pmc_zip_from_s3, fake_download_archive_zip_from_s3):
+                                 fake_sftp_to_endpoint, fake_ftp,
+                                 fake_download_pmc_zip_from_s3):
         fake_sftp_to_endpoint = MagicMock()
-        fake_ftp_to_endpoint = MagicMock()
+        fake_ftp.return_value = FakeFTP()
         fake_download_pmc_zip_from_s3 = MagicMock()
-        fake_download_archive_zip_from_s3.return_value = True
         # Cause an exception by setting elife_id as non numeric for now
         activity_data = {
             'data': {
@@ -133,6 +131,49 @@ class TestFTPArticle(unittest.TestCase):
         with zipfile.ZipFile(expected_pmc_zip_file) as zip_file:
             # check pmc zip file contents
             self.assertEqual(sorted(zip_file.namelist()), sorted(expected_pmc_zip_file_contents))
+
+
+class TestFTPArticleFTPToEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.activity = activity_FTPArticle(settings_mock, FakeLogger(), None, None, None)
+        self.activity.FTP_URI = "ftp.example.org"
+        self.activity.FTP_CWD = "folder"
+        self.uploadfiles = ["zipfile.zip"]
+        self.sub_dir_list = ["subfolder", "subsubfolder"]
+
+    @patch.object(FakeFTP, 'ftp_connect')
+    @patch('activity.activity_FTPArticle.FTP')
+    def test_ftp_connect_exception(self, fake_ftp, fake_ftp_connect):
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_connect.side_effect = Exception("An exception")
+        with self.assertRaises(Exception):
+            self.activity.ftp_to_endpoint(self.uploadfiles)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            'Exception connecting to FTP server ftp.example.org: An exception')
+
+    @patch.object(FakeFTP, 'ftp_upload')
+    @patch('activity.activity_FTPArticle.FTP')
+    def test_ftp_upload_exception(self, fake_ftp, fake_ftp_upload):
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_upload.side_effect = Exception("An exception")
+        with self.assertRaises(Exception):
+            self.activity.ftp_to_endpoint(self.uploadfiles, self.sub_dir_list)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            'Exception in uploading file zipfile.zip by FTP in FTPArticle: An exception')
+
+    @patch.object(FakeFTP, 'ftp_disconnect')
+    @patch('activity.activity_FTPArticle.FTP')
+    def test_ftp_disconnect_exception(self, fake_ftp, fake_ftp_disconnect):
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_disconnect.side_effect = Exception("An exception")
+        with self.assertRaises(Exception):
+            self.activity.ftp_to_endpoint(self.uploadfiles)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            'Exception disconnecting from FTP server ftp.example.org: An exception')
 
 
 @ddt


### PR DESCRIPTION
Part of issue https://github.com/elifesciences/issues/issues/5603

In order to improve the exception handling when sending article zip file by FTP, the `FTPArticle` activity is modified to use the `provider/ftp.py` module for connecting, changing the working directory, upload files, and disconnecting.

Exceptions will be caught when connecting, if an exception is raised during the transfer of any file, or when disconnecting.

If an exception is raised while trying to upload a file, it will attempt to disconnect from the FTP server (if possible).

There is more info logged as each operation is successful.

Existing test cases are cleaned up a bit and coverage is increased by mocking the FTP server. New tests are added for each possible exception in `ftp_to_endpoint()`.

Test coverage of the activity is increased from 71% to 83%.