### PR TITLE
Software heritage deposit readme file

### DIFF
--- a/activity/activity_GenerateSWHMetadata.py
+++ b/activity/activity_GenerateSWHMetadata.py
@@ -43,6 +43,7 @@ class activity_GenerateSWHMetadata(Activity):
         input_file = session.get_value("input_file")
         bucket_resource = session.get_value("bucket_resource")
         create_origin_url = get_create_origin(data)
+        session.store_value("create_origin_url", create_origin_url)
         self.logger.info(
             (
                 "%s activity session data: article_id: %s, version: %s, input_file: %s, "

--- a/activity/activity_GenerateSWHReadme.py
+++ b/activity/activity_GenerateSWHReadme.py
@@ -1,0 +1,151 @@
+import json
+import os
+from elifearticle import parse
+import provider.article as articlelib
+from provider.execution_context import get_session
+from provider import software_heritage, utils
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+README_FILENAME = "README"
+
+
+class activity_GenerateSWHReadme(Activity):
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_GenerateSWHReadme, self).__init__(
+            settings, logger, conn, token, activity_task
+        )
+
+        self.name = "GenerateSWHReadme"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Generate readme file for inclusion in a Software Heritage deposit"
+        )
+        self.logger = logger
+
+        # Local directory settings
+        self.directories = {
+            "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+    def do_activity(self, data=None):
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        self.make_activity_directories()
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+        article_id = session.get_value("article_id")
+        version = session.get_value("version")
+        input_file = session.get_value("input_file")
+        bucket_resource = session.get_value("bucket_resource")
+        create_origin_url = session.get_value("create_origin_url")
+        self.logger.info(
+            (
+                "%s activity session data: article_id: %s, version: %s, input_file: %s, "
+                "bucket_resource: %s, create_origin_url: %s"
+            )
+            % (
+                self.name,
+                article_id,
+                version,
+                input_file,
+                bucket_resource,
+                create_origin_url,
+            )
+        )
+
+        storage = storage_context(self.settings)
+
+        # download article XML file
+        try:
+            bot_article = articlelib.article(self.settings, self.get_tmp_dir())
+            article_xml_filename = bot_article.download_article_xml_from_s3(
+                utils.pad_msid(article_id)
+            )
+            self.logger.info(
+                "Downloaded article XML for %s to %s"
+                % (article_id, article_xml_filename)
+            )
+        except Exception:
+            self.logger.exception(
+                "Exception raised downloading article XML for %s" % article_id
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # parse XML into article object
+        try:
+            article, error_count = parse.build_article_from_xml(
+                os.path.join(self.get_tmp_dir(), article_xml_filename), detail="full"
+            )
+            self.logger.info(
+                "Parsed article doi %s, error_count: %s" % (article.doi, error_count)
+            )
+        except Exception:
+            self.logger.exception(
+                "Exception raised parsing article XML for %s" % article_xml_filename
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # generate readme file
+        try:
+            readme_keywords = {
+                "article_title": article.title,
+                "doi": article.doi,
+                "article_id": utils.pad_msid(article_id),
+                "create_origin_url": create_origin_url,
+                "content_license": article.license.href,
+            }
+            readme_string = software_heritage.readme(readme_keywords)
+            readme_string = bytes(readme_string, "utf8")
+            self.logger.info("Readme generated for article doi %s" % article.doi)
+        except Exception:
+            self.logger.exception(
+                "Exception raised creating readme for article doi %s" % article.doi
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        self.logger.info(
+            "Readme string for article doi %s: %s" % (article.doi, readme_string)
+        )
+
+        # upload XML metadata file to bucket
+        try:
+            readme_filename = README_FILENAME
+            resource_path = "/".join(
+                [
+                    software_heritage.BUCKET_FOLDER,
+                    run,
+                    readme_filename,
+                ]
+            )
+            resource_dest = "%s://%s/%s" % (
+                self.settings.storage_provider,
+                self.settings.bot_bucket,
+                resource_path,
+            )
+            storage.set_resource_from_string(resource_dest, readme_string)
+            self.logger.info(
+                "Uploaded readme for article %s to %s" % (article.doi, resource_dest)
+            )
+        except Exception:
+            self.logger.exception(
+                "Exception raised uploading readme to bucket for article doi %s"
+                % article.doi
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # save S3 location in session
+        session.store_value("bucket_readme_resource", resource_path)
+
+        # clean temporary directory
+        self.clean_tmp_dir()
+
+        # return success
+        return self.ACTIVITY_SUCCESS

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -3,6 +3,7 @@
 import os
 import requests
 from collections import OrderedDict
+from string import Template
 from xml.dom import minidom
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
@@ -174,6 +175,16 @@ def codemeta_author_affiliations(root, author):
         for affiliation in author.get("affiliations"):
             affiliation_tag = SubElement(root, "%s:%s" % (prefix, section_name))
             affiliation_tag.text = affiliation
+
+
+def readme(kwargs):
+    "generate readme file using a template with string substitutions"
+    string_template = None
+    with open("template/swh_readme_template.txt", "r") as open_file:
+        string_template = Template(open_file.read())
+    if string_template:
+        return string_template.safe_substitute(kwargs)
+    return ""
 
 
 def swh_post_request(

--- a/register.py
+++ b/register.py
@@ -117,6 +117,7 @@ def start(settings):
     activity_names.append("DownstreamStart")
     activity_names.append("PackageSWH")
     activity_names.append("GenerateSWHMetadata")
+    activity_names.append("GenerateSWHReadme")
     activity_names.append("PushSWHDeposit")
     activity_names.append("ValidateAcceptedSubmission")
 

--- a/template/swh_readme_template.txt
+++ b/template/swh_readme_template.txt
@@ -1,0 +1,19 @@
+# Executable Research Article for "$article_title", $doi.
+
+This is an archived version of an Executable Research Article created using tools developed by [Stencila](https://stenci.la/) and published by [eLife Sciences](https://elifesciences.org/).
+
+This repository and the files herein are for the purpose of archiving a static snapshot of the executable article only, and is not intended to preserve the executable features which are dependant on the presence of external services and infrastructure.
+
+The executable article is created using the original article XML, and built into a [Docker](https://www.docker.com/) container which is published in [Stencila Hub](https://hub.stenci.la/projects/).
+
+# Quick Start
+
+The article can be viewed as a static snapshot, minus the executable functionality, by simply opening `index.html` in the browser of your choice.
+
+A version of this article with executable support can be viewed [here]($create_origin_url) or [here](https://elifesciences.org/articles/$article_id/executable)
+
+# License
+
+The article content is licensed under the $content_license.
+
+The code is licensed as per the contents of LICENSE.md.

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -90,6 +90,7 @@ SoftwareHeritageDeposit_session_example = {
     "workflow": "software_heritage",
     "recipient": "software_heritage",
     "input_file": "https://hub.stenci.la/api/projects/518/snapshots/15/archive",
+    "create_origin_url": "https://elife.stencila.io/article-30274/",
     "bucket_resource": (
         "software_heritage/run/"
         "cf9c7e86-7355-4bb4-b48e-0bc284221251/elife-30274-v1-era.zip"
@@ -97,6 +98,10 @@ SoftwareHeritageDeposit_session_example = {
     "bucket_metadata_resource": (
         "software_heritage/run/"
         "cf9c7e86-7355-4bb4-b48e-0bc284221251/elife-30274-v1-era.xml"
+    ),
+    "bucket_readme_resource": (
+        "software_heritage/run/"
+        "cf9c7e86-7355-4bb4-b48e-0bc284221251/README"
     ),
 }
 

--- a/tests/activity/test_activity_generate_swh_readme.py
+++ b/tests/activity/test_activity_generate_swh_readme.py
@@ -1,0 +1,170 @@
+import os
+import shutil
+import unittest
+from mock import patch
+import activity.activity_GenerateSWHReadme as activity_module
+from activity.activity_GenerateSWHReadme import (
+    activity_GenerateSWHReadme as activity_object,
+)
+from provider.article import article
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeStorageContext,
+    FakeSession,
+)
+import tests.activity.test_activity_data as testdata
+import tests.activity.helpers as helpers
+
+
+def fake_download_xml(filename, to_dir):
+    source_doc = os.path.join("tests", "files_source", "software_heritage", filename)
+    dest_doc = os.path.join(to_dir, filename)
+    try:
+        shutil.copy(source_doc, dest_doc)
+        return filename
+    except IOError:
+        pass
+    # default return assume a failure
+    return False
+
+
+class TestGenerateSWHReadme(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+        helpers.delete_files_in_folder(
+            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
+
+    @patch.object(article, "download_article_xml_from_s3")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity(
+        self, mock_storage_context, mock_session, fake_download_article_xml
+    ):
+        article_xml_file = "elife-30274-v2.xml"
+        mock_storage_context.return_value = FakeStorageContext(
+            testdata.ExpandArticle_files_dest_folder
+        )
+        mock_session.return_value = FakeSession(
+            testdata.SoftwareHeritageDeposit_session_example
+        )
+        fake_download_article_xml.return_value = fake_download_xml(
+            article_xml_file, self.activity.get_tmp_dir()
+        )
+
+        return_value = self.activity.do_activity(
+            testdata.SoftwareHeritageDeposit_data_example
+        )
+        self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
+
+        # look at the file contents
+        files = os.listdir(testdata.ExpandArticle_files_dest_folder)
+        readme_files = [
+            file_name
+            for file_name in files
+            if file_name != ".gitkeep" and file_name.startswith("README")
+        ]
+        readme_file = readme_files[0]
+        with open(
+            os.path.join(testdata.ExpandArticle_files_dest_folder, readme_file), "rb"
+        ) as open_file:
+            readme_string = open_file.read()
+            self.assertTrue(
+                b'# Executable Research Article for "Replication Study: Transcriptional '
+                in readme_string
+            )
+
+    @patch.object(article, "download_article_xml_from_s3")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity_article_xml_exception(
+        self, mock_storage_context, mock_session, fake_download_article_xml
+    ):
+        mock_storage_context.return_value = FakeStorageContext()
+        mock_session.return_value = FakeSession(
+            testdata.SoftwareHeritageDeposit_session_example
+        )
+        fake_download_article_xml.side_effect = Exception(
+            "Exception in downloading article XML"
+        )
+
+        return_value = self.activity.do_activity(
+            testdata.SoftwareHeritageDeposit_data_example
+        )
+        self.assertEqual(return_value, self.activity.ACTIVITY_PERMANENT_FAILURE)
+
+    @patch("elifearticle.parse.build_article_from_xml")
+    @patch.object(article, "download_article_xml_from_s3")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity_article_parse_exception(
+        self, mock_storage_context, mock_session, fake_download_article_xml, fake_parse
+    ):
+        article_xml_file = "elife-30274-v2.xml"
+        mock_storage_context.return_value = FakeStorageContext()
+        mock_session.return_value = FakeSession(
+            testdata.SoftwareHeritageDeposit_session_example
+        )
+        fake_download_article_xml.return_value = fake_download_xml(
+            article_xml_file, self.activity.get_tmp_dir()
+        )
+        fake_parse.side_effect = Exception("Exception parsing article XML")
+        return_value = self.activity.do_activity(
+            testdata.SoftwareHeritageDeposit_data_example
+        )
+        self.assertEqual(return_value, self.activity.ACTIVITY_PERMANENT_FAILURE)
+
+    @patch("provider.software_heritage.readme")
+    @patch.object(article, "download_article_xml_from_s3")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity_readme_exception(
+        self,
+        mock_storage_context,
+        mock_session,
+        fake_download_article_xml,
+        fake_readme,
+    ):
+        article_xml_file = "elife-30274-v2.xml"
+        mock_storage_context.return_value = FakeStorageContext()
+        mock_session.return_value = FakeSession(
+            testdata.SoftwareHeritageDeposit_session_example
+        )
+        fake_download_article_xml.return_value = fake_download_xml(
+            article_xml_file, self.activity.get_tmp_dir()
+        )
+        fake_readme.side_effect = Exception("Exception generating readme")
+        return_value = self.activity.do_activity(
+            testdata.SoftwareHeritageDeposit_data_example
+        )
+        self.assertEqual(return_value, self.activity.ACTIVITY_PERMANENT_FAILURE)
+
+    @patch.object(FakeStorageContext, "set_resource_from_string")
+    @patch.object(article, "download_article_xml_from_s3")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity_bucket_exception(
+        self,
+        mock_storage_context,
+        mock_session,
+        fake_download_article_xml,
+        fake_set_resource,
+    ):
+        article_xml_file = "elife-30274-v2.xml"
+        mock_storage_context.return_value = FakeStorageContext()
+        mock_session.return_value = FakeSession(
+            testdata.SoftwareHeritageDeposit_session_example
+        )
+        fake_download_article_xml.return_value = fake_download_xml(
+            article_xml_file, self.activity.get_tmp_dir()
+        )
+        fake_set_resource.side_effect = Exception("Exception uploading readme")
+        return_value = self.activity.do_activity(
+            testdata.SoftwareHeritageDeposit_data_example
+        )
+        self.assertEqual(return_value, self.activity.ACTIVITY_PERMANENT_FAILURE)

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -56,6 +56,11 @@ class TestPushSWHDeposit(unittest.TestCase):
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"
             ),
         )
+        self.assertTrue(
+            self.activity.logger.loginfo[-4].startswith(
+                "PushSWHDeposit, added README file to the zip"
+            )
+        )
 
     @patch("requests.post")
     @patch.object(activity_module, "get_session")

--- a/tests/files_source/software_heritage/run/cf9c7e86-7355-4bb4-b48e-0bc284221251/README
+++ b/tests/files_source/software_heritage/run/cf9c7e86-7355-4bb4-b48e-0bc284221251/README
@@ -1,0 +1,19 @@
+# Executable Research Article for "Replication Study: Transcriptional amplification in tumor cells with elevated c-Myc", 10.7554/eLife.30274.
+
+This is an archived version of an Executable Research Article created using tools developed by [Stencila](https://stenci.la/) and published by [eLife Sciences](https://elifesciences.org/).
+
+This repository and the files herein are for the purpose of archiving a static snapshot of the executable article only, and is not intended to preserve the executable features which are dependant on the presence of external services and infrastructure.
+
+The executable article is created using the original article XML, and built into a [Docker](https://www.docker.com/) container which is published in [Stencila Hub](https://hub.stenci.la/projects/).
+
+# Quick Start
+
+The article can be viewed as a static snapshot, minus the executable functionality, by simply opening `index.html` in the browser of your choice.
+
+A version of this article with executable support can be viewed [here](https://elife.stencila.io/article-30274/) or [here](https://elifesciences.org/articles/30274/executable)
+
+# License
+
+The article content is licensed under the http://creativecommons.org/licenses/by/4.0/.
+
+The code is licensed as per the contents of LICENSE.md.

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -3,9 +3,10 @@
 import unittest
 from collections import OrderedDict
 from xml.etree.ElementTree import Element
+from mock import patch
 from elifearticle import parse
 from elifearticle.article import Article, Contributor
-import provider.software_heritage as software_heritage
+from provider import software_heritage, utils
 
 
 def pretty_string(bytes):
@@ -98,3 +99,25 @@ class TestSoftwareHeritageProviderMetadata(unittest.TestCase):
             OrderedDict([("name", "Test Research Group")]),
         ]
         self.assertEqual(metadata_object.codemeta["authors"], expected)
+
+
+class TestSoftwareHeritageProviderReadme(unittest.TestCase):
+    def test_readme(self):
+        kwargs = {
+            "article_title": "The eLife research article",
+            "doi": "10.7554/eLife.00666",
+            "article_id": utils.pad_msid(666),
+            "create_origin_url": "https://stencila.example.org/article-00666/",
+            "content_license": "http://creativecommons.org/licenses/by/4.0/",
+        }
+        with open("tests/test_data/software_heritage/README", "r") as open_file:
+            expected = open_file.read()
+        readme_string = software_heritage.readme(kwargs)
+        self.assertEqual(readme_string, expected)
+
+    @patch.object(software_heritage, "Template")
+    def test_readme_(self, mock_template):
+        mock_template.return_value = None
+        kwargs = {}
+        readme_string = software_heritage.readme(kwargs)
+        self.assertEqual(readme_string, "")

--- a/tests/test_data/software_heritage/README
+++ b/tests/test_data/software_heritage/README
@@ -1,0 +1,19 @@
+# Executable Research Article for "The eLife research article", 10.7554/eLife.00666.
+
+This is an archived version of an Executable Research Article created using tools developed by [Stencila](https://stenci.la/) and published by [eLife Sciences](https://elifesciences.org/).
+
+This repository and the files herein are for the purpose of archiving a static snapshot of the executable article only, and is not intended to preserve the executable features which are dependant on the presence of external services and infrastructure.
+
+The executable article is created using the original article XML, and built into a [Docker](https://www.docker.com/) container which is published in [Stencila Hub](https://hub.stenci.la/projects/).
+
+# Quick Start
+
+The article can be viewed as a static snapshot, minus the executable functionality, by simply opening `index.html` in the browser of your choice.
+
+A version of this article with executable support can be viewed [here](https://stencila.example.org/article-00666/) or [here](https://elifesciences.org/articles/00666/executable)
+
+# License
+
+The article content is licensed under the http://creativecommons.org/licenses/by/4.0/.
+
+The code is licensed as per the contents of LICENSE.md.

--- a/workflow/workflow_SoftwareHeritageDeposit.py
+++ b/workflow/workflow_SoftwareHeritageDeposit.py
@@ -38,6 +38,7 @@ class workflow_SoftwareHeritageDeposit(Workflow):
                 define_workflow_step("DownstreamStart", data),
                 define_workflow_step("PackageSWH", data),
                 define_workflow_step("GenerateSWHMetadata", data),
+                define_workflow_step("GenerateSWHReadme", data),
                 define_workflow_step("PushSWHDeposit", data),
             ],
             "finish": {"requirements": None},


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6727

Generate a readme file, add it to the Software Heritage zip file prior to depositing it.

This workflow is not fully into production yet, so if green, this shoudl be safe to merge and to test on their staging environment.