### PR TITLE
More efficient bucket storage list_resources()

### DIFF
--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -108,8 +108,7 @@ class S3StorageContext:
         folder = s3_key[1:] if s3_key[:1] == "/" else s3_key
         bucketlist = bucket.list(prefix=folder + "/")
         files = []
-        for file in bucketlist:
-            key = bucket.get_key(file.key)
+        for key in bucketlist:
             filename = key.name.rsplit('/', 1)[1]
             files.append(filename)
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6685

Noticed especially in the `PMCDeposit` activity where it gets a list of zip files from a bucket folder, the `list_resources()` function was observed to be slow. On close inspection, the additional `bucket.get_key()` function call for each bucket key is superfluous, because a bucket list already returns a key which has a `key.name` property.

This is expected to be compatible with all places calling `list_resources()`, since it returns the same data, in a more efficient way now.