### PR TITLE
Convert display to origin in software heritage.

### DIFF
--- a/activity/activity_GenerateSWHMetadata.py
+++ b/activity/activity_GenerateSWHMetadata.py
@@ -154,5 +154,5 @@ class activity_GenerateSWHMetadata(Activity):
 def get_create_origin(data):
     "get create_origin url from the data if available"
     if data and data.get("data") and data.get("data").get("display"):
-        return data.get("data").get("display")
+        return software_heritage.display_to_origin(data.get("data").get("display"))
     return None

--- a/era_queue_worker.py
+++ b/era_queue_worker.py
@@ -85,8 +85,15 @@ class EraQueueWorker:
                         input_file = message_dict.get("download")
                         display = message_dict.get("display")
 
+                        origin = software_heritage.display_to_origin(display)
+                        self.logger.info(
+                            'display value "%s" turned into origin value "%s"',
+                            display,
+                            origin,
+                        )
+
                         # determine if a workflow should be started
-                        if self.approve_workflow_start(origin=display):
+                        if self.approve_workflow_start(origin=origin):
                             run = None
                             info = {
                                 "article_id": article_id,

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -1,6 +1,7 @@
 "functions for processing deposits to Software Heritage"
 
 import os
+import re
 import requests
 from collections import OrderedDict
 from string import Template
@@ -185,6 +186,19 @@ def readme(kwargs):
     if string_template:
         return string_template.safe_substitute(kwargs)
     return ""
+
+
+def display_to_origin(display):
+    """
+    from the display value, an stencila article version,
+    trim it to be the SWH origin value
+
+    e.g. for display value
+    https://elife.stencila.io/article-30274/v99/
+    return https://elife.stencila.io/article-30274/
+    """
+    match_pattern = re.compile(r"^(https://elife.stencila.io/.*?/).*$")
+    return match_pattern.sub(r"\1", display)
 
 
 def swh_post_request(

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -79,7 +79,7 @@ SoftwareHeritageDeposit_data_example = {
     "recipient": "software_heritage",
     "input_file": "https://hub.stenci.la/api/projects/518/snapshots/15/archive",
     "data": {
-        "display": "https://elife.stencila.io/article-30274/",
+        "display": "https://elife.stencila.io/article-30274/v99/",
     }
 }
 

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -126,6 +126,21 @@ class TestSoftwareHeritageProviderReadme(unittest.TestCase):
         self.assertEqual(readme_string, "")
 
 
+class TestDisplayToOrigin(unittest.TestCase):
+    def test_display_to_origin_general(self):
+        display = "https://example.org"
+        self.assertEqual(software_heritage.display_to_origin(display), display)
+
+    def test_display_to_origin_era(self):
+        display = "https://elife.stencila.io/article-30274/"
+        self.assertEqual(software_heritage.display_to_origin(display), display)
+
+    def test_display_to_origin_era_with_version(self):
+        display = "https://elife.stencila.io/article-30274/v99/"
+        expected = "https://elife.stencila.io/article-30274/"
+        self.assertEqual(software_heritage.display_to_origin(display), expected)
+
+
 class TestSWHPostRequest(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6416

Some ERA article URL values have a version added to the path, and some don't. For the ones with a version on them, we want to 

a) remove the version from the URL when checking if the origin already exists at Software Heritage, i.e. it has been deposited before, and
b) when generating the metadata file to send to Software Heritage, also remove the version number from the URL; this is how the unique identifier is registered with Software Heritage in the first place

When starting a workflow execution, the queue listener will continue to send through the `display` value which includes the version number because in the starter structure it is already named `display` so we can keep it that way. In future, we may want to do something with the entire `display` value (the versioned URL) and the version can be removed in the specific place a non-versioned URL as desired anyway, as is done here in the `GenerateSWHMetadata` activity.