### PR TITLE
Content-Disposition header to SWH zip file request

### DIFF
--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -226,8 +226,10 @@ def swh_post_request(
         )
     elif zip_file_path:
         # if only a zip file, send with a Content-Type: application/zip header
+        # also must include a Content-Disposition header
         with open(zip_file_path, "rb") as payload:
             headers["Content-Type"] = "application/zip"
+            headers["Content-Disposition"] = 'attachment; filename="%s"' % zip_file_name
             response = requests.post(
                 url,
                 data=payload,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

Another test to Software Heritage API endpoint with status code `400`, it did not contain a `Content-Disposition` header, as shown on https://docs.softwareheritage.org/devel/swh-deposit/endpoints/update-media.html this header is required.