### PR TITLE
Outbox provider

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -11,10 +11,10 @@ DepositCrossref activity
 
 
 class activity_DepositCrossref(Activity):
-
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_DepositCrossref, self).__init__(
-            settings, logger, conn, token, activity_task)
+            settings, logger, conn, token, activity_task
+        )
 
         self.name = "DepositCrossref"
         self.version = "1"
@@ -22,13 +22,15 @@ class activity_DepositCrossref(Activity):
         self.default_task_schedule_to_close_timeout = 60 * 30
         self.default_task_schedule_to_start_timeout = 30
         self.default_task_start_to_close_timeout = 60 * 15
-        self.description = ("Download article XML from crossref outbox, " +
-                            "generate crossref XML, and deposit with crossref.")
+        self.description = (
+            "Download article XML from crossref outbox, "
+            + "generate crossref XML, and deposit with crossref."
+        )
 
         # Local directory settings
         self.directories = {
             "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
-            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir")
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
         }
 
         # Bucket for outgoing files
@@ -47,7 +49,7 @@ class activity_DepositCrossref(Activity):
         """
         Activity, do the work
         """
-        self.logger.info('data: %s' % json.dumps(data, sort_keys=True, indent=4))
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
 
         # Create output directories
         self.make_activity_directories()
@@ -74,14 +76,21 @@ class activity_DepositCrossref(Activity):
 
         crossref_config = crossref.elifecrossref_config(self.settings)
 
-        article_object_map = self.get_article_objects(article_xml_files, crossref_config)
+        article_object_map = self.get_article_objects(
+            article_xml_files, crossref_config
+        )
         generate_article_object_map = crossref.approve_to_generate_list(
-            article_object_map, crossref_config, self.bad_xml_files)
+            article_object_map, crossref_config, self.bad_xml_files
+        )
 
         # Generate crossref XML
         self.statuses["generate"] = crossref.generate_crossref_xml_to_disk(
-            generate_article_object_map, crossref_config, self.good_xml_files,
-            self.bad_xml_files, submission_type="journal")
+            generate_article_object_map,
+            crossref_config,
+            self.good_xml_files,
+            self.bad_xml_files,
+            submission_type="journal",
+        )
 
         # Approve files for publishing
         self.statuses["approve"] = self.approve_for_publishing()
@@ -90,8 +99,12 @@ class activity_DepositCrossref(Activity):
         if self.statuses.get("approve") is True:
             try:
                 # Publish files
-                self.statuses["publish"], http_detail_list = self.deposit_files_to_endpoint(
-                    sub_dir=self.directories.get("TMP_DIR"))
+                (
+                    self.statuses["publish"],
+                    http_detail_list,
+                ) = self.deposit_files_to_endpoint(
+                    sub_dir=self.directories.get("TMP_DIR")
+                )
             except:
                 self.statuses["publish"] = False
 
@@ -121,16 +134,18 @@ class activity_DepositCrossref(Activity):
 
         # Set the activity status of this activity based on successes
         self.statuses["activity"] = bool(
-            self.statuses.get("publish") is not False and
-            self.statuses.get("generate") is not False)
+            self.statuses.get("publish") is not False
+            and self.statuses.get("generate") is not False
+        )
 
         # Send email
         # Only if there were files approved for publishing
-        if len(self.good_xml_files) > 0:
-            self.statuses["email"] = self.send_admin_email(outbox_s3_key_names, http_detail_list)
+        if self.good_xml_files:
+            self.statuses["email"] = self.send_admin_email(
+                outbox_s3_key_names, http_detail_list
+            )
 
-        self.logger.info(
-            "%s statuses: %s" % (self.name, self.statuses))
+        self.logger.info("%s statuses: %s" % (self.name, self.statuses))
 
         return True
 
@@ -138,11 +153,14 @@ class activity_DepositCrossref(Activity):
         """turn XML into article objects and populate their data"""
         # parse XML files into the basic article object map to start with
         article_object_map = crossref.article_xml_list_parse(
-            article_xml_files, self.bad_xml_files, self.directories.get("TMP_DIR"))
+            article_xml_files, self.bad_xml_files, self.directories.get("TMP_DIR")
+        )
         # continue with setting more article data
         for article in list(article_object_map.values()):
             # Check for a pub date otherwise set one
-            crossref.set_article_pub_date(article, crossref_config, self.settings, self.logger)
+            crossref.set_article_pub_date(
+                article, crossref_config, self.settings, self.logger
+            )
             # Check for a version number
             crossref.set_article_version(article, self.settings)
         return article_object_map
@@ -155,41 +173,64 @@ class activity_DepositCrossref(Activity):
         """Using an HTTP POST, deposit the file to the endpoint"""
         xml_files = glob.glob(sub_dir + file_type)
         payload = crossref.crossref_data_payload(
-            self.settings.crossref_login_id, self.settings.crossref_login_passwd)
+            self.settings.crossref_login_id, self.settings.crossref_login_passwd
+        )
         return crossref.upload_files_to_endpoint(
-            self.settings.crossref_url, payload, xml_files)
+            self.settings.crossref_url, payload, xml_files
+        )
 
     def send_admin_email(self, outbox_s3_key_names, http_detail_list):
         """
         After do_activity is finished, send emails to recipients
         on the status
         """
-        datetime_string = time.strftime('%Y-%m-%d %H:%M', time.gmtime())
-        activity_status_text = utils.get_activity_status_text(self.statuses.get("activity"))
+        datetime_string = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
+        activity_status_text = utils.get_activity_status_text(
+            self.statuses.get("activity")
+        )
 
-        body = email_provider.get_email_body_head(self.name, activity_status_text, self.statuses)
+        body = email_provider.get_email_body_head(
+            self.name, activity_status_text, self.statuses
+        )
         body += email_provider.get_email_body_middle(
-            "crossref", outbox_s3_key_names, self.good_xml_files,
-            self.bad_xml_files, http_detail_list)
+            "crossref",
+            outbox_s3_key_names,
+            self.good_xml_files,
+            self.bad_xml_files,
+            http_detail_list,
+        )
         body += email_provider.get_admin_email_body_foot(
-            self.get_activityId(), self.get_workflowId(), datetime_string, self.settings.domain)
+            self.get_activityId(),
+            self.get_workflowId(),
+            datetime_string,
+            self.settings.domain,
+        )
 
         subject = email_provider.get_email_subject(
-            datetime_string, activity_status_text, self.name,
-            self.settings.domain, outbox_s3_key_names)
+            datetime_string,
+            activity_status_text,
+            self.name,
+            self.settings.domain,
+            outbox_s3_key_names,
+        )
         sender_email = self.settings.ses_poa_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
-            self.settings.ses_admin_email)
+            self.settings.ses_admin_email
+        )
 
         for email in recipient_email_list:
             # Add the email to the email queue
             message = email_provider.simple_message(
-                sender_email, email, subject, body, logger=self.logger)
+                sender_email, email, subject, body, logger=self.logger
+            )
 
             email_provider.smtp_send_messages(
-                self.settings, messages=[message], logger=self.logger)
-            self.logger.info('Email sending details: admin email, email %s, to %s' %
-                             ("DepositCrossref", email))
+                self.settings, messages=[message], logger=self.logger
+            )
+            self.logger.info(
+                "Email sending details: admin email, email %s, to %s"
+                % ("DepositCrossref", email)
+            )
 
         return True

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -3,7 +3,7 @@ import json
 import time
 import glob
 from activity.objects import Activity
-from provider import crossref, email_provider, utils
+from provider import crossref, email_provider, outbox_provider, utils
 
 """
 DepositCrossref activity
@@ -57,13 +57,18 @@ class activity_DepositCrossref(Activity):
 
         date_stamp = utils.set_datestamp()
 
-        outbox_s3_key_names = crossref.get_outbox_s3_key_names(
-            self.settings, self.publish_bucket, self.outbox_folder)
+        outbox_s3_key_names = outbox_provider.get_outbox_s3_key_names(
+            self.settings, self.publish_bucket, self.outbox_folder
+        )
 
         # Download the S3 objects
-        self.statuses["download"] = crossref.download_files_from_s3_outbox(
-            self.settings, self.publish_bucket, outbox_s3_key_names,
-            self.directories.get("INPUT_DIR"), self.logger)
+        self.statuses["download"] = outbox_provider.download_files_from_s3_outbox(
+            self.settings,
+            self.publish_bucket,
+            outbox_s3_key_names,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
 
         article_xml_files = glob.glob(self.directories.get("INPUT_DIR") + "/*.xml")
 
@@ -93,14 +98,25 @@ class activity_DepositCrossref(Activity):
         if self.statuses.get("publish") is True:
             # Clean up outbox
             self.logger.info("Moving files from outbox folder to published folder")
-            to_folder = crossref.get_to_folder_name(self.published_folder, date_stamp)
-            crossref.clean_outbox(self.settings, self.publish_bucket, self.outbox_folder,
-                                  to_folder, self.good_xml_files)
+            to_folder = outbox_provider.get_to_folder_name(
+                self.published_folder, date_stamp
+            )
+            outbox_provider.clean_outbox(
+                self.settings,
+                self.publish_bucket,
+                self.outbox_folder,
+                to_folder,
+                self.good_xml_files,
+            )
             # copy the Crossref deposit XML files to the batch folder
             batch_file_names = glob.glob(self.directories.get("TMP_DIR") + "/*.xml")
             batch_file_to_folder = to_folder + "batch/"
-            crossref.upload_crossref_xml_to_s3(
-                self.settings, self.publish_bucket, batch_file_to_folder, batch_file_names)
+            outbox_provider.upload_files_to_s3_folder(
+                self.settings,
+                self.publish_bucket,
+                batch_file_to_folder,
+                batch_file_names,
+            )
             self.statuses["outbox"] = True
 
         # Set the activity status of this activity based on successes

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -15,9 +15,11 @@ def override_tmp_dir(tmp_dir):
 
 def elifecrossref_config(settings):
     "parse the config values from the elifecrossref config"
-    return parse_raw_config(raw_config(
-        settings.elifecrossref_config_section,
-        settings.elifecrossref_config_file))
+    return parse_raw_config(
+        raw_config(
+            settings.elifecrossref_config_section, settings.elifecrossref_config_file
+        )
+    )
 
 
 def parse_article_xml(article_xml_files, tmp_dir=None):
@@ -57,19 +59,20 @@ def set_article_pub_date(article, crossref_config, settings, logger):
     # if no date was found then look for one on Lax
     if not article_pub_date:
         lax_pub_date = lax_provider.article_publication_date(
-            article.manuscript, settings, logger)
+            article.manuscript, settings, logger
+        )
         if lax_pub_date:
             date_struct = time.strptime(lax_pub_date, utils.S3_DATE_FORMAT)
             pub_date_object = ArticleDate(
-                crossref_config.get('pub_date_types')[0], date_struct)
+                crossref_config.get("pub_date_types")[0], date_struct
+            )
             article.add_date(pub_date_object)
 
 
 def set_article_version(article, settings):
     """if there is no version then set it from lax data"""
     if not article.version:
-        lax_version = lax_provider.article_highest_version(
-            article.manuscript, settings)
+        lax_version = lax_provider.article_highest_version(article.manuscript, settings)
         if lax_version:
             article.version = lax_version
 
@@ -77,9 +80,9 @@ def set_article_version(article, settings):
 def article_first_pub_date(crossref_config, article):
     "find the first article pub date from the list of crossref config pub_date_types"
     pub_date = None
-    if crossref_config.get('pub_date_types'):
+    if crossref_config.get("pub_date_types"):
         # check for any useable pub date
-        for pub_date_type in crossref_config.get('pub_date_types'):
+        for pub_date_type in crossref_config.get("pub_date_types"):
             if article.get_date(pub_date_type):
                 pub_date = article.get_date(pub_date_type)
                 break
@@ -116,12 +119,14 @@ def approve_to_generate_list(article_object_map, crossref_config, bad_xml_files)
     return generate_article_object_map
 
 
-def crossref_data_payload(crossref_login_id, crossref_login_passwd, operation='doMDUpload'):
+def crossref_data_payload(
+    crossref_login_id, crossref_login_passwd, operation="doMDUpload"
+):
     """assemble a requests data payload for Crossref endpoint"""
     return {
-        'operation': operation,
-        'login_id': crossref_login_id,
-        'login_passwd': crossref_login_passwd
+        "operation": operation,
+        "login_id": crossref_login_id,
+        "login_passwd": crossref_login_passwd,
     }
 
 
@@ -133,7 +138,7 @@ def upload_files_to_endpoint(url, payload, xml_files):
     http_detail_list = []
 
     for xml_file in xml_files:
-        files = {'file': open(xml_file, 'rb')}
+        files = {"file": open(xml_file, "rb")}
 
         response = requests.post(url, data=payload, files=files)
 
@@ -148,16 +153,26 @@ def upload_files_to_endpoint(url, payload, xml_files):
     return status, http_detail_list
 
 
-def generate_crossref_xml_to_disk(article_object_map, crossref_config, good_xml_files,
-                                  bad_xml_files, submission_type="journal",
-                                  pretty=False, indent=""):
+def generate_crossref_xml_to_disk(
+    article_object_map,
+    crossref_config,
+    good_xml_files,
+    bad_xml_files,
+    submission_type="journal",
+    pretty=False,
+    indent="",
+):
     """from the article object generate crossref deposit XML"""
     for xml_file, article in list(article_object_map.items()):
         try:
             # Will write the XML to the TMP_DIR
             generate.crossref_xml_to_disk(
-                [article], crossref_config, submission_type=submission_type,
-                pretty=pretty, indent=indent)
+                [article],
+                crossref_config,
+                submission_type=submission_type,
+                pretty=pretty,
+                indent=indent,
+            )
             # Add filename to the list of good files
             good_xml_files.append(xml_file)
         except:
@@ -175,5 +190,5 @@ def doi_exists(doi, logger):
     if 300 <= response.status_code < 400:
         exists = True
     elif response.status_code < 300 or response.status_code >= 500:
-        logger.info('Status code for %s was %s' % (doi, response.status_code))
+        logger.info("Status code for %s was %s" % (doi, response.status_code))
     return exists

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -1,12 +1,10 @@
-import os
 import time
 from collections import OrderedDict
 import requests
 from elifearticle.article import ArticleDate
 from elifecrossref import generate
 from elifecrossref.conf import raw_config, parse_raw_config
-from provider import article_processing, lax_provider, utils
-from provider.storage_provider import storage_context
+from provider import lax_provider, utils
 
 
 def override_tmp_dir(tmp_dir):
@@ -167,92 +165,6 @@ def generate_crossref_xml_to_disk(article_object_map, crossref_config, good_xml_
             bad_xml_files.append(xml_file)
     # Any files generated is a sucess, even if one failed
     return True
-
-
-def get_to_folder_name(folder_name, date_stamp):
-    """
-    From the date_stamp
-    return the S3 folder name to save published files into
-    """
-    return folder_name + date_stamp + "/"
-
-
-def get_outbox_s3_key_names(settings, bucket_name, outbox_folder):
-    """get a list of .xml S3 key names from the outbox"""
-    storage = storage_context(settings)
-    storage_provider = settings.storage_provider + "://"
-    orig_resource = (
-        storage_provider + bucket_name + "/" + outbox_folder.rstrip('/'))
-    s3_key_names = storage.list_resources(orig_resource)
-    # add back the outbox_folder to the key names
-    full_s3_key_names = [(outbox_folder.rstrip('/') + '/' + key_name) for key_name in s3_key_names]
-    # return only the .xml files
-    return [key_name for key_name in full_s3_key_names if key_name.endswith('.xml')]
-
-
-def download_files_from_s3_outbox(settings, bucket_name, outbox_s3_key_names, to_dir, logger):
-    """from the s3 outbox folder,  download the .xml files"""
-    storage = storage_context(settings)
-    storage_provider = settings.storage_provider + "://"
-    orig_resource = storage_provider + bucket_name + "/"
-
-    for name in outbox_s3_key_names:
-        # Download objects from S3 and save to disk
-        file_name = name.split('/')[-1]
-        file_path = os.path.join(to_dir, file_name)
-        storage_resource_origin = orig_resource + '/' + name
-        try:
-            with open(file_path, 'wb') as open_file:
-                logger.info("Downloading %s to %s" % (storage_resource_origin, file_path))
-                storage.get_resource_to_file(storage_resource_origin, open_file)
-        except IOError:
-            logger.exception("Failed to download file %s.", name)
-            return False
-    return True
-
-
-def clean_outbox(settings, bucket_name, outbox_folder, to_folder, published_file_names):
-    """Clean out the S3 outbox folder"""
-
-    # Concatenate the expected S3 outbox file names
-    s3_key_names = []
-    for name in published_file_names:
-        filename = name.split(os.sep)[-1]
-        s3_key_name = outbox_folder + filename
-        s3_key_names.append(s3_key_name)
-
-    storage = storage_context(settings)
-    storage_provider = settings.storage_provider + "://"
-
-    for name in s3_key_names:
-        # Do not delete the from_folder itself, if it is in the list
-        if name == outbox_folder:
-            continue
-        filename = name.split("/")[-1]
-        new_s3_key_name = to_folder + filename
-
-        orig_resource = storage_provider + bucket_name + "/" + name
-        dest_resource = storage_provider + bucket_name + "/" + new_s3_key_name
-
-        # First copy
-        storage.copy_resource(orig_resource, dest_resource)
-
-        # Then delete the old key if successful
-        storage.delete_resource(orig_resource)
-
-
-def upload_crossref_xml_to_s3(settings, bucket_name, to_folder, file_names):
-    """
-    Upload a copy of the crossref XML to S3 for reference
-    """
-    storage = storage_context(settings)
-    storage_provider = settings.storage_provider + "://"
-
-    for file_name in file_names:
-        resource_dest = (
-            storage_provider + bucket_name + "/" + to_folder +
-            article_processing.file_name_from_name(file_name))
-        storage.set_resource_from_filename(resource_dest, file_name)
 
 
 def doi_exists(doi, logger):

--- a/provider/outbox_provider.py
+++ b/provider/outbox_provider.py
@@ -1,0 +1,98 @@
+import os
+from provider import article_processing
+from provider.storage_provider import storage_context
+
+
+def get_to_folder_name(folder_name, date_stamp):
+    """
+    From the date_stamp
+    return the S3 folder name to save published files into
+    """
+    return folder_name + date_stamp + "/"
+
+
+def get_outbox_s3_key_names(settings, bucket_name, outbox_folder):
+    """get a list of .xml S3 key names from the outbox"""
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+    orig_resource = storage_provider + bucket_name + "/" + outbox_folder.rstrip("/")
+    s3_key_names = storage.list_resources(orig_resource)
+    # add back the outbox_folder to the key names
+    full_s3_key_names = [
+        (outbox_folder.rstrip("/") + "/" + key_name) for key_name in s3_key_names
+    ]
+    # return only the .xml files
+    return [key_name for key_name in full_s3_key_names if key_name.endswith(".xml")]
+
+
+def download_files_from_s3_outbox(
+    settings, bucket_name, outbox_s3_key_names, to_dir, logger
+):
+    """from the s3 outbox folder,  download the .xml files"""
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+    orig_resource = storage_provider + bucket_name + "/"
+
+    for name in outbox_s3_key_names:
+        # Download objects from S3 and save to disk
+        file_name = name.split("/")[-1]
+        file_path = os.path.join(to_dir, file_name)
+        storage_resource_origin = orig_resource + "/" + name
+        try:
+            with open(file_path, "wb") as open_file:
+                logger.info(
+                    "Downloading %s to %s" % (storage_resource_origin, file_path)
+                )
+                storage.get_resource_to_file(storage_resource_origin, open_file)
+        except IOError:
+            logger.exception("Failed to download file %s.", name)
+            return False
+    return True
+
+
+def clean_outbox(settings, bucket_name, outbox_folder, to_folder, published_file_names):
+    """Clean out the S3 outbox folder"""
+
+    # Concatenate the expected S3 outbox file names
+    s3_key_names = []
+    for name in published_file_names:
+        filename = name.split(os.sep)[-1]
+        s3_key_name = outbox_folder + filename
+        s3_key_names.append(s3_key_name)
+
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+
+    for name in s3_key_names:
+        # Do not delete the from_folder itself, if it is in the list
+        if name == outbox_folder:
+            continue
+        filename = name.split("/")[-1]
+        new_s3_key_name = to_folder + filename
+
+        orig_resource = storage_provider + bucket_name + "/" + name
+        dest_resource = storage_provider + bucket_name + "/" + new_s3_key_name
+
+        # First copy
+        storage.copy_resource(orig_resource, dest_resource)
+
+        # Then delete the old key if successful
+        storage.delete_resource(orig_resource)
+
+
+def upload_files_to_s3_folder(settings, bucket_name, to_folder, file_names):
+    """
+    Upload multiple files to a folder in an S3 bucket
+    """
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+
+    for file_name in file_names:
+        resource_dest = (
+            storage_provider
+            + bucket_name
+            + "/"
+            + to_folder
+            + article_processing.file_name_from_name(file_name)
+        )
+        storage.set_resource_from_filename(resource_dest, file_name)

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -44,7 +44,7 @@ class TestDepositCrossref(unittest.TestCase):
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.crossref.storage_context')
+    @patch('provider.outbox_provider.storage_context')
     @data(
         {
             "comment": "Article 15747",

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import unittest
-import shutil
 from mock import patch
 from ddt import ddt, data
 from provider import crossref
@@ -17,38 +16,31 @@ import tests.test_data as test_case_data
 
 @ddt
 class TestDepositCrossref(unittest.TestCase):
-
     def setUp(self):
         fake_logger = FakeLogger()
-        self.activity = activity_DepositCrossref(settings_mock, fake_logger, None, None, None)
+        self.activity = activity_DepositCrossref(
+            settings_mock, fake_logger, None, None, None
+        )
         self.activity.make_activity_directories()
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
-
-    def input_dir(self):
-        "return the staging dir name for the activity"
-        return self.activity.directories.get("INPUT_DIR")
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
         return self.activity.directories.get("TMP_DIR")
 
-    def fake_download_files_from_s3_outbox(self, document):
-        source_doc = "tests/test_data/crossref/" + document
-        dest_doc = self.input_dir() + os.sep + document
-        shutil.copy(source_doc, dest_doc)
-
-    @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch('requests.post')
-    @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.outbox_provider.storage_context')
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch("requests.post")
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.outbox_provider.storage_context")
     @data(
         {
             "comment": "Article 15747",
-            "article_xml_filenames": ['elife-15747-v2.xml'],
+            "article_xml_filenames": ["elife-15747-v2.xml"],
             "post_status_code": 200,
             "expected_result": True,
             "expected_approve_status": True,
@@ -59,28 +51,36 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_activity_status": True,
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
-                '<doi>10.7554/eLife.15747</doi>',
-                ('<publication_date media_type="online"><month>06</month><day>16</day>' +
-                 '<year>2016</year></publication_date>'),
+                "<doi>10.7554/eLife.15747</doi>",
+                (
+                    '<publication_date media_type="online"><month>06</month><day>16</day>'
+                    + "<year>2016</year></publication_date>"
+                ),
                 '<item_number item_number_type="article_number">e15747</item_number>',
-                ('<citation key="bib13"><journal_title>BMC Biology</journal_title>' +
-                 '<author>Gilbert</author><volume>12</volume><cYear>2014</cYear>' +
-                 '<article_title>The Earth Microbiome project: successes and aspirations' +
-                 '</article_title><doi>10.1186/s12915-014-0069-1</doi>' +
-                 '<elocation_id>69</elocation_id></citation>')
-                ],
+                (
+                    '<citation key="bib13"><journal_title>BMC Biology</journal_title>'
+                    + "<author>Gilbert</author><volume>12</volume><cYear>2014</cYear>"
+                    + "<article_title>The Earth Microbiome project: successes and aspirations"
+                    + "</article_title><doi>10.1186/s12915-014-0069-1</doi>"
+                    + "<elocation_id>69</elocation_id></citation>"
+                ),
+            ],
             "expected_email_count": 1,
             "expected_email_subject": "DepositCrossref Success! files: 1,",
             "expected_email_from": "From: sender@example.org",
             "expected_email_body_contains": [
                 r"DepositCrossref status:\n\nSuccess!\n\nactivity_status: True",
                 r"Published files generated crossref XML: \nelife-15747-v2.xml",
-                "HTTP status: 200"],
+                "HTTP status: 200",
+            ],
         },
         {
             "comment": "Multiple files to deposit",
             "article_xml_filenames": [
-                'elife-18753-v1.xml', 'elife-23065-v1.xml', 'fake-00000-v1.xml'],
+                "elife-18753-v1.xml",
+                "elife-23065-v1.xml",
+                "fake-00000-v1.xml",
+            ],
             "post_status_code": 200,
             "expected_result": True,
             "expected_approve_status": True,
@@ -106,7 +106,7 @@ class TestDepositCrossref(unittest.TestCase):
         },
         {
             "comment": "API endpoint 404",
-            "article_xml_filenames": ['elife-18753-v1.xml'],
+            "article_xml_filenames": ["elife-18753-v1.xml"],
             "post_status_code": 404,
             "expected_result": True,
             "expected_approve_status": True,
@@ -118,10 +118,18 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_file_count": 1,
         },
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_list_resources,
-                         fake_request, fake_email_smtp_connect):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/')
+    def test_do_activity(
+        self,
+        test_data,
+        fake_storage_context,
+        fake_list_resources,
+        fake_request,
+        fake_email_smtp_connect,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         # copy XML files into the input directory
         fake_list_resources.return_value = test_data["article_xml_filenames"]
         # mock the POST to endpoint
@@ -131,27 +139,43 @@ class TestDepositCrossref(unittest.TestCase):
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions
-        for status_name in ['approve', 'generate', 'publish', 'outbox', 'email', 'activity']:
+        for status_name in [
+            "approve",
+            "generate",
+            "publish",
+            "outbox",
+            "email",
+            "activity",
+        ]:
             status_value = self.activity.statuses.get(status_name)
             expected = test_data.get("expected_" + status_name + "_status")
             self.assertEqual(
-                status_value, expected,
-                '{expected} {status_name} status not equal to {status_value} in {comment}'.format(
-                    expected=expected, status_name=status_name, status_value=status_value,
-                    comment=test_data.get("comment")))
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
         # Count crossref XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
         self.assertEqual(file_count, test_data.get("expected_file_count"))
         if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
             # Open the first crossref XML and check some of its contents
-            crossref_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
-            with open(crossref_xml_filename_path, 'rb') as open_file:
-                crossref_xml = open_file.read().decode('utf8')
+            crossref_xml_filename_path = os.path.join(
+                self.tmp_dir(), os.listdir(self.tmp_dir())[0]
+            )
+            with open(crossref_xml_filename_path, "rb") as open_file:
+                crossref_xml = open_file.read().decode("utf8")
                 for expected in test_data.get("expected_crossref_xml_contains"):
                     self.assertTrue(
                         expected in crossref_xml,
-                        '{expected} not found in crossref_xml {path}'.format(
-                            expected=expected, path=crossref_xml_filename_path))
+                        "{expected} not found in crossref_xml {path}".format(
+                            expected=expected, path=crossref_xml_filename_path
+                        ),
+                    )
 
         # check email files and contents
         email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
@@ -178,18 +202,18 @@ class TestDepositCrossref(unittest.TestCase):
                     ):
                         self.assertTrue(expected_to_contain in str(body))
 
-    @patch('provider.lax_provider.article_versions')
+    @patch("provider.lax_provider.article_versions")
     def test_get_article_objects(self, mock_article_versions):
         "example where there is not pub date and no version for an article"
-        mock_article_versions.return_value = 200, test_case_data.lax_article_versions_response_data
+        mock_article_versions.return_value = (
+            200,
+            test_case_data.lax_article_versions_response_data,
+        )
         crossref_config = crossref.elifecrossref_config(settings_mock)
-        xml_file = 'tests/test_data/crossref/outbox/elife_poa_e03977.xml'
+        xml_file = "tests/test_data/crossref/outbox/elife_poa_e03977.xml"
         articles = self.activity.get_article_objects([xml_file], crossref_config)
         article = articles[xml_file]
         self.assertIsNotNone(
-            article.get_date('pub'), 'date of type pub not found in article get_date()')
-        self.assertIsNotNone(article.version, 'version is None in article')
-
-
-if __name__ == '__main__':
-    unittest.main()
+            article.get_date("pub"), "date of type pub not found in article get_date()"
+        )
+        self.assertIsNotNone(article.version, "version is None in article")

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -1,14 +1,19 @@
 import os
 import unittest
-import shutil
 from mock import patch
 from ddt import ddt, data
 from elifearticle.article import Article, Contributor
 from provider import bigquery, crossref, lax_provider
 import activity.activity_DepositCrossrefPeerReview as activity_module
-from activity.activity_DepositCrossrefPeerReview import activity_DepositCrossrefPeerReview
+from activity.activity_DepositCrossrefPeerReview import (
+    activity_DepositCrossrefPeerReview,
+)
 from tests import bigquery_test_data
-from tests.classes_mock import FakeSMTPServer, FakeBigQueryClient, FakeBigQueryRowIterator
+from tests.classes_mock import (
+    FakeSMTPServer,
+    FakeBigQueryClient,
+    FakeBigQueryRowIterator,
+)
 from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
 import tests.activity.settings_mock as settings_mock
 import tests.activity.test_activity_data as activity_test_data
@@ -17,42 +22,34 @@ import tests.activity.helpers as helpers
 
 @ddt
 class TestDepositCrossrefPeerReview(unittest.TestCase):
-
     def setUp(self):
         fake_logger = FakeLogger()
         self.activity = activity_DepositCrossrefPeerReview(
-            settings_mock, fake_logger, None, None, None)
+            settings_mock, fake_logger, None, None, None
+        )
         self.activity.make_activity_directories()
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
-
-    def input_dir(self):
-        "return the staging dir name for the activity"
-        return self.activity.directories.get("INPUT_DIR")
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
         return self.activity.directories.get("TMP_DIR")
 
-    def fake_download_files_from_s3_outbox(self, document):
-        source_doc = "tests/test_data/crossref_peer_review/" + document
-        dest_doc = self.input_dir() + os.sep + document
-        shutil.copy(source_doc, dest_doc)
-
-    @patch.object(bigquery, 'get_client')
-    @patch.object(activity_module, 'check_vor_is_published')
-    @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch('requests.head')
-    @patch('requests.post')
-    @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.outbox_provider.storage_context')
+    @patch.object(bigquery, "get_client")
+    @patch.object(activity_module, "check_vor_is_published")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch("requests.head")
+    @patch("requests.post")
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.outbox_provider.storage_context")
     @data(
         {
             "comment": "Article 15747",
-            "article_xml_filenames": ['elife-15747-v2.xml', 'elife_poa_e03977.xml'],
+            "article_xml_filenames": ["elife-15747-v2.xml", "elife_poa_e03977.xml"],
             "post_status_code": 200,
             "expected_result": True,
             "expected_approve_status": True,
@@ -64,31 +61,43 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
             "expected_file_count": 1,
             "expected_crossref_xml_contains": [
                 '<peer_review stage="pre-publication" type="editor-report">',
-                '<title>Decision letter: Community-level cohesion without cooperation</title>',
-                '<review_date>',
-                '<month>05</month>',
-                '<month>06</month>',
-                '<ai:license_ref>http://creativecommons.org/licenses/by/4.0/</ai:license_ref>',
+                "<title>Decision letter: Community-level cohesion without cooperation</title>",
+                "<review_date>",
+                "<month>05</month>",
+                "<month>06</month>",
+                "<ai:license_ref>http://creativecommons.org/licenses/by/4.0/</ai:license_ref>",
                 '<person_name contributor_role="editor" sequence="first">',
-                '<surname>Bergstrom</surname>',
-                ('<rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">' +
-                 '10.7554/eLife.15747</rel:inter_work_relation>'),
-                '<doi>10.7554/eLife.15747.010</doi>',
-                '<resource>https://elifesciences.org/articles/15747#SA1</resource>',
-
+                "<surname>Bergstrom</surname>",
+                (
+                    '<rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">'
+                    + "10.7554/eLife.15747</rel:inter_work_relation>"
+                ),
+                "<doi>10.7554/eLife.15747.010</doi>",
+                "<resource>https://elifesciences.org/articles/15747#SA1</resource>",
                 '<peer_review stage="pre-publication" type="author-comment">',
-                '<title>Author response: Community-level cohesion without cooperation</title>',
-                '<doi>10.7554/eLife.15747.011</doi>',
-                '<resource>https://elifesciences.org/articles/15747#SA2</resource>'
-                ]
+                "<title>Author response: Community-level cohesion without cooperation</title>",
+                "<doi>10.7554/eLife.15747.011</doi>",
+                "<resource>https://elifesciences.org/articles/15747#SA2</resource>",
+            ],
         }
     )
-    def test_do_activity(self, test_data, fake_storage_context, fake_list_resources,
-                         fake_post_request, fake_head_request,
-                         fake_email_smtp_connect, fake_check_vor, fake_get_client):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+    def test_do_activity(
+        self,
+        test_data,
+        fake_storage_context,
+        fake_list_resources,
+        fake_post_request,
+        fake_head_request,
+        fake_email_smtp_connect,
+        fake_check_vor,
+        fake_get_client,
+    ):
+        fake_check_vor.return_value = True
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
         fake_get_client.return_value = True
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/')
+        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
         client = FakeBigQueryClient(rows)
         fake_get_client.return_value = client
@@ -102,116 +111,150 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions
-        for status_name in ['approve', 'generate', 'publish', 'outbox', 'email', 'activity']:
+        for status_name in [
+            "approve",
+            "generate",
+            "publish",
+            "outbox",
+            "email",
+            "activity",
+        ]:
             status_value = self.activity.statuses.get(status_name)
             expected = test_data.get("expected_" + status_name + "_status")
             self.assertEqual(
-                status_value, expected,
-                '{expected} {status_name} status not equal to {status_value} in {comment}'.format(
-                    expected=expected, status_name=status_name, status_value=status_value,
-                    comment=test_data.get("comment")))
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
         # Count crossref XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
         self.assertEqual(file_count, test_data.get("expected_file_count"))
         if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
             # Open the first crossref XML and check some of its contents
-            crossref_xml_filename_path = os.path.join(self.tmp_dir(), os.listdir(self.tmp_dir())[0])
-            with open(crossref_xml_filename_path, 'rb') as open_file:
-                crossref_xml = open_file.read().decode('utf8')
+            crossref_xml_filename_path = os.path.join(
+                self.tmp_dir(), os.listdir(self.tmp_dir())[0]
+            )
+            with open(crossref_xml_filename_path, "rb") as open_file:
+                crossref_xml = open_file.read().decode("utf8")
                 for expected in test_data.get("expected_crossref_xml_contains"):
                     self.assertTrue(
                         expected in crossref_xml,
-                        '{expected} not found in crossref_xml {path}'.format(
-                            expected=expected, path=crossref_xml_filename_path))
+                        "{expected} not found in crossref_xml {path}".format(
+                            expected=expected, path=crossref_xml_filename_path
+                        ),
+                    )
 
-    @patch.object(bigquery, 'get_client')
-    @patch.object(activity_module, 'check_vor_is_published')
-    @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch('requests.head')
-    @patch('requests.post')
-    @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.outbox_provider.storage_context')
-    def test_do_activity_crossref_exception(self, fake_storage_context, fake_list_resources,
-                                            fake_post_request, fake_head_request,
-                                            fake_email_smtp_connect, fake_check_vor,
-                                            fake_get_client):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
+    @patch.object(bigquery, "get_client")
+    @patch.object(activity_module, "check_vor_is_published")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch("requests.head")
+    @patch("requests.post")
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity_crossref_exception(
+        self,
+        fake_storage_context,
+        fake_list_resources,
+        fake_post_request,
+        fake_head_request,
+        fake_email_smtp_connect,
+        fake_check_vor,
+        fake_get_client,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
         fake_check_vor.return_value = True
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/')
+        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
         client = FakeBigQueryClient(rows)
         fake_get_client.return_value = client
         # copy XML files into the input directory
-        fake_list_resources.return_value = ['elife-15747-v2.xml', 'elife_poa_e03977.xml']
+        fake_list_resources.return_value = [
+            "elife-15747-v2.xml",
+            "elife_poa_e03977.xml",
+        ]
 
         # raise an exception on a post
-        fake_post_request.side_effect = Exception('')
+        fake_post_request.side_effect = Exception("")
         fake_head_request.return_value = FakeResponse(302)
         result = self.activity.do_activity()
         self.assertTrue(result)
 
-    @patch.object(bigquery, 'get_client')
-    @patch.object(activity_module.email_provider, 'smtp_connect')
-    @patch('requests.post')
-    @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.outbox_provider.storage_context')
-    def test_do_activity_no_good_one_bad(self, fake_storage_context, fake_list_resources,
-                                         fake_request, fake_email_smtp_connect,
-                                         fake_get_client):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.activity.get_tmp_dir())
-        fake_storage_context.return_value = FakeStorageContext('tests/test_data/')
+    @patch.object(bigquery, "get_client")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity_no_good_one_bad(
+        self,
+        fake_storage_context,
+        fake_list_resources,
+        fake_email_smtp_connect,
+        fake_get_client,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
         client = FakeBigQueryClient(rows)
         fake_get_client.return_value = client
         # copy XML files into the input directory
-        fake_list_resources.return_value = ['bad.xml']
+        fake_list_resources.return_value = ["bad.xml"]
 
         result = self.activity.do_activity()
         self.assertTrue(result)
 
-    @patch.object(activity_DepositCrossrefPeerReview, 'get_manuscript_object')
+    @patch.object(activity_DepositCrossrefPeerReview, "get_manuscript_object")
     def test_get_article_objects(self, fake_manuscript_object):
         """test for parsing an XML file as well as renaming senior_editor to editor"""
         fake_manuscript_object.return_value = bigquery.Manuscript(
-            bigquery_test_data.ARTICLE_RESULT_15747)
-        xml_file_name = 'tests/test_data/crossref_peer_review/outbox/elife-32991-v2.xml'
+            bigquery_test_data.ARTICLE_RESULT_15747
+        )
+        xml_file_name = "tests/test_data/crossref_peer_review/outbox/elife-32991-v2.xml"
         article_object_map = self.activity.get_article_objects([xml_file_name])
         self.assertEqual(len(article_object_map), 1)
         article_object = article_object_map.get(xml_file_name)
         first_sub_article = article_object.review_articles[0]
         self.assertEqual(len(first_sub_article.contributors), 2)
-        self.assertEqual(first_sub_article.contributors[0].contrib_type, 'editor')
-        self.assertEqual(first_sub_article.contributors[0].surname, 'Bronner')
-        self.assertEqual(first_sub_article.contributors[1].contrib_type, 'editor')
-        self.assertEqual(first_sub_article.contributors[1].surname, 'Brack')
+        self.assertEqual(first_sub_article.contributors[0].contrib_type, "editor")
+        self.assertEqual(first_sub_article.contributors[0].surname, "Bronner")
+        self.assertEqual(first_sub_article.contributors[1].contrib_type, "editor")
+        self.assertEqual(first_sub_article.contributors[1].surname, "Brack")
 
-    @patch.object(activity_DepositCrossrefPeerReview, 'get_manuscript_object')
+    @patch.object(activity_DepositCrossrefPeerReview, "get_manuscript_object")
     def test_get_article_objects_dedupe(self, fake_manuscript_object):
         """test for deduping the same editor exists twice"""
         fake_manuscript_object.return_value = bigquery.Manuscript(
-            bigquery_test_data.ARTICLE_RESULT_15747)
-        xml_file_name = 'tests/test_data/crossref_peer_review/outbox/elife-32311-v1.xml'
+            bigquery_test_data.ARTICLE_RESULT_15747
+        )
+        xml_file_name = "tests/test_data/crossref_peer_review/outbox/elife-32311-v1.xml"
         article_object_map = self.activity.get_article_objects([xml_file_name])
         self.assertEqual(len(article_object_map), 1)
         article_object = article_object_map.get(xml_file_name)
         first_sub_article = article_object.review_articles[0]
         self.assertEqual(len(first_sub_article.contributors), 1)
-        self.assertEqual(first_sub_article.contributors[0].contrib_type, 'editor')
-        self.assertEqual(first_sub_article.contributors[0].surname, 'Akhmanova')
+        self.assertEqual(first_sub_article.contributors[0].contrib_type, "editor")
+        self.assertEqual(first_sub_article.contributors[0].surname, "Akhmanova")
 
     def test_add_editors(self):
         article = Article()
-        editor = Contributor('senior_editor', 'Aardvark', 'Aaron')
+        editor = Contributor("senior_editor", "Aardvark", "Aaron")
         article.editors = [editor]
         sub_article = Article()
         self.activity.add_editors(article, sub_article)
-        self.assertEqual(sub_article.contributors[0].surname, 'Aardvark')
+        self.assertEqual(sub_article.contributors[0].surname, "Aardvark")
 
     def test_set_editor_orcid(self):
-        orcid = '0000-0000-0000-000X'
-        expected = 'https://orcid.org/' + orcid
+        orcid = "0000-0000-0000-000X"
+        expected = "https://orcid.org/" + orcid
         sub_article = Article()
-        sub_article.contributors = [Contributor('senior_editor', 'Baldwin', 'Ian')]
+        sub_article.contributors = [Contributor("senior_editor", "Baldwin", "Ian")]
         # start with manuscript data then set an ORCID value
         manuscript_object = bigquery.Manuscript(bigquery_test_data.ARTICLE_RESULT_15747)
         manuscript_object.reviewers[0].orcid = orcid
@@ -220,54 +263,57 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
 
 
 class TestPrune(unittest.TestCase):
-
     def setUp(self):
         article_xml_list = [
-            'tests/test_data/crossref_peer_review/outbox/elife-15747-v2.xml',
-            'tests/test_data/crossref_peer_review/outbox/elife_poa_e03977.xml',
+            "tests/test_data/crossref_peer_review/outbox/elife-15747-v2.xml",
+            "tests/test_data/crossref_peer_review/outbox/elife_poa_e03977.xml",
         ]
         self.article_object_map = crossref.article_xml_list_parse(
-            article_xml_list, [], activity_test_data.ExpandArticle_files_dest_folder)
+            article_xml_list, [], activity_test_data.ExpandArticle_files_dest_folder
+        )
         self.logger = FakeLogger()
 
     def tearDown(self):
         helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=['.gitkeep'])
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
-    @patch.object(activity_module, 'check_vor_is_published')
-    @patch('provider.crossref.doi_exists')
+    @patch.object(activity_module, "check_vor_is_published")
+    @patch("provider.crossref.doi_exists")
     def test_prune_article_object_map(self, fake_doi_exists, fake_check_vor):
         fake_doi_exists.return_value = True
         fake_check_vor.return_value = True
         good_article_map = activity_module.prune_article_object_map(
-            self.article_object_map, settings_mock, self.logger)
+            self.article_object_map, settings_mock, self.logger
+        )
         self.assertEqual(len(good_article_map), 1)
 
-    @patch.object(activity_module, 'check_vor_is_published')
-    @patch('provider.crossref.doi_exists')
-    def test_prune_article_object_map_doi_not_exists(self, fake_doi_exists, fake_check_vor):
+    @patch.object(activity_module, "check_vor_is_published")
+    @patch("provider.crossref.doi_exists")
+    def test_prune_article_object_map_doi_not_exists(
+        self, fake_doi_exists, fake_check_vor
+    ):
         fake_doi_exists.return_value = False
         fake_check_vor.return_value = True
         good_article_map = activity_module.prune_article_object_map(
-            self.article_object_map, settings_mock, self.logger)
+            self.article_object_map, settings_mock, self.logger
+        )
         self.assertEqual(len(good_article_map), 0)
 
-    @patch.object(lax_provider, 'article_status_version_map')
+    @patch.object(lax_provider, "article_status_version_map")
     def test_check_vor_is_published_vor(self, fake_version_map):
         article = Article()
         article.id = 666
-        fake_version_map.return_value = {'poa': [1], 'vor': [2]}
-        self.assertTrue(activity_module.check_vor_is_published(
-            article, settings_mock, self.logger))
+        fake_version_map.return_value = {"poa": [1], "vor": [2]}
+        self.assertTrue(
+            activity_module.check_vor_is_published(article, settings_mock, self.logger)
+        )
 
-    @patch.object(lax_provider, 'article_status_version_map')
+    @patch.object(lax_provider, "article_status_version_map")
     def test_check_vor_is_published_poa(self, fake_version_map):
         article = Article()
         article.id = 666
-        fake_version_map.return_value = {'poa': [1]}
-        self.assertFalse(activity_module.check_vor_is_published(
-            article, settings_mock, self.logger))
-
-
-if __name__ == '__main__':
-    unittest.main()
+        fake_version_map.return_value = {"poa": [1]}
+        self.assertFalse(
+            activity_module.check_vor_is_published(article, settings_mock, self.logger)
+        )

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -48,7 +48,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
     @patch('requests.head')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.crossref.storage_context')
+    @patch('provider.outbox_provider.storage_context')
     @data(
         {
             "comment": "Article 15747",
@@ -130,7 +130,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
     @patch('requests.head')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.crossref.storage_context')
+    @patch('provider.outbox_provider.storage_context')
     def test_do_activity_crossref_exception(self, fake_storage_context, fake_list_resources,
                                             fake_post_request, fake_head_request,
                                             fake_email_smtp_connect, fake_check_vor,
@@ -154,7 +154,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
     @patch.object(activity_module.email_provider, 'smtp_connect')
     @patch('requests.post')
     @patch.object(FakeStorageContext, 'list_resources')
-    @patch('provider.crossref.storage_context')
+    @patch('provider.outbox_provider.storage_context')
     def test_do_activity_no_good_one_bad(self, fake_storage_context, fake_list_resources,
                                          fake_request, fake_email_smtp_connect,
                                          fake_get_client):

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -1,0 +1,111 @@
+import os
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from provider import outbox_provider
+import tests.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+import tests.activity.helpers as helpers
+import tests.activity.test_activity_data as activity_test_data
+
+
+class TestOutboxProvider(unittest.TestCase):
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.good_xml_file = "tests/test_data/crossref/outbox/elife-18753-v1.xml"
+        self.bad_xml_file = "tests/test_data/activity.json"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
+
+    def test_get_to_folder_name(self):
+        folder_name = ""
+        date_stamp = ""
+        expected = folder_name + date_stamp + "/"
+        self.assertEqual(
+            outbox_provider.get_to_folder_name(folder_name, date_stamp), expected
+        )
+
+    @patch("provider.outbox_provider.storage_context")
+    def test_get_outbox_s3_key_names(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/crossref/outbox/"
+        )
+        outbox_folder = "crossref/outbox/"
+        expected = [outbox_folder.rstrip("/") + "/" + "elife-00353-v1.xml"]
+        key_names = outbox_provider.get_outbox_s3_key_names(
+            settings_mock, "", outbox_folder
+        )
+        # returns the default file name from FakeStorageContext in the test scenario
+        self.assertEqual(key_names, expected)
+
+    @patch("provider.outbox_provider.storage_context")
+    def test_download_files_from_s3_outbox(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext()
+        bucket_name = ""
+        outbox_folder = ""
+        key_names = outbox_provider.get_outbox_s3_key_names(
+            settings_mock, bucket_name, outbox_folder
+        )
+        result = outbox_provider.download_files_from_s3_outbox(
+            settings_mock, bucket_name, key_names, self.directory.path, FakeLogger()
+        )
+        self.assertTrue(result)
+
+    @patch.object(FakeStorageContext, "get_resource_to_file")
+    @patch("provider.outbox_provider.storage_context")
+    def test_download_files_from_s3_outbox_failure(
+        self, fake_storage_context, fake_get_resource
+    ):
+        """test IOError exception for coverage"""
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_get_resource.side_effect = IOError
+        bucket_name = ""
+        outbox_folder = ""
+        key_names = outbox_provider.get_outbox_s3_key_names(
+            settings_mock, bucket_name, outbox_folder
+        )
+        result = outbox_provider.download_files_from_s3_outbox(
+            settings_mock, bucket_name, key_names, self.directory.path, FakeLogger()
+        )
+        self.assertFalse(result)
+
+    @patch("provider.outbox_provider.storage_context")
+    def test_clean_outbox(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext(self.directory)
+        # copy two files in for cleaning
+        shutil.copy(self.good_xml_file, self.directory.path)
+        shutil.copy(self.bad_xml_file, self.directory.path)
+        # add outbox_folder name and one file to the list of published file names
+        bucket_name = "bucket"
+        outbox_folder = "crossref/outbox/"
+        to_folder = "crossref/published/"
+        published_file_names = [outbox_folder, self.good_xml_file]
+        # clean outbox
+        outbox_provider.clean_outbox(
+            settings_mock, bucket_name, outbox_folder, to_folder, published_file_names
+        )
+        # TempDirectory should have one file remaining
+        self.assertTrue(len(os.listdir(self.directory.path)), 1)
+
+    @patch("provider.outbox_provider.storage_context")
+    def test_upload_files_to_s3_folder(self, fake_storage_context):
+        fake_storage_context.return_value = FakeStorageContext()
+        file_names = [self.good_xml_file]
+        expected = [file_name.split(os.sep)[-1] for file_name in file_names]
+        outbox_provider.upload_files_to_s3_folder(
+            settings_mock, "bucket", "to_folder/", file_names
+        )
+        # filter out the .gitkeep file before comparing
+        uploaded_files = [
+            file_name
+            for file_name in os.listdir(
+                activity_test_data.ExpandArticle_files_dest_folder
+            )
+            if file_name.endswith(".xml")
+        ]
+        self.assertEqual(uploaded_files, expected)


### PR DESCRIPTION
Related to issue https://github.com/elifesciences/elife-bot/issues/1089

There were some functions in `provider/crossref.py` concerning copying to and from S3 folders which may be useful in other activities too. Here, move them to a new `provider/outbox_provider.py` module, move the test scenarios, refactor, and lots of linting.

All this before actually refactoring the `PubmedArticleDeposit` activity to use the new outbox provider, which can be in the next PR.