### PR TITLE
PublicationEmail templates and templates provider refactor

### DIFF
--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -136,7 +136,7 @@ class activity_EmailVideoArticlePublished(Activity):
 
     def download_templates(self):
         """
-        Download the email templates from s3
+        Download the email templates
         """
         # Prepare email templates
         self.templates.copy_email_templates(self.settings.email_templates_path)

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -224,11 +224,11 @@ class activity_PublicationEmail(Activity):
 
     def download_templates(self):
         """
-        Download the email templates from s3
+        Download the email templates
         """
 
         # Prepare email templates
-        self.templates.download_email_templates_from_s3()
+        self.templates.copy_email_templates(self.settings.email_templates_path)
         if self.templates.email_templates_warmed is not True:
             log_info = 'PublicationEmail email templates did not warm successfully'
             self.admin_email_content += "\n" + log_info

--- a/provider/templates.py
+++ b/provider/templates.py
@@ -4,14 +4,10 @@ import glob
 import shutil
 from jinja2 import Environment, FileSystemLoader
 
-from boto.s3.connection import S3Connection
-
-from provider.utils import unicode_encode
-
 
 """
 Templates provider
-Connects to S3, discovers, downloads, and parses templates using jinja2
+Copies and parses templates using jinja2
 """
 
 class Templates(object):
@@ -23,62 +19,12 @@ class Templates(object):
         # Default tmp_dir if not specified
         self.tmp_dir_default = "templates_provider"
 
-        # Default S3 bucket name
-        self.bucket_name = None
-        if self.settings is not None:
-            self.bucket_name = self.settings.templates_bucket
-
-        # Email template folder (prefix) in S3 bucket
-        self.s3_email_templates_dir = "email_templates"
-
-        # S3 connection
-        self.s3_conn = None
-
         # Jinja stuff
         self.jinja_env = None
 
         # Track whether templates are downloaded and ready for use
         self.email_templates_warmed = False
         self.lens_templates_warmed = False
-
-    def connect(self):
-        """
-        Connect to S3 using the settings
-        """
-        s3_conn = S3Connection(self.settings.aws_access_key_id,
-                               self.settings.aws_secret_access_key)
-        self.s3_conn = s3_conn
-        return self.s3_conn
-
-    def get_bucket(self, bucket_name=None):
-        """
-        Using the S3 connection, lookup the bucket
-        """
-        if self.s3_conn is None:
-            s3_conn = self.connect()
-        else:
-            s3_conn = self.s3_conn
-
-        if bucket_name is None:
-            # Use the object bucket_name if not provided
-            bucket_name = self.bucket_name
-
-        # Lookup the bucket
-        bucket = s3_conn.lookup(bucket_name)
-
-        return bucket
-
-    def get_s3key(self, s3_key_name, bucket=None):
-        """
-        Get the S3 key from the bucket
-        If the bucket is not provided, use the object bucket
-        """
-        if bucket is None:
-            bucket = self.get_bucket()
-
-        s3key = bucket.get_key(s3_key_name)
-
-        return s3key
 
     def get_tmp_dir(self):
         """
@@ -92,64 +38,20 @@ class Templates(object):
 
         return self.tmp_dir
 
-    def get_email_templates_list(self):
-        """
-        Get a list of email templates to download
-        in order to support author publication
-        and editor publication emails
-        """
-        template_list = []
-        template_list.append("email_header.html")
-        template_list.append("email_footer.html")
-        template_list.append("author_publication_email.html")
-        template_list.append("author_publication_email.json")
-        template_list.append("author_publication_email_Insight_to_VOR.html")
-        template_list.append("author_publication_email_Insight_to_VOR.json")
-        template_list.append("author_publication_email_POA.html")
-        template_list.append("author_publication_email_POA.json")
-        template_list.append("author_publication_email_VOR_after_POA.html")
-        template_list.append("author_publication_email_VOR_after_POA.json")
-        template_list.append("author_publication_email_VOR_no_POA.html")
-        template_list.append("author_publication_email_VOR_no_POA.json")
-        template_list.append("author_publication_email_Feature.html")
-        template_list.append("author_publication_email_Feature.json")
-
-        return template_list
-
-    def get_video_email_templates_list(self):
-        "list of templates for sending video article published emails"
-        template_list = []
-        template_list.append("email_header.html")
-        template_list.append("email_footer.html")
-        template_list.append("video_article_publication.html")
-        template_list.append("video_article_publication.json")
-        return template_list
-
-    def get_lens_templates_list(self):
-        """
-        Get a list of Lens templates
-        in order to support elife lens publication
-        """
-        template_list = []
-        template_list.append("lens_article.html")
-
-        return template_list
-
     def copy_lens_templates(self, from_dir):
         """
         Prepare the tmp_dir jinja template directory
         to hold template files used in author publication
         and editor publication emails
         """
-        template_list = self.get_lens_templates_list()
+        template_list = ["lens_article.html"]
 
         template_missing = False
 
         for template in template_list:
-            filename = os.path.join(from_dir, template)
             try:
-                with open(filename, 'r') as fp:
-                    self.save_template_contents_to_tmp_dir(template, fp.read())
+                file_path = os.path.join(from_dir, template)
+                shutil.copy(file_path, self.get_tmp_dir())
             except:
                 template_missing = True
 
@@ -167,82 +69,6 @@ class Templates(object):
         for file_path in template_file_paths:
             shutil.copy(file_path, self.get_tmp_dir())
         self.email_templates_warmed = True
-
-    def download_templates_from_s3(self, template_list):
-        "download template files from s3"
-        template_missing = False
-        for t in template_list:
-            success = self.download_template_from_s3(
-                template_type="email",
-                template_name=t)
-            if not success:
-                template_missing = True
-        if template_missing:
-            self.email_templates_warmed = False
-        elif template_missing is False:
-            self.email_templates_warmed = True
-
-    def download_email_templates_from_s3(self):
-        "donwload template files used in author publication emails"
-        self.download_templates_from_s3(self.get_email_templates_list())
-
-    def download_video_email_templates_from_s3(self):
-        "donwload template files used in video published emails"
-        self.download_templates_from_s3(self.get_video_email_templates_list())
-
-    def download_template_from_s3(self, template_type=None, template_name=None, s3_key_name=None):
-        """
-        Download a template from the S3 bucket to the
-        tmp_dir, so it can be loaded by jinja
-        """
-
-        # If no specific s3_key_name supplied, assemble one
-        if s3_key_name is None:
-            s3_key_name = self.get_s3_key_name(template_type, template_name)
-
-        # Get the object by key and save it to the filesystem
-        s3_key = self.get_s3key(s3_key_name)
-        try:
-            contents = s3_key.get_contents_as_string()
-        except AttributeError:
-            # File may be missing from S3 bucket
-            contents = None
-
-        if contents is not None:
-            self.save_template_contents_to_tmp_dir(template_name, contents)
-            return True
-
-        # Default
-        return False
-
-    def save_template_contents_to_tmp_dir(self, template_name, contents):
-        """
-        Given a template_name and UTF-8 content for a template,
-        save it to the tmp_dir for later use
-        Can be used from S3 object content, or local filesystem
-        loaded content in the case of running tests
-        """
-        if contents is not None:
-            with open(os.path.join(self.get_tmp_dir(), template_name), 'w') as fp:
-                fp.write(unicode_encode(contents))
-            return True
-
-        # Default
-        return False
-
-    def get_s3_key_name(self, template_type, template_name):
-        """
-        Given a template type and template name, return the expected
-        s3_key_name for an S3 object in the templates_bucket
-        """
-        s3_key_name = None
-        delimiter = "/"
-
-        if template_type == "email":
-            # Email templates stored in email folder
-            s3_key_name = self.s3_email_templates_dir + delimiter + template_name
-
-        return s3_key_name
 
     def get_jinja_env(self):
         """
@@ -272,7 +98,7 @@ class Templates(object):
 
         # Warm the template files
         if self.email_templates_warmed is not True:
-            self.download_email_templates_from_s3()
+            raise Exception("Templates no warmed in templates provider get_email_body()")
 
         if format == "html":
             template_name = email_type + ".html"
@@ -299,7 +125,7 @@ class Templates(object):
 
         # Warm the template files
         if self.email_templates_warmed is not True:
-            self.download_email_templates_from_s3()
+            raise Exception("Templates no warmed in templates provider get_email_headers()")
 
         template_name = email_type + ".json"
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -143,8 +143,7 @@ class exp():
     # EJP S3 settings
     ejp_bucket = 'elife-ejp-ftp-dev'
 
-    # Templates S3 settings
-    templates_bucket = 'elife-bot-dev'
+    # Templates settings
     email_templates_path = "/opt/elife-email-templates"
 
     # Article subjects data
@@ -445,8 +444,7 @@ class dev():
     # EJP S3 settings
     ejp_bucket = 'elife-ejp-ftp-dev'
 
-    # Templates S3 settings
-    templates_bucket = 'elife-bot-dev'
+    # Templates settings
     email_templates_path = "/opt/elife-email-templates"
 
     # Article subjects data
@@ -744,8 +742,7 @@ class live():
     # EJP S3 settings
     ejp_bucket = 'elife-ejp-ftp'
 
-    # Templates S3 settings
-    templates_bucket = 'elife-bot'
+    # Templates settings
     email_templates_path = "/opt/elife-email-templates"
 
     # Crossref generation

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -33,7 +33,6 @@ ses_poa_sender_email = ""
 ses_poa_recipient_email = ""
 ses_admin_email = ""
 ses_bcc_recipient_email = ""
-templates_bucket = ""
 email_templates_path = "tests/test_data/templates"
 ppp_cdn_bucket = 'ppd_cdn_bucket'
 digest_cdn_bucket = 'ppd_cdn_bucket/digests'

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -50,7 +50,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "normal article with dict input_data",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife00013.xml"],
             "article_id": "00013",
             "activity_success": True,
@@ -67,7 +66,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "normal article with input_data None",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": None,
-            "templates_warmed": True,
             "article_xml_filenames": ["elife03385.xml"],
             "article_id": "03385",
             "activity_success": True,
@@ -82,7 +80,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "basic PoA article",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_1,
             "input_data": None,
-            "templates_warmed": True,
             "article_xml_filenames": ["elife_poa_e03977.xml"],
             "article_id": "03977",
             "activity_success": True,
@@ -97,7 +94,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "Cannot build article",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": None,
-            "templates_warmed": True,
             "article_xml_filenames": ["does_not_exist.xml"],
             "article_id": None,
             "activity_success": self.activity.ACTIVITY_PERMANENT_FAILURE,
@@ -108,24 +104,9 @@ class TestPublicationEmail(unittest.TestCase):
             })
 
         self.do_activity_passes.append({
-            "comment": "Not warmed templates",
-            "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
-            "input_data": None,
-            "templates_warmed": False,
-            "article_xml_filenames": ["elife_poa_e03977.xml"],
-            "article_id": None,
-            "activity_success": self.activity.ACTIVITY_PERMANENT_FAILURE,
-            "admin_email_content_contains":
-                [
-                    'PublicationEmail email templates did not warm successfully'
-                ]
-            })
-
-        self.do_activity_passes.append({
             "comment": "article-commentary with a related article",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-18753-v1.xml"],
             "related_article": "tests/test_data/elife-15747-v2.xml",
             "article_id": "18753",
@@ -141,7 +122,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "article-commentary, related article cannot be found",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-18753-v1.xml"],
             "related_article": None,
             "article_id": "18753",
@@ -158,7 +138,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "article-commentary plus its matching insight",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-18753-v1.xml", "elife-15747-v2.xml"],
             "article_id": "18753",
             "activity_success": True,
@@ -176,7 +155,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "feature article",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-00353-v1.xml"],
             "article_id": "00353",
             "activity_success": True,
@@ -191,7 +169,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "article-commentary with no related-article tag",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-23065-v1.xml"],
             "article_id": "23065",
             "activity_success": True,
@@ -208,7 +185,6 @@ class TestPublicationEmail(unittest.TestCase):
             "comment": "recipients from the article XML file",
             "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
             "input_data": {},
-            "templates_warmed": True,
             "article_xml_filenames": ["elife-32991-v2.xml"],
             "article_id": "23065",
             "activity_success": True,
@@ -228,19 +204,10 @@ class TestPublicationEmail(unittest.TestCase):
         TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
 
-    def fake_download_email_templates_from_s3(self, to_dir, templates_warmed):
-        template_list = self.activity.templates.get_email_templates_list()
-        for filename in template_list:
-            source_doc = "tests/test_data/templates/" + filename
-            dest_doc = os.path.join(to_dir, filename)
-            shutil.copy(source_doc, dest_doc)
-        self.activity.templates.email_templates_warmed = templates_warmed
-
     @patch.object(activity_module, 'get_related_article')
     @patch('provider.article.article.download_article_xml_from_s3')
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('provider.lax_provider.article_versions')
-    @patch.object(Templates, 'download_email_templates_from_s3')
     @patch.object(EJP, 'get_s3key')
     @patch.object(EJP, 'find_latest_s3_file_name')
     @patch.object(FakeStorageContext, 'list_resources')
@@ -248,7 +215,6 @@ class TestPublicationEmail(unittest.TestCase):
     def test_do_activity(self, fake_storage_context, fake_list_resources,
                          fake_find_latest_s3_file_name,
                          fake_ejp_get_s3key,
-                         fake_download_email_templates,
                          fake_article_versions,
                          fake_email_smtp_connect,
                          fake_download_xml,
@@ -279,9 +245,6 @@ class TestPublicationEmail(unittest.TestCase):
             fake_article_versions.return_value = (
                 200, pass_test_data.get("lax_article_versions_response_data"))
 
-            self.fake_download_email_templates_from_s3(
-                self.activity.get_tmp_dir(), pass_test_data["templates_warmed"])
-
             fake_list_resources.return_value = pass_test_data["article_xml_filenames"]
 
             success = self.activity.do_activity(pass_test_data["input_data"])
@@ -304,7 +267,13 @@ class TestPublicationEmail(unittest.TestCase):
 
     @patch.object(activity_PublicationEmail, "download_templates")
     def test_do_activity_download_failure(self, fake_download_templates):
-        fake_download_templates.side_effect = Exception("Something went wrong!")
+        fake_download_templates.return_value = False
+        result = self.activity.do_activity()
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
+
+    @patch.object(Templates, "copy_email_templates")
+    def test_do_activity_download_exception(self, fake_copy_email_templates):
+        fake_copy_email_templates.side_effect = Exception("Something went wrong!")
         result = self.activity.do_activity()
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
@@ -332,6 +301,14 @@ class TestPublicationEmail(unittest.TestCase):
         fake_send_emails.return_value = Exception("Something went wrong!")
         result = self.activity.do_activity()
         self.assertEqual(result, True)
+
+    @patch.object(Templates, "copy_email_templates")
+    def test_download_templates_failure(self, fake_copy_email_templates):
+        fake_copy_email_templates.return_value = False
+        result = self.activity.download_templates()
+        self.assertFalse(result)
+        self.assertEqual(self.activity.logger.loginfo[-1],
+            "PublicationEmail email templates did not warm successfully")
 
     @patch('provider.article.article.download_article_xml_from_s3')
     @patch('provider.lax_provider.article_versions')
@@ -385,10 +362,9 @@ class TestPublicationEmail(unittest.TestCase):
             article_type, is_poa, was_ever_poa, feature_article)
         self.assertEqual(email_type, expected_email_type)
 
-    @patch.object(Templates, 'download_email_templates_from_s3')
-    def test_template_get_email_headers_00013(self, fake_download_email_templates):
+    def test_template_get_email_headers_00013(self):
 
-        self.fake_download_email_templates_from_s3(self.activity.get_tmp_dir(), True)
+        self.activity.download_templates()
 
         email_type = "author_publication_email_VOR_no_POA"
 
@@ -422,10 +398,9 @@ class TestPublicationEmail(unittest.TestCase):
 
         self.assertEqual(body, expected_headers)
 
-    @patch.object(Templates, 'download_email_templates_from_s3')
-    def test_template_get_email_body_00353(self, fake_download_email_templates):
+    def test_template_get_email_body_00353(self):
 
-        self.fake_download_email_templates_from_s3(self.activity.get_tmp_dir(), True)
+        self.activity.download_templates()
 
         email_type = "author_publication_email_Feature"
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -22,7 +22,6 @@ redis_db = 0
 redis_expire_key = 86400  # seconds
 
 ejp_bucket = 'ejp_bucket'
-templates_bucket = 'templates_bucket'
 ppp_cdn_bucket = 'ppd_cdn_bucket'
 archive_bucket = "archive_bucket"
 bot_bucket = 'bot_bucket'


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6595

Next step after merging PR https://github.com/elifesciences/elife-bot/pull/1215

The previously merged code to load email templates from a folder on disk instead of from an S3 bucket did not report any errors and was deployed to the `prod` environment.

This PR contains changes to the `PublicationEmail` activity to also use the templates from disk storage.

That allowed all the S3 bucket interaction code in the `provider/templates.py` module to be surplus to requirements, and it is removed and refactored accordingly.

The `provider/templates.py` module does not check against a list of expected templates anymore; if a template is missing then it will cause an error elsewhere.

Test scenarios are simplified slightly and changed, maintaining a similar level of code coverage.