### PR TITLE
Load email templates from disk, first part

### DIFF
--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -139,7 +139,7 @@ class activity_EmailVideoArticlePublished(Activity):
         Download the email templates from s3
         """
         # Prepare email templates
-        self.templates.download_video_email_templates_from_s3()
+        self.templates.copy_email_templates(self.settings.email_templates_path)
         if self.templates.email_templates_warmed is not True:
             if self.logger:
                 log_info = 'EmailVideoArticlePublished email templates did not warm successfully'

--- a/provider/templates.py
+++ b/provider/templates.py
@@ -1,6 +1,7 @@
 import json
 import os
-
+import glob
+import shutil
 from jinja2 import Environment, FileSystemLoader
 
 from boto.s3.connection import S3Connection
@@ -156,6 +157,16 @@ class Templates(object):
             self.lens_templates_warmed = False
         elif template_missing is False:
             self.lens_templates_warmed = True
+
+    def copy_email_templates(self, from_dir):
+        "copy email templates from from_dir to the tmp_dir"
+        template_file_paths = []
+        for file_type in ["html", "json"]:
+            match_pattern = "%s/*.%s" % (from_dir, file_type)
+            template_file_paths += glob.glob(match_pattern)
+        for file_path in template_file_paths:
+            shutil.copy(file_path, self.get_tmp_dir())
+        self.email_templates_warmed = True
 
     def download_templates_from_s3(self, template_list):
         "download template files from s3"

--- a/settings-example.py
+++ b/settings-example.py
@@ -145,6 +145,7 @@ class exp():
 
     # Templates S3 settings
     templates_bucket = 'elife-bot-dev'
+    email_templates_path = "/opt/elife-email-templates"
 
     # Article subjects data
     article_subjects_data_bucket = "elife-bot-dev/article_subjects_data"
@@ -446,6 +447,7 @@ class dev():
 
     # Templates S3 settings
     templates_bucket = 'elife-bot-dev'
+    email_templates_path = "/opt/elife-email-templates"
 
     # Article subjects data
     article_subjects_data_bucket = "elife-bot-dev/article_subjects_data"
@@ -744,6 +746,7 @@ class live():
 
     # Templates S3 settings
     templates_bucket = 'elife-bot'
+    email_templates_path = "/opt/elife-email-templates"
 
     # Crossref generation
     elifecrossref_config_file = 'crossref.cfg'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -34,6 +34,7 @@ ses_poa_recipient_email = ""
 ses_admin_email = ""
 ses_bcc_recipient_email = ""
 templates_bucket = ""
+email_templates_path = "tests/test_data/templates"
 ppp_cdn_bucket = 'ppd_cdn_bucket'
 digest_cdn_bucket = 'ppd_cdn_bucket/digests'
 

--- a/tests/activity/test_activity_email_video.py
+++ b/tests/activity/test_activity_email_video.py
@@ -45,16 +45,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
     def tearDown(self):
         self.activity.clean_tmp_dir()
 
-    def fake_download_video_email_templates(self, to_dir, templates_warmed):
-        template_list = self.activity.templates.get_video_email_templates_list()
-        for filename in template_list:
-            source_doc = "tests/test_data/templates/" + filename
-            dest_doc = os.path.join(to_dir, filename)
-            shutil.copy(source_doc, dest_doc)
-        self.activity.templates.email_templates_warmed = templates_warmed
-
     @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch.object(Templates, 'download_video_email_templates_from_s3')
     @patch('provider.lax_provider.article_first_by_status')
     @patch('provider.lax_provider.get_xml_file_name')
     @patch.object(article_processing, 'storage_context')
@@ -63,7 +54,6 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         {
             "comment": "article has video and not a duplicate email",
             "xml_file": "elife-00007-v1.xml",
-            "templates_warmed": True,
             "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", None),
             "first_vor": True,
             "activity_success": activity_object.ACTIVITY_SUCCESS
@@ -81,7 +71,6 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         {
             "comment": "article is not the first VoR",
             "xml_file": "elife-00007-v1.xml",
-            "templates_warmed": True,
             "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", None),
             "first_vor": None,
             "activity_success": activity_object.ACTIVITY_SUCCESS
@@ -89,11 +78,31 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         {
             "comment": "article does not have a video",
             "xml_file": "elife-00353-v1.xml",
-            "templates_warmed": None,
             "input_data": activity_data(BASE_ACTIVITY_DATA, "00353", "vor", None),
             "first_vor": True,
             "activity_success": activity_object.ACTIVITY_SUCCESS
-        },
+        }
+    )
+    def test_do_activity(self, test_data, fake_emit,
+                         fake_processing_storage_context, fake_get_xml_file_name, fake_first,
+                         fake_email_smtp_connect):
+        # mock objects
+        fake_emit.return_value = None
+        fake_processing_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = test_data.get("xml_file")
+        fake_first.return_value = test_data.get("first_vor")
+        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        # do the activity
+        success = self.activity.do_activity(test_data.get("input_data"))
+        # check assertions
+        self.assertEqual(success, test_data.get("activity_success"))
+
+    @patch.object(Templates, "copy_email_templates")
+    @patch('provider.lax_provider.article_first_by_status')
+    @patch('provider.lax_provider.get_xml_file_name')
+    @patch.object(article_processing, 'storage_context')
+    @patch.object(activity_object, 'emit_monitor_event')
+    @data(
         {
             "comment": "article has video but templates were not downloaded",
             "xml_file": "elife-00007-v1.xml",
@@ -103,25 +112,22 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
             "activity_success": activity_object.ACTIVITY_PERMANENT_FAILURE
         }
     )
-    def test_do_activity(self, test_data, fake_emit,
+    def test_do_activity_templatest_error(self, test_data, fake_emit,
                          fake_processing_storage_context, fake_get_xml_file_name, fake_first,
-                         fake_download_email_templates,
-                         fake_email_smtp_connect):
+                         fake_copy_email_templates
+                         ):
         # mock objects
         fake_emit.return_value = None
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = test_data.get("xml_file")
         fake_first.return_value = test_data.get("first_vor")
-        self.fake_download_video_email_templates(
-            self.activity.get_tmp_dir(), test_data.get("templates_warmed"))
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+        self.activity.templates.email_templates_warmed = False
         # do the activity
         success = self.activity.do_activity(test_data.get("input_data"))
         # check assertions
         self.assertEqual(success, test_data.get("activity_success"))
 
     @patch.object(email_provider, 'smtp_send_messages')
-    @patch.object(Templates, 'download_video_email_templates_from_s3')
     @data(
         {
             "recipient": {},
@@ -134,12 +140,12 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
             "expected": False
         },
     )
-    def test_send_email(self, test_data, fake_download_email_templates, fake_smtp_send_messages):
+    def test_send_email(self, test_data, fake_smtp_send_messages):
         """test cases for exceptions in send_email"""
         article_object = article()
         article_object.doi_id = 666
-        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
         fake_smtp_send_messages.return_value = OrderedDict([("error", 1), ("success", 1)])
+        self.activity.download_templates()
         # call the method
         return_value = self.activity.send_email(
             test_data.get("email_type"), test_data.get("recipient"), article_object)
@@ -165,10 +171,9 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         # check assertions
         self.assertEqual(return_value, test_data.get("expected"))
 
-    @patch.object(Templates, 'download_video_email_templates_from_s3')
-    def test_template_get_email_headers_00013(self, fake_download_email_templates):
+    def test_template_get_email_headers_00013(self):
 
-        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
+        self.activity.download_templates()
 
         email_type = "video_article_publication"
 
@@ -193,10 +198,9 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
 
         self.assertEqual(body, expected_headers)
 
-    @patch.object(Templates, 'download_video_email_templates_from_s3')
-    def test_template_get_email_body_00353(self, fake_download_email_templates):
+    def test_template_get_email_body_00353(self):
 
-        self.fake_download_video_email_templates(self.activity.get_tmp_dir(), True)
+        self.activity.download_templates()
 
         email_type = "video_article_publication"
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6595

Testing in the `end2end` environment is not loading email templates properly, which up until now are stored in an S3 bucket and are downloaded for each activity using them. This PR is a first test to make email templates easier to use. The builder formula is now altered to add the email templates to `/opt/elife-email-templates` on the instance, and then we can copy them over from there instead of interacting with an S3 bucket.

Here, only the basic logic of copying the templates is added, and is enabled in the `EmailVideoArticlePublished` activity. If this test is successful, then the `PublicationEmail` activity can also be changed to use the templates from disk, and the `provider/templates.py` library have the old S3 bucket code removed.