### PR TITLE
DepositDOAJ starter refactoring

### DIFF
--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,29 +1,33 @@
 import re
 import urllib
 import base64
-import arrow
 from argparse import ArgumentParser
+import arrow
 
 
-S3_DATE_FORMAT = '%Y%m%d%H%M%S'
+S3_DATE_FORMAT = "%Y%m%d%H%M%S"
 PUB_DATE_FORMAT = "%Y-%m-%d"
 DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000Z"
 
 
 def pad_msid(msid):
-    return '{:05d}'.format(int(msid))
+    return "{:05d}".format(int(msid))
+
 
 def pad_volume(volume):
-    return '{:02d}'.format(int(volume))
+    return "{:02d}".format(int(volume))
+
 
 def tidy_whitespace(string):
-    string = re.sub('\n', ' ', string)
-    string = re.sub(' +', ' ', string)
+    string = re.sub("\n", " ", string)
+    string = re.sub(" +", " ", string)
     string = string.strip()
     return string
 
+
 def article_status(is_poa):
-    return 'POA' if is_poa else 'VOR'
+    return "POA" if is_poa else "VOR"
+
 
 def msid_from_doi(doi):
     "return just the id portion of the doi"
@@ -33,6 +37,7 @@ def msid_from_doi(doi):
         msid = None
     return msid
 
+
 def volume_from_year(year, start_year=2011):
     "calculate the volume from the year, default start_year value for elife journal"
     try:
@@ -40,6 +45,7 @@ def volume_from_year(year, start_year=2011):
     except:
         volume = None
     return volume
+
 
 def volume_from_pub_date(pub_date, start_year=2011):
     "calculate the volume from a time.struct_time, default start_year value for elife journal"
@@ -61,7 +67,7 @@ def unquote_plus(string):
 def bytes_decode(bytes_string):
     "try to decode to utf8"
     try:
-        bytes_string = bytes_string.decode('utf8')
+        bytes_string = bytes_string.decode("utf8")
     except (UnicodeEncodeError, AttributeError):
         pass
     return bytes_string
@@ -69,12 +75,12 @@ def bytes_decode(bytes_string):
 
 def base64_encode_string(string):
     "base64 endcode string for python 3"
-    return base64.encodebytes(bytes(string, 'utf8')).decode()
+    return base64.encodebytes(bytes(string, "utf8")).decode()
 
 
 def base64_decode_string(string):
     "base64 decode string for python 3"
-    return base64.decodebytes(bytes(string, 'utf8')).decode()
+    return base64.decodebytes(bytes(string, "utf8")).decode()
 
 
 def unicode_encode(string):
@@ -120,8 +126,15 @@ def get_doi_url(doi):
 def console_start_env():
     """capture ENV from arguments when running standalone"""
     parser = ArgumentParser()
-    parser.add_argument("-e", "--env", default="dev", action="store", type=str, dest="env",
-                        help="set the environment to run, either dev or live")
+    parser.add_argument(
+        "-e",
+        "--env",
+        default="dev",
+        action="store",
+        type=str,
+        dest="env",
+        help="set the environment to run, either dev or live",
+    )
     args, unknown = parser.parse_known_args()
     return args.env
 
@@ -154,4 +167,5 @@ def console_start_env_doi_id():
 def get_settings(env):
     """for runtime importing of settings module"""
     import settings as settings_lib
+
     return settings_lib.get_settings(env)

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -126,6 +126,31 @@ def console_start_env():
     return args.env
 
 
+def console_start_env_doi_id():
+    """capture ENV and DOI_ID from arguments when running standalone"""
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-e",
+        "--env",
+        default="dev",
+        action="store",
+        type=str,
+        dest="env",
+        help="set the environment to run, either dev or live",
+    )
+    parser.add_argument(
+        "-d",
+        "--doi-id",
+        default=None,
+        action="store",
+        type=str,
+        dest="doi_id",
+        help="specify the DOI id of a single article",
+    )
+    args, unknown = parser.parse_known_args()
+    return args.env, args.doi_id
+
+
 def get_settings(env):
     """for runtime importing of settings module"""
     import settings as settings_lib

--- a/starter/starter_DepositDOAJ.py
+++ b/starter/starter_DepositDOAJ.py
@@ -1,6 +1,4 @@
 import json
-import uuid
-from optparse import OptionParser
 from provider import utils
 from starter.objects import Starter, default_workflow_params
 from starter.starter_helper import NullRequiredDataException
@@ -64,42 +62,11 @@ class starter_DepositDOAJ(Starter):
 
 if __name__ == "__main__":
 
-    doi_id = None
-    workflow = None
+    ENV, DOI_ID = utils.console_start_env_doi_id()
+    SETTINGS = utils.get_settings(ENV)
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option(
-        "-e",
-        "--env",
-        default="dev",
-        action="store",
-        type="string",
-        dest="env",
-        help="set the environment to run, either dev or live",
-    )
-    parser.add_option(
-        "-d",
-        "--doi-id",
-        default=None,
-        action="store",
-        type="string",
-        dest="doi_id",
-        help="specify the DOI id of a single article",
-    )
+    STARTER = starter_DepositDOAJ()
 
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-    if options.doi_id:
-        doi_id = options.doi_id
+    INFO = {"article_id": utils.pad_msid(DOI_ID)}
 
-    import settings as settingsLib
-
-    settings = settingsLib.get_settings(ENV)
-
-    o = starter_DepositDOAJ()
-
-    info = {"article_id": utils.pad_msid(doi_id)}
-
-    o.start(settings=settings, info=info)
+    STARTER.start(settings=SETTINGS, info=INFO)

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -147,5 +147,28 @@ class TestConsoleStart(unittest.TestCase):
             self.assertEqual(utils.console_start_env(), expected)
 
 
-if __name__ == '__main__':
+class TestConsoleStartEnvDoiId(unittest.TestCase):
+    def test_console_start_env_doi_id(self):
+        env = "foo"
+        doi_id = "7"
+        expected = env, doi_id
+        testargs = ["cron.py", "-e", env, "-d", doi_id]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_doi_id(), expected)
+
+    def test_console_start_env_doi_id_blank(self):
+        expected = "dev", None
+        testargs = ["cron.py"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_doi_id(), expected)
+
+    def test_console_start_env_doi_id_unrecognized_arguments(self):
+        env = "foo"
+        expected = env, None
+        testargs = ["cron.py", "-e", env, "0"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_doi_id(), expected)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -11,50 +11,45 @@ import provider.utils as utils
 
 @ddt
 class TestUtils(unittest.TestCase):
-
     def setUp(self):
         pass
 
     @unpack
     @data(
-        (7, '00007'),
-        ('7', '00007'),
-        )
+        (7, "00007"),
+        ("7", "00007"),
+    )
     def test_pad_msid(self, msid, expected):
         self.assertEqual(utils.pad_msid(msid), expected)
 
     @unpack
     @data(
-        (2, '02'),
-        ('2', '02'),
-        )
+        (2, "02"),
+        ("2", "02"),
+    )
     def test_pad_volume(self, volume, expected):
         self.assertEqual(utils.pad_volume(volume), expected)
 
     @unpack
     @data(
-        ('clean', 'clean'),
-        ("  very \n   messy  ", 'very messy'),
-        )
+        ("clean", "clean"),
+        ("  very \n   messy  ", "very messy"),
+    )
     def test_tidy_whitespace(self, string, expected):
         self.assertEqual(utils.tidy_whitespace(string), expected)
 
     @unpack
     @data(
-        (None, 'VOR'),
-        (True, 'POA'),
-        (False, 'VOR'),
-        ('Anything', 'POA'),
-        )
+        (None, "VOR"),
+        (True, "POA"),
+        (False, "VOR"),
+        ("Anything", "POA"),
+    )
     def test_article_status(self, value, expected):
         self.assertEqual(utils.article_status(value), expected)
 
     @unpack
-    @data(
-        (None, None),
-        ("10.7554/eLife.00003", 3),
-        ("not_a_doi", None)
-        )
+    @data((None, None), ("10.7554/eLife.00003", 3), ("not_a_doi", None))
     def test_msid_from_doi(self, value, expected):
         self.assertEqual(utils.msid_from_doi(value), expected)
 
@@ -63,7 +58,7 @@ class TestUtils(unittest.TestCase):
         (None, None, None),
         ("2018", None, 7),
         (2018, 2020, -2),
-        )
+    )
     def test_volume_from_year(self, year, start_year, expected):
         if start_year:
             self.assertEqual(utils.volume_from_year(year, start_year), expected)
@@ -75,11 +70,11 @@ class TestUtils(unittest.TestCase):
         (None, None, None),
         ("2018-01-01", None, 7),
         ("2018-01-01", 2020, -2),
-        )
+    )
     def test_volume_from_pub_date(self, pub_date_str, start_year, expected):
         pub_date = None
         if pub_date_str:
-            pub_date = time.strptime(pub_date_str,  "%Y-%m-%d")
+            pub_date = time.strptime(pub_date_str, "%Y-%m-%d")
         if start_year:
             self.assertEqual(utils.volume_from_pub_date(pub_date, start_year), expected)
         else:
@@ -89,18 +84,18 @@ class TestUtils(unittest.TestCase):
     @data(
         (None, None),
         ("file_name.jpg", "file_name.jpg"),
-        ("file+name.jpg", "file name.jpg")
-        )
+        ("file+name.jpg", "file name.jpg"),
+    )
     def test_unquote_plus(self, value, expected):
         self.assertEqual(utils.unquote_plus(value), expected)
 
     @unpack
     @data(
         (None, None, type(None)),
-        (u'', '',  str),
+        (u"", "", str),
         (u"tmp/foldér", "tmp/foldér", str),
-        (b"tmp/folde\xcc\x81r", "tmp/foldér", str)
-        )
+        (b"tmp/folde\xcc\x81r", "tmp/foldér", str),
+    )
     def test_unicode_encode(self, value, expected, expected_type):
         encoded_value = utils.unicode_encode(value)
         self.assertEqual(encoded_value, expected)
@@ -125,25 +120,24 @@ class TestUtils(unittest.TestCase):
 
 
 class TestConsoleStart(unittest.TestCase):
-
     def test_console_start(self):
-        env = 'foo'
+        env = "foo"
         expected = env
-        testargs = ['cron.py', '-e', env]
-        with patch.object(sys, 'argv', testargs):
+        testargs = ["cron.py", "-e", env]
+        with patch.object(sys, "argv", testargs):
             self.assertEqual(utils.console_start_env(), expected)
 
     def test_console_start_blank(self):
-        expected = 'dev'
-        testargs = ['cron.py']
-        with patch.object(sys, 'argv', testargs):
+        expected = "dev"
+        testargs = ["cron.py"]
+        with patch.object(sys, "argv", testargs):
             self.assertEqual(utils.console_start_env(), expected)
 
     def test_console_unrecognized_arguments(self):
-        env = 'foo'
+        env = "foo"
         expected = env
-        testargs = ['cron.py', '-e', env, '0']
-        with patch.object(sys, 'argv', testargs):
+        testargs = ["cron.py", "-e", env, "0"]
+        with patch.object(sys, "argv", testargs):
             self.assertEqual(utils.console_start_env(), expected)
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/992

`starter/starter_DepositDOAJ.py` is further refactored to so console arguments are extracted with `ArgumentParser` and it makes it slightly more testable, by expanding the `provider/utils.py` module for starters which require an `ENV` and a `DOI_ID` value to start a workflow execution.