### PR TITLE
Basic usage of elifecleaner library.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -1,0 +1,8 @@
+from elifecleaner import configure_logging, parse
+
+LOG_FILENAME = "elifecleaner.log"
+
+
+def log_to_file(filename=None):
+    "configure logging to file"
+    return configure_logging(filename) if filename else configure_logging(LOG_FILENAME)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ git+https://github.com/elifesciences/elife-tools.git@8ef9fd866909749bb23c23b9b76
 elifearticle==0.2.0
 configparser==3.5.0
 elifecrossref==0.2.0
+elifecleaner==0.2.1
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@ebd128176df5044673a9dd4777ff432dcd8aaa66#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser
 git+https://github.com/elifesciences/jats-generator.git@7dde779b334e7d554174dbed1a78d63603ded293#egg=jatsgenerator
@@ -19,7 +20,7 @@ docker==4.0.2
 pypandoc==1.4
 git+https://github.com/elifesciences/decision-letter-parser.git@c307488b1864c6922d4c39e944277dfe47c561c6#egg=letterparser
 PyYAML==5.4
-Wand==0.5.1
+Wand==0.5.2
 paramiko==2.4.2
 mock==1.3.0
 redis==2.10.5

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+import wand
+from provider import cleaner
+
+
+class TestCleanerProvider(unittest.TestCase):
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.logfile = os.path.join(self.directory.path, "elifecleaner.log")
+        cleaner.log_to_file(self.logfile)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_pdf_page_count(self):
+        file_path = "tests/files_source/elife-00353-v1.pdf"
+        page_count = cleaner.parse.pdf_page_count(file_path)
+        self.assertEqual(page_count, 2)
+
+    @patch.object(wand.image.Image, "allocate")
+    def test_pdf_page_count_exception(self, mock_image_allocate):
+        mock_image_allocate.side_effect = wand.exceptions.WandRuntimeError()
+        file_path = "tests/files_source/elife-00353-v1.pdf"
+        with self.assertRaises(wand.exceptions.WandRuntimeError):
+            page_count = cleaner.parse.pdf_page_count(file_path)
+        with open(self.logfile, "r") as open_file:
+            self.assertEqual(
+                open_file.readline(),
+                (
+                    "ERROR elifecleaner:parse:pdf_page_count: WandRuntimeError "
+                    "in pdf_page_count(), imagemagick may not be installed\n"
+                ),
+            )


### PR DESCRIPTION
To start with using `elifecleaner` library, a provider module is added and minimal test cases to check the PDF page count function. A slight upgrade of `Wand` library is included. I expect the results of the test pipeline on this PR will indicate if the `elife-bot-formula` needs adjusting to allow `wand` to read PDF files.