### PR TITLE
Starter object tests

### DIFF
--- a/tests/starter/test_starter_helper.py
+++ b/tests/starter/test_starter_helper.py
@@ -1,39 +1,47 @@
 import unittest
-import starter.starter_helper as starter_helper
-import tests.test_data as test_data
 import json
 from ddt import ddt, data, unpack
+import starter.starter_helper as starter_helper
+import tests.test_data as test_data
 from tests.activity.classes_mock import FakeLogger
 
 
-example_workflow_name = "PostPerfectPublication"
-example_workflow_id = lambda fe, version: "PostPerfectPublication_00353." + version + "." + fe
+EXAMPLE_WORKFLOW_NAME = "PostPerfectPublication"
+EXAMPLE_WORKFLOW_ID = (
+    lambda fe, version: "PostPerfectPublication_00353." + version + "." + fe
+)
 
 
 @ddt
 class TestStarterHelper(unittest.TestCase):
-
     @unpack
-    @data({'data': test_data.data_published_lax, 'execution': 'lax'},
-          {'data': test_data.data_error_lax, 'execution':'lax'},
-          {'data': test_data.data_published_website, 'execution':'website'})
+    @data(
+        {"data": test_data.data_published_lax, "execution": "lax"},
+        {"data": test_data.data_error_lax, "execution": "lax"},
+        {"data": test_data.data_published_website, "execution": "website"},
+    )
     def test_set_workflow_information_lax(self, data, execution):
 
-        workflow_id, \
-        workflow_name, \
-        workflow_version, \
-        child_policy, \
-        execution_start_to_close_timeout, \
-        workflow_input = starter_helper.set_workflow_information(
-            example_workflow_name,
+        (
+            workflow_id,
+            workflow_name,
+            workflow_version,
+            child_policy,
+            execution_start_to_close_timeout,
+            workflow_input,
+        ) = starter_helper.set_workflow_information(
+            EXAMPLE_WORKFLOW_NAME,
             "1",
             None,
             data,
-            "%s.%s" % (data.get('article_id'), data.get('version')),
-            execution)
+            "%s.%s" % (data.get("article_id"), data.get("version")),
+            execution,
+        )
 
-        self.assertEqual(example_workflow_id(execution, data.get('version')), workflow_id)
-        self.assertEqual(example_workflow_name, workflow_name)
+        self.assertEqual(
+            EXAMPLE_WORKFLOW_ID(execution, data.get("version")), workflow_id
+        )
+        self.assertEqual(EXAMPLE_WORKFLOW_NAME, workflow_name)
         self.assertEqual("1", workflow_version)
         self.assertIsNone(child_policy)
         self.assertEqual("1800", execution_start_to_close_timeout)
@@ -41,21 +49,18 @@ class TestStarterHelper(unittest.TestCase):
 
     def test_get_starter_module(self):
         "for coverage successful starter module import"
-        starter_name = 'starter_PackagePOA'
+        starter_name = "starter_PackagePOA"
         module_object = starter_helper.get_starter_module(starter_name, FakeLogger())
         self.assertIsNotNone(module_object)
 
     def test_get_starter_module_failure(self):
         "for coverage test failure"
-        starter_name = 'not_a_starter'
+        starter_name = "not_a_starter"
         module_object = starter_helper.get_starter_module(starter_name, FakeLogger())
         self.assertIsNone(module_object)
 
     def test_import_starter_module_failure(self):
         "for coverage test import failure"
-        starter_name = 'not_a_starter'
+        starter_name = "not_a_starter"
         return_value = starter_helper.import_starter_module(starter_name, FakeLogger())
         self.assertFalse(return_value)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/starter/test_starter_objects.py
+++ b/tests/starter/test_starter_objects.py
@@ -1,0 +1,74 @@
+import unittest
+from collections import OrderedDict
+from mock import patch
+from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
+from starter.objects import Starter, default_workflow_params
+import tests.settings_mock as settings_mock
+from tests.classes_mock import FakeLayer1
+from tests.activity.classes_mock import FakeLogger
+
+
+class TestStarterObjectInit(unittest.TestCase):
+    def test_starter_init_no_logger(self):
+        starter_object = Starter(settings_mock, name="Ping")
+        self.assertIsNotNone(starter_object.logger)
+        self.assertIsNotNone(starter_object.name)
+
+    def test_starter_init_no_logger_no_name(self):
+        starter_object = Starter(settings_mock)
+        self.assertIsNotNone(starter_object.logger)
+
+
+class TestStarterObject(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.starter = Starter(settings_mock, self.logger)
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_connect_to_swf(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        self.starter.connect_to_swf()
+        self.assertIsNotNone(self.starter.conn)
+
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_swf_workflow_execution(self, fake_conn):
+        fake_conn.return_value = FakeLayer1()
+        workflow_params = {}
+        self.starter.start_swf_workflow_execution(workflow_params)
+        self.assertEqual(self.logger.loginfo[-1], "got response: \nnull")
+
+    @patch.object(FakeLayer1, "start_workflow_execution")
+    @patch("boto.swf.layer1.Layer1")
+    def test_start_swf_workflow_execution_exception(self, fake_conn, fake_start):
+        fake_conn.return_value = FakeLayer1()
+        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError(
+            "message", None
+        )
+        workflow_params = {}
+        with self.assertRaises(SWFWorkflowExecutionAlreadyStartedError):
+            self.starter.start_swf_workflow_execution(workflow_params)
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            (
+                "SWFWorkflowExecutionAlreadyStartedError: "
+                "There is already a running workflow with ID None"
+            ),
+        )
+
+
+class TestDefaultWorkflowParams(unittest.TestCase):
+    def test_default_workflow_params(self):
+        expected = OrderedDict(
+            [
+                ("domain", ""),
+                ("task_list", ""),
+                ("workflow_id", None),
+                ("workflow_name", None),
+                ("workflow_version", None),
+                ("child_policy", None),
+                ("execution_start_to_close_timeout", None),
+                ("input", None),
+            ]
+        )
+        params = default_workflow_params(settings_mock)
+        self.assertEqual(params, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/992

Test cases for `objects.py` module, and linting of tests for `starter_helper.py`.