### PR TITLE
PackagePOA CSV parsing error reporting improvements

### DIFF
--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -327,14 +327,15 @@ class TestPackagePOA(unittest.TestCase):
                                    test_data.get('expected_outbox_count'),
                                    test_data.get('scenario'))
 
-    @patch.object(activity_module.generate, 'build_article_from_csv')
+    @patch.object(activity_module.parse, "build_article")
     def test_generate_xml_build_article_exception(self, fake_build_article):
-        fake_build_article.side_effect = Exception('An exception')
+        fake_build_article.side_effect = Exception("An exception")
         with self.assertRaises(Exception):
             self.poa.generate_xml(12717)
         self.assertEqual(
             self.poa.logger.logexception,
-            'Exception in build_article_from_csv for article_id 12717: An exception')
+            "Exception in build_article for article_id 12717: An exception",
+        )
 
     @patch.object(activity_module.generate, 'build_xml_to_disk')
     def test_generate_xml_expat_exception(self, fake_build_xml):

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -337,6 +337,22 @@ class TestPackagePOA(unittest.TestCase):
             "Exception in build_article for article_id 12717: An exception",
         )
 
+    @patch.object(activity_module.parse, "build_article")
+    def test_generate_xml_build_article_errors(self, fake_build_article):
+        article_id = 12717
+        error_count = 1
+        error_messages = ["article_id %s error in set_title" % article_id]
+        fake_build_article.return_value = None, error_count, error_messages
+        with self.assertRaises(Exception):
+            self.poa.generate_xml(article_id)
+        self.assertEqual(
+            self.poa.logger.logexception,
+            (
+                "Exception raised in generate_xml, error count: %s, error_messages: %s"
+                % (error_count, ", ".join(error_messages))
+            ),
+        )
+
     @patch.object(activity_module.generate, 'build_xml_to_disk')
     def test_generate_xml_expat_exception(self, fake_build_xml):
         fake_build_xml.side_effect = ExpatError('An exception')


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6552

I think when this was refactored previously, we lost some of the XML generation error detection and the inclusion of CSV parsing errors in the email body.

This PR should improve those. Instead of relying on the function in the `jatsgenerator` library to create an `Article` object from CSV data, this uses the function from the `ejpcsvparser`, which returns the `error_count` and `error_messages` when it encounters problems using the CSV data. If `error_count` is greater than one then it will raise an exception. It will also populate the activity object's `error_count` and `error_messages` properties so they can be included in the email body again.