### PR TITLE
Update dependencies including elifecleaner update.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -133,11 +133,11 @@
         },
         "configparser": {
             "hashes": [
-                "sha256:85d5de102cfe6d14a5172676f09d19c465ce63d6019cf0a4ef13385fc535e828",
-                "sha256:af59f2cdd7efbdd5d111c1976ecd0b82db9066653362f0962d7bf1d3ab89a1fa"
+                "sha256:202b9679a809b703720afa2eacaad4c6c2d63196070e5d9edc953c0489dfd536",
+                "sha256:f99c2256b24c551de13cf9e42c7b5db96fb133f0ca4de5dcb1df1aaf89f48298"
             ],
             "index": "pypi",
-            "version": "==5.0.2"
+            "version": "==5.1.0"
         },
         "cryptography": {
             "hashes": [
@@ -289,11 +289,11 @@
         },
         "google-cloud-bigquery": {
             "hashes": [
-                "sha256:9bf0a192af28132765a394dcf655e62bf7a1a146580d5b574b56119bbf2a8f83",
-                "sha256:aab082a2e741cc976b729192ec299d348f045320cee9b2d09fd6a18376087cb7"
+                "sha256:4e3b5e3dcc475d5a601d84872ac0b63e059540be2251b1c4165c51106d572855",
+                "sha256:c62d601aa0f62388e1909d11de40db7597b02fb8602ccb7f21a3ac2a0997495b"
             ],
             "index": "pypi",
-            "version": "==2.29.0"
+            "version": "==2.30.1"
         },
         "google-cloud-core": {
             "hashes": [
@@ -603,24 +603,24 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:2a202ef71227fa924af2caa5012afd628c68749108c447c0d58d50c91ec8cecf",
-                "sha256:2ac87dd5992b344a1ab12a1408b79897387ccd4ca0d2d5c256ae375e88a3fc10",
-                "sha256:36784600b52d99964780aea411b615f63bd1f6eb9b8ecb29330978e7a4936254",
-                "sha256:3998e1fc9c92052b6ad0002a8558e11fce26c51e2f085aa4e9866b8940f5b318",
-                "sha256:3fef5573b673fefa5745300ff362adde273d36f10c9330ac6cf80b08b5b195fb",
-                "sha256:4ac6d9e2eed03d437f97eeb0c520904090546d3749e413e3126ad303428ca1d4",
-                "sha256:672d6cf5720dd0dee8ebef99446bf06af5dbde9a3553dde2531ea0c22e069846",
-                "sha256:7a5bc90ca2cf338629108893ed88e78a8805b629dc1466ce3ac18fb91bfb983e",
-                "sha256:ace9bb3e5090dc434479f516a4204893384182cb19a4915f55584b969acd5557",
-                "sha256:aed6fa67ba951cd6e44732d15aec4f50ef20f9384cb2ce63bc14fbb4e2091312",
-                "sha256:cb531e9c74e04f8c52e02ea7243ee3f6a7869ea2fc405db9853a2b95775a87fe",
-                "sha256:d3c85a9392ec638dc735163cdf8a0ce8034384b6b4267e7d69256833646d6c29",
-                "sha256:d6a55ab67fa618f45f01240ece453cf98e4281c54504e7c54554cdd6077a1f24",
-                "sha256:e351dd5c47a6284173f9010811f8637509cdc707bba3c4ab7aa6d13296a391d8",
-                "sha256:f64aaa2d2cd531b0db8d16826919403954135c45ffee208300d71dc43ce967f3"
+                "sha256:214ddc23b744bee59bb30ccf73f3cb58c4861e55bf051a10a50c974b5e50f7dd",
+                "sha256:2daa5ae766aa86ace4dfa8983ac909e590cd4c67749c7bdedd8879ed73c7aa4b",
+                "sha256:2e2d25be691f75365a5e194730c3258c805c83910635eaf3f1c3f9d8701c72e0",
+                "sha256:4467d9645d7045f2d938802ce1efc60528d7b54acc6ec7ae85c49378554341f4",
+                "sha256:4f2d85e6835c547f921ad462d70ee669630b8c75c38bc2a839bad3c8901bfd17",
+                "sha256:66961d2396cd631fdd06763821f87c4794a61c17bb9745c9707c292e296c1a4d",
+                "sha256:737358cdc6d7e73e93a0d25a3683247bff26f735d35132a981bdc482f8722b7f",
+                "sha256:78c7eef31a5fc5985d179455325d75ccddca5997a7b28cf739a1600b34584fa4",
+                "sha256:83c82e70e1a6546883d05aa4581c1543dcc09df406fc7f3028cba49cff7d29fe",
+                "sha256:8a85920b5b7a9423b463ff5d6f32c59b250de9e7734f932d9b2593b438c966de",
+                "sha256:a8c5b81ac11f559b5ed0f429882b2443687c74f60ba7f2f6996f48556169fc61",
+                "sha256:be7d8ce05ab43556f75a4b8f491f2b77766f6582218567fb1aaa721aff54249b",
+                "sha256:c80dca134bc9a3ce8804c7c536a5570209e997e1afed122e55eb05835e809501",
+                "sha256:ced76b5899db260c878e254f1b41040b6ac7dd0c8d8e8e9ea9eb0b0e210726a8",
+                "sha256:d47b5bfcbdf743b07add3eaa6d3b6cfd4aa5d99963d87d6b228b4f769d68f457"
             ],
             "index": "pypi",
-            "version": "==7.2.2.169"
+            "version": "==7.2.3.170"
         },
         "packagepoa": {
             "hashes": [
@@ -934,11 +934,11 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
-                "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
+                "sha256:617ffc4d0dfd39c66f4d1413a6e165663a34eca86be9b54f97b91756300ff6df",
+                "sha256:e4860f889dfa88774c07da0b276b70c073b6470fa1a4a8350800bb7bce3dcc76"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.2.1"
+            "version": "==2.3"
         },
         "tabulate": {
             "hashes": [
@@ -968,7 +968,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "wand": {
@@ -1070,13 +1070,29 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
-        "elifecleaner": {
+        "beautifulsoup4": {
             "hashes": [
-                "sha256:3e0ef951407583c6ad61cdc8729cd1204c5181f8e54b77acb7d211eec41504e0",
-                "sha256:788aadb8736f55f5885fa537c9cba50daa8eb848f9d41d955deaef221fc4156c"
+                "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf",
+                "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"
             ],
             "index": "pypi",
-            "version": "==0.5.1"
+            "version": "==4.10.0"
+        },
+        "elifecleaner": {
+            "hashes": [
+                "sha256:7e49166ca3d2af422e87468b9d35e6ba61b765bf544bff0c40e303ff7f7688d4",
+                "sha256:c472ad29c4b064b466b9459e301839d1846b2a95ba18bd753cb7a605a496edaa"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
+        "elifetools": {
+            "hashes": [
+                "sha256:5ade73c9551b79be88272db6212d2c966af1423c8fd7e939c60de78ce739967b",
+                "sha256:ca0774c39f5989dbc1c9710966746dcbab4d324c5adce200d69624fe8916d5bb"
+            ],
+            "index": "pypi",
+            "version": "==0.13.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -1095,11 +1111,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899",
-                "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"
+                "sha256:1a18ccace2ed8910bd9458b74a3ecbafd7b2f581301b0ab65cfdd4338272d76f",
+                "sha256:e52ff6d38012b131628cf0f26c51e7bd3a7c81592eefe3ac71411e692f1b9345"
             ],
             "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
-            "version": "==5.9.3"
+            "version": "==5.10.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -1128,6 +1144,72 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.6.0"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:08eb9200d88b376a8ed5e50f1dc1d1a45b49305169674002a3b5929943390591",
+                "sha256:0b12c95542f04d10cba46b3ff28ea52ea56995b78cf918f0b11b05e75812bb79",
+                "sha256:0c15e1cd55055956e77b0732270f1c6005850696bc3ef3e03d01e78af84eaa42",
+                "sha256:15d0381feb56f08f78c5cc4fc385ddfe0bde1456e37f54a9322833371aec4060",
+                "sha256:197b7cb7a753cf553a45115739afd8458464a28913da00f5c525063f94cd3f48",
+                "sha256:20d7c8d90d449c6a353b15ee0459abae8395dbe59ad01e406ccbf30cd81c6f98",
+                "sha256:240db6f3228d26e3c6f4fad914b9ddaaf8707254e8b3efd564dc680c8ec3c264",
+                "sha256:2901625f4a878a055d275beedc20ba9cb359cefc4386a967222fee29eb236038",
+                "sha256:2b06a91cf7b8acea7793006e4ae50646cef0fe35ce5acd4f5cb1c77eb228e4a1",
+                "sha256:2eb90f6ec3c236ef2f1bb38aee7c0d23e77d423d395af6326e7cca637519a4cb",
+                "sha256:351482da8dd028834028537f08724b1de22d40dcf3bb723b469446564f409074",
+                "sha256:35752ee40f7bbf6adc9ff4e1f4b84794a3593736dcce80db32e3c2aa85e294ac",
+                "sha256:38b9de0de3aa689fe9fb9877ae1be1e83b8cf9621f7e62049d0436b9ecf4ad64",
+                "sha256:433df8c7dde0f9e41cbf4f36b0829d50a378116ef5e962ba3881f2f5f025c7be",
+                "sha256:4341d135f5660db10184963d9c3418c3e28d7f868aaf8b11a323ebf85813f7f4",
+                "sha256:45fdb2899c755138722797161547a40b3e2a06feda620cc41195ee7e97806d81",
+                "sha256:4717123f7c11c81e0da69989e5a64079c3f402b0efeb4c6241db6c369d657bd8",
+                "sha256:47e955112ce64241fdb357acf0216081f9f3255b3ac9c502ca4b3323ec1ca558",
+                "sha256:48eaac2991b3036175b42ee8d3c23f4cca13f2be8426bf29401a690ab58c88f4",
+                "sha256:4aa349c5567651f34d4eaae7de6ed5b523f6d70a288f9c6fbac22d13a0784e04",
+                "sha256:4ba74afe5ee5cb5e28d83b513a6e8f0875fda1dc1a9aea42cc0065f029160d2a",
+                "sha256:4ec9a80dd5704ecfde54319b6964368daf02848c8954d3bacb9b64d1c7659159",
+                "sha256:50790313df028aa05cf22be9a8da033b86c42fa32523e4fd944827b482b17bf0",
+                "sha256:51a0e5d243687596f46e24e464121d4b232ad772e2d1785b2a2c0eb413c285d4",
+                "sha256:523f195948a1ba4f9f5b7294d83c6cd876547dc741820750a7e5e893a24bbe38",
+                "sha256:543b239b191bb3b6d9bef5f09f1fb2be5b7eb09ab4d386aa655e4d53fbe9ff47",
+                "sha256:5ff5bb2a198ea67403bb6818705e9a4f90e0313f2215428ec51001ce56d939fb",
+                "sha256:601f0ab75538b280aaf1e720eb9d68d4fa104ac274e1e9e6971df488f4dcdb0f",
+                "sha256:6020c70ff695106bf80651953a23e37718ef1fee9abd060dcad8e32ab2dc13f3",
+                "sha256:619c6d2b552bba00491e96c0518aad94002651c108a0f7364ff2d7798812c00e",
+                "sha256:6298f5b42a26581206ef63fffa97c754245d329414108707c525512a5197f2ba",
+                "sha256:662523cd2a0246740225c7e32531f2e766544122e58bee70e700a024cfc0cf81",
+                "sha256:6764998345552b1dfc9326a932d2bad6367c6b37a176bb73ada6b9486bf602f7",
+                "sha256:6d422b3c729737d8a39279a25fa156c983a56458f8b2f97661ee6fb22b80b1d6",
+                "sha256:72e730d33fe2e302fd07285f14624fca5e5e2fb2bb4fb2c3941e318c41c443d1",
+                "sha256:75d3c5bbc0ddbad03bb68b9be638599f67e4b98ed3dcd0fec9f6f39e41ee96cb",
+                "sha256:7ae7089d81fc502df4b217ad77f03c54039fe90dac0acbe70448d7e53bfbc57e",
+                "sha256:80d10d53d3184837445ff8562021bdd37f57c4cadacbf9d8726cc16220a00d54",
+                "sha256:877666418598f6cb289546c77ff87590cfd212f903b522b0afa0b9fb73b3ccfb",
+                "sha256:9b87727561c1150c0cc91c5d9d389448b37a7d15f0ba939ed3d1acb2f11bf6c5",
+                "sha256:9c91a73971a922c13070fd8fa5a114c858251791ba2122a941e6aa781c713e44",
+                "sha256:9db24803fa71e3305fe4a7812782b708da21a0b774b130dd1860cf40a6d7a3ee",
+                "sha256:a75c1ad05eedb1a3ff2a34a52a4f0836cfaa892e12796ba39a7732c82701eff4",
+                "sha256:a77a3470ba37e11872c75ca95baf9b3312133a3d5a5dc720803b23098c653976",
+                "sha256:ab6db93a2b6b66cbf62b4e4a7135f476e708e8c5c990d186584142c77d7f975a",
+                "sha256:afd60230ad9d8bcba005945ec3a343722f09e0b7f8ae804246e5d2cfc6bd71a6",
+                "sha256:b0ca0ada9d3bc18bd6f611bd001a28abdd49ab9698bd6d717f7f5394c8e94628",
+                "sha256:b567178a74a2261345890eac66fbf394692a6e002709d329f28a673ca6042473",
+                "sha256:b667c51682fe9b9788c69465956baa8b6999531876ccedcafc895c74ad716cd8",
+                "sha256:bbf2dc330bd44bfc0254ab37677ec60f7c7ecea55ad8ba1b8b2ea7bf20c265f5",
+                "sha256:bdc224f216ead849e902151112efef6e96c41ee1322e15d4e5f7c8a826929aee",
+                "sha256:cf201bf5594d1aab139fe53e3fca457e4f8204a5bbd65d48ab3b82a16f517868",
+                "sha256:d43bd68714049c84e297c005456a15ecdec818f7b5aa5868c8b0a865cfb78a44",
+                "sha256:daf9bd1fee31f1c7a5928b3e1059e09a8d683ea58fb3ffc773b6c88cb8d1399c",
+                "sha256:e678a643177c0e5ec947b645fa7bc84260dfb9b6bf8fb1fdd83008dfc2ca5928",
+                "sha256:e91d24623e747eeb2d8121f4a94c6a7ad27dc48e747e2dc95bfe88632bd028a2",
+                "sha256:e95da348d57eb448d226a44b868ff2ca5786fbcbe417ac99ff62d0a7d724b9c7",
+                "sha256:ee9e4b07b0eba4b6a521509e9e1877476729c1243246b6959de697ebea739643",
+                "sha256:f5dd358536b8a964bf6bd48de038754c1609e72e5f17f5d21efe2dda17594dbf",
+                "sha256:ffd65cfa33fed01735c82aca640fde4cc63f0414775cba11e06f84fae2085a6e"
+            ],
+            "index": "pypi",
+            "version": "==4.6.4"
         },
         "mccabe": {
             "hashes": [
@@ -1170,11 +1252,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pylint": {
             "hashes": [
@@ -1200,6 +1282,22 @@
             "index": "pypi",
             "version": "==6.2.5"
         },
+        "python-slugify": {
+            "hashes": [
+                "sha256:6d8c5df75cd4a7c3a2d21e257633de53f52ab0265cd2d1dc62a730e8194a7380",
+                "sha256:f13383a0b9fcbe649a1892b9c8eb4f8eab1d6d84b84bb7a624317afa98159cab"
+            ],
+            "index": "pypi",
+            "version": "==5.0.2"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:617ffc4d0dfd39c66f4d1413a6e165663a34eca86be9b54f97b91756300ff6df",
+                "sha256:e4860f889dfa88774c07da0b276b70c073b6470fa1a4a8350800bb7bce3dcc76"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.3"
+        },
         "testfixtures": {
             "hashes": [
                 "sha256:2600100ae96ffd082334b378e355550fef8b4a529a6fa4c34f47130905c7426d",
@@ -1207,6 +1305,13 @@
             ],
             "index": "pypi",
             "version": "==6.18.3"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
         },
         "toml": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2021-11-02 - see update-dependencies.sh
+# file generated 2021-11-04 - see update-dependencies.sh
 arrow==1.2.1
 astroid==2.8.4
 attrs==21.2.0
@@ -9,7 +9,7 @@ cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.7
-configparser==5.0.2
+configparser==5.1.0
 cryptography==35.0.0
 ddt==1.4.4
 Deprecated==1.2.13
@@ -18,7 +18,7 @@ dill==0.3.4
 docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
-elifecleaner==0.5.1
+elifecleaner==0.6.0
 elifecrossref==0.9.0
 elifepubmed==0.3.0
 elifetools==0.13.0
@@ -27,7 +27,7 @@ gitdb==4.0.9
 GitPython==3.1.18
 google-api-core==2.2.2
 google-auth==2.3.3
-google-cloud-bigquery==2.29.0
+google-cloud-bigquery==2.30.1
 google-cloud-core==2.1.0
 google-crc32c==1.3.0
 google-resumable-media==2.1.0
@@ -37,7 +37,7 @@ grpcio-status==1.41.1
 idna==3.3
 importlib-metadata==4.8.1
 iniconfig==1.1.1
-isort==5.9.3
+isort==5.10.0
 jatsgenerator==0.1.2
 Jinja2==3.0.2
 lazy-object-proxy==1.6.0
@@ -47,7 +47,7 @@ MarkupSafe==2.0.1
 mccabe==0.6.1
 medium @ git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6
 mock==4.0.3
-newrelic==7.2.2.169
+newrelic==7.2.3.170
 packagepoa==0.1.2
 packaging==21.2
 paramiko==2.8.0
@@ -56,7 +56,7 @@ pluggy==1.0.0
 proto-plus==1.19.7
 protobuf==3.19.1
 psutil==5.8.0
-py==1.10.0
+py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20
@@ -78,7 +78,7 @@ requests==2.26.0
 rsa==4.7.2
 six==1.16.0
 smmap==5.0.0
-soupsieve==2.2.1
+soupsieve==2.3
 tabulate==0.8.9
 testfixtures==6.18.3
 text-unidecode==1.3


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7000

In order to start using `elifecleaner==0.6.0`, all the dependencies are updated by running the project's shell script.