### PR TITLE
Clear cached CSV data after PackagePOA is done.

### DIFF
--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -4,6 +4,7 @@ import time
 import zipfile
 import glob
 import shutil
+import importlib
 from collections import OrderedDict
 from xml.parsers.expat import ExpatError
 from ejpcsvparser import parse
@@ -132,6 +133,9 @@ class activity_PackagePOA(Activity):
 
         if self.activity_status is True:
             self.clean_tmp_dir()
+
+        # reload the ejpcsvparser/csv_data.py module to clear cached CSV data
+        importlib.reload(parse.data)
 
         return result
 

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -261,6 +261,13 @@ class TestPackagePOA(unittest.TestCase):
                 loginfo_message in self.logger.loginfo,
                 'failed in scenario %s' % test_data.get('scenario'))
 
+        # assert the cached csv data was cleared at the end of do_activity
+        # this function call should raise an exception trying to parse the csv file again, e.g.
+        # FileNotFoundError: [Errno 2] No such file or directory: 'tests/test_data/poa_funding.csv'
+        # ../site-packages/ejpcsvparser/csv_data.py:142: FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            activity_module.parse.data.index_funding_table()
+
     def boolean_assertion(self, value, expected, scenario=None):
         "shorthand for checking and displaying output for equality assertions"
         self.assertEqual(value, expected,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6064

Ever since the `PackagePOA` workflow is set to run multiple times per day, the CSV data caching has occasionally caused problems. Previously the cached data bug was masked because the `worker.py` processes on the instance are restarted nightly, and when `PackagePOA` was only run once a day, it would never have cached CSV data.

As a result of testing on a running test instance with real workflows and data, this simple solution was found, to reload the `ejpcsvparser.csv_data` module, which when imported is named `parse.data` in this activity, which causes the data cached by the `@memoize` decorator to be erased.

Added to the existing tests for `do_activity()` is a check to confirm the cached CSV data is not available, and a function call results in trying to load a CSV file to parse, which is not available, resulting in a `FileNotFoundError` exception.