### PR TITLE
Test tweaks and some linting

### DIFF
--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -36,26 +36,30 @@ class MetaData(object):
                 self.codemeta["license"] = OrderedDict()
                 self.codemeta["license"]["url"] = article.license.href
             self.codemeta["authors"] = []
-            for author in [author for author in article.contributors]:
+            for author in article.contributors:
                 author_dict = OrderedDict()
                 if author.collab:
                     author_dict["name"] = author.collab
-                else:
-                    if not author.group_author_key:
-                        author_dict["name"] = " ".join(
-                            [
-                                part
-                                for part in [author.given_name, author.surname, author.suffix]
-                                if part is not None
+                elif not author.group_author_key:
+                    author_dict["name"] = " ".join(
+                        [
+                            part
+                            for part in [
+                                author.given_name,
+                                author.surname,
+                                author.suffix,
                             ]
-                        )
+                            if part is not None
+                        ]
+                    )
                 if not author_dict.get("name"):
                     continue
 
                 if author.affiliations:
-                    author_dict["affiliations"] = []
-                    for aff in author.affiliations:
-                        author_dict["affiliations"].append(aff.text)
+                    author_dict["affiliations"] = [
+                        aff.text for aff in author.affiliations
+                    ]
+
                 self.codemeta["authors"].append(author_dict)
 
         if file_name:

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -262,15 +262,18 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         self.assertEqual(sub_article.contributors[0].orcid, expected)
 
 
+ARTICLE_OBJECT_MAP = crossref.article_xml_list_parse(
+    [
+        "tests/test_data/crossref_peer_review/outbox/elife-15747-v2.xml",
+        "tests/test_data/crossref_peer_review/outbox/elife_poa_e03977.xml",
+    ],
+    [],
+    activity_test_data.ExpandArticle_files_dest_folder,
+)
+
+
 class TestPrune(unittest.TestCase):
     def setUp(self):
-        article_xml_list = [
-            "tests/test_data/crossref_peer_review/outbox/elife-15747-v2.xml",
-            "tests/test_data/crossref_peer_review/outbox/elife_poa_e03977.xml",
-        ]
-        self.article_object_map = crossref.article_xml_list_parse(
-            article_xml_list, [], activity_test_data.ExpandArticle_files_dest_folder
-        )
         self.logger = FakeLogger()
 
     def tearDown(self):
@@ -284,7 +287,7 @@ class TestPrune(unittest.TestCase):
         fake_doi_exists.return_value = True
         fake_check_vor.return_value = True
         good_article_map = activity_module.prune_article_object_map(
-            self.article_object_map, settings_mock, self.logger
+            ARTICLE_OBJECT_MAP, settings_mock, self.logger
         )
         self.assertEqual(len(good_article_map), 1)
 
@@ -296,9 +299,14 @@ class TestPrune(unittest.TestCase):
         fake_doi_exists.return_value = False
         fake_check_vor.return_value = True
         good_article_map = activity_module.prune_article_object_map(
-            self.article_object_map, settings_mock, self.logger
+            ARTICLE_OBJECT_MAP, settings_mock, self.logger
         )
         self.assertEqual(len(good_article_map), 0)
+
+
+class TestCheckVorIsPublished(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
 
     @patch.object(lax_provider, "article_status_version_map")
     def test_check_vor_is_published_vor(self, fake_version_map):

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -56,7 +56,7 @@ class FakeLayer1:
 
 class FakeFlag():
     "a fake object to return process monitoring status"
-    def __init__(self, timeout_seconds=1):
+    def __init__(self, timeout_seconds=0.1):
         self.timeout_seconds = timeout_seconds
         self.green_value = True
 

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -6,14 +6,14 @@ from collections import OrderedDict
 from xml.etree.ElementTree import Element
 from mock import patch
 from elifearticle import parse
-from elifearticle.article import Article, Contributor
+from elifearticle.article import Contributor
 from provider import software_heritage, utils
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeResponse
 
 
-def pretty_string(bytes):
-    return str(bytes).replace("\\n", "\n")
+def pretty_string(byte_string):
+    return str(byte_string).replace("\\n", "\n")
 
 
 class TestSoftwareHeritageProviderMetadata(unittest.TestCase):


### PR DESCRIPTION
In an attempt to see if there were some performance gains to be had in running the test scenarios, here are a few changes to tests and to `provider/software_heritage.py`. I'm showing these reduce the running of tests by about 10 seconds, from 67 seconds down to 57 seconds.