### PR TITLE
Revert back to pytest==2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ paramiko==2.7.2
 mock==4.0.3
 redis==3.5.3
 testfixtures==6.18.3
-pytest==6.2.5
+pytest==2.9.1
 ddt==1.4.4
 newrelic==7.0.0.166
 pylint==2.11.1


### PR DESCRIPTION
A guess at the one end2end test pipeline failure is due to an inability to find the `junitxml`output from running `pytest`, this PR will revert it back to the old version to test the theory its update is the cause of the error.