### PR TITLE
Only up to six keywords per article for DOAJ.

### DIFF
--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -36,7 +36,7 @@ def bibjson(article_json, settings=None):
         article_json, eissn=getattr(settings, "journal_eissn", None)
     )
     bibjson["journal"] = journal(article_json)
-    bibjson["keywords"] = keywords(article_json.get("keywords", []))
+    bibjson["keywords"] = keywords(article_json.get("keywords", []), max=6)
     bibjson["link"] = link(
         article_json, url_link_pattern=getattr(settings, "doaj_url_link_pattern", None)
     )
@@ -132,7 +132,8 @@ def journal(article_json):
     return journal_json
 
 
-def keywords(keywords_json):
+def keywords(keywords_json, max=6):
+    # DOAJ allows up to six keywords per article
     keyword_list = []
     for keyword in keywords_json:
         # check for any HTML tags to remove
@@ -140,7 +141,7 @@ def keywords(keywords_json):
             for tag_name in REMOVE_TITLE_TAGS:
                 keyword = etoolsutils.remove_tag(tag_name, keyword)
         keyword_list.append(keyword)
-    return keyword_list
+    return keyword_list[:max]
 
 
 def link(article_json, url_link_pattern=None):

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -284,6 +284,7 @@ class TestDoajJournal(unittest.TestCase):
 
 class TestDoajKeywords(unittest.TestCase):
     def test_keywords(self):
+        # maximum number of keywords per article is six
         keywords_json = [
             "integrated stress response",
             "remyelination",
@@ -291,7 +292,7 @@ class TestDoajKeywords(unittest.TestCase):
             "oligodendrocyte",
             "cuprizone",
             "multiple sclerosis",
-            "<i>eLife</i>",
+            "seventh keyword",
         ]
         expected = [
             "integrated stress response",
@@ -300,6 +301,14 @@ class TestDoajKeywords(unittest.TestCase):
             "oligodendrocyte",
             "cuprizone",
             "multiple sclerosis",
+        ]
+        self.assertEqual(doaj.keywords(keywords_json), expected)
+
+    def test_keywords_italic(self):
+        keywords_json = [
+            "<i>eLife</i>",
+        ]
+        expected = [
             "eLife",
         ]
         self.assertEqual(doaj.keywords(keywords_json), expected)


### PR DESCRIPTION
Bug fix to DOAJ code added in PR https://github.com/elifesciences/elife-bot/pull/1204

DOAJ allows a maximum of six keywords per article, the error observed when sending real data to them.


