### PR TITLE
Add DepositDOAJ to the post publication workflow.

### DIFF
--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -41,6 +41,7 @@ class workflow_PostPerfectPublication(Workflow):
                     define_workflow_step("PublishDigest", data),
                     define_workflow_step("CreateDigestMediumPost", data),
                     define_workflow_step("GeneratePDFCovers", data),
+                    define_workflow_step("DepositDOAJ", data),
                 ],
 
             "finish":


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6484

Post-publication, deposit the article metadata to DOAJ using the `DepositDOAJ` activity. It will only deposit VoR articles and only the most recently published article, so it should be safe to run after each publishing event, PoR or silent corrections.