### PR TITLE
Use latest elifearticle, elifecrossref libraries.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ beautifulsoup4==4.7.1
 lxml==4.6.3
 python-slugify==1.2.4
 git+https://github.com/elifesciences/elife-tools.git@66c248f0e5b32fbd3427c2f1586afa44bbf1382c#egg=elifetools
-elifearticle==0.4.0
+elifearticle==0.5.0
 configparser==3.5.0
-elifecrossref==0.3.1
+elifecrossref==0.4.0
 elifecleaner==0.3.1
 git+https://github.com/elifesciences/elife-pubmed-xml-generation.git@ebd128176df5044673a9dd4777ff432dcd8aaa66#egg=elifepubmed
 git+https://github.com/elifesciences/ejp-csv-parser.git@2e07c7a9bf60c435dac78207858b4c80d250511a#egg=ejpcsvparser


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6811

[part of] Deploying support for depositing `Editor's evaluation` Crossref peer review deposit data. The currently supported peer review deposits are unchanged and should continue to be compatible.