### PR TITLE
Add DepositCrossrefPendingPublication to the list.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -317,6 +317,7 @@ def start_workflow(settings, starter_name, workflow_id=None):
             "starter_PublicationEmail",
             "starter_DepositCrossref",
             "starter_DepositCrossrefPeerReview",
+            "starter_DepositCrossrefPendingPublication",
             "starter_PubmedArticleDeposit"]):
         starter_object.start(settings=settings)
 


### PR DESCRIPTION
Missed a spot in PR https://github.com/elifesciences/elife-bot/pull/1343, and this update will make the starter run.