### PR TITLE
Tweak to download_helper path concatenation.

### DIFF
--- a/provider/download_helper.py
+++ b/provider/download_helper.py
@@ -8,7 +8,7 @@ def file_resource_origin(storage_provider, filename, bucket_name, bucket_folder)
         return None
     storage_provider_prefix = storage_provider + "://"
     orig_resource = storage_provider_prefix + bucket_name + "/" + bucket_folder
-    return orig_resource + '/' + filename
+    return orig_resource.rstrip("/") + "/" + filename
 
 
 def download_file(storage, filename, resource_origin, to_dir):


### PR DESCRIPTION
A small improvement to the `download_helper` provider, if the `bucket_folder` argument is a blank string, it can end up with `//` in the path string. This will remove the first `/` before adding the second `/`.