### PR TITLE
Crossref library update, add assertion tags to crossmark custom_metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ beautifulsoup4==4.7.1
 lxml==4.6.3
 python-slugify==1.2.4
 git+https://github.com/elifesciences/elife-tools.git@8ef9fd866909749bb23c23b9b76364cef8a25fcf#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@a3cc8244d3ddcb45039d8a3d876dfd4673c9975e#egg=elifearticle
+elifearticle==0.2.0
 configparser==3.5.0
-git+https://github.com/elifesciences/elife-crossref-xml-generation.git@1c4d2d9755634ef8440dc27fcc074bd56f01fe2c#egg=elifecrossref
+elifecrossref==0.2.0
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@ebd128176df5044673a9dd4777ff432dcd8aaa66#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@7dde779b334e7d554174dbed1a78d63603ded293#egg=jatsgenerator

--- a/tests/activity/crossref.cfg
+++ b/tests/activity/crossref.cfg
@@ -26,6 +26,8 @@ reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
 clinical_trials_registries: https://doi.org/10.18810/registries
+# if the article has one of the following display_channel value then add crossmark custom_metadata assertion tags,case-insensitive matching
+assertion_display_channel_types: ["research article", "short report", "tools and resources", "research advance", "review article"]
 
 [elife]
 registrant: eLife


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6620

Deploying an enhancement to Crossref deposits adding `<assertion>` tags.

Also, in `requirements.txt` there are two libraries (`elifearticle` and `elifecrossref`) switched over to loading by version number instead of by specifying a git commit hash, as part of trying to move all libraries to a semver versioning scheme.