### PR TITLE
Change deletion of temp files in PushSWHDeposit.

### DIFF
--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -104,7 +104,9 @@ class activity_PushSWHDeposit(Activity):
             return self.ACTIVITY_PERMANENT_FAILURE
 
         # clean temporary directory
-        self.clean_tmp_dir()
+
+        # do not deleted files from the temp folder for now so they can be inspected
+        # self.clean_tmp_dir()
 
         # return success
         return self.ACTIVITY_SUCCESS

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -21,6 +21,7 @@ class TestPushSWHDeposit(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
             testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
         )


### PR DESCRIPTION
During initial testing of `PushSWHDeposit`, in order to inspect the files that were sent, do not delete them from the activity's temporary directory after a success.

For cleaner testing, delete the temporary files which accumlate after testing.