### PR TITLE
Refactor starter for FTPArticle workflow

### DIFF
--- a/provider/utils.py
+++ b/provider/utils.py
@@ -123,18 +123,43 @@ def get_doi_url(doi):
     return "https://doi.org/%s" % doi
 
 
+CONSOLE_ARGUMENT_MAP = {
+    "e": {
+        "flags": ["-e", "--env"],
+        "default": "dev",
+        "action": "store",
+        "type": str,
+        "dest": "env",
+        "help": "set the environment to run, either dev or live",
+    },
+    "d": {
+        "flags": ["-d", "--doi-id"],
+        "default": None,
+        "action": "store",
+        "type": str,
+        "dest": "doi_id",
+        "help": "specify the DOI id of a single article",
+    },
+}
+
+
+def add_console_argument(parser, argument_name):
+    details = CONSOLE_ARGUMENT_MAP.get(argument_name)
+    if details:
+        parser.add_argument(
+            *details.get("flags"),
+            default=details.get("default"),
+            action=details.get("action"),
+            type=details.get("type"),
+            dest=details.get("dest"),
+            help=details.get("help")
+        )
+
+
 def console_start_env():
     """capture ENV from arguments when running standalone"""
     parser = ArgumentParser()
-    parser.add_argument(
-        "-e",
-        "--env",
-        default="dev",
-        action="store",
-        type=str,
-        dest="env",
-        help="set the environment to run, either dev or live",
-    )
+    add_console_argument(parser, "e")
     args, unknown = parser.parse_known_args()
     return args.env
 
@@ -142,24 +167,8 @@ def console_start_env():
 def console_start_env_doi_id():
     """capture ENV and DOI_ID from arguments when running standalone"""
     parser = ArgumentParser()
-    parser.add_argument(
-        "-e",
-        "--env",
-        default="dev",
-        action="store",
-        type=str,
-        dest="env",
-        help="set the environment to run, either dev or live",
-    )
-    parser.add_argument(
-        "-d",
-        "--doi-id",
-        default=None,
-        action="store",
-        type=str,
-        dest="doi_id",
-        help="specify the DOI id of a single article",
-    )
+    add_console_argument(parser, "e")
+    add_console_argument(parser, "d")
     args, unknown = parser.parse_known_args()
     return args.env, args.doi_id
 

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -140,6 +140,14 @@ CONSOLE_ARGUMENT_MAP = {
         "dest": "doi_id",
         "help": "specify the DOI id of a single article",
     },
+    "w": {
+        "flags": ["-w", "--workflow-name"],
+        "default": None,
+        "action": "store",
+        "type": str,
+        "dest": "workflow",
+        "help": "specify the workflow name to start",
+    },
 }
 
 
@@ -171,6 +179,16 @@ def console_start_env_doi_id():
     add_console_argument(parser, "d")
     args, unknown = parser.parse_known_args()
     return args.env, args.doi_id
+
+
+def console_start_env_workflow_doi_id():
+    """capture ENV, WORKFLOW, and DOI_ID from arguments when running standalone"""
+    parser = ArgumentParser()
+    add_console_argument(parser, "e")
+    add_console_argument(parser, "d")
+    add_console_argument(parser, "w")
+    args, unknown = parser.parse_known_args()
+    return args.env, args.doi_id, args.workflow
 
 
 def get_settings(env):

--- a/starter/starter_FTPArticle.py
+++ b/starter/starter_FTPArticle.py
@@ -1,116 +1,103 @@
-import boto.swf
-import log
 import json
-import random
-from optparse import OptionParser
+from starter.starter_helper import NullRequiredDataException
+from starter.objects import Starter, default_workflow_params
+from provider import utils
 
 """
 Amazon SWF PublishArticle starter, for Fluidinfo API publishing
 """
 
+WORKFLOW_NAMES = [
+    "HEFCE",
+    "Cengage",
+    "WoS",
+    "GoOA",
+    "CNPIEC",
+    "CNKI",
+    "CLOCKSS",
+    "OVID",
+    "Zendy",
+]
 
-class starter_FTPArticle():
 
-    def start(self, settings, workflow=None, doi_id=None):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        #logFile = None
-        logger = log.logger(logFile, settings.setLevel, identity)
+class starter_FTPArticle(Starter):
+    def __init__(self, settings=None, logger=None):
+        super(starter_FTPArticle, self).__init__(settings, logger, "FTPArticle")
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+    def get_workflow_params(
+        self,
+        workflow=None,
+        doi_id=None,
+    ):
+        if workflow is None:
+            raise NullRequiredDataException(
+                "Did not get a workflow argument. Required."
+            )
+        if workflow not in WORKFLOW_NAMES:
+            raise NullRequiredDataException(
+                "Value of workflow not found in supported WORKFLOW_NAMES."
+            )
+        if doi_id is None:
+            raise NullRequiredDataException("Did not get a doi_id argument. Required.")
 
-        if doi_id is not None and workflow is not None:
-
-            (workflow_id, workflow_name, workflow_version,
-             child_policy, execution_start_to_close_timeout,
-             input) = self.get_workflow_params(workflow, doi_id, settings)
-
-            logger.info('Starting workflow: %s' % workflow_id)
-            try:
-                response = conn.start_workflow_execution(settings.domain, workflow_id,
-                                                         workflow_name, workflow_version,
-                                                         settings.default_task_list, child_policy,
-                                                         execution_start_to_close_timeout, input)
-
-                logger.info('got response: \n%s' % json.dumps(response, sort_keys=True, indent=4))
-
-            except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-                # There is already a running workflow with that ID, cannot start another
-                message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                           'a running workflow with ID %s' % workflow_id)
-                print(message)
-                logger.info(message)
-
-    def get_workflow_params(self, workflow, doi_id, settings):
-
-        workflow_id = None
-        workflow_name = None
-        workflow_version = None
-        child_policy = None
-        execution_start_to_close_timeout = None
-
-        # Setting timeout to 23 hours temporarily during article resupply
-        execution_start_to_close_timeout = str(60 * 60* 23)
-        input = None
-
-        if (
-            workflow == "HEFCE"
-            or workflow == "Cengage"
-            or workflow == "WoS"
-            or workflow == "GoOA"
-            or workflow == "CNPIEC"
-            or workflow == "CNKI"
-            or workflow == "CLOCKSS"
-            or workflow == "OVID"
-            or workflow == "Zendy"
-        ):
-            workflow_id = "FTPArticle_" + workflow + "_" + str(doi_id)
-
-        # workflow_id as set above
-        workflow_id = workflow_id
-        workflow_name = "FTPArticle"
-        workflow_version = "1"
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s_%s" % (self.name, workflow, doi_id)
+        workflow_params["workflow_name"] = self.name
+        workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 60 * 23)
 
         data = {}
-        data['workflow'] = workflow
-        data['elife_id'] = doi_id
+        data["workflow"] = workflow
+        data["elife_id"] = doi_id
 
-        input_json = {}
-        input_json['data'] = data
+        info = {
+            "data": data,
+        }
 
-        input = json.dumps(input_json)
+        workflow_params["input"] = json.dumps(info, default=lambda ob: None)
+        return workflow_params
 
-        return (workflow_id, workflow_name, workflow_version, child_policy,
-                execution_start_to_close_timeout, input)
+    def start(
+        self,
+        settings,
+        workflow=None,
+        doi_id=None,
+    ):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(
+            workflow,
+            doi_id,
+        )
+
+    def start_workflow(
+        self,
+        workflow=None,
+        doi_id=None,
+    ):
+
+        workflow_params = self.get_workflow_params(workflow, doi_id)
+
+        self.connect_to_swf()
+
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)
 
 
 if __name__ == "__main__":
 
-    doi_id = None
-    workflow = None
+    ENV, DOI_ID, WORKFLOW = utils.console_start_env_workflow_doi_id()
+    SETTINGS = utils.get_settings(ENV)
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string", dest="env",
-                      help="set the environment to run, either dev or live")
-    parser.add_option("-w", "--workflow-name", default=None, action="store", type="string",
-                      dest="workflow", help="specify the workflow name to start")
-    parser.add_option("-d", "--doi-id", default=None, action="store", type="string",
-                      dest="doi_id", help="specify the DOI id of a single article")
+    STARTER = starter_FTPArticle(SETTINGS)
 
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-    if options.workflow:
-        workflow = options.workflow
-    if options.doi_id:
-        doi_id = options.doi_id
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
-
-    o = starter_FTPArticle()
-
-    o.start(settings=settings, workflow=workflow, doi_id=doi_id)
+    STARTER.start_workflow(workflow=WORKFLOW, doi_id=DOI_ID)

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -340,6 +340,10 @@ class TestPackagePOA(unittest.TestCase):
 
     @patch.object(activity_module.parse, "build_article")
     def test_generate_xml_build_article_exception(self, fake_build_article):
+        # make directories first
+        self.poa.make_activity_directories()
+        # add CSV files to folder
+        self.fake_download_latest_csv()
         fake_build_article.side_effect = Exception("An exception")
         with self.assertRaises(Exception):
             self.poa.generate_xml(12717)
@@ -350,6 +354,10 @@ class TestPackagePOA(unittest.TestCase):
 
     @patch.object(activity_module.parse, "build_article")
     def test_generate_xml_build_article_errors(self, fake_build_article):
+        # make directories first
+        self.poa.make_activity_directories()
+        # add CSV files to folder
+        self.fake_download_latest_csv()
         article_id = 12717
         error_count = 1
         error_messages = ["article_id %s error in set_title" % article_id]
@@ -366,6 +374,10 @@ class TestPackagePOA(unittest.TestCase):
 
     @patch.object(activity_module.generate, 'build_xml_to_disk')
     def test_generate_xml_expat_exception(self, fake_build_xml):
+        # make directories first
+        self.poa.make_activity_directories()
+        # add CSV files to folder
+        self.fake_download_latest_csv()
         fake_build_xml.side_effect = ExpatError('An exception')
         with self.assertRaises(ExpatError):
             self.poa.generate_xml(12717)

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -164,5 +164,29 @@ class TestConsoleStartEnvDoiId(unittest.TestCase):
             self.assertEqual(utils.console_start_env_doi_id(), expected)
 
 
+class TestConsoleStartEnvWorkflowDoiId(unittest.TestCase):
+    def test_console_start_env_workflow_doi_id(self):
+        env = "foo"
+        doi_id = "7"
+        workflow = "HEFCE"
+        expected = env, doi_id, workflow
+        testargs = ["cron.py", "-e", env, "-d", doi_id, "-w", workflow]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_workflow_doi_id(), expected)
+
+    def test_console_start_env_workflow_doi_id_blank(self):
+        expected = "dev", None, None
+        testargs = ["cron.py"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_workflow_doi_id(), expected)
+
+    def test_console_start_env_workflow_doi_id_unrecognized_arguments(self):
+        env = "foo"
+        expected = env, None, None
+        testargs = ["cron.py", "-e", env, "0"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_workflow_doi_id(), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/starter/test_starter_ftp_article.py
+++ b/tests/starter/test_starter_ftp_article.py
@@ -1,31 +1,75 @@
 import unittest
+from collections import OrderedDict
+from mock import patch
 from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.starter_FTPArticle import starter_FTPArticle
+from starter.starter_helper import NullRequiredDataException
 from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterFTPArticle(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_FTPArticle()
+        self.logger = FakeLogger()
+        self.starter = starter_FTPArticle(settings_mock, self.logger)
 
-    @patch('boto.swf.layer1.Layer1')
+    def test_get_workflow_params(self):
+        expected = OrderedDict(
+            [
+                ("domain", ""),
+                ("task_list", ""),
+                ("workflow_id", "FTPArticle_HEFCE_666"),
+                ("workflow_name", "FTPArticle"),
+                ("workflow_version", "1"),
+                ("child_policy", None),
+                ("execution_start_to_close_timeout", "82800"),
+                ("input", '{"data": {"workflow": "HEFCE", "elife_id": "666"}}'),
+            ]
+        )
+        params = self.starter.get_workflow_params(workflow="HEFCE", doi_id="666")
+        self.assertEqual(params, expected)
+
+    def test_get_workflow_params_no_workflow(self):
+        with self.assertRaises(NullRequiredDataException) as test_exception:
+            self.starter.get_workflow_params()
+        self.assertEqual(
+            str(test_exception.exception), "Did not get a workflow argument. Required."
+        )
+
+    def test_get_workflow_params_unknown_workflow(self):
+        with self.assertRaises(NullRequiredDataException) as test_exception:
+            self.starter.get_workflow_params(workflow="Foo")
+        self.assertEqual(
+            str(test_exception.exception),
+            "Value of workflow not found in supported WORKFLOW_NAMES.",
+        )
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.get_workflow_params,
+        )
+
+    def test_get_workflow_params_no_doi_id(self):
+        with self.assertRaises(NullRequiredDataException) as test_exception:
+            self.starter.get_workflow_params(workflow="HEFCE")
+        self.assertEqual(
+            str(test_exception.exception), "Did not get a doi_id argument. Required."
+        )
+
+    @patch("boto.swf.layer1.Layer1")
     def test_start(self, fake_conn):
-        workflow = 'HEFCE'
+        workflow = "HEFCE"
         doi_id = 3
         fake_conn.return_value = FakeLayer1()
         self.assertIsNone(self.starter.start(settings_mock, workflow, doi_id))
 
-    @patch.object(FakeLayer1, 'start_workflow_execution')
-    @patch('boto.swf.layer1.Layer1')
+    @patch.object(FakeLayer1, "start_workflow_execution")
+    @patch("boto.swf.layer1.Layer1")
     def test_start_exception(self, fake_conn, fake_start):
-        workflow = 'HEFCE'
+        workflow = "HEFCE"
         doi_id = 3
         fake_conn.return_value = FakeLayer1()
-        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError(
+            "message", None
+        )
         self.assertIsNone(self.starter.start(settings_mock, workflow, doi_id))
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/992

`starter/starter_FTPArticle.py` refactored and its tests, including greater test coverage.

The console arguments definitions in `provider/utils.py` were also refactored to reduce the duplicate code in different argument configurations.

Also, included a bug fix to the tests for `activity/activity_PackagePOA.py`, where sometimes a CSV file is missing, so for those, create the activity directories and copy in the CSV files before running tests which expect the files to be there.