### PR TITLE
Deposit article metadata to DOAJ

### DIFF
--- a/activity/activity_DepositDOAJ.py
+++ b/activity/activity_DepositDOAJ.py
@@ -1,0 +1,96 @@
+import json
+from provider.execution_context import get_session
+from provider import doaj, lax_provider
+from activity.objects import Activity
+
+
+class activity_DepositDOAJ(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_DepositDOAJ, self).__init__(
+            settings, logger, conn, token, activity_task
+        )
+
+        self.name = "DepositDOAJ"
+        self.pretty_name = "POST article metadata to the DOAJ API endpoint"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "POST article metadata to the DOAJ API endpoint"
+
+        # Track the success of some steps
+        self.statuses = {"download": None, "build": None, "post": None}
+
+    def do_activity(self, data=None):
+        if self.logger:
+            self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        # first check if there is an endpoint in the settings specified
+        if not hasattr(self.settings, "doaj_endpoint"):
+            self.logger.info("No doaj_endpoint in settings, skipping %s." % self.name)
+            return self.ACTIVITY_SUCCESS
+        if not self.settings.doaj_endpoint:
+            self.logger.info(
+                "doaj_endpoint in settings is blank, skipping %s." % self.name
+            )
+            return self.ACTIVITY_SUCCESS
+
+        try:
+            run = data["run"]
+            session = get_session(self.settings, data, run)
+            article_id = session.get_value("article_id")
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s getting article_id from session, run %s: %s" %
+                (self.name, run, str(exception)),
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # get JSON from Lax
+        try:
+            status_code, article_json_string = lax_provider.article_json(
+                article_id, self.settings
+            )
+            article_json = json.loads(article_json_string)
+            self.statuses["build"] = True
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s getting article json using lax_provider, article_id %s: %s" %
+                (self.name, article_id, str(exception))
+            )
+            return self.ACTIVITY_TEMPORARY_FAILURE
+
+        # convert Lax JSON to DOAJ JSON
+        try:
+            doaj_json = doaj.doaj_json(article_json, self.settings)
+            self.logger.info("%s doaj_json for article_id %s: %s" % (self.name, article_id, doaj_json))
+            self.statuses["download"] = True
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s building DOAJ json, article_id %s: %s" %
+                (self.name, article_id, str(exception)),
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # post to DOAJ endpoint
+        try:
+            response = doaj.doaj_post_request(
+                self.settings.doaj_endpoint,
+                article_id,
+                doaj_json,
+                self.settings.doaj_api_key,
+            )
+            self.statuses["post"] = True
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s posting to DOAJ API endpoint, article_id %s: %s" %
+                (self.name, article_id, str(exception)),
+            )
+            return self.ACTIVITY_TEMPORARY_FAILURE
+
+        self.logger.info(
+            "%s for article_id %s statuses: %s" % (self.name, article_id, self.statuses)
+        )
+
+        return self.ACTIVITY_SUCCESS

--- a/activity/activity_DepositDOAJ.py
+++ b/activity/activity_DepositDOAJ.py
@@ -61,6 +61,14 @@ class activity_DepositDOAJ(Activity):
             )
             return self.ACTIVITY_TEMPORARY_FAILURE
 
+        # check for VoR status
+        if not article_json.get("status") == "vor":
+            self.logger.info(
+                "%s, article_id %s is not VoR status and will not be deposited"
+                % (self.name, article_id)
+            )
+            return self.ACTIVITY_SUCCESS
+
         # convert Lax JSON to DOAJ JSON
         try:
             doaj_json = doaj.doaj_json(article_json, self.settings)

--- a/activity/activity_DepositDOAJ.py
+++ b/activity/activity_DepositDOAJ.py
@@ -42,8 +42,8 @@ class activity_DepositDOAJ(Activity):
             article_id = session.get_value("article_id")
         except Exception as exception:
             self.logger.exception(
-                "Exception in %s getting article_id from session, run %s: %s" %
-                (self.name, run, str(exception)),
+                "Exception in %s getting article_id from session, run %s: %s"
+                % (self.name, run, str(exception)),
             )
             return self.ACTIVITY_PERMANENT_FAILURE
 
@@ -56,8 +56,8 @@ class activity_DepositDOAJ(Activity):
             self.statuses["build"] = True
         except Exception as exception:
             self.logger.exception(
-                "Exception in %s getting article json using lax_provider, article_id %s: %s" %
-                (self.name, article_id, str(exception))
+                "Exception in %s getting article json using lax_provider, article_id %s: %s"
+                % (self.name, article_id, str(exception))
             )
             return self.ACTIVITY_TEMPORARY_FAILURE
 
@@ -72,12 +72,15 @@ class activity_DepositDOAJ(Activity):
         # convert Lax JSON to DOAJ JSON
         try:
             doaj_json = doaj.doaj_json(article_json, self.settings)
-            self.logger.info("%s doaj_json for article_id %s: %s" % (self.name, article_id, doaj_json))
+            self.logger.info(
+                "%s doaj_json for article_id %s: %s"
+                % (self.name, article_id, doaj_json)
+            )
             self.statuses["download"] = True
         except Exception as exception:
             self.logger.exception(
-                "Exception in %s building DOAJ json, article_id %s: %s" %
-                (self.name, article_id, str(exception)),
+                "Exception in %s building DOAJ json, article_id %s: %s"
+                % (self.name, article_id, str(exception)),
             )
             return self.ACTIVITY_PERMANENT_FAILURE
 
@@ -92,8 +95,8 @@ class activity_DepositDOAJ(Activity):
             self.statuses["post"] = True
         except Exception as exception:
             self.logger.exception(
-                "Exception in %s posting to DOAJ API endpoint, article_id %s: %s" %
-                (self.name, article_id, str(exception)),
+                "Exception in %s posting to DOAJ API endpoint, article_id %s: %s"
+                % (self.name, article_id, str(exception)),
             )
             return self.ACTIVITY_TEMPORARY_FAILURE
 

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -1,0 +1,121 @@
+import time
+from collections import OrderedDict
+
+
+LINK_URL_PATTERN = "https://elifesciences.org/articles/%s"
+EISSN = "2050-084X"
+
+
+def doaj_json(article_json):
+    doaj_json = OrderedDict()
+    doaj_json["bibjson"] = bibjson(article_json)
+    return doaj_json
+
+
+def bibjson(article_json):
+    bibjson = OrderedDict()
+    bibjson["abstract"] = abstract(article_json.get("abstract", {}))
+    bibjson["author"] = author(article_json.get("authors", []))
+    bibjson["identifier"] = identifier(article_json)
+    bibjson["journal"] = journal(article_json)
+    bibjson["keywords"] = keywords(article_json.get("keywords", []))
+    bibjson["link"] = link(article_json)
+    published_date = time.strptime(article_json["published"], "%Y-%m-%dT%H:%M:%SZ")
+    bibjson["month"] = month(published_date)
+    bibjson["title"] = title(article_json)
+    bibjson["year"] = year(published_date)
+    return bibjson
+
+
+def abstract(abstract_json):
+    # todo!!! formatting structured abstracts
+    # todo!! strip out inline formatting
+    # todo!! replace maths with a placeholder string
+    abstract = abstract_json.get("content")[0].get("text")
+    return abstract
+
+
+def author(authors_json):
+
+    author_list = []
+    for author in authors_json:
+        author_json = OrderedDict()
+        # todo!!! test and format group author name
+
+        # affiliations
+        affiliations = []
+        for aff_json in author.get("affiliations"):
+            affiliations.append(affiliation_string(aff_json))
+        if affiliations:
+            author_json["affiliation"] = "; ".join(affiliations)
+        # name
+        author_json["name"] = author.get("name").get("preferred")
+        # orcid
+        if author.get("orcid"):
+            author_json["orcid_id"] = "https://orcid.org/%s" % author.get("orcid")
+
+        author_list.append(author_json)
+    return author_list
+
+
+def affiliation_string(aff_json):
+    "format one affiliation into a string value"
+    aff_parts = []
+    # name is a list, join it, although in reality it seems to only contain one item
+    aff_parts.append(", ".join(aff_json.get("name")))
+    if aff_json.get("address") and aff_json.get("address").get("formatted"):
+        aff_parts = aff_parts + aff_json.get("address").get("formatted")
+    return ", ".join(aff_parts)
+
+
+def identifier(article_json):
+    identifier_list = []
+    # doi
+    doi = OrderedDict()
+    doi["id"] = article_json.get("doi")
+    doi["type"] = "doi"
+    identifier_list.append(doi)
+    # eissn
+    eissn = OrderedDict()
+    eissn["id"] = EISSN
+    eissn["type"] = "eissn"
+    identifier_list.append(eissn)
+    # elocationid
+    elocationid = OrderedDict()
+    elocationid["id"] = article_json.get("elocationId")
+    elocationid["type"] = "elocationid"
+    identifier_list.append(elocationid)
+    return identifier_list
+
+
+def journal(article_json):
+    journal_json = OrderedDict()
+    journal_json["volume"] = str(article_json.get("volume"))
+    return journal_json
+
+
+def keywords(keywords_json):
+    keyword_list = keywords_json
+    return keyword_list
+
+
+def link(article_json):
+    link_json = OrderedDict()
+    link_json["content_type"] = "text/html"
+    link_json["type"] = "fulltext"
+    link_json["url"] = LINK_URL_PATTERN % article_json.get("id")
+    return link_json
+
+
+def month(date_struct):
+    return str(date_struct.tm_mon)
+
+
+def title(article_json):
+    # todo!!! remove inline formatting tags
+    title = article_json.get("title")
+    return title
+
+
+def year(date_struct):
+    return str(date_struct.tm_year)

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -1,6 +1,8 @@
+from pprint import pformat
 import re
 import time
 from collections import OrderedDict
+import requests
 from elifetools import utils as etoolsutils
 
 
@@ -165,3 +167,28 @@ def title(article_json):
 
 def year(date_struct):
     return str(date_struct.tm_year)
+
+
+def doaj_post_request(url, article_id, data, api_key, verify_ssl=False, logger=None):
+    "POST JSON data to DOAJ API endpoint"
+    headers = {"Content-Type": "application/json"}
+    params = {"api_key": api_key}
+    response = requests.post(
+        url, params=params, json=data, verify=verify_ssl, headers=headers
+    )
+    if logger:
+        logger.info(
+            "Post article %s to DOAJ API: POST %s\n%s"
+            % (article_id, url, pformat(data))
+        )
+        logger.info(
+            "Response from DOAJ API: %s\n%s" % (response.status_code, response.content)
+        )
+    status_code = response.status_code
+    if not 300 > status_code >= 200:
+        raise Exception(
+            "Error in doaj_post_request %s to DOAJ API: %s\n%s"
+            % (article_id, status_code, response.content)
+        )
+
+    return response

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -135,12 +135,14 @@ def keywords(keywords_json):
 
 
 def link(article_json, url_link_pattern=None):
+    link_list = []
     link_json = OrderedDict()
     if url_link_pattern:
         link_json["content_type"] = "text/html"
         link_json["type"] = "fulltext"
         link_json["url"] = url_link_pattern.format(article_id=article_json.get("id"))
-    return link_json
+        link_list.append(link_json)
+    return link_list
 
 
 def month(date_struct):

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -66,7 +66,6 @@ def author(authors_json):
     author_list = []
     for author in authors_json:
         author_json = OrderedDict()
-        # todo!!! test and format group author name
 
         # affiliations
         affiliations = []
@@ -74,8 +73,15 @@ def author(authors_json):
             affiliations.append(affiliation_string(aff_json))
         if affiliations:
             author_json["affiliation"] = "; ".join(affiliations)
+
         # name
-        author_json["name"] = author.get("name").get("preferred")
+        if author.get("type") == "group":
+            # format group author name
+            author_json["name"] = author.get("name")
+        else:
+            # person name
+            author_json["name"] = author.get("name").get("preferred")
+
         # orcid
         if author.get("orcid"):
             author_json["orcid_id"] = "https://orcid.org/%s" % author.get("orcid")

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -71,7 +71,7 @@ def author(authors_json):
 
         # affiliations
         affiliations = []
-        for aff_json in author.get("affiliations"):
+        for aff_json in author.get("affiliations", []):
             affiliations.append(affiliation_string(aff_json))
         if affiliations:
             author_json["affiliation"] = "; ".join(affiliations)

--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -130,7 +130,13 @@ def journal(article_json):
 
 
 def keywords(keywords_json):
-    keyword_list = keywords_json
+    keyword_list = []
+    for keyword in keywords_json:
+        # check for any HTML tags to remove
+        if "<" in keyword:
+            for tag_name in REMOVE_TITLE_TAGS:
+                keyword = etoolsutils.remove_tag(tag_name, keyword)
+        keyword_list.append(keyword)
     return keyword_list
 
 

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -51,6 +51,13 @@ def lax_auth_key(settings, auth=False):
     return 'public'
 
 
+def article_json(article_id, settings, auth=False):
+    "get json for the latest article version from lax"
+    url = settings.lax_article_endpoint.replace('{article_id}', article_id)
+    return lax_request(url, article_id, settings.verify_ssl, None,
+                       lax_auth_key(settings, auth))
+
+
 def article_versions(article_id, settings, auth=False):
     "get json for article versions from lax"
     url = settings.lax_article_versions.replace('{article_id}', article_id)

--- a/register.py
+++ b/register.py
@@ -40,6 +40,7 @@ def start(settings):
     workflow_names.append("PostPerfectPublication")
     workflow_names.append("IngestDigest")
     workflow_names.append("IngestDecisionLetter")
+    workflow_names.append("DepositDOAJ")
     workflow_names.append("SoftwareHeritageDeposit")
 
     for workflow_name in workflow_names:

--- a/register.py
+++ b/register.py
@@ -111,6 +111,7 @@ def start(settings):
     activity_names.append("DecisionLetterReceipt")
     activity_names.append("DepositDecisionLetterIngestAssets")
     activity_names.append("PostDecisionLetterJATS")
+    activity_names.append("DepositDOAJ")
     activity_names.append("DownstreamStart")
     activity_names.append("PackageSWH")
     activity_names.append("GenerateSWHMetadata")

--- a/settings-example.py
+++ b/settings-example.py
@@ -41,6 +41,7 @@ class exp():
     digest_cdn_bucket = 'elife-published/digests'
     archive_bucket = 'elife-publishing-archive'
 
+    lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
     verify_ssl = True  # False when testing
@@ -305,6 +306,10 @@ class exp():
     # BigQuery settings
     big_query_project_id = ''
 
+    # DOAJ deposit settings
+    journal_eissn = ""
+    doaj_url_link_pattern = "https://example.org/articles/{article_id}"
+
 
 class dev():
     # AWS settings
@@ -335,6 +340,7 @@ class dev():
     digest_cdn_bucket = 'elife-published/digests'
     archive_bucket = 'elife-publishing-archive'
 
+    lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
     verify_ssl = True  # False when testing
@@ -595,6 +601,10 @@ class dev():
     # BigQuery settings
     big_query_project_id = ''
 
+    # DOAJ deposit settings
+    journal_eissn = ""
+    doaj_url_link_pattern = "https://example.org/articles/{article_id}"
+
 
 class live():
     # AWS settings
@@ -626,6 +636,7 @@ class live():
     digest_cdn_bucket = 'prod-elife-published/digests'
     archive_bucket = 'prod-elife-publishing-archive'
 
+    lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
     verify_ssl = True  # False when testing
@@ -885,6 +896,10 @@ class live():
 
     # BigQuery settings
     big_query_project_id = ''
+
+    # DOAJ deposit settings
+    journal_eissn = ""
+    doaj_url_link_pattern = "https://example.org/articles/{article_id}"
 
 
 def get_settings(ENV="dev"):

--- a/settings-example.py
+++ b/settings-example.py
@@ -309,6 +309,8 @@ class exp():
     # DOAJ deposit settings
     journal_eissn = ""
     doaj_url_link_pattern = "https://example.org/articles/{article_id}"
+    doaj_endpoint = "https://doaj/api/v2/articles"
+    doaj_api_key = ""
 
 
 class dev():
@@ -604,6 +606,8 @@ class dev():
     # DOAJ deposit settings
     journal_eissn = ""
     doaj_url_link_pattern = "https://example.org/articles/{article_id}"
+    doaj_endpoint = "https://doaj/api/v2/articles"
+    doaj_api_key = ""
 
 
 class live():
@@ -900,6 +904,8 @@ class live():
     # DOAJ deposit settings
     journal_eissn = ""
     doaj_url_link_pattern = "https://example.org/articles/{article_id}"
+    doaj_endpoint = "https://doaj/api/v2/articles"
+    doaj_api_key = ""
 
 
 def get_settings(ENV="dev"):

--- a/starter/starter_DepositDOAJ.py
+++ b/starter/starter_DepositDOAJ.py
@@ -1,0 +1,114 @@
+import json
+import uuid
+from optparse import OptionParser
+from provider import utils
+from provider.execution_context import get_session
+from starter.objects import Starter, default_workflow_params
+from starter.starter_helper import NullRequiredDataException
+
+
+class starter_DepositDOAJ(Starter):
+    def __init__(self, settings=None, logger=None):
+        super(starter_DepositDOAJ, self).__init__(settings, logger, "DepositDOAJ")
+
+    def get_workflow_params(self, run, info):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s" % (
+            self.name,
+            str(info.get("article_id")),
+        )
+        workflow_params["workflow_name"] = self.name
+        workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 15)
+
+        input_data = info
+        input_data["run"] = run
+        workflow_params["input"] = json.dumps(input_data, default=lambda ob: None)
+
+        return workflow_params
+
+    def start(self, settings, run, info):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(run, info)
+
+    def start_workflow(self, run=None, info=None):
+
+        if run is None:
+            run = str(uuid.uuid4())
+
+        if not info:
+            raise NullRequiredDataException(
+                "Did not get info in starter %s" % self.name
+            )
+        for info_key in ["article_id"]:
+            if info.get(info_key) is None or str(info.get(info_key)) == "":
+                raise NullRequiredDataException(
+                    "Did not get a %s in starter %s" % (info_key, self.name)
+                )
+
+        # save article_id into the session for stand-alone workflow execution
+        session = get_session(self.settings, info, run)
+        session.store_value("article_id", info.get("article_id"))
+
+        self.connect_to_swf()
+
+        workflow_params = self.get_workflow_params(run, info)
+
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except NullRequiredDataException as null_exception:
+            self.logger.exception(null_exception.message)
+            raise
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)
+
+
+if __name__ == "__main__":
+
+    doi_id = None
+    workflow = None
+
+    # Add options
+    parser = OptionParser()
+    parser.add_option(
+        "-e",
+        "--env",
+        default="dev",
+        action="store",
+        type="string",
+        dest="env",
+        help="set the environment to run, either dev or live",
+    )
+    parser.add_option(
+        "-d",
+        "--doi-id",
+        default=None,
+        action="store",
+        type="string",
+        dest="doi_id",
+        help="specify the DOI id of a single article",
+    )
+
+    (options, args) = parser.parse_args()
+    if options.env:
+        ENV = options.env
+    if options.doi_id:
+        doi_id = options.doi_id
+
+    import settings as settingsLib
+
+    settings = settingsLib.get_settings(ENV)
+
+    o = starter_DepositDOAJ()
+
+    info = {"article_id": utils.pad_msid(doi_id)}
+
+    o.start(settings=settings, run=None, info=info)

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -209,3 +209,9 @@ typesetter_decision_letter_api_key = 'typesetter_api_key'
 typesetter_decision_letter_account_key = '1'
 decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
 decision_letter_jats_error_recipient_email = "error@example.org"
+
+# DOAJ deposit settings
+journal_eissn = "2050-084X"
+doaj_url_link_pattern = "https://elifesciences.org/articles/{article_id}"
+doaj_endpoint = "https://doaj/api/v2/articles"
+doaj_api_key = ""

--- a/tests/activity/test_activity_deposit_doaj.py
+++ b/tests/activity/test_activity_deposit_doaj.py
@@ -107,6 +107,24 @@ class TestDepositDOAJ(unittest.TestCase):
             ),
         )
 
+    @patch.object(lax_provider, "article_json")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_article_poa_status(self, mock_session, fake_article_json):
+        mock_session.return_value = self.session
+        poa_article_json_string = self.article_json_string.replace(b'"vor"', b'"poa"')
+        fake_article_json.return_value = (200, poa_article_json_string)
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "DepositDOAJ, article_id 65469 is not VoR status and will not be deposited"
+            ),
+        )
+
     @patch.object(doaj, "doaj_json")
     @patch.object(lax_provider, "article_json")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_deposit_doaj.py
+++ b/tests/activity/test_activity_deposit_doaj.py
@@ -1,0 +1,152 @@
+# coding=utf-8
+
+import unittest
+from mock import patch
+import activity.activity_DepositDOAJ as activity_module
+from activity.activity_DepositDOAJ import activity_DepositDOAJ as activity_object
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeSession
+from tests import read_fixture
+from provider import doaj, lax_provider
+
+
+class TestDepositDOAJ(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        self.data = {"run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda"}
+        self.session = FakeSession(
+            {
+                "article_id": "65469",
+            }
+        )
+        self.article_json_string = read_fixture("e65469_article_json.txt", "doaj")
+
+    @patch("requests.post")
+    @patch.object(lax_provider, "article_json")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity(self, mock_session, fake_article_json, fake_post):
+        mock_session.return_value = self.session
+        fake_article_json.return_value = (200, self.article_json_string)
+        response = FakeResponse(201)
+        fake_post.return_value = response
+        expected_doaj_json = read_fixture("e65469_doaj_json.py", "doaj")
+
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "DepositDOAJ for article_id 65469 statuses: "
+                "{'download': True, 'build': True, 'post': True}"
+            ),
+        )
+        doaj_json_loginfo_expected = (
+            "DepositDOAJ doaj_json for article_id 65469: %s" % expected_doaj_json
+        )
+        self.assertEqual(self.activity.logger.loginfo[-2], doaj_json_loginfo_expected)
+
+    def test_do_activity_settings_no_endpoint(self):
+        self.activity.settings = {}
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            "No doaj_endpoint in settings, skipping DepositDOAJ.",
+        )
+
+    def test_do_activity_settings_blank_endpoint(self):
+        self.activity.settings.doaj_endpoint = ""
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            "doaj_endpoint in settings is blank, skipping DepositDOAJ.",
+        )
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_session_exception(self, mock_session):
+        mock_session.side_effect = Exception("A session exception")
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "Exception in DepositDOAJ getting article_id from session, "
+                "run 1ee54f9a-cb28-4c8e-8232-4b317cf4beda: A session exception"
+            ),
+        )
+
+    @patch.object(lax_provider, "article_json")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_lax_exception(self, mock_session, fake_article_json):
+        mock_session.return_value = self.session
+        fake_article_json.side_effect = Exception("A lax exception")
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_TEMPORARY_FAILURE)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "Exception in DepositDOAJ getting article json using lax_provider, "
+                "article_id 65469: A lax exception"
+            ),
+        )
+
+    @patch.object(doaj, "doaj_json")
+    @patch.object(lax_provider, "article_json")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_json_build_exception(
+        self, mock_session, fake_article_json, fake_doaj_json
+    ):
+        mock_session.return_value = self.session
+        fake_article_json.return_value = (200, self.article_json_string)
+        fake_doaj_json.side_effect = Exception("Exception building json")
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "Exception in DepositDOAJ building DOAJ json, "
+                "article_id 65469: Exception building json"
+            ),
+        )
+
+    @patch("requests.post")
+    @patch.object(lax_provider, "article_json")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_doaj_exception(
+        self, mock_session, fake_article_json, fake_post
+    ):
+        mock_session.return_value = self.session
+        fake_article_json.return_value = (200, self.article_json_string)
+        fake_post.side_effect = Exception("DOAJ endpoint exception")
+        # do the activity
+        result = self.activity.do_activity(self.data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_TEMPORARY_FAILURE)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "Exception in DepositDOAJ posting to DOAJ API endpoint, "
+                "article_id 65469: DOAJ endpoint exception"
+            ),
+        )

--- a/tests/fixtures/doaj/e65469_article_json.txt
+++ b/tests/fixtures/doaj/e65469_article_json.txt
@@ -1,0 +1,4434 @@
+{
+    "status": "vor",
+    "id": "65469",
+    "version": 1,
+    "type": "research-article",
+    "doi": "10.7554/eLife.65469",
+    "authorLine": "Yanan Chen et al.",
+    "title": "Prolonging the integrated stress response enhances CNS remyelination in an inflammatory environment",
+    "published": "2021-03-23T00:00:00Z",
+    "versionDate": "2021-03-23T00:00:00Z",
+    "volume": 10,
+    "elocationId": "e65469",
+    "pdf": "https://cdn.elifesciences.org/articles/65469/elife-65469-v1.pdf",
+    "xml": "https://cdn.elifesciences.org/articles/65469/elife-65469-v1.xml",
+    "figuresPdf": "https://cdn.elifesciences.org/articles/65469/elife-65469-figures-v1.pdf",
+    "subjects": [
+        {
+            "id": "neuroscience",
+            "name": "Neuroscience"
+        }
+    ],
+    "researchOrganisms": [
+        "Mouse"
+    ],
+    "abstract": {
+        "content": [
+            {
+                "text": "The inflammatory environment of demyelinated lesions in multiple sclerosis (MS) patients contributes to remyelination failure. Inflammation activates a cytoprotective pathway, the integrated stress response (ISR), but it remains unclear whether enhancing the ISR can improve remyelination in an inflammatory environment. To examine this possibility, the remyelination stage of experimental autoimmune encephalomyelitis (EAE), as well as a mouse model that incorporates cuprizone-induced demyelination along with CNS delivery of the proinflammatory cytokine IFN-\u03b3 were used here. We demonstrate that either genetic or pharmacological ISR enhancement significantly increased the number of remyelinating oligodendrocytes and remyelinated axons in the inflammatory lesions. Moreover, the combined treatment of the ISR modulator Sephin1 with the oligodendrocyte differentiation enhancing reagent bazedoxifene increased myelin thickness of remyelinated axons to pre-lesion levels. Taken together, our findings indicate that prolonging the ISR protects remyelinating oligodendrocytes and promotes remyelination in the presence of inflammation, suggesting that ISR enhancement may provide reparative benefit to MS patients.",
+                "type": "paragraph"
+            }
+        ]
+    },
+    "copyright": {
+        "license": "CC-BY-4.0",
+        "holder": "Chen et al.",
+        "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+    },
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States",
+                            "locality": [
+                                "Chicago"
+                            ]
+                        },
+                        "formatted": [
+                            "Chicago",
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+                    ]
+                }
+            ],
+            "competingInterests": "No competing interests declared",
+            "contribution": "Conceptualization, Resources, Data curation, Software, Formal analysis, Supervision, Validation, Investigation, Visualization, Methodology, Writing - original draft, Project administration, Writing - review and editing",
+            "name": {
+                "index": "Chen, Yanan",
+                "preferred": "Yanan Chen"
+            },
+            "orcid": "0000-0001-5510-231X",
+            "type": "person"
+        },
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States",
+                            "locality": [
+                                "Chicago"
+                            ]
+                        },
+                        "formatted": [
+                            "Chicago",
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+                    ]
+                }
+            ],
+            "competingInterests": "No competing interests declared",
+            "contribution": "Formal analysis, Investigation, Methodology",
+            "name": {
+                "index": "Kunjamma, Rejani B",
+                "preferred": "Rejani B Kunjamma"
+            },
+            "type": "person"
+        },
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States",
+                            "locality": [
+                                "Chicago"
+                            ]
+                        },
+                        "formatted": [
+                            "Chicago",
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+                    ]
+                }
+            ],
+            "competingInterests": "No competing interests declared",
+            "contribution": "Formal analysis, Investigation",
+            "name": {
+                "index": "Weiner, Molly",
+                "preferred": "Molly Weiner"
+            },
+            "type": "person"
+        },
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States",
+                            "locality": [
+                                "San Francisco"
+                            ]
+                        },
+                        "formatted": [
+                            "San Francisco",
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Weill Institute for Neuroscience, Department of Neurology, University of California, San Francisco"
+                    ]
+                }
+            ],
+            "competingInterests": "has received personal compensation for consulting from Inception Sciences (Inception 5) and Pipeline Therapeutics Inc, and has contributed to and received personal compensation for a US Provisional Patent Application concerning the use of BZA as a remyelination therapy (US Provisional Patent Application Serial Number 62/374,270 (issued 08/12/2016)).",
+            "contribution": "Conceptualization, Writing - review and editing",
+            "name": {
+                "index": "Chan, Jonah R",
+                "preferred": "Jonah R Chan"
+            },
+            "orcid": "0000-0002-2176-1242",
+            "type": "person"
+        },
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States",
+                            "locality": [
+                                "Chicago"
+                            ]
+                        },
+                        "formatted": [
+                            "Chicago",
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+                    ]
+                }
+            ],
+            "competingInterests": "is an inventor on US Patent #10,905,663 entitled \"Treatment of Demyelinating Disorders\" that describes a small molecule approach to enhancing the ISR as a therapeutic approach for demyelinating disorders. The structure of Sephin1 is included in the molecules covered.",
+            "contribution": "Conceptualization, Resources, Supervision, Funding acquisition, Methodology, Project administration, Writing - review and editing",
+            "emailAddresses": [
+                "b.p@example.org"
+            ],
+            "name": {
+                "index": "Popko, Brian",
+                "preferred": "Brian Popko"
+            },
+            "orcid": "0000-0001-9948-2553",
+            "type": "person"
+        }
+    ],
+    "reviewers": [
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "United States"
+                        },
+                        "formatted": [
+                            "United States"
+                        ]
+                    },
+                    "name": [
+                        "Harvard Medical School"
+                    ]
+                }
+            ],
+            "name": {
+                "index": "Chiu, Isaac M",
+                "preferred": "Isaac M Chiu"
+            },
+            "role": "Reviewing Editor",
+            "type": "person"
+        },
+        {
+            "affiliations": [
+                {
+                    "address": {
+                        "components": {
+                            "country": "India"
+                        },
+                        "formatted": [
+                            "India"
+                        ]
+                    },
+                    "name": [
+                        "Indian Institute of Science Education and Research (IISER)"
+                    ]
+                }
+            ],
+            "name": {
+                "index": "Rath, Satyajit",
+                "preferred": "Satyajit Rath"
+            },
+            "role": "Senior Editor",
+            "type": "person"
+        }
+    ],
+    "ethics": [
+        {
+            "text": "Animal experimentation: This study was performed in strict accordance with the recommendations in the Guide for the Care and Use of Laboratory Animals of the National Institutes of Health. All of the animals were handled according to approved institutional animal care and use committee (IACUC) protocols (#IS00013825) of Northwestern University. The protocol was approved by the Committee on the Ethics of Animal Experiments of Northwestern University.",
+            "type": "paragraph"
+        }
+    ],
+    "funding": {
+        "awards": [
+            {
+                "awardId": "R01 NS034939",
+                "id": "fund1",
+                "recipients": [
+                    {
+                        "name": {
+                            "index": "Popko, Brian",
+                            "preferred": "Brian Popko"
+                        },
+                        "type": "person"
+                    }
+                ],
+                "source": {
+                    "funderId": "10.13039/100000065",
+                    "name": [
+                        "National Institute of Neurological Disorders and Stroke"
+                    ]
+                }
+            },
+            {
+                "id": "fund2",
+                "recipients": [
+                    {
+                        "name": {
+                            "index": "Popko, Brian",
+                            "preferred": "Brian Popko"
+                        },
+                        "type": "person"
+                    },
+                    {
+                        "name": {
+                            "index": "Chan, Jonah R",
+                            "preferred": "Jonah R Chan"
+                        },
+                        "type": "person"
+                    }
+                ],
+                "source": {
+                    "funderId": "10.13039/100005984",
+                    "name": [
+                        "Dr. Miriam and Sheldon G. Adelson Medical Research Foundation"
+                    ]
+                }
+            },
+            {
+                "id": "fund3",
+                "recipients": [
+                    {
+                        "name": {
+                            "index": "Popko, Brian",
+                            "preferred": "Brian Popko"
+                        },
+                        "type": "person"
+                    }
+                ],
+                "source": {
+                    "name": [
+                        "Rampy MS Research Foundation"
+                    ]
+                }
+            }
+        ],
+        "statement": "The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+    },
+    "additionalFiles": [
+        {
+            "filename": "elife-65469-transrepform-v1.docx",
+            "id": "transrepform",
+            "label": "Transparent reporting form",
+            "mediaType": "application/docx",
+            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-transrepform-v1.docx"
+        }
+    ],
+    "dataSets": {
+        "availability": [
+            {
+                "text": "All data generated or analysed during this study are included in the manuscript and supporting files.",
+                "type": "paragraph"
+            }
+        ]
+    },
+    "impactStatement": "Oligodendrocytes with an enhanced ability to withstand cytotoxic stress display an increased capacity to remyelinate demyelination lesions of the CNS in the presence of an inflammatory environment.",
+    "keywords": [
+        "integrated stress response",
+        "remyelination",
+        "interferon gamma",
+        "oligodendrocyte",
+        "cuprizone",
+        "multiple sclerosis"
+    ],
+    "body": [
+        {
+            "content": [
+                {
+                    "text": "Multiple sclerosis (MS) is an autoimmune inflammatory disorder characterized by focal demyelinated lesions in the CNS (<a href=\"#bib19\">Frohman et al., 2006</a>; <a href=\"#bib53\">Yadav et al., 2015</a>; <a href=\"#bib44\">Reich et al., 2018</a>). Although current immunomodulatory therapies can reduce the frequency and severity of relapses, they have demonstrated limited impact on the progression of disease (<a href=\"#bib9\">Dargahi et al., 2017</a>; <a href=\"#bib23\">Hauser and Cree, 2020</a>). Complementary strategies are therefore urgently needed to protect oligodendrocytes and promote repair of the CNS in order to slow or even stop the progression of MS (<a href=\"#bib22\">Hart and Bainbridge, 2016</a>; <a href=\"#bib45\">Rodgers et al., 2013</a>; <a href=\"#bib52\">Way and Popko, 2016</a>).",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "Remyelination is the process of restoring demyelinated nerve fibers with new myelin, which involves the generation of new mature oligodendrocytes from oligodendrocyte precursor cells (OPCs) (<a href=\"#bib16\">Franklin and Ffrench-Constant, 2008a</a>). Failure of myelin repair during relapsing-remitting MS leads to chronically demyelinated axons, which is thought to contribute to axonal degeneration and disease progression (<a href=\"#bib17\">Franklin and Kotter, 2008b</a>; <a href=\"#bib14\">Fancy et al., 2010</a>; <a href=\"#bib4\">Chari, 2007</a>). The inflammatory environment in MS lesions is considered a major contributor to impaired remyelination (<a href=\"#bib47\">Starost et al., 2020</a>). Strategies to enhance myelin regeneration could preserve axonal integrity and increase clinical function of patients. A number of small molecules have recently been described to promote OPC maturation and/or enhance remyelination, but most of these molecules were identified in in vitro screens under ideal conditions and tested in animal models of non-inflammatory demyelination (<a href=\"#bib11\">Deshmukh et al., 2013</a>; <a href=\"#bib38\">Mei et al., 2014</a>; <a href=\"#bib43\">Rankin et al., 2019</a>; <a href=\"#bib40\">Najm et al., 2015</a>). Given that remyelination in MS occurs in lesions with ongoing inflammation, a remyelination model with an inflammatory environment would provide a better indication of the potential of remyelinating-promoting compounds for MS treatment.",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "The integrated stress response (ISR) plays a key role in the response of oligodendrocytes to CNS inflammation (<a href=\"#bib5\">Chen et al., 2019</a>; <a href=\"#bib31\">Lin et al., 2005</a>; <a href=\"#bib51\">Way et al., 2015</a>). The ISR is a cytoprotective pathway that is activated by various cytotoxic insults, including inflammation (<a href=\"#bib8\">Costa-Mattioli and Walter, 2020</a>). The ISR is initiated by phosphorylation of eukaryotic translation initiation factor two alpha (p-eIF2\u03b1), by one of four known stress-sensing kinases, to diminish global protein translation and selectively allow for the synthesis of protective proteins. p-eIF2\u03b1 is dephosphorylated by the protein phosphatase 1 (PP1)- DNA-damage inducible 34 (GADD34) complex to terminate the ISR upon stress relief (<a href=\"#bib54\">Zhang and Kaufman, 2008</a>). Sephin1, a recently-identified small molecule, disrupts PP1-GADD34 phosphatase activity and prolongs elevated p-eIF2\u03b1 levels, thereby enhancing the ISR protective response (<a href=\"#bib10\">Das et al., 2015</a>; <a href=\"#bib3\">Carrara et al., 2017</a>). We previously showed that GADD34 deficiency or Sephin1 treatment protects matures oligodendrocytes, diminishes demyelination, and delays clinical symptoms in a mouse model of MS, experimental autoimmune encephalomyelitis (EAE) (<a href=\"#bib5\">Chen et al., 2019</a>). It is not known whether a protracted ISR would protect newly generated remyelinating oligodendrocytes and enhance remyelination in an inflammatory environment.",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "Here, we investigated the potential impact of genetic or pharmacological ISR enhancement on remyelinating oligodendrocytes and the remyelination process in the presence of inflammation. In these studies, we used the EAE model, as well as the cuprizone-induced demyelination model on GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mice, which ectopically express interferon gamma (IFN-\u03b3) in the CNS in a regulated manner (<a href=\"#bib30\">Lin et al., 2004</a>; <a href=\"#bib31\">Lin et al., 2005</a>). IFN-\u03b3 is a pleotropic T-cell-specific cytokine that stimulates key inflammatory aspects of MS (<a href=\"#bib33\">Lin et al., 2007</a>; <a href=\"#bib29\">Lees and Cross, 2007</a>). Using these inflammatory demyelination models, we show that prolonging the ISR protects remyelinating oligodendrocytes and increases the level of remyelination. Moreover, we explored the effects of combining Sephin1 treatment with bazedoxifene (BZA) (<a href=\"#bib43\">Rankin et al., 2019</a>) on remyelination. BZA has been shown to enhance OPC differentiation and CNS remyelination in response to focal demyelination (<a href=\"#bib43\">Rankin et al., 2019</a>). We demonstrate that BZA increases the number of remyelinating oligodendrocytes and enhances remyelination in the presence of inflammation. When combined with Sephin1, BZA further facilitates the remyelinating process.",
+                    "type": "paragraph"
+                }
+            ],
+            "id": "s1",
+            "title": "Introduction",
+            "type": "section"
+        },
+        {
+            "content": [
+                {
+                    "content": [
+                        {
+                            "text": "To determine whether pharmacological prolongation of the ISR can enhance remyelination after inflammatory demyelination, we first examined C57BL/6J mice in the late stage of EAE. Sephin1 (8 mg/kg) or vehicle treatment was initiated in each EAE mouse on the day it reached the peak of disease (clinical score = 3) and was continued to the late stage of EAE, which resulted in diminished EAE disease severity in the final week of Sephin1 treatment (<a href=\"#fig1\">Figure 1A</a>). Spinal cord axons were examined under electron microscope (EM). We sorted remyelinated axons by examining g-ratios (axon diameter / total fiber diameter) in the lumbar spinal cord white matter of EAE mice after vehicle or Sephin1 treatment. The presence of axons with thinner myelin sheaths and a higher g<i>-</i>ratio is considered the hallmark of remyelination (<a href=\"#bib12\">Duncan et al., 2017</a>). A recent study indicated that axons in the spinal cord with a g-ratio greater than 0.8 are likely remyelinated axons in the EAE model (<a href=\"#bib39\">Mei et al., 2016</a>). Our data demonstrated that the density of remyelinated axons (g &gt; 0.8) was significantly higher in EAE mice treated with Sephin1 than those treated with vehicle (p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.81) (<a href=\"#fig1\">Figure 1B,C</a>), although no difference was detected in the total number of myelinated axons (<a href=\"#fig1\">Figure 1D</a>). The data suggest that Sephin1 promotes remyelination in the neuroinflammatory environment of EAE, presumably by protecting remyelinating oligodendrocytes against inflammatory stress.",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "(<b>A</b>) Cumulative clinical scores of C57BL/6J female mice immunized with MOG<sub>35-55</sub>/CFA to induce chronic EAE, treated with vehicle (<i>n =</i> 7) and 8 mg/kg Sephin1 (<i>n =</i> 7) from the peak disease. *p&lt;0.05. Significance based on Kolmogorov-Smirnov test. (<b>B</b>) Representative EM images of axons in the spinal cord white matter tracts of EAE mice treated with vehicle or Sephin1 at PID30. Remyelinated axons in the EAE spinal cord were identified by thinner myelin sheaths (*). Scale bar = 1 \u00b5m. (<b>C</b>) Density of myelinated axons with g-ratio &lt;0.8 in the EAE spinal cord. (<b>D</b>) Density of total myelinated axons in the EAE spinal cord. Data are presented as the mean \u00b1 SEM (n = 3 mice/group). Over 300 axons were analyzed per mouse. *p<i>&lt;</i>0.05. Significance based on unpaired <i>t</i>-test.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig1",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig1-v1.tif",
+                                        "size": {
+                                            "width": 2446,
+                                            "height": 4627
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig1-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig1-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 1",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig1-data1-v1.xlsx",
+                                            "id": "fig1sdata1",
+                                            "label": "Figure 1\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "Disease scores and axon measurement of late stage of EAE.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig1-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "Sephin1 treatment enhances remyelination after inflammatory demyelination.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        }
+                    ],
+                    "id": "s2-1",
+                    "title": "Sephin1 treatment enhances remyelination in late-stage EAE",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "Our finding of increased remyelination in the Sephin1 treated late stage EAE mice raised the possibility that prolonging the ISR might provide protection against inflammation to remyelinating oligodendrocytes and thereby promote remyelination. To examine this possibility, we used a more quantitative demyelination/remyelination model (cuprizone model) for further exploration. We have previously shown that in response to IFN-\u03b3, myelinating oligodendrocytes with a <i>Ppp1r15a (Gadd34)</i> mutation display increased levels of p-eIF2\u03b1, indicating a prolongation of the ISR, and increased oligodendrocyte survival (<a href=\"#bib34\">Lin et al., 2008</a>). We hence mated GADD34 KO;GFAP-tTA mice with GADD34 KO;TRE-IFN-\u03b3 mice to generate GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mice homozygous for the <i>Ppp1r15a</i> mutation (GADD34 KO) to prolong the ISR (<a href=\"#bib34\">Lin et al., 2008</a>). GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mice allow for ectopic release of IFN-\u03b3 in the CNS in a doxycycline (Dox)-dependent manner (<a href=\"#bib30\">Lin et al., 2004</a>; <a href=\"#bib32\">Lin et al., 2006</a>; <a href=\"#bib34\">Lin et al., 2008</a>). Expression of the tetracycline-controlled transactivator (tTA) is driven by the astrocyte-specific transcriptional regulatory region of the <i>Gfap</i> gene. In the TRE-IFN-\u03b3 mice, the IFN-\u03b3 cDNA is transcriptionally controlled by the tetracycline response element (TRE) (<a href=\"#fig2\">Figure 2A</a>). The expression of the IFN-\u03b3 transgene is repressed in the GFAP-tTA;TRE-IFN-\u03b3 mice by providing water treated with Dox from conception. At 6 weeks of age, transgenic mice were taken off Dox water to induce CNS expression of IFN-\u03b3 (IFN-\u03b3+) and placed on a diet of 0.2% cuprizone chow (<a href=\"#bib32\">Lin et al., 2006</a>; <a href=\"#bib30\">Lin et al., 2004</a>). After 5 weeks of cuprizone exposure, mice were placed back on a normal diet for up to 3 weeks to allow remyelination to occur. Control mice received Dox water throughout the study to repress CNS expression of IFN-\u03b3 (IFN-\u03b3-) (<a href=\"#fig2\">Figure 2B</a>). Mice with the highest level of IFN-\u03b3 expression in the CNS were selected by isolating the cerebellum of each mouse and using real-time reverse transcription (RT)-PCR to determine IFN-\u03b3 expression levels. We found that at 5 weeks of cuprizone exposure (W5) and during remyelination (W8), removal of Dox significantly increased the levels of IFN-\u03b3 in the cerebellum of mice (<a href=\"#fig2s1\">Figure 2\u2014figure supplement 1A</a>).",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "(<b>A</b>) GFAP-tTA mice are mated with TRE-IFN-\u03b3 mice to produce double-positive animals. When these mice are maintained on doxycycline (Dox), the expression of the IFN-\u03b3 is repressed. When they are released from Dox, IFN-\u03b3 is expressed in the CNS. (<b>B</b>) Cuprizone demyelination/remyelination model of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT. Dox is removed and cuprizone chow is added when mice are at 6-week-old (W0). After 5 weeks of cuprizone exposure (W5), mice were placed back on normal chow for up to 3 weeks to allow remyelination. (<b>C</b>) Cuprizone demyelination/remyelination model of GFAP-tTA;TRE-IFN-\u03b3 with designed treatment. Drug treatment is started at 3 weeks of cuprizone exposure (W3) and lasts to the end of remyelination (W8).",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig2",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig2-v1.tif",
+                                        "size": {
+                                            "width": 4209,
+                                            "height": 1615
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig2-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig2-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 2",
+                                    "title": "Schematics of GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mouse model of cuprizone demyelination/remyelination.",
+                                    "type": "image"
+                                },
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "Real-time qPCR analyses for detection of mRNA levels of ectopically expressed IFN-\u03b3 in the brains of GFAP-tTA;TRE-IFN-\u03b3 mice. (<b>A</b>) The expression of IFN-\u03b3 in the GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT with the doxycycline (Dox+) and without doxycycline (Dox-). (<b>B</b>) The expression of IFN-\u03b3 in the GFAP-tTA;TRE-IFN-\u03b3 treated with vehicle and Sephin1 with the doxycycline (Dox+) and without doxycycline (Dox-). Data are presented as the mean \u00b1 SEM (n = 4 mice/group). *p<i>&lt;</i>0.05, **p<i>&lt;</i>0.01. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig2s1",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig2-figsupp1-v1.tif",
+                                        "size": {
+                                            "width": 3745,
+                                            "height": 1419
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig2-figsupp1-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig2-figsupp1-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 2\u2014figure supplement 1",
+                                    "title": "GFAP-tTA;TRE-IFN-\u03b3 mice express IFN-\u03b3 after release from doxycycline.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        },
+                        {
+                            "text": "We next investigated whether the <i>Gadd34</i> mutation promotes oligodendrocyte survival in the presence of IFN-\u03b3 during demyelination/remyelination in the cuprizone model. It has been demonstrated that cuprizone-fed mice exhibit apoptotic death of oligodendrocytes and demyelination in the corpus callosum. Complete remyelination spontaneously occurs a few weeks after the cuprizone challenge is terminated (<a href=\"#bib36\">Matsushima and Morell, 2001</a>). We found no significant difference in the number of cells labeled with the mature oligodendrocyte marker ASPA between GADD34 wildtype (WT) and GADD34 KO, GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mice before cuprizone exposure (<a href=\"#fig3\">Figure 3A,B</a>). After 5 weeks on cuprizone chow, both GADD34 WT and KO double-transgenic mice presented similarly with a significantly reduced number of ASPA+ mature oligodendrocytes in the presence of IFN-\u03b3 (IFN-\u03b3+) (WT, p&lt;<i>0.001</i>; KO, p&lt;<i>0.05</i>) (<a href=\"#fig3\">Figure 3A,B</a>). During the remyelination period, ASPA+ oligodendrocytes reappeared and reached approximately 800/mm<sup>2</sup> in both IFN-\u03b3-repressed GADD34 WT and KO mice (IFN-\u03b3-) after 3 weeks of normal chow. In the presence of IFN-\u03b3 (IFN-\u03b3+), this number dropped in the lesions of WT double-transgenic mice to roughly 500/mm<sup>2</sup> of ASPA+ cells (p&lt;<i>0.05</i>) (<a href=\"#fig3\">Figure 3A,C</a>), which is consistent with our previous finding that IFN-\u03b3 expression in the CNS suppresses the repopulation of oligodendrocytes following cuprizone-induced oligodendrocyte toxicity (<a href=\"#bib32\">Lin et al., 2006</a>). Compared to GADD34 WT, GFAP-tTA;TRE-IFN-\u03b3 mice with the <i>Gadd34</i> mutation had significantly increased numbers of ASPA+ oligodendrocytes during remyelination in the presence of IFN<i>-\u03b3</i> (IFN-\u03b3+/W8) (p&lt;<i>0.01</i>) (<a href=\"#fig3\">Figure 3A,C</a>). Myelin status in these mice was also evaluated with EM. After 5 weeks of cuprizone chow, a significant number of axons exhibited myelin sheath loss in control mice (IFN-\u03b3<i>-</i>), compared to 0 weeks (WT, p&lt;<i>0.0001</i>; KO, p&lt;<i>0.001</i>) (<a href=\"#fig4\">Figure 4A,C</a>). Similarly, both WT and KO double-transgenic mice presented with markedly reduced numbers of myelinated axons in the presence of IFN<i>-</i>\u03b3 (IFN-\u03b3+) (WT: 25.2 \u00b1 3.0%, p&lt;<i>0.0001</i>; KO: 24.4 \u00b1 2.7%, p&lt;<i>0.0001</i>). Nevertheless, no difference in the percentage of myelinated axons was observed between IFN-\u03b3+ and IFN-\u03b3- groups (<a href=\"#fig4\">Figure 4A,C</a>). At 3 weeks after cuprizone withdrawal, both IFN-\u03b3-repressed WT and KO mice (IFN-\u03b3-) showed spontaneous remyelination (WT: 42.7 \u00b1 6.2%; KO: 42.6 \u00b1 4.7%) (<a href=\"#fig4\">Figure 4B,D</a>). Meanwhile, remyelination was significantly suppressed in the corpus callosum of IFN<i>-</i>\u03b3-expressing WT mice (WT: 29.4 \u00b1 2.9%) (p&lt;<i>0.05</i>), but not in that of IFN<i>-</i>\u03b3-expressing KO mice (KO: 49.1 \u00b1 8.8%) (<a href=\"#fig4\">Figure 4B,D</a>). Together, these data suggest that prolonging the ISR has no impact in the absence of IFN-\u03b3, but it results in increased repopulation of oligodendrocytes and remyelination following demyelination in the presence of IFN-\u03b3.",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpora callosa of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT were taken at W0, W5, and W8. (<b>A</b>) Immunofluorescent staining for ASPA (a mature oligodendrocyte marker) and DAPI (nuclei). Scale bar = 100 \u00b5m. (<b>B</b>) Quantification of cells positive for ASPA in the corpus callosum areas at W0 and W5 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). WT: eight males and one female; KO: five males and four females. **p<i>&lt;</i>0.01, <sup>#</sup>p<i>&lt;</i>0.05 (#vs W0/WT), <sup>###</sup>p<i>&lt;</i>0.001 (# vs W0/KO). Significance based on ANOVA. (<b>C</b>) Quantification of cells positive for ASPA in the corpus callosum areas at W8 in the absence or presence of IFN-\u03b3. WT: two males and four females; KO: four males and two females. Data are presented as the mean \u00b1 SEM (n = 3 mice/group). *p<i>&lt;</i>0.05, **p<i>&lt;</i>0.01. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig3",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig3-v1.tif",
+                                        "size": {
+                                            "width": 2906,
+                                            "height": 4178
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig3-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig3-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 3",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig3-data1-v1.xlsx",
+                                            "id": "fig3sdata1",
+                                            "label": "Figure 3\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of ASAP+ cells in WT and KO.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig3-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "GADD34 deficiency protects remyelinating oligodendrocytes in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpora callosa of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT were harvested for EM processing. (<b>A</b>) Representative EM images of axons in the corpus callosum at W0 and W5. Scale bar = 1 \u00b5m. (<b>B</b>) Representative EM images of axons in the corpus callosum at W8. Scale bar = 1 \u00b5m. (<b>C</b>) Percentage of myelinated axons at W0 and W5. WT: nine males and three females; KO: six males and six females. ****p&lt;0.0001 (* vs W0/WT); <sup>###</sup>p<i>&lt;</i>0.001, <sup>####</sup>p<i>&lt;</i>0.0001 ( #vs W0/KO). Significance based on ANOVA. (<b>D</b>) Percentage of myelinated axons at W8. WT: four males and four females; KO: five males and three females. Data are presented as the mean \u00b1 SEM (n = 4 mice/group). *p<i>&lt;</i>0.05 Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig4",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig4-v1.tif",
+                                        "size": {
+                                            "width": 3144,
+                                            "height": 3238
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig4-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig4-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 4",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig4-data1-v1.xlsx",
+                                            "id": "fig4sdata1",
+                                            "label": "Figure 4\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of myelinated axons in WT and KO.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig4-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "GADD34 deficiency enhances remyelination in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        }
+                    ],
+                    "id": "s2-2",
+                    "title": "GADD34 deficiency protects remyelinating oligodendrocytes and enhances remyelination in the presence of IFN-\u03b3",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "We have previously demonstrated that Sephin1 treatment can prolong the ISR in primary oligodendrocytes exposed to IFN-\u03b3, as shown by prolonged elevated eIF2\u03b1 phosphorylation levels (<a href=\"#bib5\">Chen et al., 2019</a>). In addition, Sephin1 protects mature oligodendrocytes against inflammation in the EAE model (<a href=\"#bib5\">Chen et al., 2019</a>). Therefore, using Sephin1, we tested the ability of pharmacological enhancement of the ISR to protect remyelinating oligodendrocytes from inflammatory insults in the cuprizone model. Similar to the GADD34 mouse experiment, 6-week-old GFAP-tTA;TRE-IFN-\u03b3 double transgenic mice that had been on Dox water since conception were either kept on (IFN-\u03b3-) or removed from Dox (IFN-\u03b3+) and fed with a chow containing 0.2% cuprizone for 5 weeks. Mice were then placed back on a normal diet for 3 weeks. Sephin1 (8 mg/kg) or vehicle was administered daily to the mice by intraperitoneal injections beginning 3 weeks after the start of the cuprizone diet. This time point represents the peak of oligodendrocyte loss during cuprizone-mediated demyelination (<a href=\"#bib36\">Matsushima and Morell, 2001</a>; <a href=\"#fig2\">Figure 2C</a>).",
+                            "type": "paragraph"
+                        },
+                        {
+                            "text": "We first examined IFN-\u03b3 expression in the double-transgenic mice, which showed that mice removed from Dox (IFN-\u03b3+) expressed significantly higher levels of IFN-\u03b3 in the cerebellum than mice on Dox water (IFN-\u03b3-) at 5 weeks and 8 weeks of cuprizone treatment in all groups (<a href=\"#fig2s1\">Figure 2\u2014figure supplement 1B</a>). Next, we investigated the number of mature oligodendrocytes in the corpus callosum by immunofluorescent staining of ASPA. 3 weeks of cuprizone exposure led to a significant decrease of the ASPA+ oligodendrocytes in both IFN-\u03b3- (p&lt;<i>0.01</i>) and IFN-\u03b3+ (p&lt;<i>0.01</i>) groups (<a href=\"#fig5\">Figure 5A,B</a>). After 5 weeks of cuprizone chow, we did not detect further oligodendrocyte loss in the absence of IFN-\u03b3. It has been shown that oligodendrocytes start regenerating after significant loss at 3 weeks, even in the presence of cuprizone (<a href=\"#bib1\">Armstrong et al., 2006</a>). We observed a further reduction in the number of oligodendrocytes in the presence of IFN<i>-</i>\u03b3 (p&lt;0.01), although we found no difference between vehicle and Sephin1 treatment (veh: 315 \u00b1 44/mm<sup>2</sup>; Seph 394 \u00b1 67/mm<sup>2</sup>) (<a href=\"#fig5\">Figure 5A,B</a>). At 3 weeks after cuprizone withdrawal, the density of oligodendrocytes returned to the initial levels seen at week 0 (W0) in both vehicle- and Sephin1-treated mice in the absence of IFN-<i>\u03b3</i>. Activation of IFN-\u03b3 expression by removing Dox (IFN-\u03b3+) suppressed the repopulation of ASPA+ oligodendrocytes in the vehicle treated mice, but Sephin1 treatment significantly increased the survival of these cells (veh: 531 \u00b1 32/mm<sup>2</sup>, Seph: 672 \u00b1 52/mm<sup>2</sup>, p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.74) (<a href=\"#fig5\">Figure 5A,C</a>). In addition, we observed an approximate 50% reduction in the percentage of myelinated axons after 5 weeks of cuprizone exposure in both IFN-\u03b3- and IFN-\u03b3+ double-transgenic mice (<i>p&lt;0.0001</i>) (<a href=\"#fig6\">Figure 6A,C</a>). Similar to the changes in oligodendrocyte numbers, our data demonstrated that during remyelination, CNS delivery of IFN-\u03b3 resulted in diminished numbers of remyelinated axons (p&lt;<i>0.05</i>), while mice treated with Sephin1 exhibited a significantly higher percentage of remyelinated axons (veh: 30.3 \u00b1 3.3%, Seph: 43.2 \u00b1 4.6%, p&lt;<i>0.01</i>, \u03b7<sup>2</sup> = 0.72) (<a href=\"#fig6\">Figure 6B,D</a>). These data indicate that although the pharmacological enhancement of the ISR with Sephin1 has no impact in the absence of IFN-\u03b3, it can provide protection to remyelinating oligodendrocytes and promote remyelination in the presence of IFN-\u03b3.",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpora callosa of GFAP-tTA;TRE-IFN-\u03b3 were taken at W0 and W3 prior to any treatment as well as after either vehicle or Sephin1 treatment at W5 and W8. (<b>A</b>) Immunofluorescent staining for ASPA (a mature oligodendrocyte marker) and DAPI (nuclei). Scale bar = 100 \u00b5m. (<b>B</b>) Quantification of cells positive for ASPA in the corpus callosum areas at W0, W3, and W5 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3\u20134 mice/group). W0: four males; W3: five males and one female; W5 (Veh): four males and two females; W5 (Seph): four males and two females. **p<i>&lt;</i>0.01, <sup>##</sup>p<i>&lt;</i>0.01, <sup>###</sup>p<i>&lt;</i>0.001, <sup>####</sup>p<i>&lt;</i>0.0001 (#vs W0). Significance based on ANOVA. (<b>C</b>) Quantification of cells positive for ASPA in the corpus callosum areas at W8 in the absence or presence of IFN-\u03b3. Data are presented as the mean \u00b1 SEM (n = 3 mice/group). W8 (Veh): five males and one female; W8 (Seph): five males and one female. *p<i>&lt;</i>0.05. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig5",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig5-v1.tif",
+                                        "size": {
+                                            "width": 2850,
+                                            "height": 4370
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig5-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig5-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 5",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig5-data1-v1.xlsx",
+                                            "id": "fig5sdata1",
+                                            "label": "Figure 5\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of ASAP+ cells in Veh and Seph groups.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig5-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "Sephin1 protects remyelinating oligodendrocytes in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpora callosa of GFAP-tTA;TRE-IFN-\u03b3 were harvested for EM processing. (<b>A</b>) Representative EM images of axons in the corpus callosum at W5. Scale bar = 1 \u00b5m. (<b>B</b>) Representative EM images of axons in the corpus callosum at W8. Scale bar = 1 \u00b5m. (<b>C</b>) Percentage of remyelinated axons at W0 and W5. W0: four males; W5 (Veh): five males and three females; W5 (Seph): five males and three females. (<b>D</b>) Percentage of remyelinated axons at W8. Data are presented as the mean \u00b1 SEM (n = 4 mice/group). W8 (Veh): six males and two females; W8 (Seph): six males and two females. *p<i>&lt;</i>0.05, **p<i>&lt;</i>0.01, ****p&lt;0.0001. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig6",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig6-v1.tif",
+                                        "size": {
+                                            "width": 3551,
+                                            "height": 2698
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig6-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig6-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 6",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig6-data1-v1.xlsx",
+                                            "id": "fig6sdata1",
+                                            "label": "Figure 6\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of myelinated axons in Veh and Seph groups.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig6-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "Sephin1 enhances remyelination in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        }
+                    ],
+                    "id": "s2-3",
+                    "title": "Sephin1 treatment protects remyelinating oligodendrocytes and enhances remyelination in the presence of IFN-\u03b3",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "Recruitment of OPCs is required for spontaneous remyelination, during which OPCs proliferate and migrate to the demyelinated area to mature into functional oligodendrocytes (<a href=\"#bib24\">Huang and Franklin, 2011</a>; <a href=\"#bib16\">Franklin and Ffrench-Constant, 2008a</a>). Using the OPC marker PDGFR\u03b1 and the proliferation marker Ki67, we noted the appearance of PDGFR\u03b1+ OPCs and proliferating OPCs (PDGFR\u03b1+/Ki67+) near the demyelinated lesions (W5) and remyelinated areas (W8) in the corpus callosum of double-transgenic mice, which was not affected by GADD34 deficiency (<a href=\"#fig7\">Figure 7A\u2013C</a>) or Sephin1 treatment (<a href=\"#fig7\">Figure 7D\u2013F</a>). Interestingly, at week 5 of cuprizone exposure, the induction of IFN-\u03b3 by Dox removal (IFN-\u03b3+) diminished the number of proliferating OPCs (PDGFR\u03b1+/Ki67+) in vehicle-treated mice (p&lt;<i>0.05</i>), but no difference between vehicle and Sephin1 was found in the number of OPCs in the presence of IFN-\u03b3 (<a href=\"#fig7\">Figure 7D,E</a>).",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "(<b>A</b>) Immunofluorescent staining for PDGFR\u03b1 (an OPC marker), Ki67 and DAPI (nuclei) from the corpus callosum of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT was taken at W5 and W8. Scale bar = 50 \u00b5m. Quantification of cells positive for PDGFR\u03b1 and cells positive for both PDGFR\u03b1 and Ki67 in the corpus callosum areas of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+) at W5 (<b>B</b>) and W8 (<b>C</b>). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). W5 (WT): five males and one female; W5 (KO): four males and two females. W8 (WT): two males and four females; W8 (KO): four males and two females. (<b>D</b>) Immunofluorescent staining for PDGFR\u03b1, Ki67 and DAPI from the corpus callosum of GFAP-tTA;TRE-IFN-\u03b3 was taken after either vehicle or Sephin1 treatment at W5 and W8. Quantification of cells positive for PDGFR\u03b1 and cells positive for both PDGFR\u03b1 and Ki67 in the corpus callosum areas of GFAP-tTA;TRE-IFN-\u03b3 treated with treatment in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+) at W5 (<b>E</b>) and W8 (<b>F</b>). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). W5 (Veh): four males and two females; W5 (Seph): four males and two females. W8 (Veh): five males and one female; W8 (Seph): five males and one female. #p<i>&lt;</i>0.05 (vs. veh from W5/IFN-\u03b3-). Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig7",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-v1.tif",
+                                        "size": {
+                                            "width": 4086,
+                                            "height": 4751
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig7-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 7",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig7-data1-v1.xlsx",
+                                            "id": "fig7sdata1",
+                                            "label": "Figure 7\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of total OPCs and proliferating OPCs.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig7-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "GADD34 deficiency or Sephin1 does not affect OPC proliferation during remyelination.",
+                                    "type": "image"
+                                },
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpus callosum of GFAP-tTA;TRE-IFN-\u03b3/GADD34 KO or WT was taken at W0, W5 and W8. (<b>A</b>) Immunofluorescent staining for IBA1 (a microglia marker), MBP (a myelin marker) and DAPI. Scale bar = 50 \u00b5m. (<b>B</b>) Quantification of cells positive for IBA1 in the corpus callosum areas at W0 and W5 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). *p&lt;0.05, ***p<i>&lt;</i>0.001 (*vs W0/WT), <sup>#</sup>p<i>&lt;</i>0.05, <sup>###</sup>p<i>&lt;</i>0.001 (# vs W0/KO). Significance based on ANOVA. (<b>C</b>) Quantification of cells positive for IBA1 in the corpus callosum areas at W8 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). *p&lt;0.05. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig7s1",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-figsupp1-v1.tif",
+                                        "size": {
+                                            "width": 3221,
+                                            "height": 3680
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-figsupp1-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig7-figsupp1-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 7\u2014figure supplement 1",
+                                    "title": "GADD34 deficiency does not affect microglial activation during remyelination in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                },
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "The corpus callosum of GFAP-tTA;TRE-IFN-\u03b3 was taken at W0, W5, and W8 with vehicle or Sephin1 treatment. (<b>A</b>) Immunofluorescent staining for IBA1, MBP, and DAPI. Scale bar = 50 \u00b5m. (<b>B</b>) Quantification of cells positive for IBA1 in the corpus callosum areas at W0 and W5 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). *p&lt;0.05, **p<i>&lt;</i>0.01 (*vs W0). Significance based on ANOVA. (<b>C</b>) Quantification of cells positive for IBA1 in the corpus callosum areas at W8 in the absence (IFN-\u03b3-) or presence of IFN-\u03b3 (IFN-\u03b3+). Data are presented as the mean \u00b1 SEM (n = 3 mice/group). *p&lt;0.05, ****p&lt;0.0001. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig7s2",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-figsupp2-v1.tif",
+                                        "size": {
+                                            "width": 3236,
+                                            "height": 3090
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig7-figsupp2-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig7-figsupp2-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 7\u2014figure supplement 2",
+                                    "title": "Sephin1 treatment does not affect microglial activation during remyelination in the presence of IFN-\u03b3.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        },
+                        {
+                            "text": "Studies have indicated that recruitment of microglia is required for myelin clearance and efficient initiation of remyelination (<a href=\"#bib41\">Neumann et al., 2009</a>; <a href=\"#bib50\">Voss et al., 2012</a>; <a href=\"#bib20\">Gudi et al., 2014</a>). To examine the activation of microglia, we immuno-stained sections of corpus callosum with the microglia marker IBA1 and quantified the density of these cells in the lesions. A significantly stronger microgliosis was observed in the corpus callosum of double-transgenic mice after 5 weeks of cuprizone chow (W5) and activated microglia persisted after 3 weeks of remyelination (W8) (<a href=\"#fig7s1\">Figure 7\u2014figure supplement 1</a> and <a href=\"#fig7s2\">Figure 7\u2014figure supplement 2</a>). Interestingly, in the group of GADD34 KO and of Sephin1 treatment, the number of IBA1+ cells at W8 was significantly increased in the presence of IFN-\u03b3 than those in the absence of IFN-\u03b3 (<a href=\"#fig7s1\">Figure 7\u2014figure supplement 1A,C</a> and <a href=\"#fig7s2\">Figure 7\u2014figure supplement 2A,C</a>), but we did not detect a statistical change in the density of IBA1+ cells between WT mice and KO or between vehicle and Sephin1 treatment (<a href=\"#fig7s1\">Figure 7\u2014figure supplement 1A,C</a> and <a href=\"#fig7s2\">Figure 7\u2014figure supplement 2A,C</a>).",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s2-4",
+                    "title": "GADD34 deficiency or Sephin1 treatment does not affect OPC proliferation or microglial recruitment following cuprizone demyelination/remyelination",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "As mentioned above, a number of small molecules have been identified that promote OPC maturation and CNS remyelination as shown in non-inflammatory models of demyelination, and here we have demonstrated that ISR enhancement permits remyelination in the presence of inflammation (<a href=\"#fig3\">Figures 3</a>\u2013<a href=\"#fig6\">6</a>). We next tested the hypothesis that the effectiveness of a remyelination-enhancing agent would be augmented in an inflammatory environment when combined with an ISR enhancing agent. BZA is a selective estrogen receptor modulator (SERM) that is currently FDA-approved to be used in combination with conjugated estrogen in menopausal women (<a href=\"#bib37\">McKeand et al., 2014</a>). Recently, Rankin et al. showed that BZA significantly enhances OPC differentiation and accelerates remyelination in the lysolecithin non-inflammatory demyelination model (<a href=\"#bib43\">Rankin et al., 2019</a>). To test whether the effectiveness of BZA would be enhanced in the presence of inflammation by ISR modulation, we combined BZA and Sephin1 treatments in our cuprizone GFAP-tTA;TRE-IFN-\u03b3 double transgenic model. We began the daily administration of BZA and Sephin1 3 weeks after the start of the cuprizone diet and withdrawal of Dox from the animal\u2019s water (<a href=\"#fig2\">Figure 2C</a>). At 3 weeks after cuprizone withdrawal, we found that Sephin1, BZA, and combined Sephin1/BZA treatment significantly increased ASPA+ oligodendrocyte numbers in the corpus callosum during remyelination in the presence of IFN-\u03b3 (W8/ IFN-\u03b3+) (Sephin1: p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.78; BZA: p&lt;<i>0.01</i>, \u03b7<sup>2</sup> = 0.67; Sephin1/BZA: p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.77) (<a href=\"#fig8\">Figure 8A,C</a>). Accordingly, compared with vehicle controls, a significant increase in the percentage of myelinated axons was noted in the groups treated with Sephin1, BZA, and combined Sephin1/BZA treatment (Sephin1: p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.81; BZA: p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.77; Sephin1/BZA: p&lt;<i>0.01</i>, \u03b7<sup>2</sup> = 0.80) (<a href=\"#fig8\">Figure 8B,D</a>). Nonetheless, no difference between treatment groups was observed either for oligodendrocyte survival or number of remyelinated axons, although the number of remyelinated axons in treatment groups reached pre-lesion levels (<a href=\"#fig8\">Figure 8B,D</a>). In addition to measuring the percentage of myelinated axons, we also examined myelin thickness using EM analysis of g-ratios after remyelination and using W0 as the pre-lesion reference point. The vehicle-treated mice (W8/IFN-\u03b3+) demonstrated significantly thinner myelin than those at W0 (IFN-\u03b3-). In contrast, corpora callosa axons in mice receiving the combination treatment of Sephin1 and BZA (g-ratio: 0.778 \u00b1 0.006) reached myelin thickness levels comparable with pre-lesion W0 axons (<a href=\"#fig8\">Figure 8B,E</a>). The g-ratios of myelinated axons were significantly lower in the combination treatment group than the vehicle-treated group (p&lt;<i>0.01</i>, \u03b7<sup>2</sup> = 0.77) or either of the single treatment group (p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.72 vs Sephin1, p&lt;<i>0.05</i>, \u03b7<sup>2</sup> = 0.72 vs BZA).",
+                            "type": "paragraph"
+                        },
+                        {
+                            "assets": [
+                                {
+                                    "caption": [
+                                        {
+                                            "text": "GFAP-tTA;TRE-IFN-\u03b3 mice were released from Dox at W0 and given cuprizone chow for 5 weeks. Treatment with vehicle, Sephin1, BZA or combined BZA and Sephin1 was started at W3, and the corpus callosum was harvested and processed at W0 and after 3 weeks of remyelination (W8). (<b>A</b>) Immunofluorescent staining for ASPA and DAPI in the corpus callosum at W8 in the presence of IFN-\u03b3. Scale bar = 100 \u00b5m. (<b>B</b>) Representative EM images of axons in the corpus callosum at W8 in the presence of IFN-\u03b3. Scale bar = 1 \u00b5m. Quantifications of the number of cells positive for ASPA (<b>C</b>), percentage of remyelinated axons (<b>D</b>) and g-ratios of axons (<b>E</b>) in the corpus callosum areas at W0 and W8 in the presence of IFN-\u03b3. Two males and two females in each treatment group and four males at W0. Data are presented as the mean \u00b1 SEM (n = 4 mice/group). *p<i>&lt;</i>0.05, **p<i>&lt;</i>0.01, ****p&lt;0.0001. Significance based on ANOVA.",
+                                            "type": "paragraph"
+                                        }
+                                    ],
+                                    "id": "fig8",
+                                    "image": {
+                                        "alt": "",
+                                        "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig8-v1.tif",
+                                        "size": {
+                                            "width": 4445,
+                                            "height": 3175
+                                        },
+                                        "source": {
+                                            "mediaType": "image/jpeg",
+                                            "uri": "https://iiif.elifesciences.org/lax:65469%2Felife-65469-fig8-v1.tif/full/full/0/default.jpg",
+                                            "filename": "elife-65469-fig8-v1.jpg"
+                                        }
+                                    },
+                                    "label": "Figure 8",
+                                    "sourceData": [
+                                        {
+                                            "filename": "elife-65469-fig8-data1-v1.xlsx",
+                                            "id": "fig8sdata1",
+                                            "label": "Figure 8\u2014source data 1",
+                                            "mediaType": "application/xlsx",
+                                            "title": "The number of ASAP+ cells, myelinated axons and g-ratio of various treatments.",
+                                            "uri": "https://cdn.elifesciences.org/articles/65469/elife-65469-fig8-data1-v1.xlsx"
+                                        }
+                                    ],
+                                    "title": "Combined treatment of Sephin1 and BZA accelerates remyelination.",
+                                    "type": "image"
+                                }
+                            ],
+                            "type": "figure"
+                        }
+                    ],
+                    "id": "s2-5",
+                    "title": "Combined treatment of Sephin1 and BZA accelerated remyelination in the presence of IFN-\u03b3",
+                    "type": "section"
+                }
+            ],
+            "id": "s2",
+            "title": "Results",
+            "type": "section"
+        },
+        {
+            "content": [
+                {
+                    "text": "Endogenous remyelination plays a crucial role in preserving axons and restoring neuronal function, but is frequently insufficient in MS. The adverse extracellular environment of MS lesions is thought to contribute to remyelination failure (<a href=\"#bib6\">Chew et al., 2005</a>; <a href=\"#bib18\">Frischer et al., 2015</a>; <a href=\"#bib28\">Kuhlmann et al., 2008</a>; <a href=\"#bib16\">Franklin and Ffrench-Constant, 2008a</a>). Efforts to re-populate oligodendrocytes that remyelinate neuronal axons within the CNS will advance reparative therapeutics for MS (<a href=\"#bib17\">Franklin and Kotter, 2008b</a>; <a href=\"#bib14\">Fancy et al., 2010</a>; <a href=\"#bib4\">Chari, 2007</a>). Although many agents identified from high-throughput screening studies appear to accelerate remyelination, it is unclear whether they are capable of initiating repair and restoring neuronal function in a complex inflammatory environment (<a href=\"#bib11\">Deshmukh et al., 2013</a>; <a href=\"#bib39\">Mei et al., 2016</a>). A recent study, which investigated the differentiation of induced pluripotent stem-cell-derived oligodendrocytes from MS patients, indicated that the inflammation in MS lesions is a major contributor to impaired remyelination, and many remyelinating agents failed to restore impaired differentiation caused by inflammation (<a href=\"#bib47\">Starost et al., 2020</a>). Our mouse model used here, which combines primary demyelination induced by cuprizone with CNS delivery of IFN-\u03b3, provides a unique platform to facilitate the assessment of remyelination therapies in the setting of inflammation. In our previous studies, we demonstrated that prolonging the ISR provides protection to mature oligodendrocytes, which maintain the myelin sheath, from inflammatory attack (<a href=\"#bib52\">Way and Popko, 2016</a>; <a href=\"#bib51\">Way et al., 2015</a>; <a href=\"#bib34\">Lin et al., 2008</a>; <a href=\"#bib5\">Chen et al., 2019</a>). Herein we investigated whether a similar enhancement of the ISR would provide protection to newly generated remyelinating oligodendrocytes and promote the repair of demyelinated axons in a neuroinflammatory environment.",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "We have previously shown that a prolonged ISR response protects mature oligodendrocytes during the peak of disease in EAE in a manner not related to direct immunomodulation (<a href=\"#bib5\">Chen et al., 2019</a>). Here, we demonstrated that Sephin1 treatment, when initiated at the peak of disease, facilitated the clinical recovery of the EAE animals, which correlated with enhanced remyelination. These results motivated us to examine the remyelination enhancing potential of an augmented ISR in a more controlled model of CNS remyelination.",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "To further investigate the potential of the ISR to confer protection to remyelinating oligodendrocytes and remyelination during inflammation, we utilized an inducible double-transgenic mouse model (GFAP-tTA;TRE-IFN-\u03b3) to temporally deliver IFN-\u03b3 to the CNS in the cuprizone model (<a href=\"#bib32\">Lin et al., 2006</a>). The T cell cytokine IFN-\u03b3 is a critical inflammatory mediator of MS/EAE pathogenesis (<a href=\"#bib29\">Lees and Cross, 2007</a>; <a href=\"#bib42\">Ottum et al., 2015</a>). In addition, it has been suggested that IFN-\u03b3 could induce immune transitions of OPCs and oligodendrocytes to an inflammatory state with major histocompatibility complex (MHC)-I and MHC-II presentation (<a href=\"#bib26\">Kirby and Castelo-Branco, 2020</a>). IFN-\u03b3 delivery is required because cuprizone-induced demyelination/remyelination occurs in the absence of an adaptive immune response and thus does not reflect the inflammatory environment in the MS lesions. Importantly, the level of IFN-\u03b3 present in the CNS of GFAP-tTA;TRE-IFN-\u03b3 double transgenic mice is approximately equivalent to that of EAE mice (data not shown), which suggests that Dox-controlled IFN-\u03b3 release is within the range observed in inflammatory demyelination. Our previous studies with GFAP-tTA;TRE-IFN-\u03b3 double-transgenic mice demonstrated that ectopic expression of IFN-\u03b3 in the CNS results in a reduction in the number of myelinating oligodendrocytes and hypomyelination during development, and results in diminished remyelination following cuprizone-induced oligodendrocyte toxicity (<a href=\"#bib34\">Lin et al., 2008</a>; <a href=\"#bib32\">Lin et al., 2006</a>). In our current study we found that CNS expression of IFN-\u03b3 suppresses the repopulation of oligodendrocytes and results in diminished numbers of remyelinated axons following cuprizone-induced demyelination. In the GFAP-tTA;TRE-IFN-\u03b3 model, it takes about 2\u20133 weeks for IFN-\u03b3 levels to become elevated in the CNS following the removal of Dox from the animal\u2019s diet (<a href=\"#fig2s1\">Figure 2\u2014figure supplement 1</a>; <a href=\"#bib32\">Lin et al., 2006</a>). Since Dox removal occurred at the time of the initiation of cuprizone exposure, the majority of mature oligodendrocytes had already been lost (W3) by the time IFN-\u03b3 levels became elevated. Therefore, in this model, mainly newly generated remyelinating oligodendrocytes are exposed to IFN-\u03b3. Using the same mouse model, our group previously showed that the effect of IFN-\u03b3 on the remyelination process in the cuprizone model is associated with an activated ISR response in remyelinating oligodendrocytes (<a href=\"#bib31\">Lin et al., 2005</a>; <a href=\"#bib32\">Lin et al., 2006</a>). Indeed, GADD34 deficiency or Sephin1 treatment, both of which prolong the ISR, significantly increased the number of remyelinating oligodendrocytes and myelinated axons in the presence of IFN-\u03b3. Nevertheless, the enhancement of the ISR had no effect on remyelination in the absence of IFN-\u03b3. This is consistent with a recent study that showed that guanabenz, a drug closely related to Sephin1 (<a href=\"#bib10\">Das et al., 2015</a>), did not improve remyelination in the non-inflammatory cuprizone model of demyelination (<a href=\"#bib48\">Thompson and Tsirka, 2020</a>).",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "The genetic and pharmacologic approaches used here to modulate the ISR do not target specific cell types in the CNS. The increased numbers of remyelinating oligodendrocytes that result from an enhanced ISR might originate from increased OPC survival in the lesion or from more efficient OPC differentiation to mature oligodendrocytes. We observed that proliferating OPC numbers at the peak of cuprizone-induced demyelination were diminished by the presence of IFN-\u03b3, which is consistent with previous findings that showed that IFN-\u03b3 predisposed OPCs to apoptosis (<a href=\"#bib6\">Chew et al., 2005</a>; <a href=\"#bib25\">Kirby et al., 2019</a>). Nevertheless, prolonging the ISR by the <i>Gadd34</i> mutation or by Sephin1 treatment did not alter the number of proliferating OPCs in the presence of inflammation. Therefore, it is likely that the benefits of ISR enhancement on remyelination in the presence of inflammation are primarily due to the protection of actively myelinating oligodendrocytes, similar to what we have observed during developmental myelination (<a href=\"#bib6\">Chew et al., 2005</a>; <a href=\"#bib31\">Lin et al., 2005</a>).",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "The FDA-approved SERM, BZA, has been shown to be capable of enhancing OPC differentiation and remyelination independently of its estrogen receptor (<a href=\"#bib43\">Rankin et al., 2019</a>). We show here that BZA can promote remyelination in the presence of the inflammatory cytokine IFN-\u03b3, which provides valuable preclinical support to the current MS clinical trial of BZA as a remyelination-enhancing agent (<a href=\"https://clinicaltrials.gov/\">ClinicalTrials.gov</a> Identifier: NCT04002934). Encouragingly, we found that the combination treatment of BZA and Sephin1 resulted in more axons with thicker myelin, indicating a more substantial recovery. Although with our current data we cannot exclude the possibility that this combination treatment might protect mature oligodendrocytes and myelin during cuprizone-induced demyelination, we believe that because the treatment was started at the time-point of substantial oligodendrocyte loss and demyelination in the corpus callosum, it is more likely that the primary beneficial effect is on the repopulation of oligodendrocytes and remyelination. The myelin sheaths of remyelinated axons are uniformly thin regardless of axon diameter, but the underlying mechanism that controls the thickness of remyelinated axons is unknown (<a href=\"#bib15\">Fancy et al., 2011</a>). Although previous studies have shown that the transgenic overexpression of neuregulin (<i>Nrg</i>) or the conditional knockout of <i>Petn</i> increases myelin sheath thickness in developmental myelination, the remyelinated myelin sheaths remain thin in these models (<a href=\"#bib2\">Brinkmann et al., 2008</a>; <a href=\"#bib21\">Harrington et al., 2010</a>). Increased myelin thickness after the combination treatment of BZA and Sephin1 in our inflammatory de/remyelination model suggests that remyelination can be more efficiently induced by using therapies promoting OPC differentiation in combination with therapies that protect the remyelinating oligodendrocytes against inflammatory environment.",
+                    "type": "paragraph"
+                },
+                {
+                    "text": "Effective MS therapies need to both suppress the aggressive CNS inflammation and promote restoring neuronal functions, including remyelination (<a href=\"#bib45\">Rodgers et al., 2013</a>; <a href=\"#bib49\">Titus et al., 2020</a>). Our current study demonstrates that the ISR modulator Sephin1 protects remyelinating oligodendrocytes in the presence of an inflammatory environment, leading to remarkably improved remyelination. In our previous EAE study, we showed that Sephin1 protects mature oligodendrocytes, myelin and axons, in addition to indirectly dampening the CNS inflammation that drives EAE (<a href=\"#bib5\">Chen et al., 2019</a>). We also showed that combining Sephin1 with the anti-inflammatory MS drug IFN-\u03b2 resulted in an additive effect in alleviating EAE. Combining current and previous findings, we believe that Sephin1 or similar ISR enhancing strategies will likely provide significant therapeutic benefit to MS patients when combined with current immunosuppressive treatment.",
+                    "type": "paragraph"
+                }
+            ],
+            "id": "s3",
+            "title": "Discussion",
+            "type": "section"
+        },
+        {
+            "content": [
+                {
+                    "assets": [
+                        {
+                            "id": "keyresource",
+                            "label": "Key resources table",
+                            "tables": [
+                                "<table><thead><tr><th valign=\"top\">Reagent type <br/>(species) or <br/>resource</th><th valign=\"top\">Designation</th><th valign=\"top\">Source or <br/>reference</th><th valign=\"top\">Identifiers</th><th valign=\"top\">Additional <br/>information</th></tr></thead><tbody><tr><td valign=\"top\">Strain, strain background (<i>M. musculus</i>)</td><td valign=\"top\">C57Bl/6J</td><td valign=\"top\">Jackson lab</td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:IMSR_JAX:000664\">IMSR_JAX:000664</a></td><td valign=\"top\"/></tr><tr><td valign=\"top\">Strain, strain background (<i>M. musculus</i>)</td><td valign=\"top\">GFAP-tTA mice</td><td valign=\"top\"><a href=\"#bib30\">Lin et al., 2004</a></td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:IMSR_JAX:005964\">IMSR_JAX:005964</a></td><td valign=\"top\"/></tr><tr><td valign=\"top\">Strain, strain background (<i>M. musculus</i>)</td><td valign=\"top\">TRE-IFN-\u03b3 mice</td><td valign=\"top\"><a href=\"#bib30\">Lin et al., 2004</a></td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:IMSR_JAX:009344\">IMSR_JAX:009344</a></td><td valign=\"top\"/></tr><tr><td valign=\"top\">Strain, strain background (<i>M. musculus</i>)</td><td valign=\"top\"><i>Ppp1r15a-/-</i>(GADD34 KO) mice</td><td valign=\"top\">Gift from David Ron</td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:MGI:3040935\">MGI:3040935</a></td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, drug</td><td valign=\"top\">doxycycline</td><td valign=\"top\">Sigma-Aldrich</td><td valign=\"top\">Cat # D9891</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, drug</td><td valign=\"top\">0.2% cuprizone</td><td valign=\"top\">Envigo</td><td valign=\"top\">Cat # TD.160049</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, <br/>drug</td><td valign=\"top\">Sephin1</td><td valign=\"top\">Apexbio</td><td valign=\"top\">Cat # A8708</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, drug</td><td valign=\"top\">bazedoxifene acetate</td><td valign=\"top\">Sigma-Aldrich</td><td valign=\"top\">Cat # PZ0018</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, drug</td><td valign=\"top\">MOG <sub>35-55</sub>peptide</td><td valign=\"top\">Genemed synthesis</td><td valign=\"top\">Cat # MOG3555-P-5</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Chemical compound, drug</td><td valign=\"top\">pertussis toxin</td><td valign=\"top\">List Biological Laboratories</td><td valign=\"top\">Cat # 179</td><td valign=\"top\"/></tr><tr><td valign=\"top\">Sequence-based reagent</td><td valign=\"top\"><i>Gapdh</i>-f</td><td valign=\"top\">This paper</td><td valign=\"top\">qPCR primer</td><td valign=\"top\">TGTGTCCGTCGTGGATCTGA</td></tr><tr><td valign=\"top\">Sequence-based reagent</td><td valign=\"top\"><i>Gapdh</i>-r</td><td valign=\"top\">This paper</td><td valign=\"top\">qPCR primer</td><td valign=\"top\">TTGCTGTTGAAGTCGCAGGAG</td></tr><tr><td valign=\"top\">Sequence-based reagent</td><td valign=\"top\"><i>Ifng</i>-f</td><td valign=\"top\">This paper</td><td valign=\"top\">qPCR primer</td><td valign=\"top\">GATATCTGGAGGAACTGGCAAAA</td></tr><tr><td valign=\"top\">Sequence-based reagent</td><td valign=\"top\"><i>Ifng</i>-r</td><td valign=\"top\">This paper</td><td valign=\"top\">qPCR primer</td><td valign=\"top\">CTTCAAAGAGTCTGAGGTAGAAAGAGATAAT</td></tr><tr><td valign=\"top\">Antibody</td><td valign=\"top\">Anti-MBP (mouse monoclonal)</td><td valign=\"top\">Abcam</td><td valign=\"top\">Cat # ab24567 <br/>RRID:<a href=\"https://identifiers.org/RRID/RRID:AB_448144\">AB_448144</a></td><td valign=\"top\">(1:700)</td></tr><tr><td valign=\"top\">Antibody</td><td valign=\"top\">Anti-ASPA (rabbit polyclonal)</td><td valign=\"top\">Genetex</td><td valign=\"top\">Cat # GTX113389 <br/>RRID:<a href=\"https://identifiers.org/RRID/RRID:AB_2036283\">AB_2036283</a></td><td valign=\"top\">(1:500)</td></tr><tr><td valign=\"top\">Antibody</td><td valign=\"top\">Anti-Ki67 (rabbit polyclonal)</td><td valign=\"top\">Abcam</td><td valign=\"top\">Cat # AB15580 <br/>RRID:<a href=\"https://identifiers.org/RRID/RRID:AB_443209\">AB_443209</a></td><td valign=\"top\">(1:100)</td></tr><tr><td valign=\"top\">Antibody</td><td valign=\"top\">Anti-PDGFR-alpha (mouse monoclonal)</td><td valign=\"top\">BD Biosciences</td><td valign=\"top\">Cat # 558774 <br/>RRID:<a href=\"https://identifiers.org/RRID/RRID:AB_397117\">AB_397117</a></td><td valign=\"top\">(1:100)</td></tr><tr><td valign=\"top\">Antibody</td><td valign=\"top\">Anti-Iba1 (rabbit polyclonal)</td><td valign=\"top\">Wako Pure Chemical</td><td valign=\"top\">Cat # 019\u201319741 <br/>RRID:<a href=\"https://identifiers.org/RRID/RRID:AB_839504\">AB_839504</a></td><td valign=\"top\">(1:500)</td></tr><tr><td valign=\"top\">Software, algorithm</td><td valign=\"top\">ImageJ</td><td valign=\"top\">National Institutes of Health</td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:SCR_003070\">SCR_003070</a></td><td valign=\"top\"/></tr><tr><td valign=\"top\">Software, algorithm</td><td valign=\"top\">Prism 6.0</td><td valign=\"top\">Graphpad</td><td valign=\"top\">RRID:<a href=\"https://identifiers.org/RRID/RRID:SCR_002798\">SCR_002798</a></td><td valign=\"top\"/></tr></tbody></table>"
+                            ],
+                            "type": "table"
+                        }
+                    ],
+                    "type": "figure"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "Six-week-old female C57BL/6J mice were purchased from the Jackson Laboratory (Bar Harbor, ME, USA). The mice were allowed to acclimate for 7 days prior to the EAE experiment. The GFAP-tTA mice on the C57BL/6J background were mated with the TRE-IFN-\u03b3 mice on the C57BL/6J background to produce GFAP-tTA; TRE-IFN-\u03b3 double-transgenic mice (<a href=\"#bib32\">Lin et al., 2006</a>; <a href=\"#bib35\">Lin and Popko, 2009</a>; <a href=\"#bib30\">Lin et al., 2004</a>). Moreover, GFAP-tTA mice or TRE-IFN-\u03b3 were crossed with <i>Ppp1r15a-/-</i> (GADD34 KO) mice (<a href=\"#bib27\">Kojima et al., 2003</a>), and the resulting progeny GFAP-tTA; <i>Ppp1r15a-/-</i> were crossed with TRE-IFN-\u03b3; <i>Ppp1r15a-/-</i> to obtain double-transgenic mice that were homozygous for the <i>Ppp1r15a</i> mutation. To prevent transcriptional activation of IFN-\u03b3, 0.05 mg/ml doxycycline (Dox, Sigma-Aldrich, St. Louis, MO, USA) was added to the drinking water and provided ad libitum from conception. Animals used in this study were housed under pathogen-free conditions at controlled temperatures and relative humidity with a 12/12 hr light/dark cycle and free access to pelleted food and water. All animal experiments were conducted in accordance with ARRIVE guidelines and in complete compliance with Animal Care and Use Committee guidelines of the University of Chicago and Northwestern University.",
+                            "type": "paragraph"
+                        },
+                        {
+                            "text": "The mice were randomly assigned to the different experimental groups. Sephin1 (free base) was purchased from Apexbio (Houston, TX, USA), and BZA from Sigma-Aldrich. Stock solutions of Sephin1 (24 mg/ml) and BZA (10 mg/ml) in dimethyl sulfoxide (DMSO) were stored at \u221220C\u00b0. Final solutions were prepared in sterile 0.9% NaCl (DMSO concentration: 1%) for animal treatment.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-1",
+                    "title": "Animal study",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "EAE was induced in 7-week-old female C57BL/6J mice by subcutaneous flank administration of 200 \u00b5g MOG<sub>35-55</sub> peptide (Genemed synthesis, San Antonio, TX, USA) emulsified with complete Freund\u2019s adjuvant (CFA) (MOG<sub>35-55</sub>/CFA) (BD Biosciences, San Jose, CA, USA) supplemented with inactive <i>Mycobacterium tuberculosis</i> H37Ra (BD Biosciences). Intraperitoneal (i.p.) injections of 200 ng pertussis toxin (List Biological Laboratories) were given immediately after administration of the MOG emulsion and again 48 hr later. Mice were blindly scored daily for clinical signs of EAE as follows: 0 = healthy, 1 = flaccid tail, 2 = ataxia and/or paresis, 3 = paralysis of hindlimbs and/or paresis of forelimbs, 4 = tetraparalysis, 5 = moribund or death. Mouse groups were randomized during the treatment. Mice were injected intraperitoneally with Sephin1 or the equivalent amount of vehicle (1% DMSO in 0.9% NaCl) daily starting from the peak of disease (score = 3). Lumbar spinal cords were collected at PID30.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-2",
+                    "title": "EAE immunization and treatment",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "To induce demyelination, GFAP-tTA;TRE-IFN-\u03b3 and GFAP-tTA;TRE-IFN-\u03b3;GADD34-/- double transgenic mice (male and female) were fed with a 0.2% cuprizone diet (Envigo, Madison, WI, USA) starting from 6-week-old. Dox water was discontinued at the time of cuprizone treatment (Week 0, W0). Cuprizone feeding lasted 5 weeks and then mice were placed back on normal chow for up to 3 weeks to allow remyelination to occur. Control mice were maintained on Dox water during the entire experiment. 8 mg/kg of Sephin1 (i.p.) or 10 mg/kg of BZA (gavage) was given daily to the GFAP-tTA; TRE-IFN-\u03b3 mice, starting from three weeks of cuprizone exposure (W3). The corpus callosum of each mouse was collected at 3 weeks (W3), 5 weeks (W5), or 8 weeks (W8) after cuprizone feeding was initiated. A total of 90 double transgenic mice were used for the study.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-3",
+                    "title": "Cuprizone administration",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "GFAP-tTA;TRE-IFN-\u03b3 mice were perfused with ice-cold phosphate-buffered saline (PBS). Total RNA was isolated from the cerebellum using the Aurum Total RNA Fatty and Fibrous Tissue Kit (Bio-Rad, Hercules, CA, USA). Reverse transcription was performed using the iScript cDNA synthesis kit (Bio-Rad). Quantitative real-time reverse transcription PCR was performed on a CFX96 RT-PCR detection system (Bio-Rad) using SYBR Green technology. Results were analyzed and presented as the fold induction relative to the internal control primer for the housekeeping gene <i>GAPDH.</i> The primers (5\u2032\u20133\u2032) for mouse gene sequences were as follows: <i>Gapdh</i>-f: <span class=\"sequence\">TGTGTCCGTCGTGGATCTGA</span>, <i>Gapdh</i>-r: <span class=\"sequence\">TTGCTGTTGAAGTCGCAGGAG</span>; <i>Ifng</i>-f: <span class=\"sequence\">GATATCTGGAGGAACTGGCAAAA</span>, <i>Ifng</i>-r: <span class=\"sequence\">CTTCAAAGAGTCTGAGGTAGAAAGAGATAAT</span>.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-4",
+                    "title": "Quantitative real-time reverse transcription PCR",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "GFAP-tTA; TRE-IFN-\u03b3 mice were initially perfused with PBS only before cerebellum harvesting. The same mice were then perfused with 4% paraformaldehyde (Electron Microscopy Sciences, Hatfield, PA, USA) in PBS for 15 min. The brains were removed and cut coronally at approximately 1.3 mm before the bregma. The posterior parts of the brains were post-fixed overnight and embedded in O.C.T. compound (Sakura Finetek, Torrance, CA, USA). The tissue was sectioned in a series of 10 \u00b5m on a cryostat. Cryosections were treated with acetone at \u221220\u00b0C, then blocked with PBS containing 5% goat serum and 0.1% Triton X-100, and incubated overnight with the primary antibodies at 4\u00b0C. Sections were incubated with secondary antibodies for 1 hr at room temperature. Coronal sections at the fornix region of the corpus callosum corresponding to Sidman sections 241-251 (<a href=\"#bib46\">Sidman et al., 1972</a>). Primary antibodies include the following anti-MBP (Abcam, ab24567, 1:700), anti-ASPA (Genetex, GTX113389, 1:500), anti-Ki67 (Abcam, AB15580, 1:100), anti-PDGFR-alpha (BD Biosciences, 558774, 1:100), and anti-Iba1(Wako Pure Chemical, 09\u201319741, 1:500). The fluorescent stained sections were scanned with Olympus VS-120 slide scanner and quantified by ImageJ. At least three serial sections of corpus callosum were quantified. The representative fluorescent images were acquired under Nikon A1R confocal microscope. The investigators were blinded to allocation of treatment groups in the processes of image capture and the following quantification.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-5",
+                    "title": "Immunostaining",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "For GFAP-tTA;TRE-IFN-\u03b3 mice, the anterior parts of the brains were immersed into EM buffer for two weeks at 4\u00b0C. EM buffer contains 4% paraformaldehyde (Electron Microscopy Sciences), 2.5% glutaraldehyde (Electron Microscopy Sciences) in 0.1 M sodium cacodylate (Electron Microscopy Sciences) at pH 7.3. The sections corresponding to the corpus callosum were trimmed, and postfixed in 1% osmium tetroxide (Electron Microscopy Sciences) in 0.1 M Sodium Cacodylate. Sections were then dehydrated in ethanol, cleared in propylene oxide, and embedded in EMBed 812 resin (Electron Microscopy Sciences). EAE mice were perfused with EM buffer, and then the lumbar spinal cords were processed, embedded, and sectioned as above. Semi-thin sections were stained with toluidine blue. Samples were next ultrathin sectioned on a Leica EM UC7 ultramicrotome. Grids were examined on a FEI Tecnai Spirit G2 transmission electron microscope. We calculated the total percentage of remyelinated axons averaged from 10 images (area = 518.3504 \u00b5m<sup>2</sup>) in each mouse. G-ratio was calculated as the ratio of the inner diameter to the outer diameter of a myelinated axon; a minimum of 300 fibers per mouse was analyzed. The investigators were blinded to allocation of treatment groups in the processes of image capture and the following quantification.",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-6",
+                    "title": "Electron microscopy (EM)",
+                    "type": "section"
+                },
+                {
+                    "content": [
+                        {
+                            "text": "Statistical tests were performed in Prism eight software. No statistical methods were used to predetermine sample size. Each n value represents individual animal. All data were presented as mean \u00b1 SEM (standard error of mean). Multiple comparisons were carried out by one-way ANOVA followed by Tukey\u2019s post hoc test; single comparisons were evaluated by unpaired t-test. Cumulative scores of EAE mice were analyzed using Kolmogorov-Smirnov method. Differences were considered statistically significant when p&lt;0.05. The effect size was reported as eta squared (\u03b7<sup>2</sup>), referring to effect size as small (\u03b7<sup>2</sup>=0.01), medium (\u03b7<sup>2</sup>=0.06), and large (\u03b7<sup>2</sup>=0.14) (<a href=\"#bib7\">Cohen, 1988</a>; <a href=\"#bib13\">Ellis, 2010</a>).",
+                            "type": "paragraph"
+                        }
+                    ],
+                    "id": "s4-7",
+                    "title": "Statistical analysis",
+                    "type": "section"
+                }
+            ],
+            "id": "s4",
+            "title": "Materials and methods",
+            "type": "section"
+        }
+    ],
+    "references": [
+        {
+            "articleTitle": "Endogenous cell repair of chronic demyelination",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Armstrong, RC",
+                        "preferred": "Armstrong RC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Le, TQ",
+                        "preferred": "Le TQ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Flint, NC",
+                        "preferred": "Flint NC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Vana, AC",
+                        "preferred": "Vana AC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zhou, YX",
+                        "preferred": "Zhou YX"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2006",
+            "doi": "10.1097/01.jnen.0000205142.08716.7e",
+            "id": "bib1",
+            "journal": "Journal of Neuropathology and Experimental Neurology",
+            "pages": {
+                "first": "245",
+                "last": "256",
+                "range": "245\u2013256"
+            },
+            "pmid": 16651886,
+            "type": "journal",
+            "volume": "65"
+        },
+        {
+            "articleTitle": "Neuregulin-1/ErbB signaling serves distinct functions in myelination of the peripheral and central nervous system",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Brinkmann, BG",
+                        "preferred": "Brinkmann BG"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Agarwal, A",
+                        "preferred": "Agarwal A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Sereda, MW",
+                        "preferred": "Sereda MW"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Garratt, AN",
+                        "preferred": "Garratt AN"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "M\u00fcller, T",
+                        "preferred": "M\u00fcller T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wende, H",
+                        "preferred": "Wende H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Stassart, RM",
+                        "preferred": "Stassart RM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Nawaz, S",
+                        "preferred": "Nawaz S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Humml, C",
+                        "preferred": "Humml C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Velanac, V",
+                        "preferred": "Velanac V"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Radyushkin, K",
+                        "preferred": "Radyushkin K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Goebbels, S",
+                        "preferred": "Goebbels S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Fischer, TM",
+                        "preferred": "Fischer TM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lai, C",
+                        "preferred": "Lai C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ehrenreich, H",
+                        "preferred": "Ehrenreich H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Birchmeier, C",
+                        "preferred": "Birchmeier C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Schwab, MH",
+                        "preferred": "Schwab MH"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Nave, KA",
+                        "preferred": "Nave KA"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "doi": "10.1016/j.neuron.2008.06.028",
+            "id": "bib2",
+            "journal": "Neuron",
+            "pages": {
+                "first": "581",
+                "last": "595",
+                "range": "581\u2013595"
+            },
+            "pmid": 18760695,
+            "type": "journal",
+            "volume": "59"
+        },
+        {
+            "articleTitle": "Decoding the selectivity of eIF2\u03b1 holophosphatases and PPP1R15A inhibitors",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Carrara, M",
+                        "preferred": "Carrara M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Sigurdardottir, A",
+                        "preferred": "Sigurdardottir A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bertolotti, A",
+                        "preferred": "Bertolotti A"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2017",
+            "doi": "10.1038/nsmb.3443",
+            "id": "bib3",
+            "journal": "Nature Structural & Molecular Biology",
+            "pages": {
+                "first": "708",
+                "last": "716",
+                "range": "708\u2013716"
+            },
+            "pmid": 28759048,
+            "type": "journal",
+            "volume": "24"
+        },
+        {
+            "articleTitle": "Remyelination in multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Chari, DM",
+                        "preferred": "Chari DM"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2007",
+            "doi": "10.1016/S0074-7742(07)79026-8",
+            "id": "bib4",
+            "journal": "International Review of Neurobiology",
+            "pages": {
+                "first": "589",
+                "last": "620",
+                "range": "589\u2013620"
+            },
+            "pmid": 17531860,
+            "type": "journal",
+            "volume": "79"
+        },
+        {
+            "articleTitle": "Sephin1, which prolongs the integrated stress response, is a promising therapeutic for multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Chen, Y",
+                        "preferred": "Chen Y"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Podojil, JR",
+                        "preferred": "Podojil JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kunjamma, RB",
+                        "preferred": "Kunjamma RB"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Jones, J",
+                        "preferred": "Jones J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Weiner, M",
+                        "preferred": "Weiner M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2019",
+            "doi": "10.1093/brain/awy322",
+            "id": "bib5",
+            "journal": "Brain",
+            "pages": {
+                "first": "344",
+                "last": "361",
+                "range": "344\u2013361"
+            },
+            "pmid": 30657878,
+            "type": "journal",
+            "volume": "142"
+        },
+        {
+            "articleTitle": "Interferon-gamma inhibits cell cycle exit in differentiating oligodendrocyte progenitor cells",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Chew, LJ",
+                        "preferred": "Chew LJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "King, WC",
+                        "preferred": "King WC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kennedy, A",
+                        "preferred": "Kennedy A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Gallo, V",
+                        "preferred": "Gallo V"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2005",
+            "doi": "10.1002/glia.20232",
+            "id": "bib6",
+            "journal": "Glia",
+            "pages": {
+                "first": "127",
+                "last": "143",
+                "range": "127\u2013143"
+            },
+            "pmid": 15920731,
+            "type": "journal",
+            "volume": "52"
+        },
+        {
+            "authors": [
+                {
+                    "name": {
+                        "index": "Cohen, J",
+                        "preferred": "Cohen J"
+                    },
+                    "type": "person"
+                }
+            ],
+            "bookTitle": "Statistical Power Analysis for the Behavioral Sciences",
+            "date": "1988",
+            "doi": "10.4324/9780203771587",
+            "id": "bib7",
+            "publisher": {
+                "name": [
+                    "Lawrence Erlbaum Associates"
+                ]
+            },
+            "type": "book"
+        },
+        {
+            "articleTitle": "The integrated stress response: from mechanism to disease",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Costa-Mattioli, M",
+                        "preferred": "Costa-Mattioli M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Walter, P",
+                        "preferred": "Walter P"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.1126/science.aat5314",
+            "id": "bib8",
+            "journal": "Science",
+            "pages": "eaat5314",
+            "pmid": 32327570,
+            "type": "journal",
+            "volume": "368"
+        },
+        {
+            "articleTitle": "Multiple sclerosis: immunopathology and treatment update",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Dargahi, N",
+                        "preferred": "Dargahi N"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Katsara, M",
+                        "preferred": "Katsara M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Tselios, T",
+                        "preferred": "Tselios T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Androutsou, M-E",
+                        "preferred": "Androutsou M-E"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "de Courten, M",
+                        "preferred": "de Courten M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Matsoukas, J",
+                        "preferred": "Matsoukas J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Apostolopoulos, V",
+                        "preferred": "Apostolopoulos V"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2017",
+            "doi": "10.3390/brainsci7070078",
+            "id": "bib9",
+            "journal": "Brain Sciences",
+            "pages": "78",
+            "type": "journal",
+            "volume": "7"
+        },
+        {
+            "articleTitle": "Preventing proteostasis diseases by selective inhibition of a phosphatase regulatory subunit",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Das, I",
+                        "preferred": "Das I"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Krzyzosiak, A",
+                        "preferred": "Krzyzosiak A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Schneider, K",
+                        "preferred": "Schneider K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wrabetz, L",
+                        "preferred": "Wrabetz L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "D'Antonio, M",
+                        "preferred": "D'Antonio M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Barry, N",
+                        "preferred": "Barry N"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Sigurdardottir, A",
+                        "preferred": "Sigurdardottir A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bertolotti, A",
+                        "preferred": "Bertolotti A"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.1126/science.aaa4484",
+            "id": "bib10",
+            "journal": "Science",
+            "pages": {
+                "first": "239",
+                "last": "242",
+                "range": "239\u2013242"
+            },
+            "pmid": 25859045,
+            "type": "journal",
+            "volume": "348"
+        },
+        {
+            "articleTitle": "A regenerative approach to the treatment of multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Deshmukh, VA",
+                        "preferred": "Deshmukh VA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Tardif, V",
+                        "preferred": "Tardif V"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lyssiotis, CA",
+                        "preferred": "Lyssiotis CA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Green, CC",
+                        "preferred": "Green CC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kerman, B",
+                        "preferred": "Kerman B"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kim, HJ",
+                        "preferred": "Kim HJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Padmanabhan, K",
+                        "preferred": "Padmanabhan K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Swoboda, JG",
+                        "preferred": "Swoboda JG"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ahmad, I",
+                        "preferred": "Ahmad I"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kondo, T",
+                        "preferred": "Kondo T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Gage, FH",
+                        "preferred": "Gage FH"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Theofilopoulos, AN",
+                        "preferred": "Theofilopoulos AN"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lawson, BR",
+                        "preferred": "Lawson BR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Schultz, PG",
+                        "preferred": "Schultz PG"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lairson, LL",
+                        "preferred": "Lairson LL"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2013",
+            "doi": "10.1038/nature12647",
+            "id": "bib11",
+            "journal": "Nature",
+            "pages": {
+                "first": "327",
+                "last": "332",
+                "range": "327\u2013332"
+            },
+            "pmid": 24107995,
+            "type": "journal",
+            "volume": "502"
+        },
+        {
+            "articleTitle": "Thin myelin sheaths as the hallmark of remyelination persist over time and preserve axon function",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Duncan, ID",
+                        "preferred": "Duncan ID"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Marik, RL",
+                        "preferred": "Marik RL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Broman, AT",
+                        "preferred": "Broman AT"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Heidari, M",
+                        "preferred": "Heidari M"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2017",
+            "doi": "10.1073/pnas.1714183114",
+            "id": "bib12",
+            "journal": "PNAS",
+            "pages": {
+                "first": "E9685",
+                "last": "E9691",
+                "range": "E9685\u2013E9691"
+            },
+            "pmid": 29078396,
+            "type": "journal",
+            "volume": "114"
+        },
+        {
+            "authors": [
+                {
+                    "name": {
+                        "index": "Ellis, PD",
+                        "preferred": "Ellis PD"
+                    },
+                    "type": "person"
+                }
+            ],
+            "bookTitle": "The Essential Guide to Effect Sizes: Statistical Power, Meta-Analysis, and the Interpretation of Research Results",
+            "date": "2010",
+            "doi": "10.1017/CBO9780511761676",
+            "id": "bib13",
+            "publisher": {
+                "address": {
+                    "components": {
+                        "locality": [
+                            "Cambridge"
+                        ]
+                    },
+                    "formatted": [
+                        "Cambridge"
+                    ]
+                },
+                "name": [
+                    "Cambridge University Press"
+                ]
+            },
+            "type": "book"
+        },
+        {
+            "articleTitle": "Overcoming remyelination failure in multiple sclerosis and other myelin disorders",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Fancy, SP",
+                        "preferred": "Fancy SP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kotter, MR",
+                        "preferred": "Kotter MR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Harrington, EP",
+                        "preferred": "Harrington EP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Huang, JK",
+                        "preferred": "Huang JK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zhao, C",
+                        "preferred": "Zhao C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Rowitch, DH",
+                        "preferred": "Rowitch DH"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2010",
+            "doi": "10.1016/j.expneurol.2009.12.020",
+            "id": "bib14",
+            "journal": "Experimental Neurology",
+            "pages": {
+                "first": "18",
+                "last": "23",
+                "range": "18\u201323"
+            },
+            "pmid": 20044992,
+            "type": "journal",
+            "volume": "225"
+        },
+        {
+            "articleTitle": "Myelin regeneration: a recapitulation of development?",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Fancy, SP",
+                        "preferred": "Fancy SP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chan, JR",
+                        "preferred": "Chan JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Baranzini, SE",
+                        "preferred": "Baranzini SE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Rowitch, DH",
+                        "preferred": "Rowitch DH"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2011",
+            "doi": "10.1146/annurev-neuro-061010-113629",
+            "id": "bib15",
+            "journal": "Annual Review of Neuroscience",
+            "pages": {
+                "first": "21",
+                "last": "43",
+                "range": "21\u201343"
+            },
+            "pmid": 21692657,
+            "type": "journal",
+            "volume": "34"
+        },
+        {
+            "articleTitle": "Remyelination in the CNS: from biology to therapy",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ffrench-Constant, C",
+                        "preferred": "Ffrench-Constant C"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "discriminator": "a",
+            "doi": "10.1038/nrn2480",
+            "id": "bib16",
+            "journal": "Nature Reviews Neuroscience",
+            "pages": {
+                "first": "839",
+                "last": "855",
+                "range": "839\u2013855"
+            },
+            "pmid": 18931697,
+            "type": "journal",
+            "volume": "9"
+        },
+        {
+            "articleTitle": "The biology of CNS remyelination: the key to therapeutic advances",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kotter, MR",
+                        "preferred": "Kotter MR"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "discriminator": "b",
+            "doi": "10.1007/s00415-008-1004-6",
+            "id": "bib17",
+            "journal": "Journal of Neurology",
+            "pages": {
+                "first": "19",
+                "last": "25",
+                "range": "19\u201325"
+            },
+            "pmid": 18317673,
+            "type": "journal",
+            "volume": "255"
+        },
+        {
+            "articleTitle": "Clinical and pathological insights into the dynamic nature of the white matter multiple sclerosis plaque",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Frischer, JM",
+                        "preferred": "Frischer JM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Weigand, SD",
+                        "preferred": "Weigand SD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Guo, Y",
+                        "preferred": "Guo Y"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kale, N",
+                        "preferred": "Kale N"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Parisi, JE",
+                        "preferred": "Parisi JE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Pirko, I",
+                        "preferred": "Pirko I"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Mandrekar, J",
+                        "preferred": "Mandrekar J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bramow, S",
+                        "preferred": "Bramow S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Metz, I",
+                        "preferred": "Metz I"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Br\u00fcck, W",
+                        "preferred": "Br\u00fcck W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lassmann, H",
+                        "preferred": "Lassmann H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lucchinetti, CF",
+                        "preferred": "Lucchinetti CF"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.1002/ana.24497",
+            "id": "bib18",
+            "journal": "Annals of Neurology",
+            "pages": {
+                "first": "710",
+                "last": "721",
+                "range": "710\u2013721"
+            },
+            "pmid": 26239536,
+            "type": "journal",
+            "volume": "78"
+        },
+        {
+            "articleTitle": "Multiple sclerosis \u2014 The Plaque and Its Pathogenesis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Frohman, EM",
+                        "preferred": "Frohman EM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Racke, MK",
+                        "preferred": "Racke MK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Raine, CS",
+                        "preferred": "Raine CS"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2006",
+            "doi": "10.1056/NEJMra052130",
+            "id": "bib19",
+            "journal": "New England Journal of Medicine",
+            "pages": {
+                "first": "942",
+                "last": "955",
+                "range": "942\u2013955"
+            },
+            "type": "journal",
+            "volume": "354"
+        },
+        {
+            "articleTitle": "Glial response during cuprizone-induced de- and remyelination in the CNS: lessons learned",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Gudi, V",
+                        "preferred": "Gudi V"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Gingele, S",
+                        "preferred": "Gingele S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Skripuletz, T",
+                        "preferred": "Skripuletz T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Stangel, M",
+                        "preferred": "Stangel M"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2014",
+            "doi": "10.3389/fncel.2014.00073",
+            "id": "bib20",
+            "journal": "Frontiers in Cellular Neuroscience",
+            "pages": "73",
+            "pmid": 24659953,
+            "type": "journal",
+            "volume": "8"
+        },
+        {
+            "articleTitle": "Oligodendrocyte PTEN is required for myelin and axonal integrity, not remyelination",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Harrington, EP",
+                        "preferred": "Harrington EP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zhao, C",
+                        "preferred": "Zhao C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Fancy, SPJ",
+                        "preferred": "Fancy SPJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kaing, S",
+                        "preferred": "Kaing S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJM",
+                        "preferred": "Franklin RJM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Rowitch, DH",
+                        "preferred": "Rowitch DH"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2010",
+            "doi": "10.1002/ana.22090",
+            "id": "bib21",
+            "journal": "Annals of Neurology",
+            "pages": {
+                "first": "703",
+                "last": "716",
+                "range": "703\u2013716"
+            },
+            "type": "journal",
+            "volume": "68"
+        },
+        {
+            "articleTitle": "Current and emerging treatment of multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Hart, FM",
+                        "preferred": "Hart FM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bainbridge, J",
+                        "preferred": "Bainbridge J"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2016",
+            "id": "bib22",
+            "journal": "The American Journal of Managed Care",
+            "pages": {
+                "first": "s159",
+                "last": "s170",
+                "range": "s159\u2013s170"
+            },
+            "pmid": 27356025,
+            "type": "journal",
+            "volume": "22"
+        },
+        {
+            "articleTitle": "Treatment of multiple sclerosis: a review",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Hauser, SL",
+                        "preferred": "Hauser SL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Cree, BAC",
+                        "preferred": "Cree BAC"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.1016/j.amjmed.2020.05.049",
+            "id": "bib23",
+            "journal": "The American Journal of Medicine",
+            "pages": {
+                "first": "1380",
+                "last": "1390",
+                "range": "1380\u20131390"
+            },
+            "pmid": 32682869,
+            "type": "journal",
+            "volume": "133"
+        },
+        {
+            "articleTitle": "Regenerative medicine in multiple sclerosis: identifying pharmacological targets of adult neural stem cell differentiation",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Huang, JK",
+                        "preferred": "Huang JK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJM",
+                        "preferred": "Franklin RJM"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2011",
+            "doi": "10.1016/j.neuint.2011.01.017",
+            "id": "bib24",
+            "journal": "Neurochemistry International",
+            "pages": {
+                "first": "329",
+                "last": "332",
+                "range": "329\u2013332"
+            },
+            "type": "journal",
+            "volume": "17"
+        },
+        {
+            "articleTitle": "Oligodendrocyte precursor cells present antigen and are cytotoxic targets in inflammatory demyelination",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Kirby, L",
+                        "preferred": "Kirby L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Jin, J",
+                        "preferred": "Jin J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Cardona, JG",
+                        "preferred": "Cardona JG"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Smith, MD",
+                        "preferred": "Smith MD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Martin, KA",
+                        "preferred": "Martin KA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wang, J",
+                        "preferred": "Wang J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Strasburger, H",
+                        "preferred": "Strasburger H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Herbst, L",
+                        "preferred": "Herbst L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Alexis, M",
+                        "preferred": "Alexis M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Karnell, J",
+                        "preferred": "Karnell J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Davidson, T",
+                        "preferred": "Davidson T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Dutta, R",
+                        "preferred": "Dutta R"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Goverman, J",
+                        "preferred": "Goverman J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bergles, D",
+                        "preferred": "Bergles D"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Calabresi, PA",
+                        "preferred": "Calabresi PA"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2019",
+            "doi": "10.1038/s41467-019-11638-3",
+            "id": "bib25",
+            "journal": "Nature Communications",
+            "pages": "3887",
+            "pmid": 31467299,
+            "type": "journal",
+            "volume": "10"
+        },
+        {
+            "articleTitle": "Crossing boundaries: interplay between the immune system and oligodendrocyte lineage cells",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Kirby, L",
+                        "preferred": "Kirby L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Castelo-Branco, G",
+                        "preferred": "Castelo-Branco G"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.1016/j.semcdb.2020.10.013",
+            "id": "bib26",
+            "journal": "Seminars in Cell & Developmental Biology",
+            "pages": {
+                "first": "30170",
+                "last": "30171",
+                "range": "30170\u201330171"
+            },
+            "type": "journal",
+            "volume": "136"
+        },
+        {
+            "articleTitle": "The function of GADD34 is a recovery from a shutoff of protein synthesis induced by ER stress: elucidation by GADD34-deficient mice",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Kojima, E",
+                        "preferred": "Kojima E"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Takeuchi, A",
+                        "preferred": "Takeuchi A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Haneda, M",
+                        "preferred": "Haneda M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Yagi, A",
+                        "preferred": "Yagi A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Hasegawa, T",
+                        "preferred": "Hasegawa T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Yamaki, K",
+                        "preferred": "Yamaki K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Takeda, K",
+                        "preferred": "Takeda K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Akira, S",
+                        "preferred": "Akira S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shimokata, K",
+                        "preferred": "Shimokata K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Isobe, K",
+                        "preferred": "Isobe K"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2003",
+            "doi": "10.1096/fj.02-1184fje",
+            "id": "bib27",
+            "journal": "The FASEB Journal",
+            "pages": {
+                "first": "1",
+                "last": "18",
+                "range": "1\u201318"
+            },
+            "pmid": 12824288,
+            "type": "journal",
+            "volume": "17"
+        },
+        {
+            "articleTitle": "Differentiation block of oligodendroglial progenitor cells as a cause for remyelination failure in chronic multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Kuhlmann, T",
+                        "preferred": "Kuhlmann T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miron, V",
+                        "preferred": "Miron V"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Cui, Q",
+                        "preferred": "Cui Q"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Cuo, Q",
+                        "preferred": "Cuo Q"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wegner, C",
+                        "preferred": "Wegner C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Antel, J",
+                        "preferred": "Antel J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Br\u00fcck, W",
+                        "preferred": "Br\u00fcck W"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "doi": "10.1093/brain/awn096",
+            "id": "bib28",
+            "journal": "Brain",
+            "pages": {
+                "first": "1749",
+                "last": "1758",
+                "range": "1749\u20131758"
+            },
+            "pmid": 18515322,
+            "type": "journal",
+            "volume": "131"
+        },
+        {
+            "articleTitle": "A little stress is good: IFN-\u03b3, demyelination, and multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lees, JR",
+                        "preferred": "Lees JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Cross, AH",
+                        "preferred": "Cross AH"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2007",
+            "doi": "10.1172/JCI31254",
+            "id": "bib29",
+            "journal": "Journal of Clinical Investigation",
+            "pages": {
+                "first": "297",
+                "last": "299",
+                "range": "297\u2013299"
+            },
+            "type": "journal",
+            "volume": "117"
+        },
+        {
+            "articleTitle": "Interferon- Induced Medulloblastoma in the Developing Cerebellum",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kemper, A",
+                        "preferred": "Kemper A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "McCarthy, KD",
+                        "preferred": "McCarthy KD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Pytel, P",
+                        "preferred": "Pytel P"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wang, J-P",
+                        "preferred": "Wang J-P"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Campbell, IL",
+                        "preferred": "Campbell IL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Utset, MF",
+                        "preferred": "Utset MF"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2004",
+            "doi": "10.1523/JNEUROSCI.2604-04.2004",
+            "id": "bib30",
+            "journal": "Journal of Neuroscience",
+            "pages": {
+                "first": "10074",
+                "last": "10083",
+                "range": "10074\u201310083"
+            },
+            "type": "journal",
+            "volume": "24"
+        },
+        {
+            "articleTitle": "Endoplasmic reticulum stress modulates the response of myelinating oligodendrocytes to the immune cytokine interferon-\u03b3",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Harding, HP",
+                        "preferred": "Harding HP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ron, D",
+                        "preferred": "Ron D"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2005",
+            "doi": "10.1083/jcb.200502086",
+            "id": "bib31",
+            "journal": "Journal of Cell Biology",
+            "pages": {
+                "first": "603",
+                "last": "612",
+                "range": "603\u2013612"
+            },
+            "type": "journal",
+            "volume": "169"
+        },
+        {
+            "articleTitle": "Interferon-\u03b3 inhibits central nervous system remyelination through a process modulated by endoplasmic reticulum stress",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kemper, A",
+                        "preferred": "Kemper A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Dupree, JL",
+                        "preferred": "Dupree JL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Harding, HP",
+                        "preferred": "Harding HP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ron, D",
+                        "preferred": "Ron D"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2006",
+            "doi": "10.1093/brain/awl044",
+            "id": "bib32",
+            "journal": "Brain",
+            "pages": {
+                "first": "1306",
+                "last": "1318",
+                "range": "1306\u20131318"
+            },
+            "type": "journal",
+            "volume": "129"
+        },
+        {
+            "articleTitle": "The integrated stress response prevents demyelination by protecting oligodendrocytes against immune-mediated damage",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bailey, SL",
+                        "preferred": "Bailey SL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ho, H",
+                        "preferred": "Ho H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Harding, HP",
+                        "preferred": "Harding HP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ron, D",
+                        "preferred": "Ron D"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2007",
+            "doi": "10.1172/JCI29571",
+            "id": "bib33",
+            "journal": "Journal of Clinical Investigation",
+            "pages": {
+                "first": "448",
+                "last": "456",
+                "range": "448\u2013456"
+            },
+            "type": "journal",
+            "volume": "117"
+        },
+        {
+            "articleTitle": "Enhanced integrated stress response promotes myelinating oligodendrocyte survival in response to interferon-gamma",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kunkler, PE",
+                        "preferred": "Kunkler PE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Harding, HP",
+                        "preferred": "Harding HP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ron, D",
+                        "preferred": "Ron D"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kraig, RP",
+                        "preferred": "Kraig RP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "doi": "10.2353/ajpath.2008.080449",
+            "id": "bib34",
+            "journal": "The American Journal of Pathology",
+            "pages": {
+                "first": "1508",
+                "last": "1517",
+                "range": "1508\u20131517"
+            },
+            "pmid": 18818381,
+            "type": "journal",
+            "volume": "173"
+        },
+        {
+            "articleTitle": "Endoplasmic reticulum stress in disorders of myelinating cells",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Lin, W",
+                        "preferred": "Lin W"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2009",
+            "doi": "10.1038/nn.2273",
+            "id": "bib35",
+            "journal": "Nature Neuroscience",
+            "pages": {
+                "first": "379",
+                "last": "385",
+                "range": "379\u2013385"
+            },
+            "pmid": 19287390,
+            "type": "journal",
+            "volume": "12"
+        },
+        {
+            "articleTitle": "The neurotoxicant, cuprizone, as a model to study demyelination and remyelination in the central nervous system",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Matsushima, GK",
+                        "preferred": "Matsushima GK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Morell, P",
+                        "preferred": "Morell P"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2001",
+            "doi": "10.1111/j.1750-3639.2001.tb00385.x",
+            "id": "bib36",
+            "journal": "Brain Pathology",
+            "pages": {
+                "first": "107",
+                "last": "116",
+                "range": "107\u2013116"
+            },
+            "pmid": 11145196,
+            "type": "journal",
+            "volume": "11"
+        },
+        {
+            "articleTitle": "A double-blind, randomized, ascending, multiple-dose study of bazedoxifene in healthy postmenopausal women",
+            "authors": [
+                {
+                    "name": {
+                        "index": "McKeand, WE",
+                        "preferred": "McKeand WE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Orczyk, GP",
+                        "preferred": "Orczyk GP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ermer, JC",
+                        "preferred": "Ermer JC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chines, AA",
+                        "preferred": "Chines AA"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2014",
+            "doi": "10.1002/cpdd.102",
+            "id": "bib37",
+            "journal": "Clinical Pharmacology in Drug Development",
+            "pages": {
+                "first": "262",
+                "last": "269",
+                "range": "262\u2013269"
+            },
+            "pmid": 27128831,
+            "type": "journal",
+            "volume": "3"
+        },
+        {
+            "articleTitle": "Micropillar arrays as a high-throughput screening platform for therapeutics in multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Mei, F",
+                        "preferred": "Mei F"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Fancy, SPJ",
+                        "preferred": "Fancy SPJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shen, YA",
+                        "preferred": "Shen YA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Niu, J",
+                        "preferred": "Niu J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zhao, C",
+                        "preferred": "Zhao C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Presley, B",
+                        "preferred": "Presley B"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miao, E",
+                        "preferred": "Miao E"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lee, S",
+                        "preferred": "Lee S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Mayoral, SR",
+                        "preferred": "Mayoral SR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Redmond, SA",
+                        "preferred": "Redmond SA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Etxeberria, A",
+                        "preferred": "Etxeberria A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Xiao, L",
+                        "preferred": "Xiao L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJM",
+                        "preferred": "Franklin RJM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Green, A",
+                        "preferred": "Green A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Hauser, SL",
+                        "preferred": "Hauser SL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chan, JR",
+                        "preferred": "Chan JR"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2014",
+            "doi": "10.1038/nm.3618",
+            "id": "bib38",
+            "journal": "Nature Medicine",
+            "pages": {
+                "first": "954",
+                "last": "960",
+                "range": "954\u2013960"
+            },
+            "pmid": 24997607,
+            "type": "journal",
+            "volume": "20"
+        },
+        {
+            "articleTitle": "Accelerated remyelination during inflammatory demyelination prevents axonal loss and improves functional recovery",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Mei, F",
+                        "preferred": "Mei F"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lehmann-Horn, K",
+                        "preferred": "Lehmann-Horn K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shen, YA",
+                        "preferred": "Shen YA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Rankin, KA",
+                        "preferred": "Rankin KA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Stebbins, KJ",
+                        "preferred": "Stebbins KJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lorrain, DS",
+                        "preferred": "Lorrain DS"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Pekarek, K",
+                        "preferred": "Pekarek K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "A Sagan, S",
+                        "preferred": "A Sagan S"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Xiao, L",
+                        "preferred": "Xiao L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Teuscher, C",
+                        "preferred": "Teuscher C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "von B\u00fcdingen, HC",
+                        "preferred": "von B\u00fcdingen HC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Wess, J",
+                        "preferred": "Wess J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lawrence, JJ",
+                        "preferred": "Lawrence JJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Green, AJ",
+                        "preferred": "Green AJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Fancy, SP",
+                        "preferred": "Fancy SP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zamvil, SS",
+                        "preferred": "Zamvil SS"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chan, JR",
+                        "preferred": "Chan JR"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2016",
+            "doi": "10.7554/eLife.18246",
+            "id": "bib39",
+            "journal": "eLife",
+            "pages": "e18246",
+            "pmid": 27671734,
+            "type": "journal",
+            "volume": "5"
+        },
+        {
+            "articleTitle": "Drug-based modulation of endogenous stem cells promotes functional remyelination in vivo",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Najm, FJ",
+                        "preferred": "Najm FJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Madhavan, M",
+                        "preferred": "Madhavan M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zaremba, A",
+                        "preferred": "Zaremba A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shick, E",
+                        "preferred": "Shick E"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Karl, RT",
+                        "preferred": "Karl RT"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Factor, DC",
+                        "preferred": "Factor DC"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, TE",
+                        "preferred": "Miller TE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Nevin, ZS",
+                        "preferred": "Nevin ZS"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kantor, C",
+                        "preferred": "Kantor C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Sargent, A",
+                        "preferred": "Sargent A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Quick, KL",
+                        "preferred": "Quick KL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Schlatzer, DM",
+                        "preferred": "Schlatzer DM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Tang, H",
+                        "preferred": "Tang H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Papoian, R",
+                        "preferred": "Papoian R"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Brimacombe, KR",
+                        "preferred": "Brimacombe KR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shen, M",
+                        "preferred": "Shen M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Boxer, MB",
+                        "preferred": "Boxer MB"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Jadhav, A",
+                        "preferred": "Jadhav A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Robinson, AP",
+                        "preferred": "Robinson AP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Podojil, JR",
+                        "preferred": "Podojil JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, RH",
+                        "preferred": "Miller RH"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Tesar, PJ",
+                        "preferred": "Tesar PJ"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.1038/nature14335",
+            "id": "bib40",
+            "journal": "Nature",
+            "pages": {
+                "first": "216",
+                "last": "220",
+                "range": "216\u2013220"
+            },
+            "type": "journal",
+            "volume": "522"
+        },
+        {
+            "articleTitle": "Debris clearance by microglia: an essential link between degeneration and regeneration",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Neumann, H",
+                        "preferred": "Neumann H"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kotter, MR",
+                        "preferred": "Kotter MR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Franklin, RJ",
+                        "preferred": "Franklin RJ"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2009",
+            "doi": "10.1093/brain/awn109",
+            "id": "bib41",
+            "journal": "Brain",
+            "pages": {
+                "first": "288",
+                "last": "295",
+                "range": "288\u2013295"
+            },
+            "pmid": 18567623,
+            "type": "journal",
+            "volume": "132"
+        },
+        {
+            "articleTitle": "Opposing roles of Interferon-Gamma on cells of the central nervous system in autoimmune neuroinflammation",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Ottum, PA",
+                        "preferred": "Ottum PA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Arellano, G",
+                        "preferred": "Arellano G"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Reyes, LI",
+                        "preferred": "Reyes LI"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Iruretagoyena, M",
+                        "preferred": "Iruretagoyena M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Naves, R",
+                        "preferred": "Naves R"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.3389/fimmu.2015.00539",
+            "id": "bib42",
+            "journal": "Frontiers in Immunology",
+            "pages": "539",
+            "pmid": 26579119,
+            "type": "journal",
+            "volume": "6"
+        },
+        {
+            "articleTitle": "Selective estrogen receptor modulators enhance CNS remyelination independent of estrogen receptors",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Rankin, KA",
+                        "preferred": "Rankin KA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Mei, F",
+                        "preferred": "Mei F"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kim, K",
+                        "preferred": "Kim K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Shen, YA",
+                        "preferred": "Shen YA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Mayoral, SR",
+                        "preferred": "Mayoral SR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Desponts, C",
+                        "preferred": "Desponts C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lorrain, DS",
+                        "preferred": "Lorrain DS"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Green, AJ",
+                        "preferred": "Green AJ"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Baranzini, SE",
+                        "preferred": "Baranzini SE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chan, JR",
+                        "preferred": "Chan JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Bove, R",
+                        "preferred": "Bove R"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2019",
+            "doi": "10.1523/JNEUROSCI.1530-18.2019",
+            "id": "bib43",
+            "journal": "The Journal of Neuroscience",
+            "pages": {
+                "first": "2184",
+                "last": "2194",
+                "range": "2184\u20132194"
+            },
+            "pmid": 30696729,
+            "type": "journal",
+            "volume": "39"
+        },
+        {
+            "articleTitle": "Multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Reich, DS",
+                        "preferred": "Reich DS"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lucchinetti, CF",
+                        "preferred": "Lucchinetti CF"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Calabresi, PA",
+                        "preferred": "Calabresi PA"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2018",
+            "doi": "10.1056/NEJMra1401483",
+            "id": "bib44",
+            "journal": "New England Journal of Medicine",
+            "pages": {
+                "first": "169",
+                "last": "180",
+                "range": "169\u2013180"
+            },
+            "type": "journal",
+            "volume": "378"
+        },
+        {
+            "articleTitle": "Strategies for protecting oligodendrocytes and enhancing remyelination in multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Rodgers, JM",
+                        "preferred": "Rodgers JM"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Robinson, AP",
+                        "preferred": "Robinson AP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2013",
+            "id": "bib45",
+            "journal": "Discovery Medicine",
+            "pages": {
+                "first": "53",
+                "last": "63",
+                "range": "53\u201363"
+            },
+            "pmid": 23911232,
+            "type": "journal",
+            "volume": "16"
+        },
+        {
+            "articleTitle": "Atlas of the mouse brain and spinal cord",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Sidman, RL",
+                        "preferred": "Sidman RL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Angevine, JB",
+                        "preferred": "Angevine JB"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Pierce, ET",
+                        "preferred": "Pierce ET"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "1972",
+            "id": "bib46",
+            "journal": "Journal of Neurology, Neurosurgery, and Psychiatry",
+            "pages": "422",
+            "type": "journal",
+            "volume": "35"
+        },
+        {
+            "articleTitle": "Extrinsic immune cell-derived, but not intrinsic oligodendroglial factors contribute to oligodendroglial differentiation block in multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Starost, L",
+                        "preferred": "Starost L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Lindner, M",
+                        "preferred": "Lindner M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Herold, M",
+                        "preferred": "Herold M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Xu, YKT",
+                        "preferred": "Xu YKT"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Drexler, HCA",
+                        "preferred": "Drexler HCA"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "He\u00df, K",
+                        "preferred": "He\u00df K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ehrlich, M",
+                        "preferred": "Ehrlich M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ottoboni, L",
+                        "preferred": "Ottoboni L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ruffini, F",
+                        "preferred": "Ruffini F"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Stehling, M",
+                        "preferred": "Stehling M"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "R\u00f6pke, A",
+                        "preferred": "R\u00f6pke A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Thomas, C",
+                        "preferred": "Thomas C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Sch\u00f6ler, HR",
+                        "preferred": "Sch\u00f6ler HR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Antel, J",
+                        "preferred": "Antel J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Winkler, J",
+                        "preferred": "Winkler J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Martino, G",
+                        "preferred": "Martino G"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Klotz, L",
+                        "preferred": "Klotz L"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kuhlmann, T",
+                        "preferred": "Kuhlmann T"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.1007/s00401-020-02217-8",
+            "id": "bib47",
+            "journal": "Acta Neuropathologica",
+            "pages": {
+                "first": "715",
+                "last": "736",
+                "range": "715\u2013736"
+            },
+            "pmid": 32894330,
+            "type": "journal",
+            "volume": "140"
+        },
+        {
+            "articleTitle": "Guanabenz modulates microglia and macrophages during demyelination",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Thompson, KK",
+                        "preferred": "Thompson KK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Tsirka, SE",
+                        "preferred": "Tsirka SE"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.1038/s41598-020-76383-w",
+            "id": "bib48",
+            "journal": "Scientific Reports",
+            "pages": "19333",
+            "pmid": 33168944,
+            "type": "journal",
+            "volume": "10"
+        },
+        {
+            "articleTitle": "Pre-clinical and clinical implications of \"Inside-Out\" vs. \"Outside-In\" Paradigms in Multiple Sclerosis Etiopathogenesis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Titus, HE",
+                        "preferred": "Titus HE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Chen, Y",
+                        "preferred": "Chen Y"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Podojil, JR",
+                        "preferred": "Podojil JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Robinson, AP",
+                        "preferred": "Robinson AP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Balabanov, R",
+                        "preferred": "Balabanov R"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2020",
+            "doi": "10.3389/fncel.2020.599717",
+            "id": "bib49",
+            "journal": "Frontiers in Cellular Neuroscience",
+            "pages": "599717",
+            "pmid": 33192332,
+            "type": "journal",
+            "volume": "14"
+        },
+        {
+            "articleTitle": "Characterisation of microglia during de- and remyelination: can they create a repair promoting environment?",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Voss, EV",
+                        "preferred": "Voss EV"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "\u0160kuljec, J",
+                        "preferred": "\u0160kuljec J"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Gudi, V",
+                        "preferred": "Gudi V"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Skripuletz, T",
+                        "preferred": "Skripuletz T"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Pul, R",
+                        "preferred": "Pul R"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Trebst, C",
+                        "preferred": "Trebst C"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Stangel, M",
+                        "preferred": "Stangel M"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2012",
+            "doi": "10.1016/j.nbd.2011.09.008",
+            "id": "bib50",
+            "journal": "Neurobiology of Disease",
+            "pages": {
+                "first": "519",
+                "last": "528",
+                "range": "519\u2013528"
+            },
+            "pmid": 21971527,
+            "type": "journal",
+            "volume": "45"
+        },
+        {
+            "articleTitle": "Pharmaceutical integrated stress response enhancement protects oligodendrocytes and provides a potential multiple sclerosis therapeutic",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Way, SW",
+                        "preferred": "Way SW"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Podojil, JR",
+                        "preferred": "Podojil JR"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Clayton, BL",
+                        "preferred": "Clayton BL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Zaremba, A",
+                        "preferred": "Zaremba A"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Collins, TL",
+                        "preferred": "Collins TL"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kunjamma, RB",
+                        "preferred": "Kunjamma RB"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Robinson, AP",
+                        "preferred": "Robinson AP"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Brugarolas, P",
+                        "preferred": "Brugarolas P"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, RH",
+                        "preferred": "Miller RH"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Miller, SD",
+                        "preferred": "Miller SD"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.1038/ncomms7532",
+            "id": "bib51",
+            "journal": "Nature Communications",
+            "pages": "6532",
+            "pmid": 25766071,
+            "type": "journal",
+            "volume": "6"
+        },
+        {
+            "articleTitle": "Harnessing the integrated stress response for the treatment of multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Way, SW",
+                        "preferred": "Way SW"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Popko, B",
+                        "preferred": "Popko B"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2016",
+            "doi": "10.1016/S1474-4422(15)00381-6",
+            "id": "bib52",
+            "journal": "The Lancet Neurology",
+            "pages": {
+                "first": "434",
+                "last": "443",
+                "range": "434\u2013443"
+            },
+            "pmid": 26873788,
+            "type": "journal",
+            "volume": "15"
+        },
+        {
+            "articleTitle": "Advances in the immunopathogenesis of multiple sclerosis",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Yadav, SK",
+                        "preferred": "Yadav SK"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Mindur, JE",
+                        "preferred": "Mindur JE"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Ito, K",
+                        "preferred": "Ito K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Dhib-Jalbut, S",
+                        "preferred": "Dhib-Jalbut S"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2015",
+            "doi": "10.1097/WCO.0000000000000205",
+            "id": "bib53",
+            "journal": "Current Opinion in Neurology",
+            "pages": {
+                "first": "206",
+                "last": "219",
+                "range": "206\u2013219"
+            },
+            "pmid": 25887768,
+            "type": "journal",
+            "volume": "28"
+        },
+        {
+            "articleTitle": "From endoplasmic-reticulum stress to the inflammatory response",
+            "authors": [
+                {
+                    "name": {
+                        "index": "Zhang, K",
+                        "preferred": "Zhang K"
+                    },
+                    "type": "person"
+                },
+                {
+                    "name": {
+                        "index": "Kaufman, RJ",
+                        "preferred": "Kaufman RJ"
+                    },
+                    "type": "person"
+                }
+            ],
+            "date": "2008",
+            "doi": "10.1038/nature07203",
+            "id": "bib54",
+            "journal": "Nature",
+            "pages": {
+                "first": "455",
+                "last": "462",
+                "range": "455\u2013462"
+            },
+            "pmid": 18650916,
+            "type": "journal",
+            "volume": "454"
+        }
+    ],
+    "acknowledgements": [
+        {
+            "text": "The authors acknowledge the members of Dr. Raj Awatramani\u2019s lab for their assistance with the VS120-S6-W slide loader system and Dr. Hongtao Chen and Mr. Lennell Reynold from the Center for Advanced Microscopy at Northwestern University for their technical support. We thank Erdong Liu for EM tissue sectioning, Dr. Vytas Bindokas from the Integrated Light Microscopy Core Facility, and Yimei Chen from the Advanced Electron Microscopy Core facility at University of Chicago for technical assistance. We also acknowledge Ani Solanki from the Animal Resource Center at University of Chicago for animal study assistance and acknowledge Sharon Way for editing the manuscript. This study was supported by NIH/NINDS R01 NS034939 (BP), the Dr. Miriam and Sheldon G Adelson Medical Research Foundation (JRC and BP) and the Rampy MS Research Foundation (BP).",
+            "type": "paragraph"
+        }
+    ],
+    "decisionLetter": {
+        "content": [
+            {
+                "text": "<b>Acceptance summary:</b>",
+                "type": "paragraph"
+            },
+            {
+                "text": "Multiple sclerosis is a demyelinating disease in an inflammatory environment, and understanding the mechanisms that allow oligodendrocyte remyelination in this environment is important for its treatment. This paper demonstrates that the integrated stress response (ISR), a cytoprotective pathway, crucially contributes to the protection of oligodendrocytes and improves remyelination during inflammation. Both pharmacological and genetic approaches were used to prolong the ISR, which led to increased numbers of remyelinating oligodendrocytes and remyelinated axons in animal models of disease.",
+                "type": "paragraph"
+            },
+            {
+                "text": "<b>Decision letter after peer review:</b>",
+                "type": "paragraph"
+            },
+            {
+                "text": "Thank you for submitting your article \"Prolonging the integrated stress response enhances CNS remyelination in an inflammatory environment\" for consideration by <i>eLife</i>. Your article has been reviewed by three peer reviewers, and the evaluation has been overseen by a Reviewing Editor and Satyajit Rath as the Senior Editor. The reviewers have remained anonymous.",
+                "type": "paragraph"
+            },
+            {
+                "text": "The reviewers have discussed their reviews with one another, and the Reviewing Editor has drafted this to help you prepare a revised submission.",
+                "type": "paragraph"
+            },
+            {
+                "text": "Essential Revisions:",
+                "type": "paragraph"
+            },
+            {
+                "text": "I am including a summary of the essential revisions required below based on the reviewers' comments.",
+                "type": "paragraph"
+            },
+            {
+                "text": "1) The Introduction requires more clarity with regards to previous literature. As written it is not clear what was known before and how this paper goes beyond the literature.",
+                "type": "paragraph"
+            },
+            {
+                "text": "2) Results and interpretation on the role of sephin1 in EAE is confusing, and needs clarification.",
+                "type": "paragraph"
+            },
+            {
+                "text": "3) Questions about methods and design:",
+                "type": "paragraph"
+            },
+            {
+                "text": "Rationale for specific experimental designs for the cuprizone and combined Sephin1/BZA experiments, ISR indicators in the models, ages and sex of mice used, numbers of mice used, and which steps of EAE and cuprizone experiments were performed blinded.",
+                "type": "paragraph"
+            },
+            {
+                "text": "3) Presentation of figures and question about panels:",
+                "type": "paragraph"
+            },
+            {
+                "text": "For presentation, it was suggested that Figures 2 and 3 be combined. There are also questions about panels in Figures 3C and 5C being duplicated.",
+                "type": "paragraph"
+            },
+            {
+                "text": "4) The combined Sephin1/BZA treatment experiment in Figure 8 need to be clarified both in terms of the rationale and interpretation of the resulting data. All three reviewers point this out. There is a need to clearly describe the rationale for combining BZA and Seph, justifications or revisions of the interpretation of the data and conclusions based on a change in the G-ratio of remyelinated axons without effects on number of ASPA cells and axons and how this can be interpreted as \"enhanced\" regeneration vs. accelerated regeneration. If it is not sufficiently strong, then the text and Abstract need to be toned down in conclusion.",
+                "type": "paragraph"
+            },
+            {
+                "text": "5) Discussion:",
+                "type": "paragraph"
+            },
+            {
+                "text": "Clearer presentation of conditions during which augmenting ISR is protective of mature and remyelinating oligodendrocytes. Implications of their study for regenerative medicines in the context of drug mediate suppression of inflammation.",
+                "type": "paragraph"
+            }
+        ],
+        "description": [
+            {
+                "text": "Our editorial process produces two outputs: i) <a href=\"https://sciety.org/articles/10.1101/2020.12.29.424699\">public reviews</a> designed to be posted alongside <a href=\"https://www.biorxiv.org/content/10.1101/2020.12.29.424699v1.full\">the preprint</a> for the benefit of readers; ii) feedback on the manuscript for the authors, including requests for revisions, shown below. We also include an acceptance summary that explains what the editors found interesting or important about the work.",
+                "type": "paragraph"
+            }
+        ],
+        "doi": "10.7554/eLife.65469.sa1",
+        "id": "sa1"
+    },
+    "authorResponse": {
+        "content": [
+            {
+                "content": [
+                    {
+                        "text": "Essential Revisions:",
+                        "type": "paragraph"
+                    },
+                    {
+                        "text": "I am including a summary of the essential revisions required below based on the reviewers' comments.",
+                        "type": "paragraph"
+                    },
+                    {
+                        "text": "1) The Introduction requires more clarity with regards to previous literature. As written it is not clear what was known before and how this paper goes beyond the literature.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewers for alerting us to the need to enhance the clarity of the Introduction. We have edited this section in the revised manuscript.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "2) Results and interpretation on the role of sephin1 in EAE is confusing, and needs clarification.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewer for this recommendation. We have reworded this section in the revised manuscript (Results).",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "3) Questions about methods and design:",
+                        "type": "paragraph"
+                    },
+                    {
+                        "text": "Rationale for specific experimental designs for the cuprizone and combined Sephin1/BZA experiments.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewer for the opportunity to clarify this point. We initiated the combined treatment after three weeks of cuprizone exposure because substantial oligodendrocyte loss and demyelination has occurred in the corpus callosum at this time point. Although we cannot rule out a potential protective effect of the drug treatments on mature oligodendrocytes and myelin, we suspect that because extensive pathology is already present at week 3, the primary protective effect of ISR enhancement in this model is on the repopulation of oligodendrocytes and remyelination in the presence of inflammation. We have revised the manuscript (Discussion).",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "ISR indicators in the models.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank reviewer for this recommendation. We have previously reported that Sephin1 can prolong the phosphorylated status of eIF2\u03b1 (p-eIF2\u03b1) in IFN-\u03b3 stressed oligodendrocytes in culture. We also observed a significant increased number of p-eIF2\u03b1 positive oligodendrocytes in the spinal cords of Sephin1 treated EAE mice, compared to EAE controls (Chen et al., 2019). In addition, using this GFAP/tTA;TRE/IFN-\u03b3 double-transgenic transgenic model, our group previously showed that the effect of IFN-\u03b3 on the remyelination process in the cuprizone model is associated with an activated ISR response in oligodendrocytes (Lin et al., 2006). In the presence of IFN-\u03b3, the levels of ISR markers (CHOP and p-eIF2\u03b1) were significantly increased during remyelination; whereas the ISR does not appear activated in the cuprizone model in the absence of IFN-\u03b3. Furthermore, our previous report demonstrated that the genetic disruption of the ISR inhibited remyelination in the cuprizone model in the presence of IFN-\u03b3 (Lin et al., 2006). In the current manuscript we examined whether prolonging the ISR response would enhance remyelination in an inflammatory environment. We have more clearly described this background information in the revised manuscript.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "Ages and sex of mice used.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewer for this comment, and we appreciate the opportunity to discuss this issue further. We agree that W8 (14 weeks of age) age-matched mice, in the absence of cuprizone or IFN-\u03b3, would be the ideal control, and we regret not including an examination of such mice for this study. Myelination continues throughout adulthood, such that the 6-week-old timepoint does not precisely reflect the myelin landscape analyzed at the later time points. Therefore, in the revised manuscript we have tried to refer to W0 timepoint (six week of age) more as a reference point, with the primary comparisons being between ISR enhanced (genetic and pharmacological) and non-ISR enhanced animals.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "Numbers of mice used.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewers for giving us the opportunity for clarifying these points. We used the same mice for the histology study and EM study; the detailed information can be found in the Materials and methods section. We used the WT mice at W0 mice also for W0 in the pharmacological study. We used WT mice at W5/IFN-\u03b3- also for vehicle controls at W5/IFN-\u03b3-. We included the total number of mice in the revised manuscript.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "Which steps of EAE and cuprizone experiments were performed blinded.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewers for the recommendation. We included the information of blinded experiments in the revised manuscript.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "4) Presentation of figures and question about panels:",
+                        "type": "paragraph"
+                    },
+                    {
+                        "text": "For presentation, it was suggested that Figures 2 and 3 be combined. There are also questions about panels in Figures 3C and 5C being duplicated.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewers for this comment. We understand the desire to consolidate the schematic Figure 2 with the following data figure. Nevertheless, we are concerned that this will reduce the clarity of the manuscript. This schematic figure describes not only the IFN-\u03b3 inducible system that we used throughout the manuscript (panel A), but it also describes the genetic (panel B) and pharmacological studies (panel C) that were used in the subsequent figures. We hope the reviewers understand our desire to maintain these schematic diagrams as a separate figure to achieve clarity.",
+                "type": "paragraph"
+            },
+            {
+                "text": "We apologize for our error with the incorrectly placed panel in Figure 3C. We have replaced this with the correct panel in the revised manuscript.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "5) The combined Sephin1/BZA treatment experiment in Figure 8 need to be clarified both in terms of the rationale and interpretation of the resulting data. All three reviewers point this out. There is a need to clearly describe the rationale for combining BZA and Seph, justifications or revisions of the interpretation of the data and conclusions based on a change in the G-ratio of remyelinated axons without effects on number of ASPA cells and axons and how this can be interpreted as \"enhanced\" regeneration vs. accelerated regeneration. If it is not sufficiently strong, then the text and Abstract need to be toned down in conclusion.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewers for giving us the opportunity to clarify this point. BZA, which is a selective estrogen receptor modulator, has been shown to significantly enhance OPC differentiation and CNS remyelination. In our study, the enhancement of the ISR, genetically or with Sephin1, provided protection to remyelinating oligodendrocytes in the presence of inflammation. In other words, BZA promotes remyelination and ISR enhancement permits remyelination to occur in the presence of inflammation. We speculated that remyelination-enhancing agents would be even more effective when combined with Sephin1. We have included a more detailed description of the rationale behind these studies in the revised manuscript (Results). We agree that the differences in g-ratio likely reflect an increase in the rate of remyelination in the presence of BZA and Sephin1. We have now discussed this possibility in the revised manuscript. We have not, however, changed the Abstract, since the statement here is factual, not an interpretation of the results: \u201cthe combined treatment of Sephin1 with the oligodendrocyte differentiation enhancing reagent bazedoxifene increased myelin thickness of remyelinated axons to pre-lesion levels\u201d.",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "6) Discussion:",
+                        "type": "paragraph"
+                    },
+                    {
+                        "text": "Clearer presentation of conditions during which augmenting ISR is protective of mature and remyelinating oligodendrocytes.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank the reviewer for the opportunity to clarify this point. It is correct: the ISR does not appear to be activated in the cuprizone model in the absence of inflammation. Oligodendrocyte protection through an enhanced ISR only occurs when the ISR is activated in our model by the presence of IFN-\u03b3. In our previous study, we showed that Sephin1 protected mature oligodendrocytes (i.e. those that are maintaining a myelin sheath) at the peak of EAE disease, where the ISR is activated by CNS inflammation (Chen et al., 2019). In the GFAP/tTA;TRE/IFN-\u03b3 transgenic model, it takes about 2 to 3 weeks for IFN-\u03b3 levels to become elevated following the removal of dox from the animal\u2019s diet (Figure 2\u2014figure supplement 1) (Lin et al., 2006). In this study, we remove dox at the time of the initiation of cuprizone exposure; therefore the majority of mature oligodendrocyte have already been lost by the time IFN-\u03b3 levels increase. We have clarified this in the revised manuscript (Discussion).",
+                "type": "paragraph"
+            },
+            {
+                "content": [
+                    {
+                        "text": "Implications of their study for regenerative medicines in the context of drug mediate suppression of inflammation.",
+                        "type": "paragraph"
+                    }
+                ],
+                "type": "excerpt"
+            },
+            {
+                "text": "We thank reviewer for the recommendation. Our previous study showed that combining Sephin1 with the first-line anti-inflammatory IFN-\u03b2 exhibited additive benefit in alleviating EAE. We believe that Sephin1 and other ISR enhancing compounds will likely provide significant reparative benefit to MS patients even when combined with current immunosuppressive treatments. We have addressed this point in the revised Discussion.",
+                "type": "paragraph"
+            }
+        ],
+        "doi": "10.7554/eLife.65469.sa2",
+        "id": "sa2"
+    },
+    "stage": "published",
+    "statusDate": "2021-03-23T00:00:00Z"
+}

--- a/tests/fixtures/doaj/e65469_doaj_json.py
+++ b/tests/fixtures/doaj/e65469_doaj_json.py
@@ -97,13 +97,15 @@ EXPECTED = OrderedDict(
                     ),
                     (
                         "link",
-                        OrderedDict(
-                            [
-                                ("content_type", "text/html"),
-                                ("type", "fulltext"),
-                                ("url", "https://elifesciences.org/articles/65469"),
-                            ]
-                        ),
+                        [
+                            OrderedDict(
+                                [
+                                    ("content_type", "text/html"),
+                                    ("type", "fulltext"),
+                                    ("url", "https://elifesciences.org/articles/65469"),
+                                ]
+                            )
+                        ],
                     ),
                     ("month", "3"),
                     (

--- a/tests/fixtures/doaj/e65469_doaj_json.py
+++ b/tests/fixtures/doaj/e65469_doaj_json.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+from collections import OrderedDict
+
+EXPECTED = OrderedDict(
+    [
+        (
+            "bibjson",
+            OrderedDict(
+                [
+                    (
+                        "abstract",
+                        "The inflammatory environment of demyelinated lesions in multiple sclerosis (MS) patients contributes to remyelination failure. Inflammation activates a cytoprotective pathway, the integrated stress response (ISR), but it remains unclear whether enhancing the ISR can improve remyelination in an inflammatory environment. To examine this possibility, the remyelination stage of experimental autoimmune encephalomyelitis (EAE), as well as a mouse model that incorporates cuprizone-induced demyelination along with CNS delivery of the proinflammatory cytokine IFN-γ were used here. We demonstrate that either genetic or pharmacological ISR enhancement significantly increased the number of remyelinating oligodendrocytes and remyelinated axons in the inflammatory lesions. Moreover, the combined treatment of the ISR modulator Sephin1 with the oligodendrocyte differentiation enhancing reagent bazedoxifene increased myelin thickness of remyelinated axons to pre-lesion levels. Taken together, our findings indicate that prolonging the ISR protects remyelinating oligodendrocytes and promotes remyelination in the presence of inflammation, suggesting that ISR enhancement may provide reparative benefit to MS patients.",
+                    ),
+                    (
+                        "author",
+                        [
+                            OrderedDict(
+                                [
+                                    (
+                                        "affiliation",
+                                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States",
+                                    ),
+                                    ("name", "Yanan Chen"),
+                                    (
+                                        "orcid_id",
+                                        "https://orcid.org/0000-0001-5510-231X",
+                                    ),
+                                ]
+                            ),
+                            OrderedDict(
+                                [
+                                    (
+                                        "affiliation",
+                                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States",
+                                    ),
+                                    ("name", "Rejani B Kunjamma"),
+                                ]
+                            ),
+                            OrderedDict(
+                                [
+                                    (
+                                        "affiliation",
+                                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States",
+                                    ),
+                                    ("name", "Molly Weiner"),
+                                ]
+                            ),
+                            OrderedDict(
+                                [
+                                    (
+                                        "affiliation",
+                                        "Weill Institute for Neuroscience, Department of Neurology, University of California, San Francisco, San Francisco, United States",
+                                    ),
+                                    ("name", "Jonah R Chan"),
+                                    (
+                                        "orcid_id",
+                                        "https://orcid.org/0000-0002-2176-1242",
+                                    ),
+                                ]
+                            ),
+                            OrderedDict(
+                                [
+                                    (
+                                        "affiliation",
+                                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States",
+                                    ),
+                                    ("name", "Brian Popko"),
+                                    (
+                                        "orcid_id",
+                                        "https://orcid.org/0000-0001-9948-2553",
+                                    ),
+                                ]
+                            ),
+                        ],
+                    ),
+                    (
+                        "identifier",
+                        [
+                            OrderedDict(
+                                [("id", "10.7554/eLife.65469"), ("type", "doi")]
+                            ),
+                            OrderedDict([("id", "2050-084X"), ("type", "eissn")]),
+                            OrderedDict([("id", "e65469"), ("type", "elocationid")]),
+                        ],
+                    ),
+                    ("journal", OrderedDict([("volume", "10")])),
+                    (
+                        "keywords",
+                        [
+                            "integrated stress response",
+                            "remyelination",
+                            "interferon gamma",
+                            "oligodendrocyte",
+                            "cuprizone",
+                            "multiple sclerosis",
+                        ],
+                    ),
+                    (
+                        "link",
+                        OrderedDict(
+                            [
+                                ("content_type", "text/html"),
+                                ("type", "fulltext"),
+                                ("url", "https://elifesciences.org/articles/65469"),
+                            ]
+                        ),
+                    ),
+                    ("month", "3"),
+                    (
+                        "title",
+                        "Prolonging the integrated stress response enhances CNS remyelination in an inflammatory environment",
+                    ),
+                    ("year", "2021"),
+                ]
+            ),
+        )
+    ]
+)

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -281,6 +281,7 @@ class TestDoajKeywords(unittest.TestCase):
             "oligodendrocyte",
             "cuprizone",
             "multiple sclerosis",
+            "<i>eLife</i>"
         ]
         expected = [
             "integrated stress response",
@@ -289,6 +290,7 @@ class TestDoajKeywords(unittest.TestCase):
             "oligodendrocyte",
             "cuprizone",
             "multiple sclerosis",
+            "eLife",
         ]
         self.assertEqual(doaj.keywords(keywords_json), expected)
 

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -1,0 +1,14 @@
+import unittest
+import json
+from provider import doaj
+from tests import read_fixture
+
+
+class TestDoajProvider(unittest.TestCase):
+
+    def test_doaj_json(self):
+        article_json_string = read_fixture("e65469_article_json.txt", "doaj")
+        article_json = json.loads(article_json_string)
+        expected = read_fixture("e65469_doaj_json.py", "doaj")
+        doaj_json = doaj.doaj_json(article_json)
+        self.assertEqual(doaj_json, expected)

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -1,14 +1,164 @@
 import unittest
 import json
+import time
+from collections import OrderedDict
 from provider import doaj
 from tests import read_fixture
 
 
 class TestDoajProvider(unittest.TestCase):
-
     def test_doaj_json(self):
         article_json_string = read_fixture("e65469_article_json.txt", "doaj")
         article_json = json.loads(article_json_string)
         expected = read_fixture("e65469_doaj_json.py", "doaj")
         doaj_json = doaj.doaj_json(article_json)
         self.assertEqual(doaj_json, expected)
+
+
+class TestDoajAbstract(unittest.TestCase):
+    def test_abstract(self):
+        abstract_json = {"content": [{"text": "The abstract.", "type": "paragraph"}]}
+        expected = "The abstract."
+        self.assertEqual(doaj.abstract(abstract_json), expected)
+
+
+class TestDoajAuthor(unittest.TestCase):
+    def test_author_person(self):
+        authors_json = [
+            {
+                "affiliations": [
+                    {
+                        "address": {
+                            "components": {
+                                "country": "United States",
+                                "locality": ["Chicago"],
+                            },
+                            "formatted": ["Chicago", "United States"],
+                        },
+                        "name": [
+                            "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+                        ],
+                    }
+                ],
+                "name": {"index": "Chen, Yanan", "preferred": "Yanan Chen"},
+                "orcid": "0000-0001-5510-231X",
+                "type": "person",
+            }
+        ]
+        expected = [
+            OrderedDict(
+                [
+                    (
+                        "affiliation",
+                        "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States",
+                    ),
+                    ("name", "Yanan Chen"),
+                    ("orcid_id", "https://orcid.org/0000-0001-5510-231X"),
+                ]
+            )
+        ]
+        self.assertEqual(doaj.author(authors_json), expected)
+
+
+class TestDoajAffiliationString(unittest.TestCase):
+    def test_affiliation_string(self):
+        aff_json = {
+            "address": {
+                "components": {
+                    "country": "United States",
+                    "locality": ["Chicago"],
+                },
+                "formatted": ["Chicago", "United States"],
+            },
+            "name": [
+                "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine"
+            ],
+        }
+        expected = "Department of Neurology, Division of Multiple Sclerosis and Neuroimmunology, Northwestern University Feinberg School of Medicine, Chicago, United States"
+        self.assertEqual(doaj.affiliation_string(aff_json), expected)
+
+
+class TestDoajIdentifier(unittest.TestCase):
+    def test_identifier_blank(self):
+        article_json = {}
+        expected = [
+            OrderedDict([("id", None), ("type", "doi")]),
+            OrderedDict([("id", "2050-084X"), ("type", "eissn")]),
+            OrderedDict([("id", None), ("type", "elocationid")]),
+        ]
+        self.assertEqual(doaj.identifier(article_json), expected)
+
+    def test_identifier_all(self):
+        article_json = {"doi": "10.7554/eLife.65469", "elocationId": "e65469"}
+        expected = [
+            OrderedDict([("id", "10.7554/eLife.65469"), ("type", "doi")]),
+            OrderedDict([("id", "2050-084X"), ("type", "eissn")]),
+            OrderedDict([("id", "e65469"), ("type", "elocationid")]),
+        ]
+        self.assertEqual(doaj.identifier(article_json), expected)
+
+
+class TestDoajJournal(unittest.TestCase):
+    def test_journal(self):
+        article_json = {"volume": 10}
+        expected = OrderedDict([("volume", "10")])
+        self.assertEqual(doaj.journal(article_json), expected)
+
+
+class TestDoajKeywords(unittest.TestCase):
+    def test_keywords(self):
+        keywords_json = [
+            "integrated stress response",
+            "remyelination",
+            "interferon gamma",
+            "oligodendrocyte",
+            "cuprizone",
+            "multiple sclerosis",
+        ]
+        expected = [
+            "integrated stress response",
+            "remyelination",
+            "interferon gamma",
+            "oligodendrocyte",
+            "cuprizone",
+            "multiple sclerosis",
+        ]
+        self.assertEqual(doaj.keywords(keywords_json), expected)
+
+
+class TestDoajLink(unittest.TestCase):
+    def test_link(self):
+        article_json = {"id": "65469"}
+        expected = OrderedDict(
+            [
+                ("content_type", "text/html"),
+                ("type", "fulltext"),
+                ("url", "https://elifesciences.org/articles/65469"),
+            ]
+        )
+        self.assertEqual(doaj.link(article_json), expected)
+
+
+class TestDoajMonth(unittest.TestCase):
+    def test_month(self):
+        published_date = time.strptime("2021-03-23T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        expected = "3"
+        self.assertEqual(doaj.month(published_date), expected)
+
+
+class TestDoajTitle(unittest.TestCase):
+    def test_title(self):
+        title = (
+            "Prolonging the integrated stress response enhances CNS remyelination "
+            "in an inflammatory environment"
+        )
+        article_json = {"title": title}
+        expected = title
+        self.assertEqual(doaj.title(article_json), expected)
+
+
+class TestDoajYear(unittest.TestCase):
+    def test_year(self):
+        published_date = time.strptime("2021-03-23T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        expected = "2021"
+        self.assertEqual(doaj.year(published_date), expected)

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -41,7 +41,7 @@ class TestDoajAbstract(unittest.TestCase):
                         'The abstract. <span class="underline">B</span> '
                         '<span class="small-caps">ON</span> '
                         '<span class="monospace">Bonsai</span> '
-                        '(within 15 ms, &gt;100 FPS) '
+                        "(within 15 ms, &gt;100 FPS) "
                         '(<a href="#bib34">Lin et al., 2017</a>).'
                     ),
                     "type": "paragraph",

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -4,6 +4,7 @@ import time
 from collections import OrderedDict
 from provider import doaj
 from tests import read_fixture
+import tests.settings_mock as settings_mock
 
 
 class TestSubstituteMathTags(unittest.TestCase):
@@ -23,7 +24,7 @@ class TestDoajProvider(unittest.TestCase):
         article_json_string = read_fixture("e65469_article_json.txt", "doaj")
         article_json = json.loads(article_json_string)
         expected = read_fixture("e65469_doaj_json.py", "doaj")
-        doaj_json = doaj.doaj_json(article_json)
+        doaj_json = doaj.doaj_json(article_json, settings_mock)
         self.assertEqual(doaj_json, expected)
 
 
@@ -248,7 +249,9 @@ class TestDoajIdentifier(unittest.TestCase):
             OrderedDict([("id", "2050-084X"), ("type", "eissn")]),
             OrderedDict([("id", None), ("type", "elocationid")]),
         ]
-        self.assertEqual(doaj.identifier(article_json), expected)
+        self.assertEqual(
+            doaj.identifier(article_json, settings_mock.journal_eissn), expected
+        )
 
     def test_identifier_all(self):
         article_json = {"doi": "10.7554/eLife.65469", "elocationId": "e65469"}
@@ -257,7 +260,9 @@ class TestDoajIdentifier(unittest.TestCase):
             OrderedDict([("id", "2050-084X"), ("type", "eissn")]),
             OrderedDict([("id", "e65469"), ("type", "elocationid")]),
         ]
-        self.assertEqual(doaj.identifier(article_json), expected)
+        self.assertEqual(
+            doaj.identifier(article_json, settings_mock.journal_eissn), expected
+        )
 
 
 class TestDoajJournal(unittest.TestCase):
@@ -298,7 +303,9 @@ class TestDoajLink(unittest.TestCase):
                 ("url", "https://elifesciences.org/articles/65469"),
             ]
         )
-        self.assertEqual(doaj.link(article_json), expected)
+        self.assertEqual(
+            doaj.link(article_json, settings_mock.doaj_url_link_pattern), expected
+        )
 
 
 class TestDoajMonth(unittest.TestCase):

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -184,6 +184,43 @@ class TestDoajAuthor(unittest.TestCase):
         ]
         self.assertEqual(doaj.author(authors_json), expected)
 
+    def test_author_group(self):
+        authors_json = [
+            {
+                "affiliations": [
+                    {
+                        "address": {
+                            "components": {
+                                "country": "United Kingdom",
+                                "locality": ["London"],
+                            },
+                            "formatted": ["London", "United Kingdom"],
+                        },
+                        "name": [
+                            "Centre for Mathematical Modelling of Infectious Diseases, Department of Infectious Disease Epidemiology, Faculty of Epidemiology and Population Health, London School of Hygiene and Tropical Medicine"
+                        ],
+                    }
+                ],
+                "name": "CMMID COVID-19 Working Group",
+                "type": "group",
+            }
+        ]
+        expected = [
+            OrderedDict(
+                [
+                    (
+                        "affiliation",
+                        "Centre for Mathematical Modelling of Infectious Diseases, "
+                        "Department of Infectious Disease Epidemiology, Faculty of "
+                        "Epidemiology and Population Health, London School of Hygiene "
+                        "and Tropical Medicine, London, United Kingdom",
+                    ),
+                    ("name", "CMMID COVID-19 Working Group"),
+                ]
+            )
+        ]
+        self.assertEqual(doaj.author(authors_json), expected)
+
 
 class TestDoajAffiliationString(unittest.TestCase):
     def test_affiliation_string(self):

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -296,13 +296,15 @@ class TestDoajKeywords(unittest.TestCase):
 class TestDoajLink(unittest.TestCase):
     def test_link(self):
         article_json = {"id": "65469"}
-        expected = OrderedDict(
-            [
-                ("content_type", "text/html"),
-                ("type", "fulltext"),
-                ("url", "https://elifesciences.org/articles/65469"),
-            ]
-        )
+        expected = [
+            OrderedDict(
+                [
+                    ("content_type", "text/html"),
+                    ("type", "fulltext"),
+                    ("url", "https://elifesciences.org/articles/65469"),
+                ]
+            )
+        ]
         self.assertEqual(
             doaj.link(article_json, settings_mock.doaj_url_link_pattern), expected
         )

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -93,6 +93,18 @@ class TestLaxProvider(unittest.TestCase):
         mock_requests_get.return_value = response
         self.assertRaises(ErrorCallingLaxException, lax_provider.article_highest_version, '08411', settings_mock)
 
+    @patch('requests.get')
+    def test_article_json_200(self, mock_requests_get):
+        article_json = {"status": "vor"}
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = article_json
+        mock_requests_get.return_value = response
+        status_code, data = lax_provider.article_json("65469", settings_mock)
+        self.assertEqual(status_code, 200)
+        # data returned will be exactly the value assigned to the mock response
+        self.assertEqual(data, article_json)
+
     def test_lax_auth_header_none(self):
         expected = {}
         self.assertEqual(lax_provider.lax_auth_header(None), expected)

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -28,6 +28,7 @@ poa_incoming_queue = ''
 ses_poa_sender_email = ""
 ses_poa_recipient_email = ""
 
+lax_article_endpoint = "https://test/eLife.{article_id}"
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
 verify_ssl = False
 lax_auth_key = 'an_auth_key'
@@ -65,3 +66,7 @@ big_query_project_id = ''
 
 letterparser_config_file = 'tests/activity/letterparser.cfg'
 letterparser_config_section = 'elife'
+
+# DOAJ deposit settings
+journal_eissn = "2050-084X"
+doaj_url_link_pattern = "https://elifesciences.org/articles/{article_id}"

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -16,6 +16,11 @@ aws_secret_access_key = ""
 workflow_starter_queue = ""
 sqs_region = ""
 
+redis_host = ""
+redis_port = 6379
+redis_db = 0
+redis_expire_key = 86400  # seconds
+
 ejp_bucket = 'ejp_bucket'
 templates_bucket = 'templates_bucket'
 ppp_cdn_bucket = 'ppd_cdn_bucket'

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -70,3 +70,5 @@ letterparser_config_section = 'elife'
 # DOAJ deposit settings
 journal_eissn = "2050-084X"
 doaj_url_link_pattern = "https://elifesciences.org/articles/{article_id}"
+doaj_endpoint = "https://doaj/api/v2/articles"
+doaj_api_key = ""

--- a/tests/starter/test_starter_deposit_doaj.py
+++ b/tests/starter/test_starter_deposit_doaj.py
@@ -1,0 +1,32 @@
+import unittest
+import starter.starter_DepositDOAJ as starter_module
+from starter.starter_DepositDOAJ import starter_DepositDOAJ
+from starter.starter_helper import NullRequiredDataException
+import tests.settings_mock as settings_mock
+from mock import patch
+from tests.classes_mock import FakeBotoConnection
+from tests.activity.classes_mock import FakeSession
+
+
+class TestStarterDepositDOAJ(unittest.TestCase):
+    def setUp(self):
+        self.starter = starter_DepositDOAJ()
+
+    @patch.object(starter_module, "get_session")
+    def test_starter_no_article(self, mock_session):
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            run="",
+            info={},
+        )
+
+    @patch.object(starter_module, "get_session")
+    @patch("starter.starter_helper.get_starter_logger")
+    @patch("boto.swf.layer1.Layer1")
+    def test_deposit_doaj_start(self, fake_boto_conn, fake_logger, mock_session):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        run = ""
+        info = {"article_id": "00353"}
+        self.starter.start(settings=settings_mock, run=run, info=info)

--- a/tests/workflow/test_workflow_deposit_doaj.py
+++ b/tests/workflow/test_workflow_deposit_doaj.py
@@ -1,0 +1,14 @@
+import unittest
+import tests.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+from workflow.workflow_DepositDOAJ import workflow_DepositDOAJ
+
+
+class TestWorkflowDepositDOAJ(unittest.TestCase):
+    def setUp(self):
+        self.workflow = workflow_DepositDOAJ(
+            settings_mock, FakeLogger(), None, None, None, None
+        )
+
+    def test_init(self):
+        self.assertEqual(self.workflow.name, "DepositDOAJ")

--- a/workflow/workflow_DepositDOAJ.py
+++ b/workflow/workflow_DepositDOAJ.py
@@ -1,0 +1,46 @@
+from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
+
+
+class workflow_DepositDOAJ(Workflow):
+
+    def __init__(self, settings, logger, conn=None, token=None, decision=None,
+                 maximum_page_size=100):
+        super(workflow_DepositDOAJ, self).__init__(
+            settings, logger, conn, token, decision, maximum_page_size)
+
+        # SWF Defaults
+        self.name = "DepositDOAJ"
+        self.version = "1"
+        self.description = "Deposit article metadata to DOAJ"
+        self.default_execution_start_to_close_timeout = 60 * 10
+        self.default_task_start_to_close_timeout = 30
+
+        # Get the input from the JSON decision response
+        data = self.get_input()
+
+        # JSON format workflow definition, for now
+        workflow_definition = {
+            "name": self.name,
+            "version": self.version,
+            "task_list": self.settings.default_task_list,
+            "input": data,
+
+            "start":
+                {
+                    "requirements": None
+                },
+
+            "steps":
+                [
+                    define_workflow_step("PingWorker", data),
+                    define_workflow_step("DepositDOAJ", data),
+                ],
+
+            "finish":
+                {
+                    "requirements": None
+                }
+        }
+
+        self.load_definition(workflow_definition)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6484

The bulk of the logic to deposit article metadata to doaj.org

The `provider/doaj.py` formats Lax JSON into the DOAJ json format, and contains some logic for issuing an HTTP POST to the DOAJ API endpoint.

The activity, workflow, and starter uses the provider code to do the deposit steps, checking for exceptions, and ensuring the article data is a `VoR` status article before continuing.

The stand-alone workflow will be used to populate the data of older articles at DOAJ. The workflows can be started outside of any existing publication workflows, which means the code in this PR is not expected to interfere with other workflows. It can be tested and fixed (if required).

Later, when it is all working well, and all the previous article data is deposited, we can add the `DepositDOAJ` activity to the end of the `PostPerfectPublication` workflow to automatically deposit articles to DOAJ after publication, if the article was a VoR.

Only the latest article version data is used when getting JSON from Lax, so silent correcitons of previous versions shouldn't cause any adverse side-effects.

If test cases are green, this should be safe to merge, and then it can be tried out to check for any bugs.