### PR TITLE
Pubmed email logic refactoring

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -14,10 +14,10 @@ from activity.objects import Activity
 
 
 class activity_PubmedArticleDeposit(Activity):
-
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_PubmedArticleDeposit, self).__init__(
-            settings, logger, conn, token, activity_task)
+            settings, logger, conn, token, activity_task
+        )
 
         self.name = "PubmedArticleDeposit"
         self.version = "1"
@@ -25,13 +25,15 @@ class activity_PubmedArticleDeposit(Activity):
         self.default_task_schedule_to_close_timeout = 60 * 30
         self.default_task_schedule_to_start_timeout = 30
         self.default_task_start_to_close_timeout = 60 * 15
-        self.description = ("Download article XML from pubmed outbox, generate pubmed " +
-                            "article XML, and deposit with pubmed.")
+        self.description = (
+            "Download article XML from pubmed outbox, generate pubmed "
+            + "article XML, and deposit with pubmed."
+        )
 
         # Local directory settings
         self.directories = {
             "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
-            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
         }
 
         self.date_stamp = utils.set_datestamp()
@@ -45,14 +47,16 @@ class activity_PubmedArticleDeposit(Activity):
         self.published_folder = "pubmed/published"
 
         # Track the success of some steps
-        self.statuses = OrderedDict([
-            ('generate', None),
-            ('approve', None),
-            ('upload', None),
-            ('publish', None),
-            ('outbox', None),
-            ('activity', None),
-        ])
+        self.statuses = OrderedDict(
+            [
+                ("generate", None),
+                ("approve", None),
+                ("upload", None),
+                ("publish", None),
+                ("outbox", None),
+                ("activity", None),
+            ]
+        )
 
         self.outbox_s3_key_names = None
 
@@ -64,7 +68,7 @@ class activity_PubmedArticleDeposit(Activity):
         """
         Activity, do the work
         """
-        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
 
         self.make_activity_directories()
 
@@ -75,36 +79,36 @@ class activity_PubmedArticleDeposit(Activity):
         self.download_files_from_s3_outbox()
 
         # Generate pubmed XML
-        self.statuses['generate'] = self.generate_pubmed_xml()
+        self.statuses["generate"] = self.generate_pubmed_xml()
 
         # Approve files for publishing
-        self.statuses['approve'] = self.approve_for_publishing()
+        self.statuses["approve"] = self.approve_for_publishing()
 
-        if self.statuses.get('approve'):
+        if self.statuses.get("approve"):
             # Publish files
             try:
-                self.statuses['upload'] = self.sftp_files_to_endpoint(
-                    from_dir=self.directories.get("TMP_DIR"),
-                    file_type="/*.xml")
+                self.statuses["upload"] = self.sftp_files_to_endpoint(
+                    from_dir=self.directories.get("TMP_DIR"), file_type="/*.xml"
+                )
             except Exception as exception:
                 self.logger.exception(str(exception))
                 return self.ACTIVITY_PERMANENT_FAILURE
 
-        if self.statuses.get('upload'):
+        if self.statuses.get("upload"):
             # Clean up outbox
             print("Moving files from outbox folder to published folder")
             self.clean_outbox()
             self.upload_pubmed_xml_to_s3()
-            self.statuses['outbox'] = True
-            self.statuses['publish'] = True
-        elif self.statuses.get('upload') is False:
-            self.statuses['publish'] = False
+            self.statuses["outbox"] = True
+            self.statuses["publish"] = True
+        elif self.statuses.get("upload") is False:
+            self.statuses["publish"] = False
 
         # Set the activity status of this activity based on successes
-        if self.statuses.get('publish') in (None, True):
-            self.statuses['activity'] = True
+        if self.statuses.get("publish") in (None, True):
+            self.statuses["activity"] = True
         else:
-            self.statuses['activity'] = False
+            self.statuses["activity"] = False
 
         # Send email
         # Only if there were files approved for publishing
@@ -115,7 +119,7 @@ class activity_PubmedArticleDeposit(Activity):
         self.clean_tmp_dir()
 
         # return a value based on the activity_status
-        if self.statuses.get('activity') is True:
+        if self.statuses.get("activity") is True:
             return True
 
         return self.ACTIVITY_PERMANENT_FAILURE
@@ -141,8 +145,8 @@ class activity_PubmedArticleDeposit(Activity):
             dirname = self.directories.get("INPUT_DIR")
             if dirname:
                 filename_plus_path = dirname + os.sep + filename
-                with open(filename_plus_path, 'wb') as open_file:
-                    storage_resource_origin = orig_resource + '/' + name
+                with open(filename_plus_path, "wb") as open_file:
+                    storage_resource_origin = orig_resource + "/" + name
                     storage.get_resource_to_file(storage_resource_origin, open_file)
 
     def get_article_version_from_lax(self, article_id):
@@ -157,14 +161,17 @@ class activity_PubmedArticleDeposit(Activity):
     def enhance_article(self, article):
         "set additional details on the article object from Lax data or other sources"
 
-        article.was_ever_poa = lax_provider.was_ever_poa(article.manuscript, self.settings)
+        article.was_ever_poa = lax_provider.was_ever_poa(
+            article.manuscript, self.settings
+        )
 
         # Check if each article is published
         article.is_published = lax_provider.published_considering_poa_status(
             article_id=article.manuscript,
             settings=self.settings,
             is_poa=article.is_poa,
-            was_ever_poa=article.was_ever_poa)
+            was_ever_poa=article.was_ever_poa,
+        )
 
         if not article.version:
             article.version = self.get_article_version_from_lax(article.manuscript)
@@ -181,8 +188,12 @@ class activity_PubmedArticleDeposit(Activity):
         for xml_file in article_xml_files:
             generate_status = True
 
-            article = parse_article_xml(xml_file, elifepubmed_config(
-                self.settings), self.directories.get("TMP_DIR"), self.logger)
+            article = parse_article_xml(
+                xml_file,
+                elifepubmed_config(self.settings),
+                self.directories.get("TMP_DIR"),
+                self.logger,
+            )
 
             if article is None:
                 self.article_not_published_file_names.append(xml_file)
@@ -192,8 +203,9 @@ class activity_PubmedArticleDeposit(Activity):
                 article = self.enhance_article(article)
             except:
                 self.logger.exception(
-                    "Exception in enhance_article for xml_file %s in %s" %
-                    (xml_file, self.name))
+                    "Exception in enhance_article for xml_file %s in %s"
+                    % (xml_file, self.name)
+                )
                 self.article_not_published_file_names.append(xml_file)
                 continue
 
@@ -201,11 +213,14 @@ class activity_PubmedArticleDeposit(Activity):
                 # generate pubmed deposit
                 try:
                     generate.pubmed_xml_to_disk(
-                        [article], config_section=self.settings.elifepubmed_config_section)
+                        [article],
+                        config_section=self.settings.elifepubmed_config_section,
+                    )
                 except:
                     self.logger.exception(
-                        "Exception in generate.pubmed_xml_to_disk for xml_file %s in %s" %
-                        (xml_file, self.name))
+                        "Exception in generate.pubmed_xml_to_disk for xml_file %s in %s"
+                        % (xml_file, self.name)
+                    )
                     generate_status = False
             else:
                 generate_status = False
@@ -246,18 +261,23 @@ class activity_PubmedArticleDeposit(Activity):
             sftp_client = sftp.sftp_connect(
                 self.settings.PUBMED_SFTP_URI,
                 self.settings.PUBMED_SFTP_USERNAME,
-                self.settings.PUBMED_SFTP_PASSWORD)
+                self.settings.PUBMED_SFTP_PASSWORD,
+            )
         except Exception as exception:
             self.logger.exception(
-                'Failed to connect to SFTP endpoint %s: %s' % (
-                    self.settings.PUBMED_SFTP_URI, str(exception)))
+                "Failed to connect to SFTP endpoint %s: %s"
+                % (self.settings.PUBMED_SFTP_URI, str(exception))
+            )
             raise
 
         try:
             sftp.sftp_to_endpoint(
-                sftp_client, uploadfiles, self.settings.PUBMED_SFTP_CWD, sub_dir)
+                sftp_client, uploadfiles, self.settings.PUBMED_SFTP_CWD, sub_dir
+            )
         except Exception as exception:
-            self.logger.exception('Failed to upload files by SFTP to PubMed: %s' % str(exception))
+            self.logger.exception(
+                "Failed to upload files by SFTP to PubMed: %s" % str(exception)
+            )
             raise
         finally:
             sftp.disconnect()
@@ -282,9 +302,11 @@ class activity_PubmedArticleDeposit(Activity):
         files_in_bucket = storage.list_resources(orig_resource)
         # add the prefix back to the file name to set the value
         # and ignore the original folder name
-        self.outbox_s3_key_names = [self.outbox_folder + '/' + filename
-                                    for filename in files_in_bucket
-                                    if filename != '']
+        self.outbox_s3_key_names = [
+            self.outbox_folder + "/" + filename
+            for filename in files_in_bucket
+            if filename != ""
+        ]
 
         return self.outbox_s3_key_names
 
@@ -315,7 +337,7 @@ class activity_PubmedArticleDeposit(Activity):
         s3_key_names = []
         for name in self.article_published_file_names:
             filename = name.split(os.sep)[-1]
-            s3_key_name = self.outbox_folder + '/' + filename
+            s3_key_name = self.outbox_folder + "/" + filename
             s3_key_names.append(s3_key_name)
 
         for name in s3_key_names:
@@ -338,12 +360,17 @@ class activity_PubmedArticleDeposit(Activity):
         storage_provider = self.settings.storage_provider + "://"
 
         date_folder_name = self.date_stamp
-        s3_folder_name = self.published_folder + '/' + date_folder_name + "/" + "batch"
+        s3_folder_name = self.published_folder + "/" + date_folder_name + "/" + "batch"
 
         for xml_file in xml_files:
-            resource_dest = (storage_provider + bucket_name + "/" +
-                             s3_folder_name + "/" +
-                             article_processing.file_name_from_name(xml_file))
+            resource_dest = (
+                storage_provider
+                + bucket_name
+                + "/"
+                + s3_folder_name
+                + "/"
+                + article_processing.file_name_from_name(xml_file)
+            )
             storage.set_resource_from_filename(resource_dest, xml_file)
 
     def send_email(self):
@@ -419,13 +446,16 @@ def parse_article_xml(xml_file, pubmed_config, tmp_dir, logger):
         # Convert the XML file to article objects
         article_list = generate.build_articles(
             article_xmls=[xml_file],
-            build_parts=pubmed_config.get('build_parts'),
-            remove_tags=pubmed_config.get('remove_tags'))
+            build_parts=pubmed_config.get("build_parts"),
+            remove_tags=pubmed_config.get("remove_tags"),
+        )
         # take the first article from the list
         if article_list:
             article = article_list[0]
     except:
-        logger.exception('Exception in parsing article XML %s for PubMed generation' % xml_file)
+        logger.exception(
+            "Exception in parsing article XML %s for PubMed generation" % xml_file
+        )
         article = None
 
     return article

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -351,113 +351,55 @@ class activity_PubmedArticleDeposit(Activity):
         After do_activity is finished, send emails to recipients
         on the status
         """
-        current_time = time.gmtime()
+        datetime_string = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
+        activity_status_text = utils.get_activity_status_text(
+            self.statuses.get("activity")
+        )
+        outbox_s3_key_names = self.get_outbox_s3_key_names()
 
-        body = self.get_email_body(current_time)
-        subject = self.get_email_subject(current_time)
+        body = email_provider.get_email_body_head(
+            self.name, activity_status_text, self.statuses
+        )
+        body += email_provider.get_email_body_middle(
+            "pubmed",
+            outbox_s3_key_names,
+            self.article_published_file_names,
+            self.article_not_published_file_names,
+        )
+        body += email_provider.get_admin_email_body_foot(
+            self.get_activityId(),
+            self.get_workflowId(),
+            datetime_string,
+            self.settings.domain,
+        )
+        subject = email_provider.get_email_subject(
+            datetime_string,
+            activity_status_text,
+            self.name,
+            self.settings.domain,
+            outbox_s3_key_names,
+        )
         sender_email = self.settings.ses_poa_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.ses_admin_email)
+            self.settings.ses_admin_email
+        )
 
         for email in recipient_email_list:
             # send the email by SMTP
             message = email_provider.simple_message(
-                sender_email, email, subject, body, logger=self.logger)
+                sender_email, email, subject, body, logger=self.logger
+            )
 
             email_provider.smtp_send_messages(
-                self.settings, messages=[message], logger=self.logger)
-            self.logger.info('Email sending details: admin email, email %s, to %s' %
-                             ("PubmedArticleDeposit", email))
+                self.settings, messages=[message], logger=self.logger
+            )
+            self.logger.info(
+                "Email sending details: admin email, email %s, to %s"
+                % ("PubmedArticleDeposit", email)
+            )
 
         return True
-
-    def get_email_subject(self, current_time):
-        """
-        Assemble the email subject
-        """
-        date_format = '%Y-%m-%d %H:%M'
-        datetime_string = time.strftime(date_format, current_time)
-
-        activity_status_text = utils.get_activity_status_text(self.statuses.get('activity'))
-
-        # Count the files moved from the outbox, the files that were processed
-        files_count = 0
-        outbox_s3_key_names = self.get_outbox_s3_key_names()
-        if outbox_s3_key_names:
-            files_count = len(outbox_s3_key_names)
-
-        subject = (self.name + " " + activity_status_text +
-                   " files: " + str(files_count) +
-                   ", " + datetime_string +
-                   ", eLife SWF domain: " + self.settings.domain)
-
-        return subject
-
-    def get_email_body(self, current_time):
-        """
-        Format the body of the email
-        """
-
-        body = ""
-
-        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, current_time)
-
-        activity_status_text = utils.get_activity_status_text(self.statuses.get('activity'))
-
-        # Bulk of body
-        body += self.name + " status:" + "\n"
-        body += "\n"
-        body += activity_status_text + "\n"
-        body += "\n"
-
-        body += "activity_status: " + str(self.statuses.get('activity')) + "\n"
-        body += "generate_status: " + str(self.statuses.get('generate')) + "\n"
-        body += "approve_status: " + str(self.statuses.get('approve')) + "\n"
-        body += "upload_status: " + str(self.statuses.get('upload')) + "\n"
-        body += "publish_status: " + str(self.statuses.get('publish')) + "\n"
-        body += "outbox_status: " + str(self.statuses.get('outbox')) + "\n"
-
-        body += "\n"
-        body += "Outbox files: " + "\n"
-
-        outbox_s3_key_names = self.get_outbox_s3_key_names()
-        files_count = 0
-        if outbox_s3_key_names:
-            files_count = len(outbox_s3_key_names)
-        if files_count > 0:
-            for name in outbox_s3_key_names:
-                body += name + "\n"
-        else:
-            body += "No files in outbox." + "\n"
-
-        # Report on published files
-        if self.article_published_file_names:
-            body += "\n"
-            body += "Published files generated pubmed XML: " + "\n"
-            for name in self.article_published_file_names:
-                body += name.split(os.sep)[-1] + "\n"
-
-        # Report on not published files
-        if self.article_not_published_file_names:
-            body += "\n"
-            body += "Files in pubmed outbox not yet published: " + "\n"
-            for name in self.article_not_published_file_names:
-                body += name.split(os.sep)[-1] + "\n"
-
-        body += "\n"
-        body += "-------------------------------\n"
-        body += "SWF workflow details: " + "\n"
-        body += "activityId: " + str(self.get_activityId()) + "\n"
-        body += "As part of workflowId: " + str(self.get_workflowId()) + "\n"
-        body += "As at " + datetime_string + "\n"
-        body += "Domain: " + self.settings.domain + "\n"
-
-        body += "\n"
-
-        body += "\n\nSincerely\n\neLife bot"
-
-        return body
 
 
 def elifepubmed_config(settings):

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -434,7 +434,7 @@ class activity_PubmedArticleDeposit(Activity):
         # Report on published files
         if self.article_published_file_names:
             body += "\n"
-            body += "Published files included in pubmed XML: " + "\n"
+            body += "Published files generated pubmed XML: " + "\n"
             for name in self.article_published_file_names:
                 body += name.split(os.sep)[-1] + "\n"
 

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -17,132 +17,161 @@ import tests.activity.helpers as helpers
 
 @ddt
 class TestPubmedArticleDeposit(unittest.TestCase):
-
     def setUp(self):
         fake_logger = FakeLogger()
-        self.activity = activity_PubmedArticleDeposit(settings_mock, fake_logger, None, None, None)
+        self.activity = activity_PubmedArticleDeposit(
+            settings_mock, fake_logger, None, None, None
+        )
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
-                                       filter_out=['.gitkeep'])
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
         return self.activity.directories.get("TMP_DIR")
 
-    @patch.object(activity_PubmedArticleDeposit, 'clean_tmp_dir')
-    @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch.object(lax_provider, 'article_versions')
-    @patch.object(activity_PubmedArticleDeposit, 'sftp_files_to_endpoint')
-    @patch('activity.activity_PubmedArticleDeposit.storage_context')
-    @patch.object(FakeStorageContext, 'list_resources')
+    @patch.object(activity_PubmedArticleDeposit, "clean_tmp_dir")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch.object(lax_provider, "article_versions")
+    @patch.object(activity_PubmedArticleDeposit, "sftp_files_to_endpoint")
+    @patch("activity.activity_PubmedArticleDeposit.storage_context")
+    @patch.object(FakeStorageContext, "list_resources")
     @data(
         {
-            "comment": 'example PoA file will have an aheadofprint',
-            "outbox_filenames": ['elife-29353-v1.xml', 'not_an_xml_file.pdf'],
+            "comment": "example PoA file will have an aheadofprint",
+            "outbox_filenames": ["elife-29353-v1.xml", "not_an_xml_file.pdf"],
             "sftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_statuses": OrderedDict(
+                [
+                    ("generate", True),
+                    ("approve", True),
+                    ("upload", True),
+                    ("publish", True),
+                    ("outbox", True),
+                    ("activity", True),
+                ]
+            ),
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
-                (b'<ArticleTitle>An evolutionary young defense metabolite influences the root' +
-                 b' growth of plants via the ancient TOR signaling pathway</ArticleTitle>'),
-                (b'<PubDate PubStatus="aheadofprint"><Year>2017</Year>' +
-                 b'<Month>December</Month><Day>12</Day></PubDate>'),
+                (
+                    b"<ArticleTitle>An evolutionary young defense metabolite influences the root"
+                    + b" growth of plants via the ancient TOR signaling pathway</ArticleTitle>"
+                ),
+                (
+                    b'<PubDate PubStatus="aheadofprint"><Year>2017</Year>'
+                    + b"<Month>December</Month><Day>12</Day></PubDate>"
+                ),
                 b'<ELocationID EIdType="doi">10.7554/eLife.29353</ELocationID>',
-                (b'<AbstractText Label="">To optimize fitness a plant should monitor its' +
-                 b' metabolism to appropriately control growth and defense.')
-                ]
+                (
+                    b'<AbstractText Label="">To optimize fitness a plant should monitor its'
+                    + b" metabolism to appropriately control growth and defense."
+                ),
+            ],
         },
         {
-            "comment": 'example VoR file will have a Replaces tag',
-            "outbox_filenames": ['elife-15747-v2.xml'],
+            "comment": "example VoR file will have a Replaces tag",
+            "outbox_filenames": ["elife-15747-v2.xml"],
             "sftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_statuses": OrderedDict(
+                [
+                    ("generate", True),
+                    ("approve", True),
+                    ("upload", True),
+                    ("publish", True),
+                    ("outbox", True),
+                    ("activity", True),
+                ]
+            ),
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
                 b'<Replaces IdType="doi">10.7554/eLife.15747</Replaces>',
-                b'<ArticleTitle>Community-level cohesion without cooperation</ArticleTitle>',
-                (b'<PubDate PubStatus="epublish"><Year>2016</Year>' +
-                 b'<Month>June</Month><Day>16</Day></PubDate>'),
+                b"<ArticleTitle>Community-level cohesion without cooperation</ArticleTitle>",
+                (
+                    b'<PubDate PubStatus="epublish"><Year>2016</Year>'
+                    + b"<Month>June</Month><Day>16</Day></PubDate>"
+                ),
                 b'<ELocationID EIdType="doi">10.7554/eLife.15747</ELocationID>',
-                b'<Identifier Source="ORCID">http://orcid.org/0000-0002-9558-1121</Identifier>'
-                ]
+                b'<Identifier Source="ORCID">http://orcid.org/0000-0002-9558-1121</Identifier>',
+            ],
         },
         {
-            "comment": 'test for if the article is published False (not published yet)',
-            "outbox_filenames": ['elife-15747-v2.xml'],
+            "comment": "test for if the article is published False (not published yet)",
+            "outbox_filenames": ["elife-15747-v2.xml"],
             "sftp_files_return_value": True,
             "article_versions_data": [],
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', False),
-                ('approve', False),
-                ('upload', None),
-                ('publish', None),
-                ('outbox', None),
-                ('activity', True),
-            ]),
-            "expected_file_count": 0
+            "expected_statuses": OrderedDict(
+                [
+                    ("generate", False),
+                    ("approve", False),
+                    ("upload", None),
+                    ("publish", None),
+                    ("outbox", None),
+                    ("activity", True),
+                ]
+            ),
+            "expected_file_count": 0,
         },
         {
-            "comment": 'test for if FTP status is False',
-            "outbox_filenames": ['elife-15747-v2.xml'],
+            "comment": "test for if FTP status is False",
+            "outbox_filenames": ["elife-15747-v2.xml"],
             "sftp_files_return_value": False,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": activity_PubmedArticleDeposit.ACTIVITY_PERMANENT_FAILURE,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', False),
-                ('publish', False),
-                ('outbox', None),
-                ('activity', False),
-            ]),
+            "expected_statuses": OrderedDict(
+                [
+                    ("generate", True),
+                    ("approve", True),
+                    ("upload", False),
+                    ("publish", False),
+                    ("outbox", None),
+                    ("activity", False),
+                ]
+            ),
             "expected_file_count": 1,
         },
         {
-            "comment": 'test for if the XML file has no version it will use lax data',
-            "outbox_filenames": ['elife-15747.xml'],
+            "comment": "test for if the XML file has no version it will use lax data",
+            "outbox_filenames": ["elife-15747.xml"],
             "sftp_files_return_value": True,
             "article_versions_data": test_case_data.lax_article_versions_response_data,
             "expected_result": True,
-            "expected_statuses": OrderedDict([
-                ('generate', True),
-                ('approve', True),
-                ('upload', True),
-                ('publish', True),
-                ('outbox', True),
-                ('activity', True),
-            ]),
+            "expected_statuses": OrderedDict(
+                [
+                    ("generate", True),
+                    ("approve", True),
+                    ("upload", True),
+                    ("publish", True),
+                    ("outbox", True),
+                    ("activity", True),
+                ]
+            ),
             "expected_file_count": 1,
             "expected_pubmed_xml_contains": [
                 b'<Replaces IdType="doi">10.7554/eLife.15747</Replaces>'
-                ]
+            ],
         },
     )
-    def test_do_activity(self, test_data, fake_list_resources, fake_storage_context,
-                         fake_sftp_files_to_endpoint, fake_article_versions,
-                         fake_email_smtp_connect, fake_clean_tmp_dir):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+    def test_do_activity(
+        self,
+        test_data,
+        fake_list_resources,
+        fake_storage_context,
+        fake_sftp_files_to_endpoint,
+        fake_article_versions,
+        fake_email_smtp_connect,
+        fake_clean_tmp_dir,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
         fake_clean_tmp_dir.return_value = None
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
@@ -150,108 +179,145 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         # lax data overrides
         fake_article_versions.return_value = 200, test_data.get("article_versions_data")
         # ftp
-        fake_sftp_files_to_endpoint.return_value = test_data.get("sftp_files_return_value")
+        fake_sftp_files_to_endpoint.return_value = test_data.get(
+            "sftp_files_return_value"
+        )
         # do the activity
         result = self.activity.do_activity()
         # check assertions
-        self.assertEqual(result, test_data.get("expected_result"),
-                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
         # check statuses assertions
         for status_name in test_data.get("expected_statuses"):
             status_value = self.activity.statuses.get(status_name)
             expected = test_data.get("expected_statuses").get(status_name)
             self.assertEqual(
-                status_value, expected,
-                '{expected} {status_name} status not equal to {status_value} in {comment}'.format(
-                    expected=expected, status_name=status_name, status_value=status_value,
-                    comment=test_data.get("comment")))
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
 
         # check the outbox_s3_key_names values
-        self.assertEqual(self.activity.outbox_s3_key_names,
-                         [self.activity.outbox_folder + '/' + filename
-                          for filename in test_data.get("outbox_filenames")],
-                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(
+            self.activity.outbox_s3_key_names,
+            [
+                self.activity.outbox_folder + "/" + filename
+                for filename in test_data.get("outbox_filenames")
+            ],
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
         # Count PubMed XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
-        self.assertEqual(file_count, test_data.get("expected_file_count"),
-                         'failed in {comment}'.format(comment=test_data.get("comment")))
+        self.assertEqual(
+            file_count,
+            test_data.get("expected_file_count"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
         if file_count > 0 and test_data.get("expected_pubmed_xml_contains"):
             # Open the first Pubmed XML and check some of its contents
-            pubmed_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
-            with open(pubmed_xml_filename_path, 'rb') as open_file:
+            pubmed_xml_filename_path = os.path.join(
+                self.tmp_dir(), os.listdir(self.tmp_dir())[0]
+            )
+            with open(pubmed_xml_filename_path, "rb") as open_file:
                 pubmed_xml = open_file.read()
                 for expected in test_data.get("expected_pubmed_xml_contains"):
                     self.assertTrue(
                         expected in pubmed_xml,
-                        'failed in {comment}: {expected} not found in pubmed_xml {path}'.format(
-                            comment=test_data.get("comment"), expected=expected,
-                            path=pubmed_xml_filename_path))
+                        "failed in {comment}: {expected} not found in pubmed_xml {path}".format(
+                            comment=test_data.get("comment"),
+                            expected=expected,
+                            path=pubmed_xml_filename_path,
+                        ),
+                    )
         # clean directory after each test
         self.activity.clean_tmp_dir()
 
-    @patch.object(activity_PubmedArticleDeposit, 'sftp_files_to_endpoint')
-    @patch.object(activity_PubmedArticleDeposit, 'approve_for_publishing')
-    @patch.object(activity_PubmedArticleDeposit, 'generate_pubmed_xml')
-    @patch.object(activity_PubmedArticleDeposit, 'download_files_from_s3_outbox')
-    @patch.object(activity_PubmedArticleDeposit, 'get_outbox_s3_key_names')
-    def test_do_activity_upload_exception(self, fake_get, fake_download, fake_generate,
-                                          fake_approve, fake_sftp_files_to_endpoint):
+    @patch.object(activity_PubmedArticleDeposit, "sftp_files_to_endpoint")
+    @patch.object(activity_PubmedArticleDeposit, "approve_for_publishing")
+    @patch.object(activity_PubmedArticleDeposit, "generate_pubmed_xml")
+    @patch.object(activity_PubmedArticleDeposit, "download_files_from_s3_outbox")
+    @patch.object(activity_PubmedArticleDeposit, "get_outbox_s3_key_names")
+    def test_do_activity_upload_exception(
+        self,
+        fake_get,
+        fake_download,
+        fake_generate,
+        fake_approve,
+        fake_sftp_files_to_endpoint,
+    ):
         fake_get.return_value = True
         fake_download.return_value = True
         fake_generate.return_value = True
         fake_approve.return_value = True
-        fake_sftp_files_to_endpoint.side_effect = Exception('SFTP upload exception')
+        fake_sftp_files_to_endpoint.side_effect = Exception("SFTP upload exception")
         # do the activity
         self.activity.do_activity()
         # check assertions
-        self.assertIsNone(self.activity.statuses.get('upload'))
-        self.assertEqual(self.activity.logger.logexception, 'SFTP upload exception')
+        self.assertIsNone(self.activity.statuses.get("upload"))
+        self.assertEqual(self.activity.logger.logexception, "SFTP upload exception")
 
-    @patch.object(sftp.SFTP, 'sftp_connect')
+    @patch.object(sftp.SFTP, "sftp_connect")
     def test_sftp_files_connection_exception(self, fake_sftp_connect):
-        fake_sftp_connect.side_effect = Exception('SFTP connect exception')
+        fake_sftp_connect.side_effect = Exception("SFTP connect exception")
         with self.assertRaises(Exception):
-            self.activity.sftp_files_to_endpoint('', '')
+            self.activity.sftp_files_to_endpoint("", "")
         self.assertEqual(
             self.activity.logger.logexception,
-            'Failed to connect to SFTP endpoint : SFTP connect exception')
+            "Failed to connect to SFTP endpoint : SFTP connect exception",
+        )
 
-    @patch.object(sftp.SFTP, 'sftp_to_endpoint')
-    @patch.object(sftp.SFTP, 'sftp_connect')
-    def test_sftp_files_transfer_exception(self, fake_sftp_connect, fake_sftp_to_endpoint):
+    @patch.object(sftp.SFTP, "sftp_to_endpoint")
+    @patch.object(sftp.SFTP, "sftp_connect")
+    def test_sftp_files_transfer_exception(
+        self, fake_sftp_connect, fake_sftp_to_endpoint
+    ):
         fake_sftp_connect.return_value = True
-        fake_sftp_to_endpoint.side_effect = Exception('SFTP transfer exception')
+        fake_sftp_to_endpoint.side_effect = Exception("SFTP transfer exception")
         with self.assertRaises(Exception):
-            self.activity.sftp_files_to_endpoint('', '')
+            self.activity.sftp_files_to_endpoint("", "")
         self.assertEqual(
             self.activity.logger.logexception,
-            'Failed to upload files by SFTP to PubMed: SFTP transfer exception')
+            "Failed to upload files by SFTP to PubMed: SFTP transfer exception",
+        )
 
 
 class TestPubmedGeneratePubmedXml(unittest.TestCase):
-
     def setUp(self):
         fake_logger = FakeLogger()
-        self.activity = activity_PubmedArticleDeposit(settings_mock, fake_logger, None, None, None)
+        self.activity = activity_PubmedArticleDeposit(
+            settings_mock, fake_logger, None, None, None
+        )
         self.activity.make_activity_directories()
         self.xml_file = "elife-15747-v2.xml"
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
-                                       filter_out=['.gitkeep'])
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
-    @patch.object(lax_provider, 'article_versions')
-    @patch('activity.activity_PubmedArticleDeposit.storage_context')
-    @patch.object(FakeStorageContext, 'list_resources')
+    @patch.object(lax_provider, "article_versions")
+    @patch("activity.activity_PubmedArticleDeposit.storage_context")
+    @patch.object(FakeStorageContext, "list_resources")
     def test_generate_pubmed_xml(
-            self, fake_list_resources, fake_storage_context,
-            fake_article_versions):
+        self, fake_list_resources, fake_storage_context, fake_article_versions
+    ):
         "test a successful result for generate_pubmed_xml()"
         expected_status = True
         expected_logexception = "First logger exception"
         # mocks
-        fake_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
+        fake_article_versions.return_value = (
+            200,
+            test_case_data.lax_article_versions_response_data,
+        )
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = [self.xml_file]
@@ -264,21 +330,29 @@ class TestPubmedGeneratePubmedXml(unittest.TestCase):
         self.assertEqual(len(self.activity.article_published_file_names), 1)
         self.assertEqual(len(self.activity.article_not_published_file_names), 0)
 
-    @patch('activity.activity_PubmedArticleDeposit.generate.build_articles')
-    @patch.object(lax_provider, 'article_versions')
-    @patch('activity.activity_PubmedArticleDeposit.storage_context')
-    @patch.object(FakeStorageContext, 'list_resources')
+    @patch("activity.activity_PubmedArticleDeposit.generate.build_articles")
+    @patch.object(lax_provider, "article_versions")
+    @patch("activity.activity_PubmedArticleDeposit.storage_context")
+    @patch.object(FakeStorageContext, "list_resources")
     def test_generate_pubmed_xml_article_exception(
-            self, fake_list_resources, fake_storage_context,
-            fake_article_versions, fake_build_articles):
+        self,
+        fake_list_resources,
+        fake_storage_context,
+        fake_article_versions,
+        fake_build_articles,
+    ):
         "test if generate.build_articles raises an exception"
         expected_status = True
         expected_logexception = (
-            "Exception in parsing article XML %s/%s for PubMed generation" %
-            (self.activity.directories.get("INPUT_DIR"), self.xml_file))
+            "Exception in parsing article XML %s/%s for PubMed generation"
+            % (self.activity.directories.get("INPUT_DIR"), self.xml_file)
+        )
         # mocks
-        fake_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        fake_build_articles.side_effect = Exception('Exception in fake_build_articles')
+        fake_article_versions.return_value = (
+            200,
+            test_case_data.lax_article_versions_response_data,
+        )
+        fake_build_articles.side_effect = Exception("Exception in fake_build_articles")
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = [self.xml_file]
@@ -291,21 +365,33 @@ class TestPubmedGeneratePubmedXml(unittest.TestCase):
         self.assertEqual(len(self.activity.article_published_file_names), 0)
         self.assertEqual(len(self.activity.article_not_published_file_names), 1)
 
-    @patch.object(activity_PubmedArticleDeposit, 'enhance_article')
-    @patch.object(lax_provider, 'article_versions')
-    @patch('activity.activity_PubmedArticleDeposit.storage_context')
-    @patch.object(FakeStorageContext, 'list_resources')
+    @patch.object(activity_PubmedArticleDeposit, "enhance_article")
+    @patch.object(lax_provider, "article_versions")
+    @patch("activity.activity_PubmedArticleDeposit.storage_context")
+    @patch.object(FakeStorageContext, "list_resources")
     def test_generate_pubmed_xml_enhance_article_exception(
-            self, fake_list_resources, fake_storage_context,
-            fake_article_versions, fake_enhance_article):
+        self,
+        fake_list_resources,
+        fake_storage_context,
+        fake_article_versions,
+        fake_enhance_article,
+    ):
         "test enhance_article raises an exception"
         expected_status = True
         expected_logexception = (
-            "Exception in enhance_article for xml_file %s/%s in %s" %
-            (self.activity.directories.get("INPUT_DIR"), self.xml_file, self.activity.name))
+            "Exception in enhance_article for xml_file %s/%s in %s"
+            % (
+                self.activity.directories.get("INPUT_DIR"),
+                self.xml_file,
+                self.activity.name,
+            )
+        )
         # mocks
-        fake_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        fake_enhance_article.side_effect = Exception('Exception in enhance_article')
+        fake_article_versions.return_value = (
+            200,
+            test_case_data.lax_article_versions_response_data,
+        )
+        fake_enhance_article.side_effect = Exception("Exception in enhance_article")
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = [self.xml_file]
@@ -318,21 +404,35 @@ class TestPubmedGeneratePubmedXml(unittest.TestCase):
         self.assertEqual(len(self.activity.article_published_file_names), 0)
         self.assertEqual(len(self.activity.article_not_published_file_names), 1)
 
-    @patch('activity.activity_PubmedArticleDeposit.generate.pubmed_xml_to_disk')
-    @patch.object(lax_provider, 'article_versions')
-    @patch('activity.activity_PubmedArticleDeposit.storage_context')
-    @patch.object(FakeStorageContext, 'list_resources')
+    @patch("activity.activity_PubmedArticleDeposit.generate.pubmed_xml_to_disk")
+    @patch.object(lax_provider, "article_versions")
+    @patch("activity.activity_PubmedArticleDeposit.storage_context")
+    @patch.object(FakeStorageContext, "list_resources")
     def test_generate_pubmed_xml_generate_pubmed_xml_exception(
-            self, fake_list_resources, fake_storage_context,
-            fake_article_versions, fake_pubmed_xml_to_disk):
+        self,
+        fake_list_resources,
+        fake_storage_context,
+        fake_article_versions,
+        fake_pubmed_xml_to_disk,
+    ):
         "test if generate.pubmed_xml_to_disk raises an exception"
         expected_status = False
         expected_logexception = (
-            "Exception in generate.pubmed_xml_to_disk for xml_file %s/%s in %s" %
-            (self.activity.directories.get("INPUT_DIR"), self.xml_file, self.activity.name))
+            "Exception in generate.pubmed_xml_to_disk for xml_file %s/%s in %s"
+            % (
+                self.activity.directories.get("INPUT_DIR"),
+                self.xml_file,
+                self.activity.name,
+            )
+        )
         # mocks
-        fake_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
-        fake_pubmed_xml_to_disk.side_effect = Exception('Exception in fake_pubmed_xml_to_disk')
+        fake_article_versions.return_value = (
+            200,
+            test_case_data.lax_article_versions_response_data,
+        )
+        fake_pubmed_xml_to_disk.side_effect = Exception(
+            "Exception in fake_pubmed_xml_to_disk"
+        )
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_list_resources.return_value = [self.xml_file]
@@ -348,43 +448,54 @@ class TestPubmedGeneratePubmedXml(unittest.TestCase):
 
 @ddt
 class TestPubmedParseArticleXml(unittest.TestCase):
-
     def tearDown(self):
-        helpers.delete_files_in_folder(activity_test_data.ExpandArticle_files_dest_folder,
-                                       filter_out=['.gitkeep'])
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @data(
         {
-            "article_xml": 'elife-29353-v1.xml',
+            "article_xml": "elife-29353-v1.xml",
             "expected_article": "not none",
-            "expected_doi": '10.7554/eLife.29353',
+            "expected_doi": "10.7554/eLife.29353",
             "expected_logexception": "First logger exception",
         },
         {
-            "article_xml": 'bad_xml.xml',
+            "article_xml": "bad_xml.xml",
             "expected_article": None,
             "expected_logexception": (
                 "Exception in parsing article XML tests/files_source/pubmed/outbox/bad_xml.xml"
-                " for PubMed generation"),
-        }
+                " for PubMed generation"
+            ),
+        },
     )
     def test_parse_article_xml(self, test_data):
         fake_logger = FakeLogger()
-        source_doc = "tests/files_source/pubmed/outbox/" + test_data.get('article_xml')
+        source_doc = "tests/files_source/pubmed/outbox/" + test_data.get("article_xml")
         article = activity_module.parse_article_xml(
-            source_doc, {}, activity_test_data.ExpandArticle_files_dest_folder, fake_logger)
-        if test_data.get('expected_article') is None:
-            self.assertEqual(article, test_data.get('expected_article'),
-                             'failed comparing expected_article')
+            source_doc,
+            {},
+            activity_test_data.ExpandArticle_files_dest_folder,
+            fake_logger,
+        )
+        if test_data.get("expected_article") is None:
+            self.assertEqual(
+                article,
+                test_data.get("expected_article"),
+                "failed comparing expected_article",
+            )
         else:
-            self.assertIsNotNone(article, 'failed comparing expected_article')
+            self.assertIsNotNone(article, "failed comparing expected_article")
         if article:
-            self.assertEqual(article.doi, test_data.get('expected_doi'),
-                             'failed comparing expected_doi')
+            self.assertEqual(
+                article.doi,
+                test_data.get("expected_doi"),
+                "failed comparing expected_doi",
+            )
         self.assertEqual(
-            str(fake_logger.logexception),
-            (test_data.get('expected_logexception')))
+            str(fake_logger.logexception), (test_data.get("expected_logexception"))
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -78,8 +78,9 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             "expected_email_from": "From: sender@example.org",
             "expected_email_body_contains": [
                 r"PubmedArticleDeposit status:\n\nSuccess!\n\nactivity_status: True",
+                r"Outbox files: \npubmed/outbox/elife-29353-v1.xml",
                 r"Published files generated pubmed XML: \nelife-29353-v1.xml",
-                r"SWF workflow details: \nactivityId:",
+                r"SWF workflow details:\nactivityId:",
             ],
         },
         {
@@ -267,6 +268,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
                     )
                 if test_data.get("expected_email_body_contains"):
                     body = helpers.body_from_multipart_email_string(first_email_content)
+                    print(body)
                     for expected_to_contain in test_data.get(
                         "expected_email_body_contains"
                     ):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/1089

Code merged in PR https://github.com/elifesciences/elife-bot/pull/1277 made it possible to re-use some email sending logic which was almost the same in the DepositCrossref activity.

There's a minor email body contents change here by making both activities share the same email body generation code, otherwise everything else is the same.

Lots of code linting with `black` too, so the diff may be hard to read.