### PR TITLE
Bug fix lax provider article_retracted_status()

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -120,6 +120,9 @@ class activity_PMCDeposit(Activity):
 
         # check if the article is retracted
         article_retracted_status = lax_provider.article_retracted_status(fid, self.settings)
+        self.logger.info(
+            "%s article_id %s article_retracted_status: %s" %
+            (self.name, fid, article_retracted_status))
         if article_retracted_status is None:
             self.logger.info(
                 "%s could not determine article retracted status for article id %s" %

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -219,12 +219,10 @@ def article_retracted_status(article_id, settings):
     retracted_status = None
     status_code, data = article_related(article_id, settings)
     if status_code == 200:
-        if not data:
-            retracted_status = False
-        else:
-            for related_article in data:
-                if related_article.get("type") == "retraction":
-                    retracted_status = True
+        retracted_status = False
+        for related_article in data:
+            if related_article.get("type") == "retraction":
+                retracted_status = True
     return retracted_status
 
 

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -283,7 +283,7 @@ class TestLaxProvider(unittest.TestCase):
         related_article_json = []
         mock_article_related.return_value = 200, related_article_json
         retracted_status = lax_provider.article_retracted_status("04132", settings_mock)
-        self.assertFalse(retracted_status)
+        self.assertEqual(retracted_status, False)
 
     @patch("provider.lax_provider.article_related")
     def test_article_retracted_status_related(self, mock_article_related):
@@ -325,6 +325,17 @@ class TestLaxProvider(unittest.TestCase):
         mock_article_related.return_value = 200, related_article_json
         retracted_status = lax_provider.article_retracted_status("44594", settings_mock)
         self.assertTrue(retracted_status)
+
+    @patch("provider.lax_provider.article_related")
+    def test_article_retracted_status_related_insight_only(self, mock_article_related):
+        related_article_json = [
+            {
+                "type":"insight"
+            }
+        ]
+        mock_article_related.return_value = 200, related_article_json
+        retracted_status = lax_provider.article_retracted_status("99999", settings_mock)
+        self.assertEqual(retracted_status, False)
 
     @patch("provider.lax_provider.article_related")
     def test_article_retracted_status_404(self, mock_article_related):


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1218

If there was a related article of type `insight` it resulted in the retracted status value of `None`, which was supposed to only indicate when a non-200 status code was returned from the API endpoint. Fix it so a `200` status will be default have a retracted status of `False`, unless there is a related retraction article the retracted status will be `True`.

This bug caused three articles to be omitted from sending to PMC today, and I will resend those after this is merged and deployed.