### PR TITLE
Use non-zero filled article_id in session data.

### DIFF
--- a/activity/activity_ArchiveArticle.py
+++ b/activity/activity_ArchiveArticle.py
@@ -2,6 +2,7 @@ import os
 import json
 import zipfile
 from datetime import datetime
+from provider import utils
 from provider.storage_provider import storage_context
 from activity.objects import Activity
 
@@ -149,5 +150,5 @@ class activity_ArchiveArticle(Activity):
 
 def zip_dir(article_id, status, version, updated_date):
     "zip directory name"
-    return ("elife-" + article_id + '-' + status + '-v' + version
+    return ("elife-" + utils.pad_msid(article_id) + '-' + status + '-v' + version
             + '-' + updated_date.strftime('%Y%m%d%H%M%S'))

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -3,10 +3,7 @@ from activity.objects import Activity
 import json
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-import provider.article_structure as article_structure
-import provider.image_conversion as image_conversion
-
-
+from provider import article_structure, image_conversion, utils
 
 
 class activity_ConvertImagesToJPG(Activity):
@@ -66,7 +63,7 @@ class activity_ConvertImagesToJPG(Activity):
                 file_pointer = storage.get_resource_to_file_pointer(figure_resource, file_path)
 
                 cdn_bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
-                cdn_resource_path = storage_provider + cdn_bucket_name + "/" + article_id + "/"
+                cdn_resource_path = storage_provider + cdn_bucket_name + "/" + utils.pad_msid(article_id) + "/"
 
                 publish_locations = [cdn_resource_path]
 

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -5,7 +5,7 @@ from activity.objects import Activity
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from provider.article_processing import download_jats
-import provider.glencoe_check as glencoe_check
+from provider import glencoe_check, utils
 
 
 """
@@ -192,7 +192,7 @@ class activity_CopyGlencoeStillImages(Activity):
         filename = glencoe_check.force_article_id(filename, article_id)
         cdn = (self.settings.storage_provider + "://" +
                self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket + "/" +
-               article_id + "/" + filename)
+               utils.pad_msid(article_id) + "/" + filename)
         return cdn
 
     def store_file(self, path, article_id):
@@ -216,7 +216,7 @@ class activity_CopyGlencoeStillImages(Activity):
         storage = storage_context(self.settings)
         article_path_in_cdn = (
             self.settings.storage_provider + "://" + self.settings.publishing_buckets_prefix +
-            self.settings.ppp_cdn_bucket + "/" + article_id)
+            self.settings.ppp_cdn_bucket + "/" + utils.pad_msid(article_id))
         return storage.list_resources(article_path_in_cdn)
 
     def validate_jpgs_against_cdn(self, cdn_all_files, cdn_still_jpgs):

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -2,7 +2,7 @@ from boto.s3.connection import S3Connection
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from mimetypes import guess_type
-from provider import article_structure
+from provider import article_structure, utils
 from activity.objects import Activity
 
 """
@@ -62,7 +62,7 @@ class activity_DepositAssets(Activity):
 
             for file_name in other_assets:
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/"
-                dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/"
+                dest_resource = storage_provider + cdn_bucket_name + "/" + utils.pad_msid(article_id) + "/"
 
                 storage.copy_resource(orig_resource + file_name, dest_resource + file_name)
 

--- a/activity/activity_DepositIngestAssets.py
+++ b/activity/activity_DepositIngestAssets.py
@@ -1,7 +1,7 @@
 from boto.s3.connection import S3Connection
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-from provider import article_structure
+from provider import article_structure, utils
 from activity.objects import Activity
 
 """
@@ -53,7 +53,7 @@ class activity_DepositIngestAssets(Activity):
             for file_name in pre_ingest_assets:
 
                 orig_resource = storage_provider + expanded_folder_bucket + "/" + expanded_folder_name + "/" + file_name
-                dest_resource = storage_provider + cdn_bucket_name + "/" + article_id + "/" + file_name
+                dest_resource = storage_provider + cdn_bucket_name + "/" + utils.pad_msid(article_id) + "/" + file_name
                 storage.copy_resource(orig_resource, dest_resource)
 
                 if self.logger:

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -12,7 +12,7 @@ from provider.execution_context import get_session
 import requests
 from provider.storage_provider import storage_context
 from provider.article_structure import ArticleInfo
-import provider.lax_provider as lax_provider
+from provider import lax_provider, utils
 from activity.objects import Activity
 
 """
@@ -67,7 +67,7 @@ class activity_ExpandArticle(Activity):
                               filename_last_element)
             return self.ACTIVITY_PERMANENT_FAILURE  # status could not be determined, exit workflow.
 
-        article_version_id = article_id + '.' + version
+        article_version_id = utils.pad_msid(article_id) + '.' + version
         session.store_value('article_version_id', article_version_id)
         session.store_value('run', run)
         session.store_value('status', status)

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -159,7 +159,7 @@ class activity_IngestDigestToEndpoint(Activity):
 
     def digest_preview_link(self, article_id):
         "preview link for the digest using the preview base url"
-        return "%s/digests/%s" % (self.settings.journal_preview_base_url, article_id)
+        return "%s/digests/%s" % (self.settings.journal_preview_base_url, utils.pad_msid(article_id))
 
     def activity_end_message(self, article_id, statuses):
         "different end message to emit based on the ingest status"

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -1,6 +1,6 @@
 import json
 
-from provider import crossref, lax_provider
+from provider import crossref, lax_provider, utils
 from provider.article_processing import download_jats
 from provider.storage_provider import storage_context
 from provider.execution_context import get_session
@@ -54,7 +54,7 @@ class activity_ScheduleCrossrefPeerReview(Activity):
                     ('%s will not deposit article %s' +
                      ' ingested by silent-correction, its version of %s does not equal the' +
                      ' highest version which is %s') %
-                    (self.name, article_id, version, highest_version))
+                    (self.name, utils.pad_msid(article_id), version, highest_version))
                 self.logger.info(log_message)
                 self.emit_monitor_event(
                     self.settings, article_id, version, run, self.pretty_name, "end", log_message)
@@ -64,7 +64,7 @@ class activity_ScheduleCrossrefPeerReview(Activity):
         if self.xml_sub_article_exists(expanded_folder_name) is False:
             log_message = (
                 '%s finds version %s of %s has no sub-article for peer review depositing' %
-                (self.name, version, article_id))
+                (self.name, version, utils.pad_msid(article_id)))
             self.logger.info(log_message)
             self.emit_monitor_event(
                 self.settings, article_id, version, run, self.pretty_name, "end", log_message)

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -3,7 +3,7 @@ from boto.s3.connection import S3Connection
 import tempfile
 from github import Github
 from github import GithubException
-from provider.utils import unicode_encode
+from provider.utils import pad_msid, unicode_encode
 import provider.lax_provider
 from provider.storage_provider import storage_context
 from activity.objects import Activity
@@ -59,7 +59,7 @@ class activity_UpdateRepository(Activity):
                                                             self.settings.publishing_buckets_prefix +
                                                             self.settings.ppp_cdn_bucket,
                                                             data['version'])
-                s3_file_path = data['article_id'] + "/" + xml_file
+                s3_file_path = pad_msid(data['article_id']) + "/" + xml_file
 
                 storage = storage_context(self.settings)
                 bucket_name = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -1,9 +1,8 @@
 import json
+import requests
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-import provider.article_structure as article_structure
-import provider.iiif as iiif
-import requests
+from provider import article_structure, iiif, utils
 from activity.objects import Activity
 
 """
@@ -49,12 +48,12 @@ class activity_VerifyImageServer(Activity):
         try:
             storage = storage_context(self.settings)
             bucket = self.settings.publishing_buckets_prefix + self.settings.ppp_cdn_bucket
-            images_resource = "".join((self.settings.storage_provider, "://", bucket, "/", article_id))
+            images_resource = "".join((self.settings.storage_provider, "://", bucket, "/", utils.pad_msid(article_id)))
 
             files_in_bucket = storage.list_resources(images_resource)
             original_figures = article_structure.get_figures_for_iiif(files_in_bucket)
 
-            iiif_path_for_article = self.settings.iiif_resolver.replace('{article_id}', article_id)
+            iiif_path_for_article = self.settings.iiif_resolver.replace('{article_id}', utils.pad_msid(article_id))
 
             results = self.retrieve_endpoints_check(original_figures, iiif_path_for_article)
 

--- a/activity/activity_VersionLookup.py
+++ b/activity/activity_VersionLookup.py
@@ -47,7 +47,7 @@ class activity_VersionLookup(Activity):
             version = self.get_version(self.settings, article_structure,
                                        data['version_lookup_function'])
             session.store_value('version', version)
-            article_id = article_structure.article_id
+            article_id = str(int(article_structure.article_id))
             session.store_value('article_id', article_id)
 
             self.emit_monitor_event(

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -5,6 +5,7 @@ import re
 
 import boto.swf
 import dashboard_queue
+from provider import utils
 
 """
 Amazon SWF activity base class
@@ -251,7 +252,7 @@ class Activity(object):
 
     @staticmethod
     def emit_monitor_event(settings, item_identifier, version, run, event_type, status, message):
-        message = dashboard_queue.build_event_message(item_identifier, version, run, event_type,
+        message = dashboard_queue.build_event_message(utils.pad_msid(item_identifier), version, run, event_type,
                                                       datetime.datetime.now(),
                                                       status, message)
 
@@ -259,6 +260,6 @@ class Activity(object):
 
     @staticmethod
     def set_monitor_property(settings, item_identifier, name, value, property_type, version=0):
-        message = dashboard_queue.build_property_message(item_identifier, version,
+        message = dashboard_queue.build_property_message(utils.pad_msid(item_identifier), version,
                                                          name, value, property_type)
         dashboard_queue.send_message(message, settings)

--- a/lax_response_adapter.py
+++ b/lax_response_adapter.py
@@ -70,7 +70,7 @@ class LaxResponseAdapter:
             date_time = parse(message_data['datetime'])
             date_time = date_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-            article_id = utils.pad_msid(message_data["id"])
+            article_id = message_data["id"]
             operation = message_data["requested-action"]
             response_message = None
             if "message" in message_data:

--- a/provider/article.py
+++ b/provider/article.py
@@ -117,8 +117,7 @@ class article(object):
         # Check for the document
 
         # Convert the value just in case
-        if type(doi_id) == int:
-            doi_id = str(doi_id).zfill(5)
+        doi_id = pad_msid(doi_id)
 
         article_id = doi_id
         # Get the highest published version from lax
@@ -194,7 +193,7 @@ class article(object):
 
     def get_pdf_cover_link(self, pdf_cover_generator_url ,doi_id, logger):
 
-        url = pdf_cover_generator_url + str(doi_id)
+        url = pdf_cover_generator_url + pad_msid(doi_id)
         logger.info("URL for PDF Generator %s", url)
         resp = requests.post(url)
         logger.info("Response code for PDF Generator %s", str(resp.status_code))

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -5,7 +5,7 @@ import json
 from dateutil.parser import parse
 import log
 import os
-from provider.utils import base64_encode_string
+from provider import utils
 
 
 identity = "process_%s" % os.getpid()
@@ -30,7 +30,7 @@ def lax_request(
     if status_code not in [200, 404]:
         raise ErrorCallingLaxException(
             "Error looking up article "
-            + article_id
+            + utils.pad_msid(article_id)
             + " %s in Lax: %s\n%s" % (request_type, status_code, response.content)
         )
 
@@ -60,7 +60,7 @@ def lax_auth_key(settings, auth=False):
 
 def article_json(article_id, settings, auth=False):
     "get json for the latest article version from lax"
-    url = settings.lax_article_endpoint.replace("{article_id}", article_id)
+    url = settings.lax_article_endpoint.replace("{article_id}", utils.pad_msid(article_id))
     return lax_request(
         url, article_id, settings.verify_ssl, None, lax_auth_key(settings, auth)
     )
@@ -68,7 +68,7 @@ def article_json(article_id, settings, auth=False):
 
 def article_versions(article_id, settings, auth=False):
     "get json for article versions from lax"
-    url = settings.lax_article_versions.replace("{article_id}", article_id)
+    url = settings.lax_article_versions.replace("{article_id}", utils.pad_msid(article_id))
     headers = {}
     if (
         hasattr(settings, "lax_article_versions_accept_header")
@@ -87,7 +87,7 @@ def article_versions(article_id, settings, auth=False):
 
 def article_related(article_id, settings, auth=False):
     "get json for related article data from lax"
-    url = settings.lax_article_related.replace("{article_id}", article_id)
+    url = settings.lax_article_related.replace("{article_id}", utils.pad_msid(article_id))
     return lax_request(
         url, article_id, settings.verify_ssl, None, lax_auth_key(settings, auth)
     )
@@ -326,7 +326,7 @@ def lax_token(run, version, expanded_folder, status, force=False, run_type=None)
         "force": force,
         "run_type": run_type,
     }
-    return base64_encode_string(json.dumps(token))
+    return utils.base64_encode_string(json.dumps(token))
 
 
 def message_from_lax(data):

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -9,7 +9,7 @@ bucket_dest_file_name = "test_dest.json"
 
 session_example = {
             'version': '1',
-            'article_id': '00353',
+            'article_id': '353',
             'run': 'cf9c7e86-7355-4bb4-b48e-0bc284221251',
             'expanded_folder': '00353.1/cf9c7e86-7355-4bb4-b48e-0bc284221251',
             'update_date': '2012-12-13T00:00:00Z',
@@ -22,7 +22,7 @@ data_example_before_publish = {
             "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
             "expanded_folder": "00353.1/cf9c7e86-7355-4bb4-b48e-0bc284221251",
             "version": "1",
-            "article_id": "00353",
+            "article_id": "353",
             'file_name': 'elife-00353-vor-v1.zip',
             'filename_last_element': 'elife-00353-vor-r1.zip'}
 
@@ -53,7 +53,7 @@ ExpandArticle_data_invalid_status = {u'event_time': u'2016-06-07T10:45:18.141126
 
 ExpandArticle_data_invalid_status1_session_example = {
             'version': '1',
-            'article_id': '00353',
+            'article_id': '353',
             'run': '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
             'expanded_folder': '00353.1/1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
             'update_date': '2012-12-13T00:00:00Z',
@@ -62,7 +62,7 @@ ExpandArticle_data_invalid_status1_session_example = {
         }
 ExpandArticle_data_invalid_status2_session_example = {
             'version': '1',
-            'article_id': '00353',
+            'article_id': '353',
             'run': '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
             'expanded_folder': '00353.1/1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
             'update_date': '2012-12-13T00:00:00Z',

--- a/tests/activity/test_activity_deposit_assets.py
+++ b/tests/activity/test_activity_deposit_assets.py
@@ -9,7 +9,7 @@ import tests.activity.test_activity_data as test_activity_data
 
 activity_data = {
                     "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-                    "article_id": "00353",
+                    "article_id": "353",
                     "result": "ingested",
                     "status": "vor",
                     "version": "1",

--- a/tests/activity/test_activity_email_video.py
+++ b/tests/activity/test_activity_email_video.py
@@ -19,7 +19,7 @@ from activity.activity_EmailVideoArticlePublished import (
 
 BASE_ACTIVITY_DATA = {
     "run": "",
-    "article_id": "00353",
+    "article_id": "353",
     "version": "1",
     "status": "vor",
     "expanded_folder": "email_video"
@@ -54,31 +54,31 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         {
             "comment": "article has video and not a duplicate email",
             "xml_file": "elife-00007-v1.xml",
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", None),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "7", "vor", None),
             "first_vor": True,
             "activity_success": activity_object.ACTIVITY_SUCCESS
         },
         {
             "comment": "poa article does not send an email",
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "poa", None),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "7", "poa", None),
             "activity_success": activity_object.ACTIVITY_SUCCESS
         },
         {
             "comment": "silent correction article does not send an email",
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", "silent-correction"),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "7", "vor", "silent-correction"),
             "activity_success": activity_object.ACTIVITY_SUCCESS
         },
         {
             "comment": "article is not the first VoR",
             "xml_file": "elife-00007-v1.xml",
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", None),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "7", "vor", None),
             "first_vor": None,
             "activity_success": activity_object.ACTIVITY_SUCCESS
         },
         {
             "comment": "article does not have a video",
             "xml_file": "elife-00353-v1.xml",
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00353", "vor", None),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "353", "vor", None),
             "first_vor": True,
             "activity_success": activity_object.ACTIVITY_SUCCESS
         }
@@ -107,7 +107,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
             "comment": "article has video but templates were not downloaded",
             "xml_file": "elife-00007-v1.xml",
             "templates_warmed": False,
-            "input_data": activity_data(BASE_ACTIVITY_DATA, "00007", "vor", None),
+            "input_data": activity_data(BASE_ACTIVITY_DATA, "7", "vor", None),
             "first_vor": True,
             "activity_success": activity_object.ACTIVITY_PERMANENT_FAILURE
         }

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -15,7 +15,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
             settings_mock, self.fake_logger, None, None, None)
         self.data = {
             "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
-            "article_id": "00353",
+            "article_id": "353",
             "version": "1"}
         self.article_snippet = {
             'subjects': [

--- a/tests/activity/test_activity_ingest_to_lax.py
+++ b/tests/activity/test_activity_ingest_to_lax.py
@@ -11,7 +11,7 @@ from testfixtures import TempDirectory
 
 
 data_example = {
-    "article_id": "00353",
+    "article_id": "353",
     "update_date": "2016-10-05T10:31:54Z",
     "expanded_folder": "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
     "message": None,

--- a/tests/activity/test_activity_invalidate_cdn.py
+++ b/tests/activity/test_activity_invalidate_cdn.py
@@ -8,7 +8,7 @@ import tests.activity.test_activity_data as test_activity_data
 
 activity_data = {
                     "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-                    "article_id": "00353",
+                    "article_id": "353",
                     "version": "1"
                 }
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -56,7 +56,7 @@ class TestPublicationEmail(unittest.TestCase):
                 "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
                 "input_data": {},
                 "article_xml_filenames": ["elife00013.xml"],
-                "article_id": "00013",
+                "article_id": "13",
                 "activity_success": True,
                 "admin_email_content_contains": [
                     "Parsed https://doi.org/10.7554/eLife.00013",
@@ -75,7 +75,7 @@ class TestPublicationEmail(unittest.TestCase):
                 "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
                 "input_data": None,
                 "article_xml_filenames": ["elife03385.xml"],
-                "article_id": "03385",
+                "article_id": "3385",
                 "activity_success": True,
                 "admin_email_content_contains": [
                     "Parsed https://doi.org/10.7554/eLife.03385",
@@ -90,7 +90,7 @@ class TestPublicationEmail(unittest.TestCase):
                 "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_1,
                 "input_data": None,
                 "article_xml_filenames": ["elife_poa_e03977.xml"],
-                "article_id": "03977",
+                "article_id": "3977",
                 "activity_success": True,
                 "admin_email_content_contains": [
                     "Parsed https://doi.org/10.7554/eLife.03977",
@@ -170,7 +170,7 @@ class TestPublicationEmail(unittest.TestCase):
                 "lax_article_versions_response_data": LAX_ARTICLE_VERSIONS_RESPONSE_DATA_3,
                 "input_data": {},
                 "article_xml_filenames": ["elife-00353-v1.xml"],
-                "article_id": "00353",
+                "article_id": "353",
                 "activity_success": True,
                 "admin_email_content_contains": [
                     "Parsed https://doi.org/10.7554/eLife.00353",

--- a/tests/activity/test_activity_publish_to_lax.py
+++ b/tests/activity/test_activity_publish_to_lax.py
@@ -11,7 +11,7 @@ from testfixtures import TempDirectory
 
 
 ACTIVITY_DATA = {
-    "article_id": "00353",
+    "article_id": "353",
     "version": "1",
     "run": "bb2d37b8-e73c-43b3-a092-d555753316af",
     "status": "vor",
@@ -21,7 +21,7 @@ ACTIVITY_DATA = {
 
 WORKFLOW_DATA = {
     "workflow_data": {
-        "article_id": u"00353",
+        "article_id": u"353",
         "expanded_folder": u"00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
         "message": None,
         "requested_action": u"publish",

--- a/tests/activity/test_activity_send_dashboard_properties.py
+++ b/tests/activity/test_activity_send_dashboard_properties.py
@@ -37,20 +37,20 @@ class TestSendDashboardEvents(unittest.TestCase):
 
         self.assertEqual(result, True)
 
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'doi', u'10.7554/eLife.00353', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'title', u'A good life', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'status', u'VOR', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'publication-date', u'2012-12-13', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'article-type', u'discussion', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'corresponding-authors', u'Eve Marder', 'text', version='1')
-        fake_emit_monitor_property.assert_any_call(ANY, '00353', 'authors', u'Eve Marder', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'doi', u'10.7554/eLife.00353', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'title', u'A good life', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'status', u'VOR', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'publication-date', u'2012-12-13', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'article-type', u'discussion', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'corresponding-authors', u'Eve Marder', 'text', version='1')
+        fake_emit_monitor_property.assert_any_call(ANY, '353', 'authors', u'Eve Marder', 'text', version='1')
 
-        fake_emit_monitor_event.assert_any_call(ANY, '00353', '1', '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
+        fake_emit_monitor_event.assert_any_call(ANY, '353', '1', '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                                                 'Send dashboard properties', 'start',
-                                                'Starting send of article properties to dashboard for article 00353')
-        fake_emit_monitor_event.assert_any_call(ANY, '00353', '1', '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
+                                                'Starting send of article properties to dashboard for article 353')
+        fake_emit_monitor_event.assert_any_call(ANY, '353', '1', '1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                                                 'Send dashboard properties', 'end',
-                                                'Article properties sent to dashboard for article  00353')
+                                                'Article properties sent to dashboard for article  353')
 
         self.directory.cleanup()
 

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -111,7 +111,7 @@ class TestVerifyGlencoe(unittest.TestCase):
             test_data.ExpandArticle_data["run"],
             self.verifyglencoe.pretty_name,
             "error",
-            'Glencoe video is not available for article 00353; message: '
+            'Glencoe video is not available for article 353; message: '
             'unhandled status code from Glencoe: 500 - '
             'url requested: 10.7554/eLife.00353')
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_TEMPORARY_FAILURE)
@@ -141,7 +141,7 @@ class TestVerifyGlencoe(unittest.TestCase):
             test_data.ExpandArticle_data["run"],
             self.verifyglencoe.pretty_name,
             "error",
-            "An error occurred when checking for Glencoe video. Article 00353; message: "
+            "An error occurred when checking for Glencoe video. Article 353; message: "
             "Fake Time out")
 
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_PERMANENT_FAILURE)

--- a/tests/activity/test_activity_verify_lax_response.py
+++ b/tests/activity/test_activity_verify_lax_response.py
@@ -17,7 +17,7 @@ class TestVerifyLaxResponse(unittest.TestCase):
 
     @data({
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "ingested",
             "status": "vor",
             "version": "1",
@@ -48,7 +48,7 @@ class TestVerifyLaxResponse(unittest.TestCase):
 
     @data({
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "ingested",
             "status": "vor",
             "version": "1",
@@ -79,7 +79,7 @@ class TestVerifyLaxResponse(unittest.TestCase):
 
     @data({
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "error",
             "status": "vor",
             "version": "1",
@@ -107,7 +107,7 @@ class TestVerifyLaxResponse(unittest.TestCase):
 
     @data({
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "error",
             "status": "poa",
             "version": "1",

--- a/tests/activity/test_activity_verify_publish_response.py
+++ b/tests/activity/test_activity_verify_publish_response.py
@@ -8,7 +8,7 @@ import tests.activity.settings_mock as settings_mock
 
 DATA_PUBLISHED_LAX = {
     "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-    "article_id": "00353",
+    "article_id": "353",
     "result": "published",
     "status": "vor",
     "version": "1",
@@ -21,7 +21,7 @@ DATA_PUBLISHED_LAX = {
 
 DATA_ERROR_LAX = {
     "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-    "article_id": "00353",
+    "article_id": "353",
     "result": "error",
     "status": "vor",
     "version": "1",

--- a/tests/provider/test_doaj.py
+++ b/tests/provider/test_doaj.py
@@ -386,7 +386,7 @@ class TestDoajPostRequest(unittest.TestCase):
         self.url = settings_mock.doaj_endpoint
         self.api_key = settings_mock.doaj_api_key
         self.logger = FakeLogger()
-        self.article_id = "00003"
+        self.article_id = "3"
         self.response_content_success = (
             b'{"status": "created", "id": "26ce51c630d04c8c8664410488150acc", '
             b'"location": "/api/v2/articles/26ce51c630d04c8c8664410488150acc"}'

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -202,13 +202,13 @@ class TestLaxProvider(unittest.TestCase):
     def test_prepare_action_message(self, fake_xml_file_name):
         fake_xml_file_name.return_value = "elife-00353-v1.xml"
         message = lax_provider.prepare_action_message(settings_mock,
-                                                      "00353", "bb2d37b8-e73c-43b3-a092-d555753316af",
+                                                      "353", "bb2d37b8-e73c-43b3-a092-d555753316af",
                                                       "00353.1/bb2d37b8-e73c-43b3-a092-d555753316af",
                                                       "1", "vor", "ingest")
         self.assertIn('token', message)
         del message['token']
         self.assertDictEqual(message, {'action': 'ingest',
-                                       'id': '00353',
+                                       'id': '353',
                                        'location': 'https://s3-external-1.amazonaws.com/origin_bucket/00353.1/bb2d37b8-e73c-43b3-a092-d555753316af/elife-00353-v1.xml',
                                        'version': 1,
                                        'force': False})
@@ -298,7 +298,7 @@ class TestLaxProvider(unittest.TestCase):
     def test_article_retracted_status_no_related(self, mock_article_related):
         related_article_json = []
         mock_article_related.return_value = 200, related_article_json
-        retracted_status = lax_provider.article_retracted_status("04132", settings_mock)
+        retracted_status = lax_provider.article_retracted_status("4132", settings_mock)
         self.assertEqual(retracted_status, False)
 
     @patch("provider.lax_provider.article_related")
@@ -356,7 +356,7 @@ class TestLaxProvider(unittest.TestCase):
     @patch("provider.lax_provider.article_related")
     def test_article_retracted_status_404(self, mock_article_related):
         mock_article_related.return_value = 404, None
-        retracted_status = lax_provider.article_retracted_status("04132", settings_mock)
+        retracted_status = lax_provider.article_retracted_status("4132", settings_mock)
         self.assertIsNone(retracted_status)
 
     @patch("provider.lax_provider.article_versions")

--- a/tests/starter/test_starter_copy_glencoe_still_images.py
+++ b/tests/starter/test_starter_copy_glencoe_still_images.py
@@ -24,7 +24,7 @@ class TestStarterCopyGlencoeStillImages(unittest.TestCase):
     @patch("boto.swf.layer1.Layer1")
     def test_copy_glencoe_still_images_starter(self, fake_boto_conn):
         fake_boto_conn.return_value = FakeLayer1()
-        self.starter.start(settings=settings_mock, article_id="00353")
+        self.starter.start(settings=settings_mock, article_id="353")
 
     @patch("boto.swf.layer1.Layer1")
     def test_main(self, fake_boto_conn):

--- a/tests/starter/test_starter_deposit_doaj.py
+++ b/tests/starter/test_starter_deposit_doaj.py
@@ -30,5 +30,5 @@ class TestStarterDepositDOAJ(unittest.TestCase):
     @patch("boto.swf.layer1.Layer1")
     def test_deposit_doaj_start(self, fake_boto_conn):
         fake_boto_conn.return_value = FakeLayer1()
-        info = {"article_id": "00353"}
+        info = {"article_id": "353"}
         self.starter.start(settings=settings_mock, info=info)

--- a/tests/starter/test_starter_helper.py
+++ b/tests/starter/test_starter_helper.py
@@ -8,7 +8,7 @@ from tests.activity.classes_mock import FakeLogger
 
 EXAMPLE_WORKFLOW_NAME = "PostPerfectPublication"
 EXAMPLE_WORKFLOW_ID = (
-    lambda fe, version: "PostPerfectPublication_00353." + version + "." + fe
+    lambda fe, version: "PostPerfectPublication_353." + version + "." + fe
 )
 
 

--- a/tests/starter/test_starter_post_perfect_publication.py
+++ b/tests/starter/test_starter_post_perfect_publication.py
@@ -19,7 +19,7 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
             [
                 ("domain", ""),
                 ("task_list", ""),
-                ("workflow_id", "PostPerfectPublication_00353.1.lax"),
+                ("workflow_id", "PostPerfectPublication_353.1.lax"),
                 ("workflow_name", "PostPerfectPublication"),
                 ("workflow_version", "1"),
                 ("child_policy", None),
@@ -29,7 +29,7 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
                     (
                         "{"
                         '"run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",'
-                        ' "article_id": "00353",'
+                        ' "article_id": "353",'
                         ' "result": "error",'
                         ' "status": "vor",'
                         ' "version": "1",'

--- a/tests/starter/test_starter_process_article_zip.py
+++ b/tests/starter/test_starter_process_article_zip.py
@@ -19,7 +19,7 @@ class TestStarterProcessArticleZip(unittest.TestCase):
             [
                 ("domain", ""),
                 ("task_list", ""),
-                ("workflow_id", "ProcessArticleZip_00353.1"),
+                ("workflow_id", "ProcessArticleZip_353.1"),
                 ("workflow_name", "ProcessArticleZip"),
                 ("workflow_version", "1"),
                 ("child_policy", None),
@@ -29,7 +29,7 @@ class TestStarterProcessArticleZip(unittest.TestCase):
                     (
                         "{"
                         '"run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",'
-                        ' "article_id": "00353",'
+                        ' "article_id": "353",'
                         ' "result": "ingested",'
                         ' "status": "vor",'
                         ' "version": "1",'

--- a/tests/starter/test_starter_silent_corrections_process.py
+++ b/tests/starter/test_starter_silent_corrections_process.py
@@ -19,7 +19,7 @@ class TestStarterSilentCorrectionsProcess(unittest.TestCase):
             [
                 ("domain", ""),
                 ("task_list", ""),
-                ("workflow_id", "SilentCorrectionsProcess_00353.1"),
+                ("workflow_id", "SilentCorrectionsProcess_353.1"),
                 ("workflow_name", "SilentCorrectionsProcess"),
                 ("workflow_version", "1"),
                 ("child_policy", None),
@@ -29,7 +29,7 @@ class TestStarterSilentCorrectionsProcess(unittest.TestCase):
                     (
                         "{"
                         '"run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",'
-                        ' "article_id": "00353",'
+                        ' "article_id": "353",'
                         ' "result": "ingested",'
                         ' "status": "vor",'
                         ' "version": "1",'

--- a/tests/starter/test_starter_software_heritage_deposit.py
+++ b/tests/starter/test_starter_software_heritage_deposit.py
@@ -11,7 +11,7 @@ from tests.classes_mock import FakeLayer1
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
 
 INFO_EXAMPLE = {
-    "article_id": "00666",
+    "article_id": "666",
     "input_file": "https://example.org/api/projects/1/snapshots/1/archive",
 }
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,7 +56,7 @@ lax_article_by_version_response_data_incomplete = {
 
 data_published_lax = {
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "published",
             "status": "vor",
             "version": "1",
@@ -68,7 +68,7 @@ data_published_lax = {
 
 data_ingested_lax = {
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "ingested",
             "status": "vor",
             "version": "1",
@@ -82,7 +82,7 @@ data_ingested_lax = {
 
 data_published_website = {
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "status": "vor",
             "version": "1",
             "expanded_folder": "00353.1/74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
@@ -91,7 +91,7 @@ data_published_website = {
 
 data_error_lax = {
             "run": "74e22d8f-6b5d-4fb7-b5bf-179c1aaa7cff",
-            "article_id": "00353",
+            "article_id": "353",
             "result": "error",
             "status": "vor",
             "version": "1",
@@ -123,7 +123,7 @@ silent_ingest_article_zip_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda
                                   u'file_size': 1097506}
 
 ingest_article_zip_no_vr_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
-                                 u"article_id": u"00353"}
+                                 u"article_id": u"353"}
 
 ingest_article_zip_data = {u'run': u'1ee54f9a-cb28-4c8e-8232-4b317cf4beda',
                             u'event_time': u'2016-07-28T16:14:27.809576Z',
@@ -211,7 +211,7 @@ queue_worker_starter_message = {
 
 def ApprovePublication_data(update_date="2012-12-13T00:00:00Z"):
         return {
-            "article_id": "00353",
+            "article_id": "353",
             "version": "1",
             "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
             "publication_data": base64_encode_string(json.dumps(ApprovePublication_publication_data(update_date)))
@@ -229,7 +229,7 @@ def ApprovePublication_publication_data(update_date):
                             "run": "cf9c7e86-7355-4bb4-b48e-0bc284221251",
                             "expanded_folder": "00353.1/cf9c7e86-7355-4bb4-b48e-0bc284221251",
                             "version": "1",
-                            "article_id": "00353"}
+                            "article_id": "353"}
                 }
 
 glencoe_metadata = \

--- a/tests/test_lax_response_adapter.py
+++ b/tests/test_lax_response_adapter.py
@@ -49,7 +49,7 @@ FAKE_LAX_MESSAGE_269 = json.dumps({
 
 WORKFLOW_MESSAGE_EXPECTED_269 = {
     'workflow_data': {
-        'article_id': u'00269',
+        'article_id': u'269',
         'expanded_folder': u'00269.1/a8bb05df-2df9-4fce-8f9f-219aca0b0148',
         'message': None,
         'requested_action': u'publish',


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/4228

From a while ago, there was a bug due to an `article_id` and using the zero-filled five digit value in workflow sessions, and the issue was raised to change the value to a non-zero filled value.

The changes in this PR should make it so the `article_id` when used from a session or from workflow execution input data will not contain the leading zeros.

It's possible I missed something which will cause an error in end2end tests, and if so I will either follow-up with a bug fix PR, or in the worst case I can revert this PR.

If it passes end2end tests, I will also test an article on the continuumtest environment to look for any errors before updating the prod environment.