### PR TITLE
Run DepositCrossrefPendingPublication each hour.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -122,6 +122,16 @@ def conditional_starts(current_datetime):
         # Jobs to start at quarter past the hour
         LOGGER.info("Quarter past the hour")
 
+        conditional_start_list.append(
+            OrderedDict(
+                [
+                    ("starter_name", "starter_DepositCrossrefPendingPublication"),
+                    ("workflow_id", "DepositCrossrefPendingPublication"),
+                    ("start_seconds", 60 * 31),
+                ]
+            )
+        )
+
         # Zendy deposits once per day 21:15 UTC
         if current_time.tm_hour == 21:
             conditional_start_list.append(

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -301,8 +301,16 @@ class TestConditionalStarts(unittest.TestCase):
         {
             "comment": "21:15 UTC",
             "date_time": "1970-01-01 21:15:00 UTC",
-            "expected_starter_names": ["cron_FiveMinute", "starter_PubRouterDeposit"],
-            "expected_workflow_ids": ["cron_FiveMinute", "PubRouterDeposit_Zendy"],
+            "expected_starter_names": [
+                "cron_FiveMinute",
+                "starter_DepositCrossrefPendingPublication",
+                "starter_PubRouterDeposit",
+            ],
+            "expected_workflow_ids": [
+                "cron_FiveMinute",
+                "DepositCrossrefPendingPublication",
+                "PubRouterDeposit_Zendy",
+            ],
         },
     )
     def test_conditional_starts_21_15_utc(self, test_data):
@@ -371,8 +379,16 @@ class TestConditionalStarts(unittest.TestCase):
         {
             "comment": "22:15 UTC",
             "date_time": "1970-01-01 22:15:00 UTC",
-            "expected_starter_names": ["cron_FiveMinute", "starter_PubRouterDeposit"],
-            "expected_workflow_ids": ["cron_FiveMinute", "PubRouterDeposit_OVID"],
+            "expected_starter_names": [
+                "cron_FiveMinute",
+                "starter_DepositCrossrefPendingPublication",
+                "starter_PubRouterDeposit",
+            ],
+            "expected_workflow_ids": [
+                "cron_FiveMinute",
+                "DepositCrossrefPendingPublication",
+                "PubRouterDeposit_OVID",
+            ],
         },
     )
     def test_conditional_starts_22_15_utc(self, test_data):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6569

Run this each hour at `:15` past the hour.