### PR TITLE
In DOAJ, article_id from input or from session.

### DIFF
--- a/activity/activity_DepositDOAJ.py
+++ b/activity/activity_DepositDOAJ.py
@@ -36,16 +36,26 @@ class activity_DepositDOAJ(Activity):
             )
             return self.ACTIVITY_SUCCESS
 
-        try:
-            run = data["run"]
-            session = get_session(self.settings, data, run)
-            article_id = session.get_value("article_id")
-        except Exception as exception:
-            self.logger.exception(
-                "Exception in %s getting article_id from session, run %s: %s"
-                % (self.name, run, str(exception)),
+        if data and not data.get("run"):
+            # get article_id from the workflow input data if this activity is not part of a run
+            article_id = data.get("article_id")
+            self.logger.info(
+                "%s got article_id %s from input data" % (self.name, article_id)
             )
-            return self.ACTIVITY_PERMANENT_FAILURE
+        else:
+            try:
+                run = data["run"]
+                session = get_session(self.settings, data, run)
+                article_id = session.get_value("article_id")
+                self.logger.info(
+                    "%s got article_id %s from session data" % (self.name, article_id)
+                )
+            except Exception as exception:
+                self.logger.exception(
+                    "Exception in %s getting article_id from session, run %s: %s"
+                    % (self.name, run, str(exception)),
+                )
+                return self.ACTIVITY_PERMANENT_FAILURE
 
         # get JSON from Lax
         try:

--- a/tests/activity/test_activity_deposit_doaj.py
+++ b/tests/activity/test_activity_deposit_doaj.py
@@ -48,6 +48,43 @@ class TestDepositDOAJ(unittest.TestCase):
             "DepositDOAJ doaj_json for article_id 65469: %s" % expected_doaj_json
         )
         self.assertEqual(self.activity.logger.loginfo[-2], doaj_json_loginfo_expected)
+        self.assertEqual(
+            self.activity.logger.loginfo[-3],
+            "DepositDOAJ got article_id 65469 from session data",
+        )
+
+    @patch("requests.post")
+    @patch.object(lax_provider, "article_json")
+    def test_do_activity_article_id_from_data(self, fake_article_json, fake_post):
+        "test passing the article_id as data rather than from a run session"
+        data = {
+            "article_id": "65469",
+        }
+        fake_article_json.return_value = (200, self.article_json_string)
+        response = FakeResponse(201)
+        fake_post.return_value = response
+        expected_doaj_json = read_fixture("e65469_doaj_json.py", "doaj")
+
+        # do the activity
+        result = self.activity.do_activity(data)
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "DepositDOAJ for article_id 65469 statuses: "
+                "{'download': True, 'build': True, 'post': True}"
+            ),
+        )
+        doaj_json_loginfo_expected = (
+            "DepositDOAJ doaj_json for article_id 65469: %s" % expected_doaj_json
+        )
+        self.assertEqual(self.activity.logger.loginfo[-2], doaj_json_loginfo_expected)
+        self.assertEqual(
+            self.activity.logger.loginfo[-3],
+            "DepositDOAJ got article_id 65469 from input data",
+        )
 
     def test_do_activity_settings_no_endpoint(self):
         self.activity.settings = {}

--- a/tests/starter/test_starter_deposit_doaj.py
+++ b/tests/starter/test_starter_deposit_doaj.py
@@ -5,28 +5,23 @@ from starter.starter_helper import NullRequiredDataException
 import tests.settings_mock as settings_mock
 from mock import patch
 from tests.classes_mock import FakeBotoConnection
-from tests.activity.classes_mock import FakeSession
 
 
 class TestStarterDepositDOAJ(unittest.TestCase):
     def setUp(self):
         self.starter = starter_DepositDOAJ()
 
-    @patch.object(starter_module, "get_session")
-    def test_starter_no_article(self, mock_session):
+    def test_starter_no_article(self):
         self.assertRaises(
             NullRequiredDataException,
             self.starter.start,
             settings=settings_mock,
-            run="",
             info={},
         )
 
-    @patch.object(starter_module, "get_session")
     @patch("starter.starter_helper.get_starter_logger")
     @patch("boto.swf.layer1.Layer1")
-    def test_deposit_doaj_start(self, fake_boto_conn, fake_logger, mock_session):
+    def test_deposit_doaj_start(self, fake_boto_conn, fake_logger):
         fake_boto_conn.return_value = FakeBotoConnection()
-        run = ""
         info = {"article_id": "00353"}
-        self.starter.start(settings=settings_mock, run=run, info=info)
+        self.starter.start(settings=settings_mock, info=info)


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/elife-bot/pull/1204

Make is so the `DepositDOAJ` activity can take the `article_id` value from either the workflow input data, in the case of stand-alone started workflow executions, or from the session data, if the activity was included as part of an existing article ingest / publish workflow.

Trying to create a populate a session from the starter was too cumbersome, because the machine that runs the starter would need access to the session Redis service, which may be running on a different machine, and this code change solves the problem by only passing it as data.