### PR TITLE
OVID to schedule downstream, pub router deposits.

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -161,6 +161,8 @@ class activity_PubRouterDeposit(Activity):
             return "cnki/outbox/"
         elif workflow == "CLOCKSS":
             return "clockss/outbox/"
+        elif workflow == "OVID":
+            return "ovid/outbox/"
 
         return None
 
@@ -186,6 +188,8 @@ class activity_PubRouterDeposit(Activity):
             return "cnki/published/"
         elif workflow == "CLOCKSS":
             return "clockss/published/"
+        elif workflow == "OVID":
+            return "ovid/published/"
 
         return None
 
@@ -446,7 +450,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ['CLOCKSS', 'PMC']:
+        if workflow not in ["CLOCKSS", "OVID", "PMC"]:
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(article.doi, workflow)
                 if was_ever_published is True:
@@ -457,7 +461,7 @@ class activity_PubRouterDeposit(Activity):
                     remove_article_doi.append(article.doi)
 
         # Check if a PMC zip file exists for this article
-        if workflow != 'PMC':
+        if workflow not in ["OVID", "PMC"]:
             for article in articles:
                 if not self.does_source_zip_exist_from_s3(doi_id=article.doi_id):
                     if self.logger:
@@ -654,6 +658,8 @@ class activity_PubRouterDeposit(Activity):
                 recipients = self.settings.CNKI_EMAIL
             elif workflow == "CLOCKSS":
                 recipients = self.settings.CLOCKSS_EMAIL
+            elif workflow == "OVID":
+                recipients = self.settings.OVID_EMAIL
         except:
             pass
 

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -118,6 +118,7 @@ def outbox_map():
     outboxes["cnpiec"] = "cnpiec/outbox/"
     outboxes["cnki"] = "cnki/outbox/"
     outboxes["clockss"] = "clockss/outbox/"
+    outboxes["ovid"] = "ovid/outbox/"
     return outboxes
 
 
@@ -128,6 +129,8 @@ def choose_outboxes(status, outbox_map, first_by_status, run_type=None):
         if first_by_status:
             outbox_list.append(outbox_map.get("publication_email"))
         outbox_list.append(outbox_map.get("pubmed"))
+
+    outbox_list.append(outbox_map.get("ovid"))
 
     if status == "poa":
         pass

--- a/provider/article.py
+++ b/provider/article.py
@@ -262,6 +262,8 @@ class article(object):
             published_folder = "cnki/published/"
         if workflow == "CLOCKSS":
             published_folder = "clockss/published/"
+        if workflow == "OVID":
+            published_folder = "ovid/published/"
 
         file_extensions = []
         file_extensions.append(".xml")

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -53,15 +53,18 @@ class starter_PubRouterDeposit():
         execution_start_to_close_timeout = None
         input = None
 
-        if (workflow == 'HEFCE'
-                or workflow == 'Cengage'
-                or workflow == 'GoOA'
-                or workflow == 'WoS'
-                or workflow == 'Scopus'
-                or workflow == 'PMC'
-                or workflow == 'CNPIEC'
-                or workflow == 'CNKI'
-                or workflow == 'CLOCKSS'):
+        if (
+            workflow == "HEFCE"
+            or workflow == "Cengage"
+            or workflow == "GoOA"
+            or workflow == "WoS"
+            or workflow == "Scopus"
+            or workflow == "PMC"
+            or workflow == "CNPIEC"
+            or workflow == "CNKI"
+            or workflow == "CLOCKSS"
+            or workflow == "OVID"
+        ):
             workflow_id = "PubRouterDeposit_" + workflow
 
         # workflow_id as set above


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6516

Next part is this should add each published article XML to the OVID S3 outbox folder, if it is PoA or VoR status, non-silent or silent correction workflow.

We can also then trigger a `PubRouterDeposit` workflow to send for all of those articles in that outbox folder.

The last piece which can be left out for now is enabling daily delivery in `cron.py` at a certain time of day. First, we can merge this PR and start to accumulate each published article in the OVID outbox "queue", test sending via `PubRouterDeposit` by manually triggering it, and send the remaining eLife article from volume 10, and then it will be ready to enable daily automated delivery.