### PR TITLE
EJP CSV file logic to look for file by name

### DIFF
--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -307,6 +307,26 @@ class EJP(object):
         fn_fragment["poa_funding"] = "ejp_query_tool_query_id_POA_Funding"
         fn_fragment["poa_ethics"] = "ejp_query_tool_query_id_POA_Ethics"
 
+        # first try to locate the s3 key by looking for the expected name
+        s3_key_name = self.latest_s3_file_name_by_convention(fn_fragment, file_type)
+
+        if not s3_key_name:
+            # find s3_key_name by checking for the latest modified date on the s3 key
+            s3_key_name = self.latest_s3_file_name_by_modified_date(
+                fn_fragment, file_type, file_list)
+        
+        return s3_key_name
+
+    def latest_s3_file_name_by_convention(self, fn_fragment, file_type):
+        "concatenate the expected s3 file name and check if it exists in the bucket"
+        date_string = utils.set_datestamp("_")
+        # remove backslashes from regular expression fragments
+        clean_fn_fragment = fn_fragment[file_type].replace("\\", "")
+        file_name_to_match = "%s_%s_eLife.csv" % (clean_fn_fragment, date_string)
+        bucket = self.get_bucket(self.settings.ejp_bucket)
+        return bucket.get_key(file_name_to_match)
+
+    def latest_s3_file_name_by_modified_date(self, fn_fragment, file_type, file_list):
         if file_list is None:
             file_list = self.ejp_bucket_file_list()
 

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -85,10 +85,15 @@ def unicode_encode(string):
     return bytes_decode(string)
 
 
-def set_datestamp():
+def set_datestamp(glue=""):
     arrow_date = arrow.utcnow()
-    date_stamp = (str(arrow_date.datetime.year) + str(arrow_date.datetime.month).zfill(2) +
-                  str(arrow_date.datetime.day).zfill(2))
+    date_stamp = glue.join(
+        [
+            str(arrow_date.datetime.year),
+            str(arrow_date.datetime.month).zfill(2),
+            str(arrow_date.datetime.day).zfill(2),
+        ]
+    )
     return date_stamp
 
 

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -124,6 +124,7 @@ class TestPackagePOA(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('activity.activity_PackagePOA.storage_context')
+    @patch("provider.ejp.EJP.latest_s3_file_name_by_convention")
     @patch('provider.ejp.EJP.ejp_bucket_file_list')
     @patch.object(lax_provider, 'article_publication_date')
     @patch.object(activity_PackagePOA, 'clean_tmp_dir')
@@ -198,7 +199,7 @@ class TestPackagePOA(unittest.TestCase):
     )
     def test_do_activity(self, test_data, fake_copy_pdf_to_output_dir, fake_clean_tmp_dir,
                          fake_article_publication_date, fake_ejp_bucket_file_list,
-                         fake_storage_context, fake_email_smtp_connect):
+                         fake_by_convention, fake_storage_context, fake_email_smtp_connect):
         # make directories first
         self.poa.make_activity_directories()
         # mock things
@@ -209,6 +210,7 @@ class TestPackagePOA(unittest.TestCase):
         bucket_list_file = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
         with open(bucket_list_file, 'rb') as open_file:
             fake_ejp_bucket_file_list.return_value = json.loads(open_file.read().decode())
+        fake_by_convention.return_value = None
         fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
         if "pub_date" in test_data and test_data["pub_date"]:
             fake_article_publication_date.return_value = test_data["pub_date"]
@@ -270,6 +272,7 @@ class TestPackagePOA(unittest.TestCase):
     @patch.object(activity_PackagePOA, 'generate_xml')
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('activity.activity_PackagePOA.storage_context')
+    @patch("provider.ejp.EJP.latest_s3_file_name_by_convention")
     @patch('provider.ejp.EJP.ejp_bucket_file_list')
     @patch.object(lax_provider, 'article_publication_date')
     @patch.object(activity_PackagePOA, 'clean_tmp_dir')
@@ -288,7 +291,7 @@ class TestPackagePOA(unittest.TestCase):
     )
     def test_do_activity_generate_xml_exception(
             self, test_data, fake_copy_pdf_to_output_dir, fake_clean_tmp_dir,
-            fake_article_publication_date, fake_ejp_bucket_file_list,
+            fake_article_publication_date, fake_ejp_bucket_file_list, fake_by_convention,
             fake_storage_context, fake_email_smtp_connect, fake_generate_xml):
         # make directories first
         self.poa.make_activity_directories()
@@ -299,6 +302,7 @@ class TestPackagePOA(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.poa.get_tmp_dir())
         test_outbox_folder = activity_test_data.ExpandArticle_files_dest_folder
         bucket_list_file = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
+        fake_by_convention.return_value = None
         with open(bucket_list_file, 'rb') as open_file:
             fake_ejp_bucket_file_list.return_value = json.loads(open_file.read().decode())
         fake_storage_context.return_value = FakeStorageContext(directory=self.test_data_dir)
@@ -363,8 +367,9 @@ class TestPackagePOA(unittest.TestCase):
             'Exception in build_xml_to_disk for article_id 12717: An exception')
 
     @patch('activity.activity_PackagePOA.storage_context')
+    @patch("provider.ejp.EJP.latest_s3_file_name_by_convention")
     @patch('provider.ejp.EJP.ejp_bucket_file_list')
-    def test_download_latest_csv(self, fake_ejp_bucket_file_list, fake_storage_context):
+    def test_download_latest_csv(self, fake_ejp_bucket_file_list, fake_by_convention, fake_storage_context):
         "test downloading CSV files from bucket storage"
         # make directories first
         self.poa.make_activity_directories()
@@ -373,6 +378,7 @@ class TestPackagePOA(unittest.TestCase):
         bucket_list_file = os.path.join("tests", "test_data", "ejp_bucket_list_new.json")
         with open(bucket_list_file, 'rb') as open_file:
             fake_ejp_bucket_file_list.return_value = json.loads(open_file.read().decode())
+        fake_by_convention.return_value = None
         # download the CSV files
         self.poa.download_latest_csv()
         # make assertions

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -3,6 +3,7 @@
 import unittest
 import time
 import sys
+import arrow
 from mock import patch
 from ddt import ddt, data, unpack
 import provider.utils as utils
@@ -104,6 +105,19 @@ class TestUtils(unittest.TestCase):
         encoded_value = utils.unicode_encode(value)
         self.assertEqual(encoded_value, expected)
         self.assertEqual(type(encoded_value), expected_type)
+
+    @patch.object(arrow, "utcnow")
+    def test_set_datestamp(self, fake_utcnow):
+        fake_utcnow.return_value = arrow.arrow.Arrow(2021, 1, 1)
+        expected = "20210101"
+        self.assertEqual(utils.set_datestamp(), expected)
+
+    @patch.object(arrow, "utcnow")
+    def test_set_datestamp_glued(self, fake_utcnow):
+        fake_utcnow.return_value = arrow.arrow.Arrow(2021, 1, 1)
+        glue = "_"
+        expected = "2021_01_01"
+        self.assertEqual(utils.set_datestamp(glue), expected)
 
     def test_get_doi_url(self):
         doi_url = utils.get_doi_url("10.7554/eLife.08411")


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6571

An alternative way to find EJP CSV files in a bucket is to look for the most recent file by its expected name, which includes the current date in the file name. It should speed up locating the most recent CSV file of each type.

If an object for the current date is not found, it will default to using the method which considers the modified date of the object.

Test scenarios for the `PackagePOA` activity are changed to use the older, compare by modified date, method which is how the tests are originally written.

I will test this on the `continuumtest` environment before deploying to to the `prod` environment to be extra sure it does not break things.