### PR TITLE
Fix article_version_date_by_version if preprint data.

### DIFF
--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -162,9 +162,10 @@ def article_next_version(article_id, settings):
 
 def article_version_date_by_version(article_id, version, settings):
     status_code, data = article_versions(article_id, settings)
-    print(data)
     if status_code == 200:
-        version_data = next(vd for vd in data if vd["version"] == int(version))
+        version_data = next(
+            vd for vd in data if vd.get("version") and vd["version"] == int(version)
+        )
         return parse(version_data["versionDate"]).strftime("%Y-%m-%dT%H:%M:%SZ")
     raise Exception(
         "Error in article_publication_date_by_version: Version date not found. Status: "

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -67,6 +67,20 @@ class TestLaxProvider(unittest.TestCase):
         result = lax_provider.article_version_date_by_version('08411', "2", settings_mock)
         self.assertEqual("2015-11-30T00:00:00Z", result)
 
+    @patch("provider.lax_provider.article_versions")
+    def test_article_version_date_by_version_with_preprint(
+        self, mock_lax_provider_article_versions
+    ):
+        response_data = [
+            {"status": "preprint"},
+            {"version": 1, "versionDate": "2015-11-30T00:00:00Z"},
+        ]
+        mock_lax_provider_article_versions.return_value = 200, response_data
+        result = lax_provider.article_version_date_by_version(
+            "08411", "1", settings_mock
+        )
+        self.assertEqual("2015-11-30T00:00:00Z", result)
+
     @patch('requests.get')
     def test_article_version_200(self, mock_requests_get):
         response = MagicMock()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6828

For a silent correction where the article versions data includes a preprint, there was a bug when iterating through the version data.

Includes a test scenario for this specific situation.