### PR TITLE
Fix doaj provider, when an article has no abstract

### DIFF
--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -29,7 +29,8 @@ def doaj_json(article_json, settings=None):
 
 def bibjson(article_json, settings=None):
     bibjson = OrderedDict()
-    bibjson["abstract"] = abstract(article_json.get("abstract", {}))
+    if article_json.get("abstract"):
+        bibjson["abstract"] = abstract(article_json.get("abstract", {}))
     bibjson["author"] = author(article_json.get("authors", []))
     bibjson["identifier"] = identifier(
         article_json, eissn=getattr(settings, "journal_eissn", None)

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -29,6 +29,14 @@ class TestDoajProvider(unittest.TestCase):
         doaj_json = doaj.doaj_json(article_json, settings_mock)
         self.assertEqual(doaj_json, expected)
 
+    def test_doaj_json_no_abstract(self):
+        "no error when an article json has no abstract"
+        article_json_string = read_fixture("e65469_article_json.txt", "doaj")
+        article_json = json.loads(article_json_string)
+        del article_json["abstract"]
+        doaj_json = doaj.doaj_json(article_json, settings_mock)
+        self.assertIsNotNone(doaj_json)
+
 
 class TestDoajAbstract(unittest.TestCase):
     def test_abstract(self):


### PR DESCRIPTION
Bug fix for PR https://github.com/elifesciences/elife-bot/pull/1204

A correction article has no abstract, and here the `doaj.py` provider is fixed to not try add an abstract when it is not available.