### PR TITLE
Increase Software Heritage workflow timeouts and log more info about sending

### DIFF
--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -108,6 +108,9 @@ class activity_PushSWHDeposit(Activity):
         new_zip_files = split_zip_file(
             zip_file_path, self.directories.get("TMP_DIR"), self.logger
         )
+        self.logger.info(
+            "%s, ready to send %s zip files" % (self.name, len(new_zip_files))
+        )
 
         # first API request, part one, upload the first file
         first_request_url = "%s/%s/" % (
@@ -146,9 +149,13 @@ class activity_PushSWHDeposit(Activity):
 
         # send multiple files in a loop if there is more than two files to upload
         if len(new_zip_files) > 2:
-
+            file_count = 2
             # second phase, send each additional file as a separate request
             for new_zip_file in new_zip_files[1:-1]:
+                self.logger.info(
+                    "%s, sending zip file %s of %s"
+                    % (self.name, file_count, len(new_zip_files))
+                )
                 zip_file_path = os.path.join(
                     self.directories.get("TMP_DIR"), new_zip_file
                 )
@@ -167,6 +174,8 @@ class activity_PushSWHDeposit(Activity):
                         % (self.name, new_zip_file),
                     )
                     return self.ACTIVITY_PERMANENT_FAILURE
+
+                file_count = file_count + 1
 
         # third and final request, upload the final file with In-Progress False header
         if len(new_zip_files) > 1:

--- a/starter/starter_SoftwareHeritageDeposit.py
+++ b/starter/starter_SoftwareHeritageDeposit.py
@@ -15,7 +15,7 @@ class starter_SoftwareHeritageDeposit(Starter):
         workflow_params["workflow_id"] = "%s_%s" % (self.name, str(info.get("article_id")))
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
-        workflow_params["execution_start_to_close_timeout"] = str(60 * 15)
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 45)
 
         input_data = info
         input_data["run"] = run

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -55,17 +55,17 @@ class TestPushSWHDeposit(unittest.TestCase):
         # note: if the assertions below on the loginfo are hard to maintain,
         # they can potentially be removed
         self.assertTrue(
-            self.activity.logger.loginfo[34].startswith(
+            self.activity.logger.loginfo[35].startswith(
                 "PushSWHDeposit, finished post request to "
                 "https://deposit.swh.example.org/1/elife/, file path"
             ),
         )
         self.assertEqual(
-            self.activity.logger.loginfo[33],
+            self.activity.logger.loginfo[34],
             "Response from SWH API: 201\n%s" % response_string,
         )
         self.assertEqual(
-            self.activity.logger.loginfo[32],
+            self.activity.logger.loginfo[33],
             (
                 "Post zip file README.md.zip, atom file elife-30274-v1-era.xml "
                 "to SWH API: POST https://deposit.swh.example.org/1/elife/"

--- a/workflow/workflow_SoftwareHeritageDeposit.py
+++ b/workflow/workflow_SoftwareHeritageDeposit.py
@@ -20,7 +20,7 @@ class workflow_SoftwareHeritageDeposit(Workflow):
         self.name = "SoftwareHeritageDeposit"
         self.version = "1"
         self.description = "Deposit article data to Software Heritage repository"
-        self.default_execution_start_to_close_timeout = 60 * 15
+        self.default_execution_start_to_close_timeout = 60 * 45
         self.default_task_start_to_close_timeout = 30
 
         # Get the input from the JSON decision response
@@ -39,7 +39,13 @@ class workflow_SoftwareHeritageDeposit(Workflow):
                 define_workflow_step("PackageSWH", data),
                 define_workflow_step("GenerateSWHMetadata", data),
                 define_workflow_step("GenerateSWHReadme", data),
-                define_workflow_step("PushSWHDeposit", data),
+                define_workflow_step(
+                    "PushSWHDeposit", data,
+                    heartbeat_timeout=60 * 45,
+                    schedule_to_close_timeout=60 * 45,
+                    schedule_to_start_timeout=60 * 5,
+                    start_to_close_timeout=60 * 45,
+                ),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6773

Extend the timeout of sending files to Software Heritage from 5 minutes to 45 minutes, as a result of testing a large file which is split into many smaller files. Also, log the total number of files to be sent, and the progress of each file sent to the info log, so it is easier to observe the sending.