### PR TITLE
Zendy as a recipient of article zip sent by SFTP.

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -120,6 +120,8 @@ class activity_FTPArticle(Activity):
                 self.ftp_to_endpoint(zipfiles, passive=True)
             if workflow == 'OVID':
                 self.ftp_to_endpoint(zipfiles, passive=True)
+            if workflow == 'Zendy':
+                self.sftp_to_endpoint(zipfiles)
 
         except:
             # Something went wrong, fail
@@ -213,6 +215,12 @@ class activity_FTPArticle(Activity):
             self.FTP_USERNAME = self.settings.OVID_FTP_USERNAME
             self.FTP_PASSWORD = self.settings.OVID_FTP_PASSWORD
             self.FTP_CWD = self.settings.OVID_FTP_CWD
+
+        if workflow == 'Zendy':
+            self.SFTP_URI = self.settings.ZENDY_SFTP_URI
+            self.SFTP_USERNAME = self.settings.ZENDY_SFTP_USERNAME
+            self.SFTP_PASSWORD = self.settings.ZENDY_SFTP_PASSWORD
+            self.SFTP_CWD = self.settings.ZENDY_SFTP_CWD
 
     def download_files_from_s3(self, doi_id, workflow):
 

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -163,6 +163,8 @@ class activity_PubRouterDeposit(Activity):
             return "clockss/outbox/"
         elif workflow == "OVID":
             return "ovid/outbox/"
+        elif workflow == "Zendy":
+            return "zendy/outbox/"
 
         return None
 
@@ -190,6 +192,8 @@ class activity_PubRouterDeposit(Activity):
             return "clockss/published/"
         elif workflow == "OVID":
             return "ovid/published/"
+        elif workflow == "Zendy":
+            return "zendy/published/"
 
         return None
 
@@ -450,7 +454,7 @@ class activity_PubRouterDeposit(Activity):
                 remove_article_doi.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ["CLOCKSS", "OVID", "PMC"]:
+        if workflow not in ["CLOCKSS", "OVID", "PMC", "Zendy"]:
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(article.doi, workflow)
                 if was_ever_published is True:
@@ -461,7 +465,7 @@ class activity_PubRouterDeposit(Activity):
                     remove_article_doi.append(article.doi)
 
         # Check if a PMC zip file exists for this article
-        if workflow not in ["OVID", "PMC"]:
+        if workflow not in ["OVID", "PMC", "Zendy"]:
             for article in articles:
                 if not self.does_source_zip_exist_from_s3(doi_id=article.doi_id):
                     if self.logger:
@@ -660,6 +664,8 @@ class activity_PubRouterDeposit(Activity):
                 recipients = self.settings.CLOCKSS_EMAIL
             elif workflow == "OVID":
                 recipients = self.settings.OVID_EMAIL
+            elif workflow == "Zendy":
+                recipients = self.settings.ZENDY_EMAIL
         except:
             pass
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -256,6 +256,13 @@ class exp():
     OVID_FTP_CWD = ""
     OVID_EMAIL = ""
 
+    # Zendy SFTP settings
+    ZENDY_SFTP_URI = ""
+    ZENDY_SFTP_USERNAME = ""
+    ZENDY_SFTP_PASSWORD = ""
+    ZENDY_SFTP_CWD = ""
+    ZENDY_EMAIL = ""
+
     # Logging
     setLevel = "INFO"
 
@@ -543,6 +550,13 @@ class dev():
     OVID_FTP_CWD = ""
     OVID_EMAIL = ""
 
+    # Zendy SFTP settings
+    ZENDY_SFTP_URI = ""
+    ZENDY_SFTP_USERNAME = ""
+    ZENDY_SFTP_PASSWORD = ""
+    ZENDY_SFTP_CWD = ""
+    ZENDY_EMAIL = ""
+
     # Logging
     setLevel = "INFO"
 
@@ -822,6 +836,13 @@ class live():
     OVID_FTP_PASSWORD = ""
     OVID_FTP_CWD = ""
     OVID_EMAIL = ""
+
+    # Zendy SFTP settings
+    ZENDY_SFTP_URI = ""
+    ZENDY_SFTP_USERNAME = ""
+    ZENDY_SFTP_PASSWORD = ""
+    ZENDY_SFTP_CWD = ""
+    ZENDY_EMAIL = ""
 
     # Logging
     setLevel = "INFO"

--- a/starter/starter_FTPArticle.py
+++ b/starter/starter_FTPArticle.py
@@ -65,6 +65,7 @@ class starter_FTPArticle():
             or workflow == "CNKI"
             or workflow == "CLOCKSS"
             or workflow == "OVID"
+            or workflow == "Zendy"
         ):
             workflow_id = "FTPArticle_" + workflow + "_" + str(doi_id)
 

--- a/starter/starter_PubRouterDeposit.py
+++ b/starter/starter_PubRouterDeposit.py
@@ -64,6 +64,7 @@ class starter_PubRouterDeposit():
             or workflow == "CNKI"
             or workflow == "CLOCKSS"
             or workflow == "OVID"
+            or workflow == "Zendy"
         ):
             workflow_id = "PubRouterDeposit_" + workflow
 

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -158,6 +158,12 @@ OVID_FTP_USERNAME = ""
 OVID_FTP_PASSWORD = ""
 OVID_FTP_CWD = ""
 
+ZENDY_SFTP_URI = "zendy.localhost"
+ZENDY_SFTP_USERNAME = ""
+ZENDY_SFTP_PASSWORD = ""
+ZENDY_SFTP_CWD = ""
+ZENDY_EMAIL = ""
+
 git_repo_name = 'elife-article-xml-ci'
 git_repo_path = '/articles/'
 github_token = '1234567890abcdef'

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -37,6 +37,7 @@ class TestFTPArticle(unittest.TestCase):
         ('CLOCKSS', True, None, 'clockss.localhost', None, True),
         ('CLOCKSS', False, True, 'clockss.localhost', None, True),
         ('OVID', False, True, 'ovid.localhost', None, True),
+        ('Zendy', False, True, None, 'zendy.localhost', True),
     )
     @unpack
     def test_do_activity(self, workflow, pmc_zip_return_value, archive_zip_return_value,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6482

Configuration to send article zip files by SFTP to Zendy by either manually triggering `FTPArticle` workflow executions or by manually triggering a `PubRouterDeposit` workflow.

Not included yet is to schedule sending to Zendy after each article is published, and the cron is not yet configured to send files daily.

First, merge this PR, test sending manually, send all the previously published articles, after that the daily scheduled sending can be enabled in anohter PR.