### PR TITLE
Software heritage deposit tweaks

### DIFF
--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -36,16 +36,24 @@ class MetaData(object):
             self.codemeta["authors"] = []
             for author in [author for author in article.contributors]:
                 author_dict = OrderedDict()
-                author_dict["name"] = " ".join(
-                    [
-                        part
-                        for part in [author.given_name, author.surname, author.suffix]
-                        if part is not None
-                    ]
-                )
-                author_dict["affiliations"] = []
-                for aff in author.affiliations:
-                    author_dict["affiliations"].append(aff.text)
+                if author.collab:
+                    author_dict["name"] = author.collab
+                else:
+                    if not author.group_author_key:
+                        author_dict["name"] = " ".join(
+                            [
+                                part
+                                for part in [author.given_name, author.surname, author.suffix]
+                                if part is not None
+                            ]
+                        )
+                if not author_dict.get("name"):
+                    continue
+
+                if author.affiliations:
+                    author_dict["affiliations"] = []
+                    for aff in author.affiliations:
+                        author_dict["affiliations"].append(aff.text)
                 self.codemeta["authors"].append(author_dict)
 
         if file_name:

--- a/starter/starter_SoftwareHeritageDeposit.py
+++ b/starter/starter_SoftwareHeritageDeposit.py
@@ -12,7 +12,7 @@ class starter_SoftwareHeritageDeposit(Starter):
 
     def get_workflow_params(self, run, info):
         workflow_params = default_workflow_params(self.settings)
-        workflow_params["workflow_id"] = "%s_%s" % (self.name, str(info.get("doi_id")))
+        workflow_params["workflow_id"] = "%s_%s" % (self.name, str(info.get("article_id")))
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
         workflow_params["execution_start_to_close_timeout"] = str(60 * 15)

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 
 import unittest
+from collections import OrderedDict
 from xml.etree.ElementTree import Element
 from elifearticle import parse
-from elifearticle.article import Article
+from elifearticle.article import Article, Contributor
 import provider.software_heritage as software_heritage
 
 
@@ -70,3 +71,30 @@ class TestSoftwareHeritageProviderMetadata(unittest.TestCase):
         element = Element("root")
         expected = b'<?xml version="1.0" encoding="utf-8"?><root/>'
         self.assertEqual(software_heritage.metadata_xml(element), expected)
+
+    def test_metadata_xml_contrib_collab(self):
+        "test for group authors in collab tags and group member contributors"
+        collab_contributor = Contributor("author", "", "", "Test Research Group")
+        collab_contributor.group_author_key = "group1"
+        group_member = Contributor("author", "Smith", "Chris")
+        group_member.group_author_key = "group1"
+        self.article.contributors.append(collab_contributor)
+        self.article.contributors.append(group_member)
+        metadata_object = software_heritage.metadata(self.file_name, self.article)
+        expected = [
+            OrderedDict(
+                [
+                    ("name", "Mikhail Tikhonov"),
+                    (
+                        "affiliations",
+                        [
+                            "Center of Mathematical Sciences and Applications, Harvard University, Cambridge, United States",
+                            "Harvard John A Paulson School of Engineering and Applied Sciences, Harvard University, Cambridge, United States",
+                            "Kavli Institute for Bionano Science and Technology, Harvard University, Cambridge, United States",
+                        ],
+                    ),
+                ]
+            ),
+            OrderedDict([("name", "Test Research Group")]),
+        ]
+        self.assertEqual(metadata_object.codemeta["authors"], expected)


### PR DESCRIPTION
Improvements after testing code merged in PR https://github.com/elifesciences/elife-bot/pull/1222

- an incorrect variable name in the `SoftwareHeritageDeposit` starter
- improve support for `collab` or `on-behalf-of` author names, and ignore authors who are a member of a group