### PR TITLE
Rewrite article title with placeholder for Crossref pending publication.

### DIFF
--- a/activity/activity_DepositCrossrefPendingPublication.py
+++ b/activity/activity_DepositCrossrefPendingPublication.py
@@ -12,6 +12,9 @@ from provider import (
 )
 
 
+PLACEHOLDER_ARTICLE_TITLE = "Title to be confirmed"
+
+
 class activity_DepositCrossrefPendingPublication(Activity):
     def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
         super(activity_DepositCrossrefPendingPublication, self).__init__(
@@ -85,6 +88,9 @@ class activity_DepositCrossrefPendingPublication(Activity):
         generate_article_object_map = prune_article_object_map(
             article_object_map, self.logger
         )
+
+        # change article title values
+        generate_article_object_map = article_title_rewrite(generate_article_object_map)
 
         # Generate crossref XML
         self.statuses["generate"] = crossref.generate_crossref_xml_to_disk(
@@ -280,6 +286,13 @@ def prune_article_object_map(article_object_map, logger):
         if check_doi_does_not_exist(article, logger):
             good_article_object_map[file_name] = article
     return good_article_object_map
+
+
+def article_title_rewrite(article_object_map):
+    """change article title to the placeholder value"""
+    for file_name, article in article_object_map.items():
+        article.title = PLACEHOLDER_ARTICLE_TITLE
+    return article_object_map
 
 
 def check_doi_does_not_exist(article, logger):

--- a/tests/activity/test_activity_deposit_crossref_pending_publication.py
+++ b/tests/activity/test_activity_deposit_crossref_pending_publication.py
@@ -2,6 +2,7 @@ import os
 import time
 import unittest
 from mock import patch
+from elifearticle.article import Article
 from provider import crossref
 import activity.activity_DepositCrossrefPendingPublication as activity_module
 from activity.activity_DepositCrossrefPendingPublication import (
@@ -214,3 +215,15 @@ class TestPrune(unittest.TestCase):
             ARTICLE_OBJECT_MAP, self.logger
         )
         self.assertEqual(len(good_article_map), 0)
+
+
+class TestArticleTitleRewrite(unittest.TestCase):
+    def test_article_title_rewrite(self):
+        filename = "filename.xml"
+        article = Article()
+        article_object_map = {filename: article}
+        article_object_map = activity_module.article_title_rewrite(article_object_map)
+        self.assertEqual(
+            article_object_map.get(filename).title,
+            activity_module.PLACEHOLDER_ARTICLE_TITLE,
+        )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6569

The plan for when depositing pending publication DOI to Crossref it was to overwrite the article title with a generic placeholder value, which is implemented here.