### PR TITLE
PMCDeposit starter refactor and change to its activity

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -38,16 +38,13 @@ class activity_PMCDeposit(Activity):
         }
 
         # Bucket settings
-        self.input_bucket = None
-        self.input_bucket_default = (settings.publishing_buckets_prefix +
-                                     settings.archive_bucket)
+        self.input_bucket = settings.publishing_buckets_prefix + settings.archive_bucket
 
         self.publish_bucket = settings.poa_packaging_bucket
         self.published_folder = "pmc/published"
         self.published_zip_folder = "pmc/zip"
 
         self.document = None
-        self.input_bucket = None
         self.zip_file_name = None
 
     def do_activity(self, data=None):
@@ -61,12 +58,6 @@ class activity_PMCDeposit(Activity):
 
         # Data passed to this activity
         self.document = data["data"]["document"]
-
-        # Custom bucket, if specified
-        if "bucket" in data["data"]:
-            self.input_bucket = data["data"]["bucket"]
-        else:
-            self.input_bucket = self.input_bucket_default
 
         # Create output directories
         self.make_activity_directories(list(self.directories.values()))

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -148,6 +148,14 @@ CONSOLE_ARGUMENT_MAP = {
         "dest": "workflow",
         "help": "specify the workflow name to start",
     },
+    "f": {
+        "flags": ["-f", "--file"],
+        "default": None,
+        "action": "store",
+        "type": str,
+        "dest": "document",
+        "help": "specify the S3 object name of the input file",
+    },
 }
 
 
@@ -179,6 +187,15 @@ def console_start_env_doi_id():
     add_console_argument(parser, "d")
     args, unknown = parser.parse_known_args()
     return args.env, args.doi_id
+
+
+def console_start_env_document():
+    """capture ENV and DOCUMENT from arguments when running standalone"""
+    parser = ArgumentParser()
+    add_console_argument(parser, "e")
+    add_console_argument(parser, "f")
+    args, unknown = parser.parse_known_args()
+    return args.env, args.document
 
 
 def console_start_env_workflow_doi_id():

--- a/starter/starter_PMCDeposit.py
+++ b/starter/starter_PMCDeposit.py
@@ -1,110 +1,72 @@
-import uuid
-import boto.swf
-import log
 import json
-import random
-from optparse import OptionParser
+import uuid
+from starter.starter_helper import NullRequiredDataException
+from starter.objects import Starter, default_workflow_params
+from provider import utils
 
 """
 Amazon SWF PMCDeposit starter
 """
 
 
-class starter_PMCDeposit():
+class starter_PMCDeposit(Starter):
+    def __init__(self, settings=None, logger=None):
+        super(starter_PMCDeposit, self).__init__(settings, logger, "PMCDeposit")
 
-    def start(self, settings, bucket=None, document=None):
-        # Log
-        identity = "starter_%s" % int(random.random() * 1000)
-        logFile = "starter.log"
-        #logFile = None
-        logger = log.logger(logFile, settings.setLevel, identity)
+    def get_workflow_params(self, document=None):
+        if not document:
+            raise NullRequiredDataException(
+                "Did not get a document argument. Required."
+            )
 
-        # Simple connect
-        conn = boto.swf.layer1.Layer1(settings.aws_access_key_id, settings.aws_secret_access_key)
+        workflow_params = default_workflow_params(self.settings)
+        workflow_params["workflow_id"] = "%s_%s" % (
+            self.name,
+            document.replace("/", "_"),
+        )
+        workflow_params["workflow_name"] = self.name
+        workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 60 * 23)
 
-        docs = None
+        data = {"document": document}
 
-        if document is not None:
-            docs = []
-            doc = {}
-            doc["document"] = document
-            if bucket is not None:
-                doc["bucket"] = bucket
-            docs.append(doc)
+        info = {
+            "run": str(uuid.uuid4()),
+            "data": data,
+        }
 
-        if docs:
-            for doc in docs:
+        workflow_params["input"] = json.dumps(info, default=lambda ob: None)
+        return workflow_params
 
-                document = doc["document"]
+    def start(self, settings, document=None):
+        """method for backwards compatibility"""
+        self.settings = settings
+        self.instantiate_logger()
+        self.start_workflow(document)
 
-                # Get a unique id from the document name for the workflow_id
-                id_string = None
-                try:
-                    id_string = ''
-                    document_file = document.split("/")[-1]
-                    if "bucket" in doc:
-                        id_string += doc['bucket'] + '_'
-                    id_string += document_file.split("_")[0]
-                except:
-                    id_string = "000"
+    def start_workflow(self, document=None):
 
-                # Start a workflow execution
-                workflow_id = "PMCDeposit_%s" % (id_string)
-                workflow_name = "PMCDeposit"
-                workflow_version = "1"
-                child_policy = None
-                execution_start_to_close_timeout = None
+        workflow_params = self.get_workflow_params(document)
 
-                input_json = {}
-                input_json['run'] = str(uuid.uuid4())
-                input_json['data'] = doc
-                workflow_input = json.dumps(input_json)
+        self.connect_to_swf()
 
-                try:
-                    response = conn.start_workflow_execution(settings.domain, workflow_id,
-                                                             workflow_name, workflow_version,
-                                                             settings.default_task_list,
-                                                             child_policy,
-                                                             execution_start_to_close_timeout,
-                                                             workflow_input)
-
-                    logger.info('got response: \n%s' %
-                                json.dumps(response, sort_keys=True, indent=4))
-
-                except boto.swf.exceptions.SWFWorkflowExecutionAlreadyStartedError:
-                    # There is already a running workflow with that ID, cannot start another
-                    message = ('SWFWorkflowExecutionAlreadyStartedError: There is already ' +
-                               'a running workflow with ID %s' % workflow_id)
-                    print(message)
-                    logger.info(message)
+        # start a workflow execution
+        self.logger.info("Starting workflow: %s", workflow_params.get("workflow_id"))
+        try:
+            self.start_swf_workflow_execution(workflow_params)
+        except:
+            message = (
+                "Exception starting workflow execution for workflow_id %s"
+                % workflow_params.get("workflow_id")
+            )
+            self.logger.exception(message)
 
 
 if __name__ == "__main__":
 
-    document = None
-    bucket = None
-    last_updated_since = None
+    ENV, DOCUMENT = utils.console_start_env_document()
+    SETTINGS = utils.get_settings(ENV)
 
-    # Add options
-    parser = OptionParser()
-    parser.add_option("-e", "--env", default="dev", action="store", type="string",
-                      dest="env", help="set the environment to run, either dev or live")
-    parser.add_option("-b", "--bucket", default=None, action="store", type="string",
-                      dest="bucket", help="specify the bucket where the file is")
-    parser.add_option("-f", "--file", default=None, action="store", type="string",
-                      dest="document", help="specify the S3 object name of the POA zip file")
+    STARTER = starter_PMCDeposit(SETTINGS)
 
-    (options, args) = parser.parse_args()
-    if options.env:
-        ENV = options.env
-    if options.document:
-        document = options.document
-    if options.bucket:
-        bucket = options.bucket
-
-    import settings as settingsLib
-    settings = settingsLib.get_settings(ENV)
-
-    o = starter_PMCDeposit()
-
-    o.start(settings=settings, bucket=bucket, document=document)
+    STARTER.start_workflow(document=DOCUMENT)

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -164,6 +164,29 @@ class TestConsoleStartEnvDoiId(unittest.TestCase):
             self.assertEqual(utils.console_start_env_doi_id(), expected)
 
 
+class TestConsoleStartEnvDocument(unittest.TestCase):
+    def test_console_start_env_document(self):
+        env = "foo"
+        document = "elife-00666-vor-v1-20210914000000.zip"
+        expected = env, document
+        testargs = ["cron.py", "-e", env, "-f", document]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_document(), expected)
+
+    def test_console_start_env_document_blank(self):
+        expected = "dev", None
+        testargs = ["cron.py"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_document(), expected)
+
+    def test_console_start_env_document_unrecognized_arguments(self):
+        env = "foo"
+        expected = env, None
+        testargs = ["cron.py", "-e", env, "0"]
+        with patch.object(sys, "argv", testargs):
+            self.assertEqual(utils.console_start_env_document(), expected)
+
+
 class TestConsoleStartEnvWorkflowDoiId(unittest.TestCase):
     def test_console_start_env_workflow_doi_id(self):
         env = "foo"

--- a/tests/starter/test_starter_pmc_deposit.py
+++ b/tests/starter/test_starter_pmc_deposit.py
@@ -1,31 +1,35 @@
 import unittest
-from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from mock import patch
+from starter.starter_helper import NullRequiredDataException
 from starter.starter_PMCDeposit import starter_PMCDeposit
+from tests.activity.classes_mock import FakeLogger
 from tests.classes_mock import FakeLayer1
 import tests.settings_mock as settings_mock
-from mock import patch
 
 
 class TestStarterPMCDeposit(unittest.TestCase):
     def setUp(self):
-        self.starter = starter_PMCDeposit()
+        self.fake_logger = FakeLogger()
+        self.starter = starter_PMCDeposit(settings_mock, logger=self.fake_logger)
 
-    @patch('boto.swf.layer1.Layer1')
+    def test_start_no_document(self):
+        self.assertRaises(
+            NullRequiredDataException,
+            self.starter.start,
+            settings=settings_mock,
+            document=None,
+        )
+
+    @patch("boto.swf.layer1.Layer1")
     def test_start(self, fake_conn):
-        bucket = None
-        document = 'document'
+        document = "document"
         fake_conn.return_value = FakeLayer1()
-        self.assertIsNone(self.starter.start(settings_mock, bucket, document))
+        self.assertIsNone(self.starter.start(settings_mock, document))
 
-    @patch.object(FakeLayer1, 'start_workflow_execution')
-    @patch('boto.swf.layer1.Layer1')
+    @patch.object(FakeLayer1, "start_workflow_execution")
+    @patch("boto.swf.layer1.Layer1")
     def test_start_exception(self, fake_conn, fake_start):
-        bucket = None
-        document = 'document'
+        document = "document"
         fake_conn.return_value = FakeLayer1()
-        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError("message", None)
-        self.assertIsNone(self.starter.start(settings_mock, bucket, document))
-
-
-if __name__ == '__main__':
-    unittest.main()
+        fake_start.side_effect = Exception("An unhandled exception")
+        self.assertIsNone(self.starter.start(settings_mock, document))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/992

In refactoring the starter module for the `PMCDeposit` workflow, the ability to specify an input `bucket` name when using the starter is also removed here, because it was not in regular use and was probably only used for when PMC deposits began and some old files were sent manually.