### PR TITLE
Option to return non-XML files in outbox_provider.

### DIFF
--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -80,7 +80,7 @@ class activity_PublishFinalPOA(Activity):
 
         # Download the S3 objects
         outbox_s3_key_names = outbox_provider.get_outbox_s3_key_names(
-            self.settings, self.input_bucket, self.outbox_folder
+            self.settings, self.input_bucket, self.outbox_folder, xml_only=False
         )
         file_extensions = [
             ".xml",

--- a/provider/outbox_provider.py
+++ b/provider/outbox_provider.py
@@ -11,7 +11,7 @@ def get_to_folder_name(folder_name, date_stamp):
     return folder_name + date_stamp + "/"
 
 
-def get_outbox_s3_key_names(settings, bucket_name, outbox_folder):
+def get_outbox_s3_key_names(settings, bucket_name, outbox_folder, xml_only=True):
     """get a list of .xml S3 key names from the outbox"""
     storage = storage_context(settings)
     storage_provider = settings.storage_provider + "://"
@@ -21,8 +21,10 @@ def get_outbox_s3_key_names(settings, bucket_name, outbox_folder):
     full_s3_key_names = [
         (outbox_folder.rstrip("/") + "/" + key_name) for key_name in s3_key_names
     ]
-    # return only the .xml files
-    return [key_name for key_name in full_s3_key_names if key_name.endswith(".xml")]
+    if xml_only:
+        # return only the .xml files
+        return [key_name for key_name in full_s3_key_names if key_name.endswith(".xml")]
+    return full_s3_key_names
 
 
 def download_files_from_s3_outbox(


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1312

The outbox_provider function was only returning `.xml` files by default, here it is now a function argument.