### PR TITLE
PMC retracted article logic enhancement

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -65,6 +65,14 @@ def article_versions(article_id, settings, auth=False):
                        lax_auth_key(settings, auth))
 
 
+def article_related(article_id, settings, auth=False):
+    "get json for related article data from lax"
+    url = settings.lax_article_related.replace("{article_id}", article_id)
+    return lax_request(
+        url, article_id, settings.verify_ssl, None, lax_auth_key(settings, auth)
+    )
+
+
 def article_snippet(article_id, version, settings, auth=False):
     "snippet from the versions list for this version"
     status_code, data = article_versions(article_id, settings, auth)
@@ -204,6 +212,20 @@ def published_considering_poa_status(article_id, settings, is_poa, was_ever_poa)
             return True
     # Default
     return False
+
+
+def article_retracted_status(article_id, settings):
+    "using related article data is this article retracted"
+    retracted_status = None
+    status_code, data = article_related(article_id, settings)
+    if status_code == 200:
+        if not data:
+            retracted_status = False
+        else:
+            for related_article in data:
+                if related_article.get("type") == "retraction":
+                    retracted_status = True
+    return retracted_status
 
 
 def prepare_action_message(settings, article_id, run, expanded_folder, version,

--- a/settings-example.py
+++ b/settings-example.py
@@ -44,6 +44,7 @@ class exp():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
     no_download_extensions = 'tif'
@@ -345,6 +346,7 @@ class dev():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
     no_download_extensions = 'tif'
@@ -643,6 +645,7 @@ class live():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
     no_download_extensions = 'tif'

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -38,6 +38,7 @@ ppp_cdn_bucket = 'ppd_cdn_bucket'
 digest_cdn_bucket = 'ppd_cdn_bucket/digests'
 
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
+lax_article_related = "https://test/eLife.{article_id}/related"
 verify_ssl = False
 lax_auth_key = 'an_auth_key'
 

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -105,6 +105,17 @@ class TestLaxProvider(unittest.TestCase):
         # data returned will be exactly the value assigned to the mock response
         self.assertEqual(data, article_json)
 
+    @patch("requests.get")
+    def test_article_related_200(self, mock_requests_get):
+        related_article_json = []
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = related_article_json
+        mock_requests_get.return_value = response
+        status_code, data = lax_provider.article_related("08411", settings_mock)
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data, related_article_json)
+
     def test_lax_auth_header_none(self):
         expected = {}
         self.assertEqual(lax_provider.lax_auth_header(None), expected)
@@ -267,7 +278,61 @@ class TestLaxProvider(unittest.TestCase):
                                                                   is_poa, was_ever_poa)
         self.assertEqual(published, expected_return_value)
 
-    @patch('provider.lax_provider.article_versions')
+    @patch("provider.lax_provider.article_related")
+    def test_article_retracted_status_no_related(self, mock_article_related):
+        related_article_json = []
+        mock_article_related.return_value = 200, related_article_json
+        retracted_status = lax_provider.article_retracted_status("04132", settings_mock)
+        self.assertFalse(retracted_status)
+
+    @patch("provider.lax_provider.article_related")
+    def test_article_retracted_status_related(self, mock_article_related):
+        related_article_json = [
+            {
+                "status": "vor",
+                "id": "65227",
+                "version": 1,
+                "type": "retraction",
+                "doi": "10.7554/eLife.65227",
+                "authorLine": "Yang Li et al.",
+                "title": (
+                    "Retraction: Endocytic recycling and vesicular transport systems "
+                    "mediatetranscytosis of Leptospira interrogans across cell monolayer"),
+                "published": "2020-12-03T00:00:00Z",
+                "versionDate": "2020-12-03T00:00:00Z",
+                "volume": 9,
+                "elocationId": "e65227",
+                "subjects": [
+                    {
+                        "id": "microbiology-infectious-disease",
+                        "name": "Microbiology and Infectious Disease",
+                    }
+                ],
+                "copyright": {
+                    "license": "CC-BY-4.0",
+                    "holder": "Li et al.",
+                    "statement": (
+                        'This article is distributed under the terms of the '
+                        '<a href="http://creativecommons.org/licenses/by/4.0/">'
+                        'Creative Commons Attribution License</a>, which permits '
+                        'unrestricted use and redistribution provided that the '
+                        'original author and source are credited.'),
+                },
+                "stage": "published",
+                "statusDate": "2020-12-03T00:00:00Z",
+            }
+        ]
+        mock_article_related.return_value = 200, related_article_json
+        retracted_status = lax_provider.article_retracted_status("44594", settings_mock)
+        self.assertTrue(retracted_status)
+
+    @patch("provider.lax_provider.article_related")
+    def test_article_retracted_status_404(self, mock_article_related):
+        mock_article_related.return_value = 404, None
+        retracted_status = lax_provider.article_retracted_status("04132", settings_mock)
+        self.assertIsNone(retracted_status)
+
+    @patch("provider.lax_provider.article_versions")
     def test_article_status_version_map(self, mock_lax_provider_article_versions):
         expected = {"poa": [1, 2], "vor": [3]}
         article_id = '04132'

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -34,6 +34,7 @@ ses_poa_recipient_email = ""
 
 lax_article_endpoint = "https://test/eLife.{article_id}"
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
+lax_article_related = "https://test/eLife.{article_id}/related"
 verify_ssl = False
 lax_auth_key = 'an_auth_key'
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6326

After an article is retracted, do not send it to PMC again; the retraction notice itself will cause PMC to be updated sufficiently so there's no need to send the retracted article data again.

Overall there are two parts to the code introduced in this PR

1. In the Lax provider, get related article data, and use it to determine an article's retracted status
2. In the PMC deposit activity, do all the same repackaging and saving an updated zip file to the eLife S3 bucket, the only thing to omit is sending it by FTP to PMC

If a retracted article is sent to PMC, it will behave much the same way, returning a success, and only the log file will a notation be present about its retracted status.
