### PR TITLE
Refactor starter for ApproveArticlePublication.

### DIFF
--- a/starter/starter_ApproveArticlePublication.py
+++ b/starter/starter_ApproveArticlePublication.py
@@ -1,88 +1,84 @@
-import boto.swf.exceptions
-import boto.swf
 import json
-from optparse import OptionParser
-import starter.starter_helper as helper
 from starter.starter_helper import NullRequiredDataException
+from starter.objects import Starter, default_workflow_params
 
 """
 Amazon SWF PublishArticle starter, for API and Lens publishing etc.
 """
 
 
-class starter_ApproveArticlePublication():
-    def __init__(self):
-        self.const_name = "ApproveArticlePublication"
+class starter_ApproveArticlePublication(Starter):
+    def get_workflow_params(
+        self,
+        article_id=None,
+        version=None,
+        run=None,
+        publication_data=None,
+        workflow=None,
+    ):
+        if workflow is None:
+            raise NullRequiredDataException("Did not get a workflow parameter")
 
-    def start(self, settings, article_id=None, version=None, run=None, publication_data=None):
-
-        # TODO : much of this is common to many starters and could probably be streamlined
-
-        # Log
-        logger = helper.get_starter_logger(settings.setLevel, helper.get_starter_identity(self.const_name))
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s" % (workflow, article_id)
+        workflow_params["workflow_name"] = workflow
+        workflow_params["workflow_version"] = "1"
 
         if article_id is None or version is None or publication_data is None:
-            raise NullRequiredDataException("Did not get an article id, version or publication data")
+            raise NullRequiredDataException(
+                "Did not get an article id, version or publication data"
+            )
 
         info = {
-            'article_id': article_id,
-            'version': str(version),
-            'run': run,
-            'publication_data': publication_data
+            "article_id": article_id,
+            "version": str(version),
+            "run": run,
+            "publication_data": publication_data,
         }
+        workflow_params["input"] = json.dumps(info, default=lambda ob: None)
+        return workflow_params
 
-        workflow_id, \
-        workflow_name, \
-        workflow_version, \
-        child_policy, \
-        execution_start_to_close_timeout, \
-        workflow_input = helper.set_workflow_information(self.const_name, "1", None, info,
-                                                         article_id + "." + str(version))
+    def start(
+        self,
+        settings,
+        article_id=None,
+        version=None,
+        run=None,
+        publication_data=None,
+    ):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(
+            article_id,
+            version,
+            run,
+            publication_data,
+            workflow="ApproveArticlePublication",
+        )
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def start_workflow(
+        self,
+        article_id=None,
+        version=None,
+        run=None,
+        publication_data=None,
+        workflow="ApproveArticlePublication",
+    ):
 
+        workflow_params = self.get_workflow_params(
+            article_id, version, run, publication_data, workflow
+        )
+
+        self.connect_to_swf()
+
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
         try:
-            response = conn.start_workflow_execution(settings.domain, workflow_id, workflow_name, workflow_version,
-                                                     settings.default_task_list, child_policy,
-                                                     execution_start_to_close_timeout, workflow_input)
-
-            logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-        except NullRequiredDataException as e:
-            logger.exception(e.message)
-            raise
-
-        except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-            # There is already a running workflow with that ID, cannot start another
-            message = 'SWFWorkflowExecutionAlreadyStartedError: There is already a running workflow with ID %s' % workflow_id
-            logger.info(message)
-
-
-def main():
-
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    parser.add_option("-i", "--article-version-id", default=None, action="store", type="string",
-                      dest="article_version_id",
-                      help="specify the DOI id the article to process")
-
-    (options, args) = parser.parse_args()
-    ENV = None
-    if options.env:
-        ENV = options.env
-    article_version_id = None
-    if options.article_version_id:
-        article_version_id = options.article_version_id
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
-
-    o = starter_ApproveArticlePublication()
-
-    o.start(settings=settings, article_version_id=article_version_id)
-
-if __name__ == "__main__":
-    main()
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)

--- a/tests/starter/test_starter_approve_article_publication.py
+++ b/tests/starter/test_starter_approve_article_publication.py
@@ -1,30 +1,66 @@
 import unittest
+import json
+from collections import OrderedDict
+from mock import patch
 from starter.starter_ApproveArticlePublication import starter_ApproveArticlePublication
 from starter.starter_helper import NullRequiredDataException
 from tests.classes_mock import FakeBotoConnection
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from mock import patch
 
 
 class TestStarterApproveArticlePublication(unittest.TestCase):
     def setUp(self):
-        self.stater_approve_article_publication = starter_ApproveArticlePublication()
+        self.starter = starter_ApproveArticlePublication()
 
     def test_process_approve_article_publication(self):
         invalid_data = test_data.ApprovePublication_data()
         invalid_data["version"] = None
-        self.assertRaises(NullRequiredDataException, self.stater_approve_article_publication.start,
-                          settings=settings_mock, **invalid_data)
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            **invalid_data
+        )
 
-    @patch('starter.starter_helper.get_starter_logger')
-    @patch('boto.swf.layer1.Layer1')
-    def test_approve_article_publication_starter_(self, fake_boto_conn, fake_logger):
+    @patch("boto.swf.layer1.Layer1")
+    def test_approve_article_publication_starter(self, fake_boto_conn):
         fake_boto_conn.return_value = FakeBotoConnection()
-        self.stater_approve_article_publication.start(settings=settings_mock, **test_data.ApprovePublication_data())
+        self.starter.start(
+            settings=settings_mock, **test_data.ApprovePublication_data()
+        )
 
 
+class TestStarterApproveArticlePublicationWorkflowParams(unittest.TestCase):
+    def setUp(self):
+        # instantiate the starter object with settings in order to test get_workflow_params
+        self.starter = starter_ApproveArticlePublication(settings_mock)
 
+    def test_get_workflow_params(self):
+        data = test_data.ApprovePublication_data()
+        workflow = "ApproveArticlePublication"
+        expected = OrderedDict(
+            [
+                ("domain", settings_mock.domain),
+                ("task_list", settings_mock.default_task_list),
+                ("workflow_id", "%s_%s" % (workflow, data.get("article_id"))),
+                ("workflow_name", workflow),
+                ("workflow_version", "1"),
+                ("child_policy", None),
+                ("execution_start_to_close_timeout", None),
+                (
+                    "input",
+                    json.dumps(data),
+                ),
+            ]
+        )
+        workflow_data = self.starter.get_workflow_params(workflow=workflow, **data)
+        self.assertEqual(workflow_data, expected)
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_get_workflow_params_no_workflow(self):
+        invalid_data = test_data.ApprovePublication_data()
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.get_workflow_params,
+            **invalid_data
+        )


### PR DESCRIPTION
Continuing starter code refactoring in issue https://github.com/elifesciences/elife-bot/issues/992

From the top, it looked like the starter for the `ApproveArticlePublication` workflow hadn't been updated yet to use some of the newer starter code.

For backwards compatibility, the `start()` method is unchanged, however because this workflow is always started from data coming from the publishing dashboard, and a workflow execution is never started manually, it is more complicated than most, and outside of carefully writing unit tests, the best way to confirm nothing is broken is to see all the `end2end` tests run successfully. For that reason, if this PR's tests are green, I will merge it to see the result, and it may need to be fixed with a subsequent PR or these commits can be reverted.