### PR TITLE
Software Heritage partial upload logic for large file support

### DIFF
--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -1,6 +1,8 @@
 import json
+import re
 import os
 import zipfile
+from xml.etree import ElementTree
 from provider.execution_context import get_session
 from provider import software_heritage, utils
 from provider.storage_provider import storage_context
@@ -96,28 +98,81 @@ class activity_PushSWHDeposit(Activity):
                 "%s, added README.md file to the zip %s" % (self.name, zip_file_path)
             )
 
-        url = "%s/%s/" % (
+        """
+        In order to support sending larger files to Software Heritage, follow a
+        particular set of requests to their API, setting the In-Progress header value
+        to True as each file is uploaded, until the final file use In-Progress of False
+        """
+
+        # preparatory step, break up the zip file into smaller zip file chunks
+        new_zip_files = split_zip_file(
+            zip_file_path, self.directories.get("TMP_DIR"), self.logger
+        )
+
+        # first API request, part one, upload the first file
+        first_request_url = "%s/%s/" % (
             self.settings.software_heritage_deposit_endpoint,
             self.settings.software_heritage_collection_name,
         )
-
+        first_zip_file_path = os.path.join(
+            self.directories.get("TMP_DIR"), new_zip_files[0]
+        )
         try:
-            response = software_heritage.swh_post_request(
-                url,
-                self.settings.software_heritage_auth_user,
-                self.settings.software_heritage_auth_pass,
-                zip_file_path,
-                atom_file_path,
-                logger=self.logger,
+            response = self.post_file_to_swh(
+                endpoint_url=first_request_url,
+                article_id=article_id,
+                zip_file_path=first_zip_file_path,
+                atom_file_path=None,
+                in_progress=True,
             )
-            self.logger.info(
-                "%s, finished post request to %s, zip_file_path %s, atom_file_path %s"
-                % (self.name, url, zip_file_path, atom_file_path)
-            )
+
         except Exception as exception:
             self.logger.exception(
-                "Exception in %s posting to SWH API endpoint, article_id %s: %s"
-                % (self.name, article_id, str(exception)),
+                "Exception in %s posting first file to endpoint, workflow permanent failure"
+                % self.name,
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # first API request, part two, get the URI of this upload to which we can send more files
+        edit_request_url = endpoint_from_response(response.content)
+        self.logger.info(
+            "%s, endpoint for sending additional files: %s"
+            % (self.name, edit_request_url)
+        )
+
+        # second phase, send each additional file as a separate request
+        for new_zip_file in new_zip_files[1:-1]:
+            zip_file_path = os.path.join(self.directories.get("TMP_DIR"), new_zip_file)
+            try:
+                response = self.post_file_to_swh(
+                    endpoint_url=edit_request_url,
+                    article_id=article_id,
+                    zip_file_path=zip_file_path,
+                    atom_file_path=None,
+                    in_progress=True,
+                )
+
+            except Exception as exception:
+                self.logger.exception(
+                    "Exception in %s posting file %s to endpoint, workflow permanent failure"
+                    % (self.name, new_zip_file),
+                )
+                return self.ACTIVITY_PERMANENT_FAILURE
+
+        # third and final request, upload the metadata XML file with In-Progress False header
+        try:
+            response = self.post_file_to_swh(
+                endpoint_url=first_request_url,
+                article_id=article_id,
+                zip_file_path=None,
+                atom_file_path=atom_file_path,
+                in_progress=False,
+            )
+
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s posting atom file to endpoint, workflow permanent failure"
+                % self.name,
             )
             return self.ACTIVITY_PERMANENT_FAILURE
 
@@ -128,6 +183,37 @@ class activity_PushSWHDeposit(Activity):
 
         # return success
         return self.ACTIVITY_SUCCESS
+
+    def post_file_to_swh(
+        self, endpoint_url, article_id, zip_file_path, atom_file_path, in_progress
+    ):
+        try:
+            response = software_heritage.swh_post_request(
+                endpoint_url,
+                self.settings.software_heritage_auth_user,
+                self.settings.software_heritage_auth_pass,
+                zip_file_path=zip_file_path,
+                atom_file_path=atom_file_path,
+                in_progress=in_progress,
+                logger=self.logger,
+            )
+            self.logger.info(
+                "%s, finished post request to %s, file paths: %s"
+                % (
+                    self.name,
+                    endpoint_url,
+                    ", ".join([str(zip_file_path), str(atom_file_path)]),
+                )
+            )
+
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in %s posting to SWH API endpoint, article_id %s: %s"
+                % (self.name, article_id, str(exception)),
+            )
+            raise
+
+        return response
 
 
 def download_bucket_resource(settings, storage_resource, to_dir, logger):
@@ -144,3 +230,41 @@ def download_bucket_resource(settings, storage_resource, to_dir, logger):
         logger.info("Downloading %s to %s", (storage_resource_origin, file_path))
         storage.get_resource_to_file(storage_resource_origin, open_file)
     return file_path
+
+
+def split_zip_file(zip_file_path, output_dir, logger):
+    "create a new zip file for each file in the original zip file"
+    with zipfile.ZipFile(
+        zip_file_path, "r", zipfile.ZIP_DEFLATED, allowZip64=True
+    ) as open_zip:
+        for zip_info in open_zip.infolist():
+            if zip_info.filename.endswith("/"):
+                logger.info(
+                    'split_zip_file, "%s" ends with a slash, skipping it'
+                    % zip_info.filename
+                )
+                continue
+            clean_filename = re.sub(
+                r"[^a-zA-Z0-9_\.]", "", re.sub(r"/", "__", zip_info.filename)
+            )
+            new_zip_filename = clean_filename + ".zip"
+            logger.info(
+                'split_zip_file, "%s" new zip file name "%s"'
+                % (zip_info.filename, new_zip_filename)
+            )
+
+            with zipfile.ZipFile(
+                os.path.join(output_dir, new_zip_filename),
+                "w",
+                zipfile.ZIP_DEFLATED,
+                allowZip64=True,
+            ) as new_zip:
+                new_zip.writestr(zip_info, open_zip.read(zip_info))
+    return os.listdir(output_dir)
+
+
+def endpoint_from_response(response_string):
+    "from the API response XML, get the endpoint where more media can be posted"
+    root = ElementTree.fromstring(response_string)
+    link_tag = root.find('{http://www.w3.org/2005/Atom}link[@rel="edit-media"]')
+    return link_tag.get("href")

--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -237,7 +237,10 @@ def split_zip_file(zip_file_path, output_dir, logger):
     with zipfile.ZipFile(
         zip_file_path, "r", zipfile.ZIP_DEFLATED, allowZip64=True
     ) as open_zip:
-        for zip_info in open_zip.infolist():
+        open_zip_info_list = open_zip.infolist()
+        for zip_info in sorted(
+            open_zip_info_list, key=lambda zip_info: zip_info.filename
+        ):
             if zip_info.filename.endswith("/"):
                 logger.info(
                     'split_zip_file, "%s" ends with a slash, skipping it'
@@ -260,7 +263,7 @@ def split_zip_file(zip_file_path, output_dir, logger):
                 allowZip64=True,
             ) as new_zip:
                 new_zip.writestr(zip_info, open_zip.read(zip_info))
-    return os.listdir(output_dir)
+    return sorted(os.listdir(output_dir))
 
 
 def endpoint_from_response(response_string):

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -203,12 +203,14 @@ def swh_post_request(
 
     multiple_files = []
 
+    zip_file_name = None
     if zip_file_path:
         zip_file_name = zip_file_path.split(os.sep)[-1]
         multiple_files.append(
             ("file", (zip_file_name, open(zip_file_path, "rb"), "application/zip"))
         )
 
+    atom_file_name = None
     if atom_file_path:
         atom_file_name = atom_file_path.split(os.sep)[-1]
         multiple_files.append(

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -193,20 +193,30 @@ def swh_post_request(
     auth_pass,
     zip_file_path,
     atom_file_path,
+    in_progress=False,
     verify_ssl=False,
     logger=None,
 ):
     "POST data to SWH API endpoint"
 
-    headers = {"In-Progress": "false"}
+    headers = {"In-Progress": "%s" % str(in_progress).lower()}
 
-    zip_file_name = zip_file_path.split(os.sep)[-1]
-    atom_file_name = atom_file_path.split(os.sep)[-1]
+    multiple_files = []
 
-    multiple_files = [
-        ("file", (zip_file_name, open(zip_file_path, "rb"), "application/zip")),
-        ("atom", (atom_file_name, open(atom_file_path, "rb"), "application/atom+xml")),
-    ]
+    if zip_file_path:
+        zip_file_name = zip_file_path.split(os.sep)[-1]
+        multiple_files.append(
+            ("file", (zip_file_name, open(zip_file_path, "rb"), "application/zip"))
+        )
+
+    if atom_file_path:
+        atom_file_name = atom_file_path.split(os.sep)[-1]
+        multiple_files.append(
+            (
+                "atom",
+                (atom_file_name, open(atom_file_path, "rb"), "application/atom+xml"),
+            )
+        )
 
     response = requests.post(
         url,
@@ -217,10 +227,13 @@ def swh_post_request(
     )
 
     if logger:
-        logger.info(
-            "Post zip file %s and atom file %s to SWH API: POST %s"
-            % (zip_file_name, atom_file_name, url)
-        )
+        file_details = []
+        if zip_file_path:
+            file_details.append("zip file %s" % zip_file_name)
+        if atom_file_path:
+            file_details.append("atom file %s" % atom_file_name)
+
+        logger.info("Post %s to SWH API: POST %s" % (", ".join(file_details), url))
         logger.info(
             "Response from SWH API: %s\n%s" % (response.status_code, response.content)
         )

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -52,7 +52,7 @@ class TestPushSWHDeposit(unittest.TestCase):
         self.assertEqual(
             self.activity.logger.loginfo[-3],
             (
-                "Post zip file elife-30274-v1-era.zip and atom file elife-30274-v1-era.xml "
+                "Post zip file elife-30274-v1-era.zip, atom file elife-30274-v1-era.xml "
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"
             ),
         )

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -67,7 +67,7 @@ class TestPushSWHDeposit(unittest.TestCase):
         self.assertEqual(
             self.activity.logger.loginfo[32],
             (
-                "Post zip file Study_48_Protocols_3_4_Combined_Means.csv.zip "
+                "Post zip file README.md.zip "
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"
             ),
         )
@@ -140,18 +140,18 @@ class TestSplitZipFile(unittest.TestCase):
         zip_file_path = os.path.join(input_dir, zip_file_name)
         # expected values after the function call
         loginfo_expected = [
-            "First logger info",
-            'split_zip_file, "article.rmd.media/" ends with a slash, skipping it',
-            'split_zip_file, "index.html.media/" ends with a slash, skipping it',
-            'split_zip_file, "index.html" new zip file name "index.html.zip"',
+            ("First logger info"),
             (
-                'split_zip_file, "Study_48_Protocol_2_Data.csv" '
-                'new zip file name "Study_48_Protocol_2_Data.csv.zip"'
+                'split_zip_file, "Study_48_Figure_2_Supplemental_Tables.csv" '
+                'new zip file name "Study_48_Figure_2_Supplemental_Tables.csv.zip"'
             ),
-            'split_zip_file, "article.rmd" new zip file name "article.rmd.zip"',
             (
                 'split_zip_file, "Study_48_Meta_Analysis.csv" '
                 'new zip file name "Study_48_Meta_Analysis.csv.zip"'
+            ),
+            (
+                'split_zip_file, "Study_48_Protocol_2_Data.csv" '
+                'new zip file name "Study_48_Protocol_2_Data.csv.zip"'
             ),
             (
                 'split_zip_file, "Study_48_Protocols_3_4_Combined_Means.csv" '
@@ -161,85 +161,92 @@ class TestSplitZipFile(unittest.TestCase):
                 'split_zip_file, "article.references.bib" '
                 'new zip file name "article.references.bib.zip"'
             ),
+            ('split_zip_file, "article.rmd" new zip file name "article.rmd.zip"'),
+            ('split_zip_file, "article.rmd.media/" ends with a slash, skipping it'),
             (
-                'split_zip_file, "Study_48_Figure_2_Supplemental_Tables.csv" '
-                'new zip file name "Study_48_Figure_2_Supplemental_Tables.csv.zip"'
-            ),
-            'split_zip_file, "index.html.media/1" new zip file name "index.html.media__1.zip"',
-            (
-                'split_zip_file, "index.html.media/fig2-figsupp2.jpg" '
-                'new zip file name "index.html.media__fig2figsupp2.jpg.zip"'
-            ),
-            (
-                'split_zip_file, "index.html.media/fig1a.png" '
-                'new zip file name "index.html.media__fig1a.png.zip"'
-            ),
-            'split_zip_file, "index.html.media/2" new zip file name "index.html.media__2.zip"',
-            (
-                'split_zip_file, "index.html.media/fig1.jpg" '
-                'new zip file name "index.html.media__fig1.jpg.zip"'
-            ),
-            (
-                'split_zip_file, "index.html.media/fig2.jpg" '
-                'new zip file name "index.html.media__fig2.jpg.zip"'
-            ),
-            (
-                'split_zip_file, "index.html.media/fig2-figsupp1.jpg" '
-                'new zip file name "index.html.media__fig2figsupp1.jpg.zip"'
-            ),
-            'split_zip_file, "index.html.media/0" new zip file name "index.html.media__0.zip"',
-            (
-                'split_zip_file, "index.html.media/fig3.jpg" '
-                'new zip file name "index.html.media__fig3.jpg.zip"'
-            ),
-            (
-                'split_zip_file, "article.rmd.media/fig2-figsupp2.jpg" '
-                'new zip file name "article.rmd.media__fig2figsupp2.jpg.zip"'
+                'split_zip_file, "article.rmd.media/fig1.jpg" '
+                'new zip file name "article.rmd.media__fig1.jpg.zip"'
             ),
             (
                 'split_zip_file, "article.rmd.media/fig1a.png" '
                 'new zip file name "article.rmd.media__fig1a.png.zip"'
             ),
             (
-                'split_zip_file, "article.rmd.media/fig1.jpg" '
-                'new zip file name "article.rmd.media__fig1.jpg.zip"'
+                'split_zip_file, "article.rmd.media/fig2-figsupp1.jpg" '
+                'new zip file name "article.rmd.media__fig2figsupp1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig2-figsupp2.jpg" '
+                'new zip file name "article.rmd.media__fig2figsupp2.jpg.zip"'
             ),
             (
                 'split_zip_file, "article.rmd.media/fig2.jpg" '
                 'new zip file name "article.rmd.media__fig2.jpg.zip"'
             ),
             (
-                'split_zip_file, "article.rmd.media/fig2-figsupp1.jpg" '
-                'new zip file name "article.rmd.media__fig2figsupp1.jpg.zip"'
-            ),
-            (
                 'split_zip_file, "article.rmd.media/fig3.jpg" '
                 'new zip file name "article.rmd.media__fig3.jpg.zip"'
             ),
+            ('split_zip_file, "index.html" new zip file name "index.html.zip"'),
+            ('split_zip_file, "index.html.media/" ends with a slash, skipping it'),
+            (
+                'split_zip_file, "index.html.media/0" new zip file name "index.html.media__0.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/1" new zip file name "index.html.media__1.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/2" new zip file name "index.html.media__2.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig1.jpg" '
+                'new zip file name "index.html.media__fig1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig1a.png" '
+                'new zip file name "index.html.media__fig1a.png.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig2-figsupp1.jpg" '
+                'new zip file name "index.html.media__fig2figsupp1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig2-figsupp2.jpg" '
+                'new zip file name "index.html.media__fig2figsupp2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig2.jpg" '
+                'new zip file name "index.html.media__fig2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig3.jpg" '
+                'new zip file name "index.html.media__fig3.jpg.zip"'
+            ),
         ]
+
         return_value_expected = [
-            "Study_48_Protocols_3_4_Combined_Means.csv.zip",
-            "Study_48_Meta_Analysis.csv.zip",
-            "article.rmd.media__fig2.jpg.zip",
-            "article.rmd.media__fig1a.png.zip",
             "Study_48_Figure_2_Supplemental_Tables.csv.zip",
-            "article.rmd.media__fig3.jpg.zip",
-            "index.html.zip",
+            "Study_48_Meta_Analysis.csv.zip",
+            "Study_48_Protocol_2_Data.csv.zip",
+            "Study_48_Protocols_3_4_Combined_Means.csv.zip",
             "article.references.bib.zip",
             "article.rmd.media__fig1.jpg.zip",
-            "index.html.media__2.zip",
+            "article.rmd.media__fig1a.png.zip",
+            "article.rmd.media__fig2.jpg.zip",
+            "article.rmd.media__fig2figsupp1.jpg.zip",
+            "article.rmd.media__fig2figsupp2.jpg.zip",
+            "article.rmd.media__fig3.jpg.zip",
+            "article.rmd.zip",
             "index.html.media__0.zip",
             "index.html.media__1.zip",
-            "article.rmd.media__fig2figsupp1.jpg.zip",
-            "Study_48_Protocol_2_Data.csv.zip",
+            "index.html.media__2.zip",
             "index.html.media__fig1.jpg.zip",
-            "index.html.media__fig2figsupp1.jpg.zip",
-            "article.rmd.zip",
-            "article.rmd.media__fig2figsupp2.jpg.zip",
-            "index.html.media__fig3.jpg.zip",
-            "index.html.media__fig2.jpg.zip",
-            "index.html.media__fig2figsupp2.jpg.zip",
             "index.html.media__fig1a.png.zip",
+            "index.html.media__fig2.jpg.zip",
+            "index.html.media__fig2figsupp1.jpg.zip",
+            "index.html.media__fig2figsupp2.jpg.zip",
+            "index.html.media__fig3.jpg.zip",
+            "index.html.zip",
         ]
         # call the function
         return_value = activity_module.split_zip_file(zip_file_path, tmp_dir, logger)

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -1,5 +1,8 @@
+import os
+import shutil
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 import activity.activity_PushSWHDeposit as activity_module
 from activity.activity_PushSWHDeposit import (
     activity_PushSWHDeposit as activity_object,
@@ -35,7 +38,11 @@ class TestPushSWHDeposit(unittest.TestCase):
             testdata.SoftwareHeritageDeposit_session_example
         )
         response = FakeResponse(201)
-        response.content = "SWH endpoint response"
+        with open(
+            "tests/test_data/software_heritage/response_content_example.xml", "rb"
+        ) as open_file:
+            response_string = open_file.read()
+        response.content = response_string
         mock_requests_post.return_value = response
 
         # do_activity
@@ -45,19 +52,27 @@ class TestPushSWHDeposit(unittest.TestCase):
 
         # assertions
         self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
-        self.assertEqual(
-            self.activity.logger.loginfo[-2],
-            "Response from SWH API: 201\nSWH endpoint response",
+        # note: if the assertions below on the loginfo are hard to maintain,
+        # they can potentially be removed
+        self.assertTrue(
+            self.activity.logger.loginfo[34].startswith(
+                "PushSWHDeposit, finished post request to "
+                "https://deposit.swh.example.org/1/elife/, file path"
+            ),
         )
         self.assertEqual(
-            self.activity.logger.loginfo[-3],
+            self.activity.logger.loginfo[33],
+            "Response from SWH API: 201\n%s" % response_string,
+        )
+        self.assertEqual(
+            self.activity.logger.loginfo[32],
             (
-                "Post zip file elife-30274-v1-era.zip, atom file elife-30274-v1-era.xml "
+                "Post zip file Study_48_Protocols_3_4_Combined_Means.csv.zip "
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"
             ),
         )
         self.assertTrue(
-            self.activity.logger.loginfo[-4].startswith(
+            self.activity.logger.loginfo[6].startswith(
                 "PushSWHDeposit, added README.md file to the zip"
             )
         )
@@ -96,4 +111,150 @@ class TestPushSWHDeposit(unittest.TestCase):
         self.assertEqual(
             self.activity.logger.loginfo[-1],
             "PushSWHDeposit, software_heritage_deposit_endpoint setting is empty or missing",
+        )
+
+
+class TestSplitZipFile(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_split_zip_file(self):
+        logger = FakeLogger()
+        zip_file_name = "elife-30274-v1-era.zip"
+        # create temporary directories for testing
+        directory = TempDirectory()
+        directory.makedir("input_dir")
+        input_dir = os.path.join(directory.path, "input_dir")
+        directory.makedir("tmp_dir")
+        tmp_dir = os.path.join(directory.path, "tmp_dir")
+        # copy the zip file into the input_dir
+        zip_file_fixture_path = os.path.join(
+            "tests",
+            "files_source",
+            "software_heritage",
+            "run",
+            "cf9c7e86-7355-4bb4-b48e-0bc284221251/",
+            zip_file_name,
+        )
+        shutil.copy(zip_file_fixture_path, input_dir)
+        zip_file_path = os.path.join(input_dir, zip_file_name)
+        # expected values after the function call
+        loginfo_expected = [
+            "First logger info",
+            'split_zip_file, "article.rmd.media/" ends with a slash, skipping it',
+            'split_zip_file, "index.html.media/" ends with a slash, skipping it',
+            'split_zip_file, "index.html" new zip file name "index.html.zip"',
+            (
+                'split_zip_file, "Study_48_Protocol_2_Data.csv" '
+                'new zip file name "Study_48_Protocol_2_Data.csv.zip"'
+            ),
+            'split_zip_file, "article.rmd" new zip file name "article.rmd.zip"',
+            (
+                'split_zip_file, "Study_48_Meta_Analysis.csv" '
+                'new zip file name "Study_48_Meta_Analysis.csv.zip"'
+            ),
+            (
+                'split_zip_file, "Study_48_Protocols_3_4_Combined_Means.csv" '
+                'new zip file name "Study_48_Protocols_3_4_Combined_Means.csv.zip"'
+            ),
+            (
+                'split_zip_file, "article.references.bib" '
+                'new zip file name "article.references.bib.zip"'
+            ),
+            (
+                'split_zip_file, "Study_48_Figure_2_Supplemental_Tables.csv" '
+                'new zip file name "Study_48_Figure_2_Supplemental_Tables.csv.zip"'
+            ),
+            'split_zip_file, "index.html.media/1" new zip file name "index.html.media__1.zip"',
+            (
+                'split_zip_file, "index.html.media/fig2-figsupp2.jpg" '
+                'new zip file name "index.html.media__fig2figsupp2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig1a.png" '
+                'new zip file name "index.html.media__fig1a.png.zip"'
+            ),
+            'split_zip_file, "index.html.media/2" new zip file name "index.html.media__2.zip"',
+            (
+                'split_zip_file, "index.html.media/fig1.jpg" '
+                'new zip file name "index.html.media__fig1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig2.jpg" '
+                'new zip file name "index.html.media__fig2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "index.html.media/fig2-figsupp1.jpg" '
+                'new zip file name "index.html.media__fig2figsupp1.jpg.zip"'
+            ),
+            'split_zip_file, "index.html.media/0" new zip file name "index.html.media__0.zip"',
+            (
+                'split_zip_file, "index.html.media/fig3.jpg" '
+                'new zip file name "index.html.media__fig3.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig2-figsupp2.jpg" '
+                'new zip file name "article.rmd.media__fig2figsupp2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig1a.png" '
+                'new zip file name "article.rmd.media__fig1a.png.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig1.jpg" '
+                'new zip file name "article.rmd.media__fig1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig2.jpg" '
+                'new zip file name "article.rmd.media__fig2.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig2-figsupp1.jpg" '
+                'new zip file name "article.rmd.media__fig2figsupp1.jpg.zip"'
+            ),
+            (
+                'split_zip_file, "article.rmd.media/fig3.jpg" '
+                'new zip file name "article.rmd.media__fig3.jpg.zip"'
+            ),
+        ]
+        return_value_expected = [
+            "Study_48_Protocols_3_4_Combined_Means.csv.zip",
+            "Study_48_Meta_Analysis.csv.zip",
+            "article.rmd.media__fig2.jpg.zip",
+            "article.rmd.media__fig1a.png.zip",
+            "Study_48_Figure_2_Supplemental_Tables.csv.zip",
+            "article.rmd.media__fig3.jpg.zip",
+            "index.html.zip",
+            "article.references.bib.zip",
+            "article.rmd.media__fig1.jpg.zip",
+            "index.html.media__2.zip",
+            "index.html.media__0.zip",
+            "index.html.media__1.zip",
+            "article.rmd.media__fig2figsupp1.jpg.zip",
+            "Study_48_Protocol_2_Data.csv.zip",
+            "index.html.media__fig1.jpg.zip",
+            "index.html.media__fig2figsupp1.jpg.zip",
+            "article.rmd.zip",
+            "article.rmd.media__fig2figsupp2.jpg.zip",
+            "index.html.media__fig3.jpg.zip",
+            "index.html.media__fig2.jpg.zip",
+            "index.html.media__fig2figsupp2.jpg.zip",
+            "index.html.media__fig1a.png.zip",
+        ]
+        # call the function
+        return_value = activity_module.split_zip_file(zip_file_path, tmp_dir, logger)
+        # test assertions
+        self.assertEqual(logger.loginfo, loginfo_expected)
+        self.assertEqual(return_value, return_value_expected)
+
+
+class TestEndpointFromResponse(unittest.TestCase):
+    def test_endpoint_from_response(self):
+        with open(
+            "tests/test_data/software_heritage/response_content_example.xml", "rb"
+        ) as open_file:
+            response_string = open_file.read()
+        endpoint = activity_module.endpoint_from_response(response_string)
+        self.assertEqual(
+            endpoint, "https://deposit.softwareheritage.org/1/elife/1677/media/"
         )

--- a/tests/test_data/software_heritage/response_content_example.xml
+++ b/tests/test_data/software_heritage/response_content_example.xml
@@ -1,0 +1,28 @@
+<entry xmlns="http://www.w3.org/2005/Atom"
+       xmlns:sword="http://purl.org/net/sword/terms/"
+       xmlns:dcterms="http://purl.org/dc/terms/"
+       xmlns:sd="https://www.softwareheritage.org/schema/2018/deposit"
+       >
+    <sd:deposit_id>1677</sd:deposit_id>
+    <sd:deposit_date>June 30, 2021, 4:14 p.m.</sd:deposit_date>
+    <sd:deposit_archive>elife-30274-v1-era.zip</sd:deposit_archive>
+    <sd:deposit_status>deposited</sd:deposit_status>
+
+    <!-- The following tags are deprecated and may be removed in the future,
+         as they do not belong in the http://www.w3.org/2005/Atom namespace. -->
+    <deposit_id>1677</deposit_id>
+    <deposit_date>June 30, 2021, 4:14 p.m.</deposit_date>
+    <deposit_archive>elife-30274-v1-era.zip</deposit_archive>
+    <deposit_status>deposited</deposit_status>
+
+    <!-- Edit-IRI -->
+    <link rel="edit" href="https://deposit.softwareheritage.org/1/elife/1677/atom/" />
+    <!-- EM-IRI -->
+    <link rel="edit-media" href="https://deposit.softwareheritage.org/1/elife/1677/media/"/>
+    <!-- SE-IRI -->
+    <link rel="http://purl.org/net/sword/terms/add" href="https://deposit.softwareheritage.org/1/elife/1677/metadata/" />
+    <!-- State-IRI -->
+    <link rel="alternate" href="https://deposit.softwareheritage.org/1/elife/1677/status/" />
+
+    <sword:packaging>http://purl.org/net/sword/package/SimpleZip</sword:packaging>
+</entry>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

An enhancement to the Software Heritage deposit workflow, as a result of trying to send a zip file exceeding the memory limit for sending in a single request.

The process is described on the issue mentioned above, but the basics are to make the "In-Progress" header of the request to be configurable (as `True` or `False`), to break apart the zip file into smaller chunks to upload each separately, and once the first file is send, we use a different endpoint to send the subsequent files.

I will not be surprised if when testing this it will uncover a bug or two, especially for when parsing the XML response content to get the new endpoint. There could be other unanticipated bugs that are not covered in the unit tests. Fortunately, this workflow is only triggered manually at this time, plus it can be tested on the staging environment first before using it on the production environment.