### PR TITLE
Add accepted_submission_queue_worker

### DIFF
--- a/accepted_submission_queue_worker.py
+++ b/accepted_submission_queue_worker.py
@@ -16,7 +16,7 @@ class AcceptedSubmissionQueueWorker(QueueWorker):
 if __name__ == "__main__":
     ENV = utils.console_start_env()
     SETTINGS = utils.get_settings(ENV)
-    queue_worker_object = CleaningQueueWorker(SETTINGS)
+    queue_worker_object = AcceptedSubmissionQueueWorker(SETTINGS)
     # only start if the queue name is specified in the settings
     if getattr(SETTINGS, QUEUE_SETTING_NAME, None):
         process.monitor_interrupt(lambda flag: queue_worker_object.work(flag))

--- a/accepted_submission_queue_worker.py
+++ b/accepted_submission_queue_worker.py
@@ -1,0 +1,22 @@
+from queue_worker import QueueWorker
+from provider import process, utils
+
+
+QUEUE_SETTING_NAME = "accepted_submission_queue"
+
+
+class AcceptedSubmissionQueueWorker(QueueWorker):
+    def __init__(
+        self, settings, logger=None, identity="accepted_submission_queue_worker"
+    ):
+        super(AcceptedSubmissionQueueWorker, self).__init__(settings, logger, identity)
+        self.input_queue_name = getattr(self.settings, QUEUE_SETTING_NAME, None)
+
+
+if __name__ == "__main__":
+    ENV = utils.console_start_env()
+    SETTINGS = utils.get_settings(ENV)
+    queue_worker_object = CleaningQueueWorker(SETTINGS)
+    # only start if the queue name is specified in the settings
+    if getattr(SETTINGS, QUEUE_SETTING_NAME, None):
+        process.monitor_interrupt(lambda flag: queue_worker_object.work(flag))

--- a/newFileWorkflows.yaml
+++ b/newFileWorkflows.yaml
@@ -17,3 +17,8 @@ DecisionLetterInputFile:
   bucket_name_pattern: '.*elife-bot-decision-letter-input$'
   file_name_pattern: '.*\.(docx|zip)'
   starter_name: 'IngestDecisionLetter'
+
+AcceptedSubmissionInputFile:
+  bucket_name_pattern: '.*elife-accepted-submission-cleaning$'
+  file_name_pattern: '.*\.zip'
+  starter_name: 'IngestAcceptedSubmission'

--- a/settings-example.py
+++ b/settings-example.py
@@ -311,6 +311,7 @@ class exp():
     # Accepted submission workflow
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
+    accepted_submission_queue = ""
 
 
 class dev():
@@ -608,6 +609,7 @@ class dev():
     # Accepted submission workflow
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
+    accepted_submission_queue = ""
 
 
 class live():
@@ -910,6 +912,7 @@ class live():
     # Accepted submission workflow
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
+    accepted_submission_queue = "cleaning-queue"
 
 
 def get_settings(ENV="dev"):

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -72,7 +72,7 @@ class FakeFlag():
 
 class FakeS3Event():
     "object to test an S3 notification event from an SQS queue"
-    def __init__(self):
+    def __init__(self, bucket_name=None):
         self.notification_type = 'S3Event'
         self.id = None
         self.body = ''
@@ -80,6 +80,8 @@ class FakeS3Event():
         self._event_name = u'ObjectCreated:Put'
         self._event_time = u'2016-07-28T16:14:27.809576Z'
         self._bucket_name = u'jen-elife-production-final'
+        if bucket_name:
+            self._bucket_name = bucket_name
         self._file_name = u'elife-00353-vor-r1.zip'
         self._file_etag = u'e7f639f63171c097d4761e2d2efe8dc4'
         self._file_size = 1097506

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -83,3 +83,5 @@ doaj_api_key = ""
 era_incoming_queue = ""
 
 software_heritage_api_get_origin_pattern = "https://archive.swh.example.org/api/1/origin/{origin}/get/"
+
+accepted_submission_queue = "cleaning_queue"

--- a/tests/test_accepted_submission_queue_worker.py
+++ b/tests/test_accepted_submission_queue_worker.py
@@ -1,0 +1,60 @@
+import unittest
+import json
+import copy
+from mock import patch
+from testfixtures import TempDirectory
+from accepted_submission_queue_worker import AcceptedSubmissionQueueWorker
+from queue_worker import get_starter_name
+from S3utility.s3_notification_info import S3NotificationInfo
+from provider.utils import bytes_decode
+from tests import settings_mock, test_data
+from tests.classes_mock import FakeFlag, FakeS3Event
+from tests.activity.classes_mock import FakeLogger, FakeSQSMessage, FakeSQSQueue
+
+
+TEST_BUCKET_NAME = "prod-elife-accepted-submission-cleaning"
+EXPECTED_STARTER_NAME = "IngestAcceptedSubmission"
+
+
+class TestAcceptedSubmissionQueueWorker(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.worker = AcceptedSubmissionQueueWorker(settings_mock, self.logger)
+        # override the sleep value for faster testing
+        self.worker.sleep_seconds = 0.1
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("queue_worker.Message")
+    @patch("tests.activity.classes_mock.FakeSQSQueue.read")
+    @patch("accepted_submission_queue_worker.AcceptedSubmissionQueueWorker.queues")
+    def test_work(self, mock_queues, mock_queue_read, mock_sqs_message):
+        "test the main method of the class"
+        directory = TempDirectory()
+        # mock_sqs_connect = FakeSQSConn(directory)
+        mock_queues.return_value = FakeSQSQueue(directory), FakeSQSQueue(directory)
+        mock_sqs_message.return_value = FakeSQSMessage(directory)
+        # create an S3 event message
+        s3_event = FakeS3Event(bucket_name=TEST_BUCKET_NAME)
+        mock_queue_read.return_value = s3_event
+        # create a fake green flag
+        flag = FakeFlag()
+        # invoke queue worker to work
+        self.worker.work(flag)
+        # assertions, should have a message in the out_queue
+        out_queue_message = json.loads(bytes_decode(directory.read("fake_sqs_body")))
+        self.assertEqual(out_queue_message.get("workflow_name"), EXPECTED_STARTER_NAME)
+        self.assertEqual(self.worker.logger.loginfo[-1], "graceful shutdown")
+        self.assertIsNotNone(self.worker.input_queue_name)
+
+
+class TestAcceptedSubmissionGetStarterName(unittest.TestCase):
+    def test_get_starter_name(self):
+        "test rules matching to the S3 notification info"
+        rules = test_data.queue_worker_rules
+        data = copy.copy(test_data.queue_worker_article_zip_data)
+        data["bucket_name"] = TEST_BUCKET_NAME
+        info = S3NotificationInfo.from_dict(data)
+        starter_name = get_starter_name(rules, info)
+        self.assertEqual(starter_name, EXPECTED_STARTER_NAME)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -188,6 +188,11 @@ queue_worker_rules = {
        'file_name_pattern': r'.*\.(docx|zip)',
        'starter_name': 'IngestDecisionLetter'
        },
+    'AcceptedSubmissionInputFile': {
+       'bucket_name_pattern': '.*elife-accepted-submission-cleaning$',
+       'file_name_pattern': r'.*\.zip',
+       'starter_name': 'IngestAcceptedSubmission'
+       },
     }
 
 queue_worker_article_zip_data = {u'event_time': u'2016-07-28T16:14:27.809576Z',


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6436 for reading new queue

Re issue https://github.com/elifesciences/issues/issues/6376 for automating the workflow when objects arrive in an S3 bucket.

The new `accepted_submission_queue_worker.py` module will be configured to run as a service, read S3 notification events from a separate queue and start `IngestAcceptedSubmission` worklfow executions if the S3 object is from a bucket name which matches the rule included in the `newFileWorkflows.yaml` file.

The class `AcceptedSubmissionQueueWorker` inherits all of its logic from the existing `QueueWorker` class, except it has a different identity for logging and application running, and it connects to a different incoming SQS queue. It is also set so if the `accepted_submission_queue` setting value is blank then it shouldn't try to read from the undefined queue.

The code here should be safe to merge and deploy since it is not set to run automatically yet.
