### PR TITLE
Ingest accepted submission

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -1,0 +1,101 @@
+import os
+import json
+import shutil
+import time
+from S3utility.s3_notification_info import parse_activity_data
+from provider import cleaner, download_helper, utils
+from activity.objects import Activity
+
+
+class activity_ValidateAcceptedSubmission(Activity):
+    "ValidateAcceptedSubmission activity"
+
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_ValidateAcceptedSubmission, self).__init__(
+            settings, logger, conn, token, activity_task
+        )
+
+        self.name = "ValidateAcceptedSubmission"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Download zip file input from the bucket, parse it, check contents "
+            + "and log warning or error messages."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"valid": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        self.make_activity_directories()
+
+        # configure log files for the cleaner provider
+        # log to a common log file
+        cleaner.log_to_file()
+        # log file for this activity only
+        cleaner.log_to_file(os.path.join(self.get_tmp_dir(), self.activity_log_file))
+
+        # parse the input data
+        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+        self.logger.info(
+            "%s, real_filename: %s, bucket_name: %s, bucket_folder: %s"
+            % (self.name, real_filename, bucket_name, bucket_folder)
+        )
+
+        # Download from S3
+        self.input_file = download_helper.download_file_from_s3(
+            self.settings,
+            real_filename,
+            bucket_name,
+            bucket_folder,
+            self.directories.get("INPUT_DIR"),
+        )
+
+        self.logger.info("%s, downloaded file to %s" % (self.name, self.input_file))
+
+        # unzip the file and validate
+        self.statuses["valid"] = cleaner.check_ejp_zip(
+            self.input_file, self.directories.get("TEMP_DIR")
+        )
+
+        self.log_statuses(self.input_file)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -6,3 +6,7 @@ LOG_FILENAME = "elifecleaner.log"
 def log_to_file(filename=None):
     "configure logging to file"
     return configure_logging(filename) if filename else configure_logging(LOG_FILENAME)
+
+
+def check_ejp_zip(zip_file, tmp_dir):
+    return parse.check_ejp_zip(zip_file, tmp_dir)

--- a/register.py
+++ b/register.py
@@ -118,6 +118,7 @@ def start(settings):
     activity_names.append("PackageSWH")
     activity_names.append("GenerateSWHMetadata")
     activity_names.append("PushSWHDeposit")
+    activity_names.append("ValidateAcceptedSubmission")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/register.py
+++ b/register.py
@@ -42,6 +42,7 @@ def start(settings):
     workflow_names.append("IngestDecisionLetter")
     workflow_names.append("DepositDOAJ")
     workflow_names.append("SoftwareHeritageDeposit")
+    workflow_names.append("IngestAcceptedSubmission")
 
     for workflow_name in workflow_names:
         # Import the workflow libraries

--- a/starter/starter_IngestAcceptedSubmission.py
+++ b/starter/starter_IngestAcceptedSubmission.py
@@ -1,0 +1,56 @@
+import json
+from S3utility.s3_notification_info import S3NotificationInfo
+from starter.objects import Starter, default_workflow_params
+from starter.starter_helper import NullRequiredDataException
+
+
+class starter_IngestAcceptedSubmission(Starter):
+    def __init__(self, settings=None, logger=None):
+        super(starter_IngestAcceptedSubmission, self).__init__(
+            settings, logger, "IngestAcceptedSubmission"
+        )
+
+    def get_workflow_params(self, run, info):
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s" % (
+            self.name,
+            info.file_name.replace("/", "_"),
+        )
+        workflow_params["workflow_name"] = self.name
+        workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 15)
+
+        input_data = S3NotificationInfo.to_dict(info)
+        input_data["run"] = run
+        workflow_params["input"] = json.dumps(input_data, default=lambda ob: None)
+
+        return workflow_params
+
+    def start(self, settings, run, info):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(run, info)
+
+    def start_workflow(self, run, info):
+
+        if hasattr(info, "file_name") is False or info.file_name is None:
+            raise NullRequiredDataException("filename is Null. Did not get a filename.")
+
+        self.connect_to_swf()
+
+        workflow_params = self.get_workflow_params(run, info)
+
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except NullRequiredDataException as null_exception:
+            self.logger.exception(null_exception.message)
+            raise
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from ddt import ddt, data
+import activity.activity_ValidateAcceptedSubmission as activity_module
+from activity.activity_ValidateAcceptedSubmission import (
+    activity_ValidateAcceptedSubmission as activity_object,
+)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeStorageContext
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestValidateAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module.download_helper, "storage_context")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_valid_status": True,
+            "expected_log_warning_count": 2,
+        },
+    )
+    def test_do_activity(self, test_data, fake_download_storage_context):
+        # copy files into the input directory using the storage context
+        fake_download_storage_context.return_value = FakeStorageContext()
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("valid"),
+            test_data.get("expected_valid_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        log_file_path = os.path.join(
+            self.activity.get_tmp_dir(), self.activity.activity_log_file
+        )
+        with open(log_file_path, "r") as open_file:
+            log_contents = open_file.read()
+        log_warnings = [
+            line for line in log_contents.split("\n") if line.startswith("WARNING ")
+        ]
+        self.assertEqual(len(log_warnings), test_data.get("expected_log_warning_count"))

--- a/tests/starter/test_starter_ingest_accepted_submission.py
+++ b/tests/starter/test_starter_ingest_accepted_submission.py
@@ -1,0 +1,81 @@
+import unittest
+from mock import patch
+from starter.starter_IngestAcceptedSubmission import starter_IngestAcceptedSubmission
+from starter.starter_helper import NullRequiredDataException
+from S3utility.s3_notification_info import S3NotificationInfo
+from tests.activity.classes_mock import FakeLogger
+import tests.settings_mock as settings_mock
+import tests.test_data as test_data
+from tests.classes_mock import FakeBotoConnection
+
+
+RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
+
+
+class TestStarterIngestAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        self.fake_logger = FakeLogger()
+        self.starter = starter_IngestAcceptedSubmission(
+            settings_mock, logger=self.fake_logger
+        )
+
+    def test_starter_no_article(self):
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            run=RUN_EXAMPLE,
+            info=test_data.data_error_lax,
+        )
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_starter(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(
+            self.starter.start(
+                settings=settings_mock,
+                run=RUN_EXAMPLE,
+                info=S3NotificationInfo.from_dict(
+                    test_data.ingest_accepted_submission_data
+                ),
+            )
+        )
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_workflow(self, fake_boto_conn):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        self.assertIsNone(
+            self.starter.start_workflow(
+                run=RUN_EXAMPLE,
+                info=S3NotificationInfo.from_dict(
+                    test_data.ingest_accepted_submission_data
+                ),
+            )
+        )
+
+    @patch.object(starter_IngestAcceptedSubmission, "start_swf_workflow_execution")
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_workflow_null_exception(self, fake_boto_conn, fake_start):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        fake_start.side_effect = NullRequiredDataException("An exception")
+        with self.assertRaises(NullRequiredDataException):
+            self.starter.start_workflow(
+                run=RUN_EXAMPLE,
+                info=S3NotificationInfo.from_dict(
+                    test_data.ingest_accepted_submission_data
+                ),
+            )
+
+    @patch.object(starter_IngestAcceptedSubmission, "start_swf_workflow_execution")
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_workflow_unhandled_exception(self, fake_boto_conn, fake_start):
+        fake_boto_conn.return_value = FakeBotoConnection()
+        fake_start.side_effect = Exception("An unhandled exception")
+        self.assertIsNone(
+            self.starter.start_workflow(
+                run=RUN_EXAMPLE,
+                info=S3NotificationInfo.from_dict(
+                    test_data.ingest_accepted_submission_data
+                ),
+            )
+        )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -140,6 +140,18 @@ ingest_digest_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                       u'bucket_name': u'exp-elife-bot-digests-input',
                       u'file_size': 14086}
 
+
+ingest_accepted_submission_data = {
+    u"run": u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda",
+    u"event_time": u"2021-06-07T16:14:27.809576Z",
+    u"event_name": u"ObjectCreated:Put",
+    u"file_name": u"30-01-2019-RA-eLife-45644.zip",
+    u"file_etag": u"e7f639f63171c097d4761e2d2efe8dc4",
+    u"bucket_name": u"elife-accepted-submission-cleaning",
+    u"file_size": 41800000,
+}
+
+
 ingest_decision_letter_data = {
   u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
   u'event_time': u'2019-12-13T16:14:27.809576Z',

--- a/tests/workflow/test_workflow_ingest_accepted_submission.py
+++ b/tests/workflow/test_workflow_ingest_accepted_submission.py
@@ -1,0 +1,14 @@
+import unittest
+import tests.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger
+from workflow.workflow_IngestAcceptedSubmission import workflow_IngestAcceptedSubmission
+
+
+class TestWorkflowIngestAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        self.workflow = workflow_IngestAcceptedSubmission(
+            settings_mock, FakeLogger(), None, None, None, None
+        )
+
+    def test_init(self):
+        self.assertEqual(self.workflow.name, "IngestAcceptedSubmission")

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -37,6 +37,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
             "start": {"requirements": None},
             "steps": [
                 define_workflow_step("PingWorker", data),
+                define_workflow_step("ValidateAcceptedSubmission", data),
             ],
             "finish": {"requirements": None},
         }

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -1,0 +1,44 @@
+from workflow.objects import Workflow
+from workflow.helper import define_workflow_step
+
+
+class workflow_IngestAcceptedSubmission(Workflow):
+    def __init__(
+        self,
+        settings,
+        logger,
+        conn=None,
+        token=None,
+        decision=None,
+        maximum_page_size=100,
+    ):
+        super(workflow_IngestAcceptedSubmission, self).__init__(
+            settings, logger, conn, token, decision, maximum_page_size
+        )
+
+        # SWF Defaults
+        self.name = "IngestAcceptedSubmission"
+        self.version = "1"
+        self.description = (
+            "Ingest an accepted submission zip file to validate and modify it"
+        )
+        self.default_execution_start_to_close_timeout = 60 * 5
+        self.default_task_start_to_close_timeout = 30
+
+        # Get the input from the JSON decision response
+        data = self.get_input()
+
+        # JSON format workflow definition, for now - may be from common YAML definition
+        workflow_definition = {
+            "name": self.name,
+            "version": self.version,
+            "task_list": self.settings.default_task_list,
+            "input": data,
+            "start": {"requirements": None},
+            "steps": [
+                define_workflow_step("PingWorker", data),
+            ],
+            "finish": {"requirements": None},
+        }
+
+        self.load_definition(workflow_definition)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6376

Here is some minimal `IngestAcceptedSubmission` workflow functionality to allow testing with bucket data files.

`provider/cleaner.py` module uses https://github.com/elifesciences/elife-cleaner to validate an EJP accepted submission zip file. The current validation is minimal, where any zip file is valid. The validation log messages will be logged to two separate files, for now, one is a unified log file `elifecleaner.log`, and then each `ValidateAcceptedSubmission` activity will log messages to a file specific to that workflow execution.

The new workflow will eventually be started when an S3 notification is read from a queue, and this is not enabled yet; to test the workflow, an S3 notification message data will be constructed and be fed into the workflow starter.

There may be small bugs with the workflow that are not covered by the unittests, and this is the next step after merging this code.

It has no conflicts with other workflows so it should be safe to merge and give it a try on the `continuumtest` or `prod` environment.