### PR TITLE
Bug fix PubmedArticleDeposit bucket folder paths.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -41,8 +41,8 @@ class activity_PubmedArticleDeposit(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "pubmed/outbox"
-        self.published_folder = "pubmed/published"
+        self.outbox_folder = "pubmed/outbox/"
+        self.published_folder = "pubmed/published/"
 
         # Track the success of some steps
         self.statuses = OrderedDict(

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -220,7 +220,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         self.assertEqual(
             self.activity.outbox_s3_key_names,
             [
-                self.activity.outbox_folder + "/" + filename
+                self.activity.outbox_folder + filename
                 for filename in test_data.get("outbox_filenames")
             ],
             "failed in {comment}".format(comment=test_data.get("comment")),


### PR DESCRIPTION
Missing a `/` on the end of the folder names does not work well in the refactored code, add the `/` to them.