### PR TITLE
Use original s3 key names in Pubmed email.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -292,16 +292,13 @@ class activity_PubmedArticleDeposit(Activity):
         activity_status_text = utils.get_activity_status_text(
             self.statuses.get("activity")
         )
-        outbox_s3_key_names = outbox_provider.get_outbox_s3_key_names(
-            self.settings, self.publish_bucket, self.outbox_folder
-        )
 
         body = email_provider.get_email_body_head(
             self.name, activity_status_text, self.statuses
         )
         body += email_provider.get_email_body_middle(
             "pubmed",
-            outbox_s3_key_names,
+            self.outbox_s3_key_names,
             self.article_published_file_names,
             self.article_not_published_file_names,
         )
@@ -316,7 +313,7 @@ class activity_PubmedArticleDeposit(Activity):
             activity_status_text,
             self.name,
             self.settings.domain,
-            outbox_s3_key_names,
+            self.outbox_s3_key_names,
         )
         sender_email = self.settings.ses_poa_sender_email
 


### PR DESCRIPTION
A small tweak after the code refactoring, to print the original list of s3 key names in the admin email, rather than getting the list again, which may be empty and not as helpful.