### PR TITLE
In Push SWH, atom file sent only on first request.

### DIFF
--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -157,7 +157,7 @@ class activity_PushSWHDeposit(Activity):
                         endpoint_url=edit_request_url,
                         article_id=article_id,
                         zip_file_path=zip_file_path,
-                        atom_file_path=atom_file_path,
+                        atom_file_path=None,
                         in_progress=True,
                     )
 
@@ -178,7 +178,7 @@ class activity_PushSWHDeposit(Activity):
                     endpoint_url=edit_request_url,
                     article_id=article_id,
                     zip_file_path=final_zip_file_path,
-                    atom_file_path=atom_file_path,
+                    atom_file_path=None,
                     in_progress=False,
                 )
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

Testing again the Software Heritage upload to their staging site, the atom XML file must be sent on the first request, and must not be sent on any subsequent request.