### PR TITLE
Changes to typesetter API endpoint interactions.

### DIFF
--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -120,10 +120,9 @@ class activity_PostDecisionLetterJATS(Activity):
         """prepare and POST jats to API endpoint"""
         url = self.settings.typesetter_decision_letter_endpoint
         params = requests_provider.jats_post_params(
-            self.settings.typesetter_decision_letter_api_key,
-            self.settings.typesetter_decision_letter_account_key)
+            self.settings.typesetter_decision_letter_api_key)
         payload = requests_provider.jats_post_payload(
-            'decision', doi, jats_content,
+            'decisionletter', utils.msid_from_doi(doi), jats_content,
             self.settings.typesetter_decision_letter_api_key,
             self.settings.typesetter_decision_letter_account_key)
         content_type = 'application/x-www-form-urlencoded'

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -129,9 +129,8 @@ class activity_PostDigestJATS(Activity):
         """prepare and POST jats to API endpoint"""
         url = self.settings.typesetter_digest_endpoint
         params = requests_provider.jats_post_params(
-            self.settings.typesetter_digest_api_key,
-            self.settings.typesetter_digest_account_key)
-        doi = doi_uri_to_doi(digest.doi)
+            self.settings.typesetter_digest_api_key)
+        doi = utils.msid_from_doi(doi_uri_to_doi(digest.doi))
         payload = requests_provider.jats_post_payload(
             'digest', doi, jats_content,
             self.settings.typesetter_digest_api_key,

--- a/provider/requests_provider.py
+++ b/provider/requests_provider.py
@@ -3,11 +3,12 @@ import requests
 from requests.exceptions import HTTPError
 
 
-def jats_post_params(api_key, account_key):
+def jats_post_params(api_key, account_key=None):
     """the full endpoint URL to authenticate via URL parameters"""
     params = OrderedDict()
     params["apiKey"] = api_key
-    params["accountKey"] = account_key
+    if account_key:
+        params["accountKey"] = account_key
     return params
 
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -111,7 +111,7 @@ class exp():
     digest_auth_key = 'digest_auth_key'
 
     # digest typesetter endpoint
-    typesetter_digest_endpoint = 'https://typesetter/updateDigest'
+    typesetter_digest_endpoint = 'https://typesetter/updatedigest'
     typesetter_digest_api_key = 'typesetter_api_key'
     typesetter_digest_account_key = '1'
 
@@ -121,7 +121,7 @@ class exp():
     decision_letter_output_bucket = 'exp-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
-    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_endpoint = 'https://typesetter/updatedigest'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
     typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
@@ -412,7 +412,7 @@ class dev():
     digest_auth_key = 'digest_auth_key'
 
     # digest typesetter endpoint
-    typesetter_digest_endpoint = 'https://typesetter/updateDigest'
+    typesetter_digest_endpoint = 'https://typesetter/updatedigest'
     typesetter_digest_api_key = 'typesetter_api_key'
     typesetter_digest_account_key = '1'
 
@@ -422,7 +422,7 @@ class dev():
     decision_letter_output_bucket = 'dev-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
-    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_endpoint = 'https://typesetter/updatedigest'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
     typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]
@@ -710,7 +710,7 @@ class live():
     digest_auth_key = 'digest_auth_key'
 
     # digest typesetter endpoint
-    typesetter_digest_endpoint = 'https://typesetter/updateDigest'
+    typesetter_digest_endpoint = 'https://typesetter/updatedigest'
     typesetter_digest_api_key = 'typesetter_api_key'
     typesetter_digest_account_key = '1'
 
@@ -720,7 +720,7 @@ class live():
     decision_letter_output_bucket = 'prod-elife-bot-decision-letter-output'
     decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
     decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
-    typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+    typesetter_decision_letter_endpoint = 'https://typesetter/updatedigest'
     typesetter_decision_letter_api_key = 'typesetter_api_key'
     typesetter_decision_letter_account_key = '1'
     decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -204,7 +204,7 @@ decision_letter_output_bucket = 'dev-elife-bot-decision-letter-output'
 decision_letter_bucket_folder_name_pattern = 'elife{manuscript:0>5}'
 decision_letter_xml_file_name_pattern = 'elife-{manuscript:0>5}.xml'
 
-typesetter_decision_letter_endpoint = 'https://typesetter/decisionLetter'
+typesetter_decision_letter_endpoint = 'https://typesetter/updatedigest'
 typesetter_decision_letter_api_key = 'typesetter_api_key'
 typesetter_decision_letter_account_key = '1'
 decision_letter_jats_recipient_email = ["e@example.org", "life@example.org"]

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -78,7 +78,7 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         self.assertEqual(result, expected_result)
         self.assertTrue(self.activity.post_error_message.startswith(
             'POST was not successful, details: Error posting decision letter JATS to endpoint'
-            ' https://typesetter/decisionLetter: status_code: 500\n'
+            ' https://typesetter/updatedigest: status_code: 500\n'
             'request headers: {}\n'
             'request body: None\n'
             'response headers: {}\n'


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6668

Typesetter endpoint is changing for where to deposit digest and decision letter JATS XML, along with some minor changes to the parameters. Both types of deposits will share the same endpoint which is reflected in the example settings and test case settings. `doi` is changed to be only the five digits article ID.