### PR TITLE
Use pytest==6.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ paramiko==2.7.2
 mock==4.0.3
 redis==3.5.3
 testfixtures==6.18.3
-pytest==2.9.1
+pytest==6.2.5
 ddt==1.4.4
 newrelic==7.0.0.166
 pylint==2.11.1


### PR DESCRIPTION
Try to update the version of `pytest` used again.

Originally part of PR https://github.com/elifesciences/elife-bot/pull/1329 which was reverted, and it was again reverted in PR https://github.com/elifesciences/elife-bot/pull/1330 due to text pipeline failures I thought were caused by the newer version of `pytest`.

This separate PR may show whether it was `pytest` or not causing pipeline warnings considered as errors.