### PR TITLE
Bug fix ejp provider CSV file name logic.

### DIFF
--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -324,7 +324,9 @@ class EJP(object):
         clean_fn_fragment = fn_fragment[file_type].replace("\\", "")
         file_name_to_match = "%s_%s_eLife.csv" % (clean_fn_fragment, date_string)
         bucket = self.get_bucket(self.settings.ejp_bucket)
-        return bucket.get_key(file_name_to_match)
+        s3_key = bucket.get_key(file_name_to_match)
+        if s3_key:
+            return s3_key.name
 
     def latest_s3_file_name_by_modified_date(self, fn_fragment, file_type, file_list):
         if file_list is None:

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -10,7 +10,7 @@ from testfixtures import tempdir
 from testfixtures import TempDirectory
 from mock import patch, MagicMock
 from ddt import ddt, data, unpack
-from tests.activity.classes_mock import FakeBucket
+from tests.activity.classes_mock import FakeBucket, FakeKey
 
 
 @ddt
@@ -123,6 +123,7 @@ class TestProviderEJP(unittest.TestCase):
         self.assertEqual(column_headings, self.editor_column_headings)
         self.assertEqual(authors, expected_editors)
 
+    @patch.object(FakeBucket, "get_key")
     @patch.object(arrow, "utcnow")
     @patch("provider.ejp.EJP.get_bucket")
     @data(
@@ -144,9 +145,17 @@ class TestProviderEJP(unittest.TestCase):
         ('poa_ethics', 'ejp_query_tool_query_id_POA_Ethics_2019_06_10_eLife.csv'),
     )
     @unpack
-    def test_find_latest_s3_file_name_by_convention(self, file_type, expected_s3_key_name, fake_get_bucket, fake_utcnow):
+    def test_find_latest_s3_file_name_by_convention(
+        self,
+        file_type,
+        expected_s3_key_name,
+        fake_get_bucket,
+        fake_utcnow,
+        fake_get_key,
+    ):
         """test finding latest CSV file names by their expected file name"""
         fake_get_bucket.return_value = FakeBucket()
+        fake_get_key.return_value = FakeKey(name=expected_s3_key_name)
         fake_utcnow.return_value = arrow.arrow.Arrow(2019, 6, 10)
         # call the function
         s3_key_name = self.ejp.find_latest_s3_file_name(file_type)


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1211

After testing, the new function returned an S3 key object instead of a string name. Here is the fix.