### PR TITLE
Format on-behalf-of authors in DOAJ metadata.

### DIFF
--- a/provider/doaj.py
+++ b/provider/doaj.py
@@ -83,6 +83,9 @@ def author(authors_json):
         if author.get("type") == "group":
             # format group author name
             author_json["name"] = author.get("name")
+        elif author.get("type") == "on-behalf-of":
+            # format group author name
+            author_json["name"] = author.get("onBehalfOf")
         else:
             # person name
             author_json["name"] = author.get("name").get("preferred")

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -232,6 +232,25 @@ class TestDoajAuthor(unittest.TestCase):
         ]
         self.assertEqual(doaj.author(authors_json), expected)
 
+    def test_author_on_behalf_of(self):
+        authors_json = [
+            {
+                "onBehalfOf": "for the HIV Genome-to-Genome Study and the Swiss HIV Cohort Study",
+                "type": "on-behalf-of",
+            }
+        ]
+        expected = [
+            OrderedDict(
+                [
+                    (
+                        "name",
+                        "for the HIV Genome-to-Genome Study and the Swiss HIV Cohort Study",
+                    ),
+                ]
+            )
+        ]
+        self.assertEqual(doaj.author(authors_json), expected)
+
 
 class TestDoajAffiliationString(unittest.TestCase):
     def test_affiliation_string(self):


### PR DESCRIPTION
Bug fix to code merged in PR https://github.com/elifesciences/elife-bot/pull/1204

An article has an `on-behalf-of` author, which causes an error when formatting it in the `doaj.py` provider library. This PR fixes the bug, adding it to the author names.