### PR TITLE
Fix article_id zerofill for video JPG file names.

### DIFF
--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -183,7 +183,7 @@ class activity_CopyGlencoeStillImages(Activity):
     def store_jpgs(self, glencoe_jpgs, article_id):
         cdn_still_jpgs = []
         for jpg in glencoe_jpgs:
-            jpg_filename = self.store_file(jpg, article_id)
+            jpg_filename = self.store_file(jpg, utils.pad_msid(article_id))
             cdn_still_jpgs.append(jpg_filename)
         return cdn_still_jpgs
 


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1313 observed after testing on the continuumtest environment with an article number less than 10000.