### PR TITLE
Use current article-history+json version=2 data from Lax

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -9,7 +9,7 @@ from provider.utils import base64_encode_string
 
 
 identity = "process_%s" % os.getpid()
-logger = log.logger("lax_provider.log", 'INFO', identity, loggerName=__name__)
+logger = log.logger("lax_provider.log", "INFO", identity, loggerName=__name__)
 
 
 class ErrorCallingLaxException(Exception):
@@ -29,8 +29,10 @@ def lax_request(
     status_code = response.status_code
     if status_code not in [200, 404]:
         raise ErrorCallingLaxException(
-            "Error looking up article " + article_id + " %s in Lax: %s\n%s" %
-            (request_type, status_code, response.content))
+            "Error looking up article "
+            + article_id
+            + " %s in Lax: %s\n%s" % (request_type, status_code, response.content)
+        )
 
     if status_code == 200:
         data = response.json()
@@ -45,7 +47,7 @@ def lax_request(
 def lax_auth_header(auth_key):
     "headers for requests to lax"
     if auth_key:
-        return {'Authorization': auth_key}
+        return {"Authorization": auth_key}
     return {}
 
 
@@ -53,14 +55,15 @@ def lax_auth_key(settings, auth=False):
     "value for the Authorization header in lax for public or auth by key"
     if auth:
         return settings.lax_auth_key
-    return 'public'
+    return "public"
 
 
 def article_json(article_id, settings, auth=False):
     "get json for the latest article version from lax"
-    url = settings.lax_article_endpoint.replace('{article_id}', article_id)
-    return lax_request(url, article_id, settings.verify_ssl, None,
-                       lax_auth_key(settings, auth))
+    url = settings.lax_article_endpoint.replace("{article_id}", article_id)
+    return lax_request(
+        url, article_id, settings.verify_ssl, None, lax_auth_key(settings, auth)
+    )
 
 
 def article_versions(article_id, settings, auth=False):
@@ -98,7 +101,9 @@ def article_snippet(article_id, version, settings, auth=False):
             vd for vd in data if vd.get("version") and vd["version"] == int(version)
         )
         return snippet
-    raise Exception("Error in article_snippet: Version not found. Status: " + str(status_code))
+    raise Exception(
+        "Error in article_snippet: Version not found. Status: " + str(status_code)
+    )
 
 
 def article_status_version_map(article_id, settings, auth=False):
@@ -149,7 +154,9 @@ def article_next_version(article_id, settings):
     if isinstance(version, int) and version >= 0:
         version = str(version + 1)
     if version is None:
-        raise RuntimeError("Error looking up article next version. Version is Null. Check call to Lax.")
+        raise RuntimeError(
+            "Error looking up article next version. Version is Null. Check call to Lax."
+        )
     return version
 
 
@@ -159,7 +166,10 @@ def article_version_date_by_version(article_id, version, settings):
     if status_code == 200:
         version_data = next(vd for vd in data if vd["version"] == int(version))
         return parse(version_data["versionDate"]).strftime("%Y-%m-%dT%H:%M:%SZ")
-    raise Exception("Error in article_publication_date_by_version: Version date not found. Status: " + str(status_code))
+    raise Exception(
+        "Error in article_publication_date_by_version: Version date not found. Status: "
+        + str(status_code)
+    )
 
 
 def article_publication_date(article_id, settings, logger=None):
@@ -175,20 +185,26 @@ def article_publication_date(article_id, settings, logger=None):
             return None
         date_str = None
         try:
-            date_struct = time.strptime(first_published_version['published'], "%Y-%m-%dT%H:%M:%SZ")
-            date_str = time.strftime('%Y%m%d%H%M%S', date_struct)
+            date_struct = time.strptime(
+                first_published_version["published"], "%Y-%m-%dT%H:%M:%SZ"
+            )
+            date_str = time.strftime("%Y%m%d%H%M%S", date_struct)
 
         except:
             if logger:
-                logger.error("Error parsing the datetime_published from Lax: "
-                             + str(first_published_version['published']))
+                logger.error(
+                    "Error parsing the datetime_published from Lax: "
+                    + str(first_published_version["published"])
+                )
 
         return date_str
     elif status_code == 404:
         return None
     else:
         if logger:
-            logger.error("Error obtaining version information from Lax" + str(status_code))
+            logger.error(
+                "Error obtaining version information from Lax" + str(status_code)
+            )
         return None
 
 
@@ -220,6 +236,7 @@ def was_ever_poa(article_id, settings):
     else:
         return None
 
+
 def published_considering_poa_status(article_id, settings, is_poa, was_ever_poa):
     """
     Check the lax data for whether an article is published
@@ -231,8 +248,9 @@ def published_considering_poa_status(article_id, settings, is_poa, was_ever_poa)
     else:
         poa_status, vor_status = None, None
     # Now a decision can be made
-    if ((is_poa is True and was_ever_poa is True) or
-        (is_poa is False and was_ever_poa is False)):
+    if (is_poa is True and was_ever_poa is True) or (
+        is_poa is False and was_ever_poa is False
+    ):
         # In this case, any version is sufficient
         if poa_status or vor_status:
             return True
@@ -257,37 +275,55 @@ def article_retracted_status(article_id, settings):
     return retracted_status
 
 
-def prepare_action_message(settings, article_id, run, expanded_folder, version,
-                           status, action, force=False, run_type=None):
-        xml_bucket = settings.publishing_buckets_prefix + settings.expanded_bucket
-        xml_file_name = get_xml_file_name(settings, expanded_folder, xml_bucket)
-        xml_path = 'https://s3-external-1.amazonaws.com/' + xml_bucket + '/' + expanded_folder + '/' + xml_file_name
-        carry_over_data = {
-            'action': action,
-            'location': xml_path,
-            'id': article_id,
-            'version': int(version),
-            'force': force,
-            'token': lax_token(run, version, expanded_folder, status, force, run_type)
-        }
-        message = carry_over_data
-        return message
+def prepare_action_message(
+    settings,
+    article_id,
+    run,
+    expanded_folder,
+    version,
+    status,
+    action,
+    force=False,
+    run_type=None,
+):
+    xml_bucket = settings.publishing_buckets_prefix + settings.expanded_bucket
+    xml_file_name = get_xml_file_name(settings, expanded_folder, xml_bucket)
+    xml_path = (
+        "https://s3-external-1.amazonaws.com/"
+        + xml_bucket
+        + "/"
+        + expanded_folder
+        + "/"
+        + xml_file_name
+    )
+    carry_over_data = {
+        "action": action,
+        "location": xml_path,
+        "id": article_id,
+        "version": int(version),
+        "force": force,
+        "token": lax_token(run, version, expanded_folder, status, force, run_type),
+    }
+    message = carry_over_data
+    return message
 
 
 def get_xml_file_name(settings, expanded_folder, xml_bucket, version=None):
     Article = article.article()
-    xml_file_name = Article.get_xml_file_name(settings, expanded_folder, xml_bucket, version)
+    xml_file_name = Article.get_xml_file_name(
+        settings, expanded_folder, xml_bucket, version
+    )
     return xml_file_name
 
 
 def lax_token(run, version, expanded_folder, status, force=False, run_type=None):
     token = {
-        'run': run, 
-        'version': version,
-        'expanded_folder': expanded_folder,
-        'status': status,
-        'force': force,
-        'run_type': run_type
+        "run": run,
+        "version": version,
+        "expanded_folder": expanded_folder,
+        "status": status,
+        "force": force,
+        "run_type": run_type,
     }
     return base64_encode_string(json.dumps(token))
 
@@ -296,4 +332,4 @@ def message_from_lax(data):
     """
     format a message from a Lax response data
     """
-    return data.get('message') if data.get('message') else '(empty message)'
+    return data.get("message") if data.get("message") else "(empty message)"

--- a/settings-example.py
+++ b/settings-example.py
@@ -44,7 +44,7 @@ class exp():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
-    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=2"
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
@@ -353,7 +353,7 @@ class dev():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
-    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=2"
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 
@@ -659,7 +659,7 @@ class live():
     lax_article_endpoint = "http://gateway.internal/articles/{article_id}"
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://gateway.internal/articles/{article_id}/versions'
-    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1" 
+    lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=2" 
     lax_article_related = "http://gateway.internal/articles/{article_id}/related"
     verify_ssl = True  # False when testing
 

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -71,11 +71,11 @@ class TestLaxProvider(unittest.TestCase):
     def test_article_version_200(self, mock_requests_get):
         response = MagicMock()
         response.status_code = 200
-        response.json.return_value = {'versions': [{'version': 1}]}
+        response.json.return_value = {'versions': [{"status": "preprint"}, {'version': 1}]}
         mock_requests_get.return_value = response
         status_code, versions = lax_provider.article_versions('08411', settings_mock)
         self.assertEqual(status_code, 200)
-        self.assertEqual(versions, [{'version': 1}])
+        self.assertEqual(versions, [{"status": "preprint"}, {'version': 1}])
 
     @patch('requests.get')
     def test_article_version_404(self, mock_requests_get):
@@ -136,7 +136,9 @@ class TestLaxProvider(unittest.TestCase):
     @patch('requests.get')
     def test_article_snippet_200_auth(self, mock_requests_get):
         expected_data = {'version': 1, 'type': 'research-article'}
-        response_data = {'versions': [expected_data]}
+        # add a preprint article, which has no version key, for test coverage
+        versions_response_data = [{"status": "preprint"}, expected_data]
+        response_data = {'versions': versions_response_data}
         response = MagicMock()
         response.status_code = 200
         response.json.return_value = response_data

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -34,7 +34,7 @@ ses_poa_recipient_email = ""
 
 lax_article_endpoint = "https://test/eLife.{article_id}"
 lax_article_versions = 'https://test/eLife.{article_id}/version/'
-lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=1"
+lax_article_versions_accept_header = "application/vnd.elife.article-history+json;version=2"
 lax_article_related = "https://test/eLife.{article_id}/related"
 verify_ssl = False
 lax_auth_key = 'an_auth_key'

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -20,7 +20,13 @@ lax_article_versions_response_data = [
                                           "version": 3,
                                           "published": "2015-11-26T00:00:00Z",
                                           "versionDate": "2015-12-29T00:00:00Z"
-                                        }
+                                        },
+                                        {
+                                          "status": "preprint",
+                                          "description": "This manuscript was published as a preprint at bioRxiv.",
+                                          "uri": "https://doi.org/10.1101/2019.08.22",
+                                          "date": "2010-01-01T00:00:00Z"
+                                        },
                                       ]
 
 lax_article_by_version_response_data_incomplete = {


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6798

The newest article verison history JSON may include a `'preprint` in the verison history. After adding one of these to the version history test fixture, some changes were required to not expect to always find a `version` key for each record, because a preprint has no version number.

Test scenarios are expanded to test if preprint data is returned when getting version data from Lax.

There's also some code linting of `lax_provider.py`.

Earlier I thought this might be unsafe to deploy right now since there's little to no preprint data to test against; after considering this today, the code here should be compatible with `version=1` data, and that is currently what is set in the production environment settings `lax_article_versions_accept_header` value. Until we update that value in the settings, this should work as normal, and when the settings are changed is when testing in `continuumtest` or `prod` is possible.