### PR TITLE
Fix push to SWH, always send atom file, plus more.

### DIFF
--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -67,7 +67,7 @@ class TestPushSWHDeposit(unittest.TestCase):
         self.assertEqual(
             self.activity.logger.loginfo[32],
             (
-                "Post zip file README.md.zip "
+                "Post zip file README.md.zip, atom file elife-30274-v1-era.xml "
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"
             ),
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

A fix to the code merged in PR https://github.com/elifesciences/elife-bot/pull/1242

When testing the updated procedure with the Software Heritage staging system, discovered that the atom XML file must be sent along side the zip file on every API request.

I also added an enhancement for any situation when there is only one or two files to be sent, to use the appropriate `In-Progress` header in the case of sending only one file, and if there are only two files, then the second file will be the final file to send.

This can be tested again on the staging environment to check for any next issues to resolve.