### PR TITLE
Change newrelic.agent.notice_error() usage.

### DIFF
--- a/log.py
+++ b/log.py
@@ -30,4 +30,4 @@ def identity(process_name):
 class NewRelicHandler(logging.Handler):
     def emit(self, record):
         if record.levelno >= logging.ERROR:
-            newrelic.agent.notice_error(*sys.exc_info())
+            newrelic.agent.notice_error()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7010

Since the recent update of the library `newrelic==2.72.0.52` to `newrelic==7.0.0.166`, an old usage of `newrelic.agent.record_exception()` is deprecated, and it was switched to `newrelic.agent.notice_error()` in `log.py`.

The function is not happy to receive the parameters from `sys.exc_info()`, as the old function did.

According to docs at https://docs.newrelic.com/docs/agents/python-agent/python-agent-api/noticeerror-python-agent-api/, it may be fine to calla `notice_error()` with no parameters.

If this turns out to be insufficent, there is an example on the documentation page about how to take the tuple returned by `sys.exc_info()` and use it explicity, which can be tried next.