### PR TITLE
Typo in log message in sftp.py provider.

### DIFF
--- a/provider/sftp.py
+++ b/provider/sftp.py
@@ -62,7 +62,7 @@ class SFTP(object):
             try:
                 self.transport.close()
                 if self.logger:
-                    self.logger.info("Closed transport connectin in SFTP provider")
+                    self.logger.info("Closed transport connection in SFTP provider")
             except Exception as exception:
                 if self.logger:
                     self.logger.exception(


### PR DESCRIPTION
Fix typo in log message introduced in PR https://github.com/elifesciences/elife-bot/pull/1200