### PR TITLE
Set MAX_EMAILS_PER_SECOND in PublicationEmail.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -19,7 +19,9 @@ from activity.objects import Activity
 # Article types for which not to send emails
 ARTICLE_TYPES_DO_NOT_SEND = ["editorial", "correction", "retraction"]
 
-# time in seconds to sleep if SMTP sending rate limit is reached
+# maximum emails to send per second
+MAX_EMAILS_PER_SECOND = 1
+# time in seconds to sleep when an smtplib.SMTPDataError exception is raised
 SLEEP_SECONDS = 5
 # number of times to sleep after reaching a sending exception
 SENDING_RETRY = 3
@@ -521,6 +523,10 @@ class activity_PublicationEmail(Activity):
             "Email sending details: result %s, tries %s, article %s, email %s, to %s"
             % (result, tries, doi_id, headers["email_type"], str(author.get("e_mail")))
         )
+
+        # sleep to not exceed max emails per second sending rate
+        if MAX_EMAILS_PER_SECOND and MAX_EMAILS_PER_SECOND > 0:
+            time.sleep(1 / MAX_EMAILS_PER_SECOND)
 
         return True
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -47,6 +47,7 @@ class TestPublicationEmail(unittest.TestCase):
         fake_logger = FakeLogger()
         # reduce the sleep time to speed up test runs
         activity_module.SLEEP_SECONDS = 0.1
+        activity_module.MAX_EMAILS_PER_SECOND = 1000
         self.activity = activity_PublicationEmail(
             settings_mock, fake_logger, None, None, None
         )


### PR DESCRIPTION
Set a hard limit of sending 1 email per second maximum in the `PublicationEmail` activity, rather than relying on an SMTP 454 error to halt the sending for 5 seconds when the sending rate is exceeded.

Re issue https://github.com/elifesciences/issues/issues/7010