### PR TITLE
storage_provider list of bucket with no folder.

### DIFF
--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -106,6 +106,7 @@ class S3StorageContext:
     def list_resources(self, folder):
         bucket, s3_key = self.s3_storage_objects(folder)
         folder = s3_key[1:] if s3_key[:1] == "/" else s3_key
+        files = []
         if not folder:
             # get a list of all bucket contents if no folder is specified
             bucketlist = bucket.list()

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -106,11 +106,17 @@ class S3StorageContext:
     def list_resources(self, folder):
         bucket, s3_key = self.s3_storage_objects(folder)
         folder = s3_key[1:] if s3_key[:1] == "/" else s3_key
-        bucketlist = bucket.list(prefix=folder + "/")
-        files = []
-        for key in bucketlist:
-            filename = key.name.rsplit('/', 1)[1]
-            files.append(filename)
+        if not folder:
+            # get a list of all bucket contents if no folder is specified
+            bucketlist = bucket.list()
+            for key in bucketlist:
+                files.append(key.name)
+        else:
+            # list files from the folder and its subfolders and return object names only
+            bucketlist = bucket.list(prefix=folder + "/")
+            for key in bucketlist:
+                filename = key.name.rsplit("/", 1)[1]
+                files.append(filename)
 
         return files
 


### PR DESCRIPTION
In doing issue https://github.com/elifesciences/issues/issues/6947, I found the `provider/storage_provider.py` would not provide a list of contents in a bucket unless a folder name was supplied.

This will make is possible to get a list of bucket objects that are not in a folder.

There is also a potential bug producing result, where when getting a list of objects from an S3 folder, all the folder names are stripped away, so any objects in a subfolder under that folder will be included in the list of files, but with no folder name prefixing the value, so there's no way to tell which folder the file name was from. Since no bugs are reported at this time with the current usage of the `list_resources()` function, I will not change that in this PR.