### PR TITLE
Add Zendy to schedule downstream and cron.

### DIFF
--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -119,6 +119,7 @@ def outbox_map():
     outboxes["cnki"] = "cnki/outbox/"
     outboxes["clockss"] = "clockss/outbox/"
     outboxes["ovid"] = "ovid/outbox/"
+    outboxes["zendy"] = "zendy/outbox/"
     return outboxes
 
 
@@ -131,6 +132,7 @@ def choose_outboxes(status, outbox_map, first_by_status, run_type=None):
         outbox_list.append(outbox_map.get("pubmed"))
 
     outbox_list.append(outbox_map.get("ovid"))
+    outbox_list.append(outbox_map.get("zendy"))
 
     if status == "poa":
         pass

--- a/cron.py
+++ b/cron.py
@@ -122,6 +122,18 @@ def conditional_starts(current_datetime):
         # Jobs to start at quarter past the hour
         LOGGER.info("Quarter past the hour")
 
+        # Zendy deposits once per day 21:15 UTC
+        if current_time.tm_hour == 21:
+            conditional_start_list.append(
+                OrderedDict(
+                    [
+                        ("starter_name", "starter_PubRouterDeposit"),
+                        ("workflow_id", "PubRouterDeposit_Zendy"),
+                        ("start_seconds", 60 * 31),
+                    ]
+                )
+            )
+
         # OVID deposits once per day 22:15 UTC
         if current_time.tm_hour == 22:
             conditional_start_list.append(

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -299,6 +299,17 @@ class TestConditionalStarts(unittest.TestCase):
 
     @data(
         {
+            "comment": "21:15 UTC",
+            "date_time": "1970-01-01 21:15:00 UTC",
+            "expected_starter_names": ["cron_FiveMinute", "starter_PubRouterDeposit"],
+            "expected_workflow_ids": ["cron_FiveMinute", "PubRouterDeposit_Zendy"],
+        },
+    )
+    def test_conditional_starts_21_15_utc(self, test_data):
+        self.conditional_start_test_run(test_data)
+
+    @data(
+        {
             "comment": "21:30 UTC",
             "date_time": "1970-01-01 21:30:00 UTC",
             "expected_starter_names": [


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6482

Enable automated daily delivery of articles to Zendy.