### PR TITLE
Accept header to request to Lax versions endpoint.

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -44,6 +44,7 @@ class exp():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
@@ -352,6 +353,7 @@ class dev():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
@@ -657,6 +659,7 @@ class live():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1" 
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -34,6 +34,7 @@ ses_poa_recipient_email = ""
 
 lax_article_endpoint = "https://test/eLife.{article_id}"
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
+lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
 lax_article_related = "https://test/eLife.{article_id}/related"
 verify_ssl = False
 lax_auth_key = 'an_auth_key'


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6732

A new settings value `lax_article_versions_accept_header` will specify the value for the `Accept:` header in a request to the API endpoint specified in the setting value `lax_article_versions`.

Previously, the API endpoint will return the most recent content version as a response, and specifying a specific content version will make transitioning to a newer version of the article versions data easier.

We can specify `Accept:` header values for other endpoints later as we like.

[new] code is linted with `black`.
