### PR TITLE
Queue worker refactoring

### DIFF
--- a/queue_worker.py
+++ b/queue_worker.py
@@ -57,7 +57,7 @@ class QueueWorker:
         # Simple connect to the queues
         queue, out_queue = self.queues()
 
-        rules = self.load_rules()
+        rules = load_rules()
         application = newrelic.agent.application()
 
         # Poll for an activity task indefinitely
@@ -81,7 +81,7 @@ class QueueWorker:
                         if queue_message.notification_type == "S3Event":
                             info = S3NotificationInfo.from_S3SQSMessage(queue_message)
                             self.logger.info("S3NotificationInfo: %s", info.to_dict())
-                            workflow_name = self.get_starter_name(rules, info)
+                            workflow_name = get_starter_name(rules, info)
                             if workflow_name is None:
                                 self.logger.error(
                                     "Could not handle file %s in bucket %s"
@@ -113,18 +113,20 @@ class QueueWorker:
         else:
             self.logger.error("error obtaining queue")
 
-    def load_rules(self):
-        # load the rules from the YAML file
-        with open("newFileWorkflows.yaml", "r") as open_file:
-            return yaml.load(open_file.read())
 
-    def get_starter_name(self, rules, info):
-        for rule_name in rules:
-            rule = rules[rule_name]
-            if re.match(rule["bucket_name_pattern"], info.bucket_name) and re.match(
-                rule["file_name_pattern"], info.file_name
-            ):
-                return rule["starter_name"]
+def load_rules():
+    # load the rules from the YAML file
+    with open("newFileWorkflows.yaml", "r") as open_file:
+        return yaml.load(open_file.read())
+
+
+def get_starter_name(rules, info):
+    for rule_name in rules:
+        rule = rules[rule_name]
+        if re.match(rule["bucket_name_pattern"], info.bucket_name) and re.match(
+            rule["file_name_pattern"], info.file_name
+        ):
+            return rule["starter_name"]
 
 
 if __name__ == "__main__":

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -89,6 +89,9 @@ class FakeSQSQueue:
     def delete_message(self, message):
         self.messages = [q_message for q_message in self.messages if message != q_message]
 
+    def set_message_class(self, message_class):
+        pass
+
 
 class FakeFTP:
     def __init__(self, ftp_instance=None):

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -15,6 +15,7 @@ aws_secret_access_key = ""
 
 workflow_starter_queue = ""
 sqs_region = ""
+S3_monitor_queue = 'incoming_queue'
 
 redis_host = ""
 redis_port = 6379

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -1,65 +1,39 @@
+import os
 import unittest
 import json
-from mock import Mock, patch
-import tests.settings_mock as settings_mock
+from mock import patch
+from testfixtures import TempDirectory
 from queue_worker import QueueWorker
+from queue_worker import load_rules, get_starter_name
 from S3utility.s3_notification_info import S3NotificationInfo
 from provider.utils import bytes_decode
-import tests.test_data as test_data
+from tests import settings_mock, test_data
 from tests.classes_mock import FakeFlag, FakeS3Event
-from tests.activity.classes_mock import FakeSQSConn, FakeSQSMessage, FakeSQSQueue
-from testfixtures import TempDirectory
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSQSConn,
+    FakeSQSMessage,
+    FakeSQSQueue,
+)
 
 
 class TestQueueWorker(unittest.TestCase):
     def setUp(self):
-        self.logger = Mock()
+        self.logger = FakeLogger()
         self.worker = QueueWorker(settings_mock, self.logger)
         # override the sleep value for faster testing
-        self.worker.sleep_seconds = 1
+        self.worker.sleep_seconds = 0.1
 
     def tearDown(self):
         TempDirectory.cleanup_all()
 
-    def test_get_load_rules(self):
-        "test loading rules YAML file"
-        rules = self.worker.load_rules()
-        self.assertIsNotNone(rules)
-
-    def test_get_starter_name(self):
-        "test rules matching to the S3 notification info"
-        rules = test_data.queue_worker_rules
-        info = S3NotificationInfo.from_dict(test_data.queue_worker_article_zip_data)
-        expected_starter_name = "InitialArticleZip"
-        starter_name = self.worker.get_starter_name(rules, info)
-        self.assertEqual(starter_name, expected_starter_name)
-
-    def test_get_starter_name_ingest_digest(self):
-        "test S3 notification info matching for the ingest digest workflow"
-        rules = test_data.queue_worker_rules
-        info = S3NotificationInfo.from_dict(test_data.ingest_digest_data)
-        expected_starter_name = "IngestDigest"
-        starter_name = self.worker.get_starter_name(rules, info)
-        self.assertEqual(starter_name, expected_starter_name)
-
-    def test_get_starter_name_ingest_decision_letter(self):
-        "test S3 notification info matching for the ingest decision letter workflow"
-        rules = test_data.queue_worker_rules
-        info = S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data)
-        expected_starter_name = "IngestDecisionLetter"
-        starter_name = self.worker.get_starter_name(rules, info)
-        self.assertEqual(starter_name, expected_starter_name)
-
     @patch("queue_worker.Message")
     @patch("tests.activity.classes_mock.FakeSQSQueue.read")
     @patch("queue_worker.QueueWorker.queues")
-    @patch("queue_worker.QueueWorker.connect")
-    def test_work(
-        self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message
-    ):
+    def test_work(self, mock_queues, mock_queue_read, mock_sqs_message):
         "test the main method of the class"
         directory = TempDirectory()
-        mock_sqs_connect = FakeSQSConn(directory)
+        # mock_sqs_connect = FakeSQSConn(directory)
         mock_queues.return_value = FakeSQSQueue(directory), FakeSQSQueue(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
         # create an S3 event message
@@ -68,22 +42,19 @@ class TestQueueWorker(unittest.TestCase):
         # create a fake green flag
         flag = FakeFlag()
         # invoke queue worker to work
-        return_value = self.worker.work(flag)
+        self.worker.work(flag)
         # assertions, should have a message in the out_queue
         out_queue_message = json.loads(bytes_decode(directory.read("fake_sqs_body")))
         self.assertEqual(out_queue_message, test_data.queue_worker_starter_message)
-        self.assertEqual(return_value, None)
+        self.assertEqual(self.worker.logger.loginfo[-1], "graceful shutdown")
 
     @patch("queue_worker.Message")
     @patch("tests.activity.classes_mock.FakeSQSQueue.read")
     @patch("queue_worker.QueueWorker.queues")
-    @patch("queue_worker.QueueWorker.connect")
-    def test_work_unknown_bucket(
-        self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message
-    ):
+    def test_work_unknown_bucket(self, mock_queues, mock_queue_read, mock_sqs_message):
         "test work method with an unrecognised bucket name"
         directory = TempDirectory()
-        mock_sqs_connect = FakeSQSConn(directory)
+
         mock_queues.return_value = FakeSQSQueue(directory), FakeSQSQueue(directory)
         mock_sqs_message.return_value = FakeSQSMessage(directory)
         # create an S3 event message
@@ -94,12 +65,84 @@ class TestQueueWorker(unittest.TestCase):
         # create a fake green flag
         flag = FakeFlag()
         # invoke queue worker to work
-        return_value = self.worker.work(flag)
+        self.worker.work(flag)
         # assertion, should be no message in the sqs queue
-        out_queue_list = directory.listdir()
-        self.assertIsNone(out_queue_list, None)
-        self.assertEqual(return_value, None)
+        out_queue_list = os.listdir(directory.path)
+        self.assertEqual(out_queue_list, [])
+        self.assertEqual(self.worker.logger.loginfo[-1], "graceful shutdown")
+
+    @patch("tests.activity.classes_mock.FakeSQSQueue.read")
+    @patch("queue_worker.QueueWorker.queues")
+    def test_work_no_messages(self, mock_queues, mock_queue_read):
+        "test work method with an unrecognised bucket name"
+        directory = TempDirectory()
+        mock_queues.return_value = FakeSQSQueue(directory), FakeSQSQueue(directory)
+        mock_queue_read.return_value = None
+        # create a fake green flag
+        flag = FakeFlag()
+        # invoke queue worker to work
+        self.worker.work(flag)
+        # assertion, should be a loginfo message
+        self.assertEqual(self.worker.logger.loginfo[1], "reading message")
+        self.assertEqual(self.worker.logger.loginfo[2], "no messages available")
+        self.assertEqual(self.worker.logger.loginfo[3], "graceful shutdown")
+
+    @patch("queue_worker.QueueWorker.queues")
+    def test_work_no_queue(self, mock_queues):
+        "test if queues are none"
+        mock_queues.return_value = None, None
+        self.worker.queues()
+        # create a fake green flag
+        flag = FakeFlag()
+        # invoke queue worker to work
+        self.worker.work(flag)
+        self.assertEqual(self.worker.logger.logerror, "error obtaining queue")
+
+    @patch("boto.sqs.connect_to_region")
+    def test_queues(self, fake_sqs_conn):
+        "test code which connects to queues for coverage using mocked objects"
+        # mock things
+        directory = TempDirectory()
+        fake_sqs_conn.return_value = FakeSQSConn(directory)
+        self.worker.queues()
+        self.assertIsNotNone(self.worker.conn)
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestQueueWorkerLogInit(unittest.TestCase):
+    def test_queue_worker_init(self):
+        "test object instantiation without passing in a log object"
+        worker = QueueWorker(settings_mock)
+        self.assertIsNotNone(worker.logger)
+
+
+class TestLoadRules(unittest.TestCase):
+    def test_load_rules(self):
+        "test loading rules YAML file"
+        rules = load_rules()
+        self.assertIsNotNone(rules)
+
+
+class TestGetStarterName(unittest.TestCase):
+    def test_get_starter_name(self):
+        "test rules matching to the S3 notification info"
+        rules = test_data.queue_worker_rules
+        info = S3NotificationInfo.from_dict(test_data.queue_worker_article_zip_data)
+        expected_starter_name = "InitialArticleZip"
+        starter_name = get_starter_name(rules, info)
+        self.assertEqual(starter_name, expected_starter_name)
+
+    def test_get_starter_name_ingest_digest(self):
+        "test S3 notification info matching for the ingest digest workflow"
+        rules = test_data.queue_worker_rules
+        info = S3NotificationInfo.from_dict(test_data.ingest_digest_data)
+        expected_starter_name = "IngestDigest"
+        starter_name = get_starter_name(rules, info)
+        self.assertEqual(starter_name, expected_starter_name)
+
+    def test_get_starter_name_ingest_decision_letter(self):
+        "test S3 notification info matching for the ingest decision letter workflow"
+        rules = test_data.queue_worker_rules
+        info = S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data)
+        expected_starter_name = "IngestDecisionLetter"
+        starter_name = get_starter_name(rules, info)
+        self.assertEqual(starter_name, expected_starter_name)

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -30,7 +30,7 @@ class TestQueueWorker(unittest.TestCase):
         "test rules matching to the S3 notification info"
         rules = test_data.queue_worker_rules
         info = S3NotificationInfo.from_dict(test_data.queue_worker_article_zip_data)
-        expected_starter_name = 'InitialArticleZip'
+        expected_starter_name = "InitialArticleZip"
         starter_name = self.worker.get_starter_name(rules, info)
         self.assertEqual(starter_name, expected_starter_name)
 
@@ -38,7 +38,7 @@ class TestQueueWorker(unittest.TestCase):
         "test S3 notification info matching for the ingest digest workflow"
         rules = test_data.queue_worker_rules
         info = S3NotificationInfo.from_dict(test_data.ingest_digest_data)
-        expected_starter_name = 'IngestDigest'
+        expected_starter_name = "IngestDigest"
         starter_name = self.worker.get_starter_name(rules, info)
         self.assertEqual(starter_name, expected_starter_name)
 
@@ -46,15 +46,17 @@ class TestQueueWorker(unittest.TestCase):
         "test S3 notification info matching for the ingest decision letter workflow"
         rules = test_data.queue_worker_rules
         info = S3NotificationInfo.from_dict(test_data.ingest_decision_letter_data)
-        expected_starter_name = 'IngestDecisionLetter'
+        expected_starter_name = "IngestDecisionLetter"
         starter_name = self.worker.get_starter_name(rules, info)
         self.assertEqual(starter_name, expected_starter_name)
 
-    @patch('queue_worker.Message')
-    @patch('tests.activity.classes_mock.FakeSQSQueue.read')
-    @patch('queue_worker.QueueWorker.queues')
-    @patch('queue_worker.QueueWorker.connect')
-    def test_work(self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message):
+    @patch("queue_worker.Message")
+    @patch("tests.activity.classes_mock.FakeSQSQueue.read")
+    @patch("queue_worker.QueueWorker.queues")
+    @patch("queue_worker.QueueWorker.connect")
+    def test_work(
+        self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message
+    ):
         "test the main method of the class"
         directory = TempDirectory()
         mock_sqs_connect = FakeSQSConn(directory)
@@ -72,11 +74,13 @@ class TestQueueWorker(unittest.TestCase):
         self.assertEqual(out_queue_message, test_data.queue_worker_starter_message)
         self.assertEqual(return_value, None)
 
-    @patch('queue_worker.Message')
-    @patch('tests.activity.classes_mock.FakeSQSQueue.read')
-    @patch('queue_worker.QueueWorker.queues')
-    @patch('queue_worker.QueueWorker.connect')
-    def test_work_unknown_bucket(self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message):
+    @patch("queue_worker.Message")
+    @patch("tests.activity.classes_mock.FakeSQSQueue.read")
+    @patch("queue_worker.QueueWorker.queues")
+    @patch("queue_worker.QueueWorker.connect")
+    def test_work_unknown_bucket(
+        self, mock_sqs_connect, mock_queues, mock_queue_read, mock_sqs_message
+    ):
         "test work method with an unrecognised bucket name"
         directory = TempDirectory()
         mock_sqs_connect = FakeSQSConn(directory)
@@ -85,7 +89,7 @@ class TestQueueWorker(unittest.TestCase):
         # create an S3 event message
         s3_event = FakeS3Event()
         # here override the bucket name
-        s3_event._bucket_name = 'not_a_real_bucket'
+        s3_event._bucket_name = "not_a_real_bucket"
         mock_queue_read.return_value = s3_event
         # create a fake green flag
         flag = FakeFlag()
@@ -96,5 +100,6 @@ class TestQueueWorker(unittest.TestCase):
         self.assertIsNone(out_queue_list, None)
         self.assertEqual(return_value, None)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Preparation for issue https://github.com/elifesciences/issues/issues/6436

In order to later create another SQS queue listener which is very similar to the existing `queue_worker.py` process, here the existing code was linted, test coverage expanded, the code was refactored, and then the identity and queue names are set in a way which will make it easier to override them when inheriting from the `QueueWorker` class.

The proposed additional SQS queue listener will be added in another PR later. It will be good to check whether the changes here are still working as expected in end2end tests first.