### PR TITLE
queue_workflow_starter IngestAcceptedSubmission config.

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -114,6 +114,10 @@ def process_data_ingestdecisionletter(workflow_data):
     return process_data_s3_notification_default(workflow_data)
 
 
+def process_data_ingestacceptedsubmission(workflow_data):
+    return process_data_s3_notification_default(workflow_data)
+
+
 workflow_data_processors = {
     'IngestArticleZip': process_data_ingestarticlezip,
     'InitialArticleZip': process_data_initialarticlezip,
@@ -122,6 +126,7 @@ workflow_data_processors = {
     'PubmedArticleDeposit': process_data_pubmedarticledeposit,
     'IngestDigest': process_data_ingestdigest,
     'IngestDecisionLetter': process_data_ingestdecisionletter,
+    'IngestAcceptedSubmission': process_data_ingestacceptedsubmission,
 }
 
 


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/elife-bot/pull/1281

The input SQS queue messages were read correctly in this case, I think, but the outgoing messages goes to the workflow starter queue, and it needs to be told which workflows it can start and how to use the workflow data.