### PR TITLE
Send XML only, unzipped, to OA Switchboard.

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -121,7 +121,11 @@ class activity_FTPArticle(Activity):
             if workflow == 'Zendy':
                 self.sftp_to_endpoint(zipfiles)
             if workflow == 'OASwitchboard':
-                self.sftp_to_endpoint(zipfiles)
+                # send XML files only, unzipped
+                with zipfile.ZipFile(zipfiles[0], "r") as open_zip:
+                    open_zip.extractall(self.directories.get("FTP_TO_SOMEWHERE_DIR"))
+                uploadfiles = glob.glob(self.directories.get("FTP_TO_SOMEWHERE_DIR") + "/*.xml")
+                self.sftp_to_endpoint(uploadfiles)
 
         except:
             # Something went wrong, fail


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6993

A small adjustment to code merged in PR https://github.com/elifesciences/elife-bot/pull/1352, we will send `.xml` file only to OA Switchboard, instead of the file in a `.zip`.