### PR TITLE
Different headers for zip only to SWH endpoint.

### DIFF
--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -169,6 +169,32 @@ class TestSWHPostRequest(unittest.TestCase):
         )
 
     @patch("requests.post")
+    def test_swh_post_request_201_zip_only(self, mock_requests_post):
+        url = "https://example.org/"
+        response_content = (
+            '<entry><link rel="edit-media" href="/1/hal/10/media/"/></entry>'
+        )
+        response = FakeResponse(201)
+        response.content = response_content
+        mock_requests_post.return_value = response
+        response = software_heritage.swh_post_request(
+            url,
+            settings_mock.software_heritage_auth_user,
+            settings_mock.software_heritage_auth_pass,
+            self.zip_file_path,
+            None,
+            in_progress=False,
+            logger=self.logger,
+        )
+        self.assertEqual(
+            self.logger.loginfo[-1], "Response from SWH API: 201\n%s" % response_content
+        )
+        self.assertEqual(
+            self.logger.loginfo[-2],
+            "Post zip file %s to SWH API: POST %s" % (self.zip_file_name, url),
+        )
+
+    @patch("requests.post")
     def test_swh_post_request_412(self, mock_requests_post):
         url = "https://example.org/"
         response = FakeResponse(412)


### PR DESCRIPTION
Discovered by testing against the Software Heritage staging site the new procedure to support the sending of large files, the first upload request, with a zip and atom XML file, can have a `Content-Type: multipart/form-data` header, but sending a zip file only needs to have a `Content-Type: application/zip` header.

Meaning, when using Python `requests` library, the first upload can use the `files` argument, but the next uploads need to use the `data` argument.

This is still to be tested and confirmed with the Software Heritage staging site endpoint again.