### PR TITLE
Update pyGithub library and change git_repo_path.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytest==6.2.5
 ddt==1.4.4
 newrelic==7.0.0.166
 pylint==2.11.1
-pyGithub==1.27.1
+pyGithub==1.55
 pyFunctional==1.4.3
 func_timeout==4.3.5
 # versions of python-docx>=0.8.9 have issues installing on python 3.5.2 (xenial default)

--- a/settings-example.py
+++ b/settings-example.py
@@ -266,7 +266,7 @@ class exp():
     # Version control for xml
     github_token = "tokenhere"
     git_repo_name = "repository-name"
-    git_repo_path = "/articles/"
+    git_repo_path = "articles/"
 
     # eLife 2.0 bot lax communication settings
     xml_info_queue = "bot-lax-exp-inc"
@@ -568,7 +568,7 @@ class dev():
     # Version control for xml
     github_token = "tokenhere"
     git_repo_name = "repository-name"
-    git_repo_path = "/articles/"
+    git_repo_path = "articles/"
 
     # videos
     video_url = "https://video.url.here/"
@@ -867,7 +867,7 @@ class live():
     # Version control for xml
     github_token = "tokenhere"
     git_repo_name = "elife-articles-xml"
-    git_repo_path = "/articles/"
+    git_repo_path = "articles/"
 
     # eLife 2.0 bot lax communication settings
     xml_info_queue = "bot-lax-prod-inc"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -155,7 +155,7 @@ ZENDY_SFTP_CWD = ""
 ZENDY_EMAIL = ""
 
 git_repo_name = 'elife-article-xml-ci'
-git_repo_path = '/articles/'
+git_repo_path = 'articles/'
 github_token = '1234567890abcdef'
 
 PUBMED_SFTP_URI = ""


### PR DESCRIPTION
Attempting to update the `pyGitHub` library used again, previously attempted in PR https://github.com/elifesciences/elife-bot/pull/1329 which uncovered an error in end2end testing where if a git path has a leading slash character it was refused. 

The `git_repo_path` value in the example settings file is changed to reflect what is believe to be the winning combination of Python library and settings.

Prior to merging this PR, the `git_repo_path` value in the `settings.py` file in a private configuration repo will be changed too, so both parts match, and to determine if the change is able to finish end2end testing successfully.