### PR TITLE
Use letterpaser library by numbered version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ git+https://github.com/elifesciences/package-poa.git@514517f5644cf3eb34514368f25
 six==1.13.0
 docker==4.0.2
 pypandoc==1.4
-git+https://github.com/elifesciences/decision-letter-parser.git@bbaae470bb1566773e7ca27cd128dc77c55586d0#egg=letterparser
+letterparser==0.2.1
 PyYAML==5.4
 Wand==0.5.2
 paramiko==2.4.2


### PR DESCRIPTION
`letterparser` is configured to release server versions of the library to pypi now, so we can install it by version number now and going forward.