### PR TITLE
Fix typo in PushSWHDeposit, missed a file upload.

### DIFF
--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -148,7 +148,7 @@ class activity_PushSWHDeposit(Activity):
         if len(new_zip_files) > 2:
 
             # second phase, send each additional file as a separate request
-            for new_zip_file in new_zip_files[1:-2]:
+            for new_zip_file in new_zip_files[1:-1]:
                 zip_file_path = os.path.join(
                     self.directories.get("TMP_DIR"), new_zip_file
                 )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

Fix a typo in list indexes which ended up missing a file to upload as part of the inner loop of API requests.