### PR TITLE
Exception in era queue worker for bad JSON format.

### DIFF
--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -197,6 +197,8 @@ def display_to_origin(display):
     https://elife.stencila.io/article-30274/v99/
     return https://elife.stencila.io/article-30274/
     """
+    if not display:
+        return None
     match_pattern = re.compile(r"^(https://elife.stencila.io/.*?/).*$")
     return match_pattern.sub(r"\1", display)
 

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -127,6 +127,10 @@ class TestSoftwareHeritageProviderReadme(unittest.TestCase):
 
 
 class TestDisplayToOrigin(unittest.TestCase):
+    def test_display_to_origin_none(self):
+        display = None
+        self.assertIsNone(software_heritage.display_to_origin(display))
+
     def test_display_to_origin_general(self):
         display = "https://example.org"
         self.assertEqual(software_heritage.display_to_origin(display), display)

--- a/tests/test_era_queue_worker.py
+++ b/tests/test_era_queue_worker.py
@@ -80,6 +80,46 @@ class TestEraQueueWorker(unittest.TestCase):
         out_queue_message = json.loads(directory.read("fake_sqs_body"))
         self.assertEqual(out_queue_message, outgoing_message_expected)
 
+    @patch("era_queue_worker.Message")
+    @patch("tests.activity.classes_mock.FakeSQSQueue.read")
+    @patch("boto.sqs.connect_to_region")
+    def test_work_bad_message_body(
+        self, fake_sqs_conn, fake_queue_read, fake_sqs_message
+    ):
+        "test if the incoming message body cannot be parsed into JSON"
+        message_body = '{"not": "good" "json": "this JSON has no commas"}'
+        # expected queue message will be similar to the incoming message,
+        # since it does not result in an outgoing message to the workflow starter queue
+        queue_message_expected = bytes(message_body, "utf8")
+
+        # mock things
+        directory = TempDirectory()
+        fake_sqs_conn.return_value = FakeSQSConn(directory)
+        fake_sqs_message.return_value = FakeSQSMessage(directory)
+
+        incoming_message = FakeSQSMessage(directory)
+        incoming_message.set_body(message_body)
+        fake_queue_read.return_value = incoming_message
+
+        # create a fake green flag
+        flag = FakeFlag()
+
+        # invoke queue worker to work
+        self.queue_worker.work(flag)
+
+        # assertions, there is no workflow starter message out_queue
+        out_queue_message = directory.read("fake_sqs_body")
+        self.assertEqual(out_queue_message, queue_message_expected)
+        # and exception is printed in the log
+        self.assertEqual(
+            self.logger.logexception,
+            (
+                "Exception loading message body as JSON: "
+                + str(queue_message_expected)
+                + ": Expecting ',' delimiter: line 1 column 16 (char 15)"
+            ),
+        )
+
     @patch("requests.head")
     def test_approve_workflow_start_200(self, mock_requests_head):
         mock_requests_head.return_value = FakeResponse(200)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6411

A sample SQS queue message body which could not be parsed as JSON, raising an exception, can be handled in particular. This should make it so the queue reader does not die due to this JSON parsing exception, the data it tries to extract is blank, and the message remains on the queue, i.e. it is not deleted from the SQS queue (noting, it was not deleted before when an error happened either).

Another test scenario included for a JSON parsing exception.