### PR TITLE
Use decision letter date for editor-report in bigquery provider.

### DIFF
--- a/provider/bigquery.py
+++ b/provider/bigquery.py
@@ -98,7 +98,7 @@ def date_to_string(datetime_date):
 
 def get_review_date(manuscript_object, article_type):
     """get date for a peer review sub article"""
-    if article_type in ['article-commentary', 'decision-letter']:
+    if article_type in ['article-commentary', 'decision-letter', 'editor-report']:
         if manuscript_object.decision_letter_datetime:
             return date_to_string(manuscript_object.decision_letter_datetime)
     elif article_type == 'reply':

--- a/tests/provider/test_bigquery.py
+++ b/tests/provider/test_bigquery.py
@@ -63,6 +63,7 @@ class TestBigQueryProvider(unittest.TestCase):
             2016, 6, 10, 6, 28, 43, tzinfo=_UTC())
         self.assertEqual(bigquery.get_review_date(manuscript, 'article-commentary'), '2016-05-31')
         self.assertEqual(bigquery.get_review_date(manuscript, 'decision-letter'), '2016-05-31')
+        self.assertEqual(bigquery.get_review_date(manuscript, 'editor-report'), '2016-05-31')
         self.assertEqual(bigquery.get_review_date(manuscript, 'reply'), '2016-06-10')
 
     def test_get_review_date_no_author_response_datetime(self):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6811

For an Editor's evaluation Crossref peer review deposit, with an article type value of `editor-report`, we can use the decision letter date for now, until a more precise date value is available from BigQuery data.