### PR TITLE
ERA queue listener tweaks

### DIFF
--- a/era_queue_worker.py
+++ b/era_queue_worker.py
@@ -124,11 +124,17 @@ class EraQueueWorker:
             self.logger.error("error obtaining queue")
 
     def approve_workflow_start(self, origin):
-        origin_exists = software_heritage.swh_origin_exists(
-            url_pattern=self.settings.software_heritage_api_get_origin_pattern,
-            origin=origin,
-            logger=self.logger,
-        )
+        try:
+            origin_exists = software_heritage.swh_origin_exists(
+                url_pattern=self.settings.software_heritage_api_get_origin_pattern,
+                origin=origin,
+                logger=self.logger,
+            )
+        except:
+            self.logger.exception(
+                "Exception when checking swh_origin_exists for origin %s" % origin
+            )
+            return False
         if origin_exists is None:
             self.logger.info("Could not determine the status of the origin %s", origin)
             return False

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -265,7 +265,7 @@ def swh_origin_exists(url_pattern, origin, verify_ssl=False, logger=None):
     url = url_pattern.format(origin=origin)
 
     if logger:
-        logger.info("Checking of SWH origin exists at API URL %s" % url)
+        logger.info("Checking if SWH origin exists at API URL %s" % url)
     response = requests.head(
         url,
         verify=verify_ssl,

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -239,7 +239,7 @@ class TestSWHOriginExists(unittest.TestCase):
         self.assertEqual(self.logger.loginfo[-2], "SWH origin status code 200")
         self.assertEqual(
             self.logger.loginfo[-3],
-            "Checking of SWH origin exists at API URL %s"
+            "Checking if SWH origin exists at API URL %s"
             % self.url_pattern.format(origin=self.origin),
         )
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6416

A temporary outage of the Software Heritage staging site led to the queue listener to die, this should improve the exception handling in this case.