### PR TITLE
Do not use PMC zip as input for sending to others.

### DIFF
--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -21,33 +21,28 @@ class TestFTPArticle(unittest.TestCase):
 
     @patch.object(activity_FTPArticle, "repackage_archive_zip_to_pmc_zip")
     @patch.object(activity_FTPArticle, "download_archive_zip_from_s3")
-    @patch.object(activity_FTPArticle, "download_pmc_zip_from_s3")
     @patch('activity.activity_FTPArticle.FTP')
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
     @data(
-        ('HEFCE', True, None, 'hefce_ftp.localhost', 'hefce_sftp.localhost', True),
-        ('Cengage', True, None, 'cengage.localhost', None, True),
-        ('GoOA', True, None, 'gooa.localhost', None, True),
-        ('WoS', True, None, 'wos.localhost', None, True),
-        ('CNPIEC', True, None, 'cnpiec.localhost', None, True),
-        ('CNPIEC', False, True, 'cnpiec.localhost', None, True),
-        ('CNKI', True, None, 'cnki.localhost', None, True),
-        ('CNKI', False, True, 'cnki.localhost', None, True),
-        ('CLOCKSS', True, None, 'clockss.localhost', None, True),
-        ('CLOCKSS', False, True, 'clockss.localhost', None, True),
-        ('OVID', False, True, 'ovid.localhost', None, True),
-        ('Zendy', False, True, None, 'zendy.localhost', True),
-        ("OASwitchboard", True, None, None, "oaswitchboard.localhost", True),
+        ('HEFCE', True, 'hefce_ftp.localhost', 'hefce_sftp.localhost', True),
+        ('Cengage', True, 'cengage.localhost', None, True),
+        ('GoOA', True, 'gooa.localhost', None, True),
+        ('WoS', True, 'wos.localhost', None, True),
+        ('CNPIEC', True, 'cnpiec.localhost', None, True),
+        ('CNKI', True, 'cnki.localhost', None, True),
+        ('CLOCKSS', True, 'clockss.localhost', None, True),
+        ('OVID', True, 'ovid.localhost', None, True),
+        ('Zendy', True, None, 'zendy.localhost', True),
+        ("OASwitchboard", True, None, "oaswitchboard.localhost", True),
     )
     @unpack
-    def test_do_activity(self, workflow, pmc_zip_return_value, archive_zip_return_value,
+    def test_do_activity(self, workflow, archive_zip_return_value,
                          expected_ftp_uri, expected_sftp_uri, expected_result,
                          fake_sftp_to_endpoint, fake_ftp,
-                         fake_download_pmc_zip_from_s3, fake_download_archive_zip_from_s3,
+                         fake_download_archive_zip_from_s3,
                          fake_repackage_pmc_zip):
         fake_sftp_to_endpoint = MagicMock()
         fake_ftp.return_value = FakeFTP()
-        fake_download_pmc_zip_from_s3.return_value = pmc_zip_return_value
         fake_download_archive_zip_from_s3.return_value = archive_zip_return_value
         fake_repackage_pmc_zip.return_value = True
         activity_data = {
@@ -60,7 +55,7 @@ class TestFTPArticle(unittest.TestCase):
         self.assertEqual(self.activity.FTP_URI, expected_ftp_uri)
         self.assertEqual(self.activity.SFTP_URI, expected_sftp_uri)
 
-    @patch.object(activity_FTPArticle, "download_pmc_zip_from_s3")
+    @patch.object(activity_FTPArticle, "download_files_from_s3")
     @patch('activity.activity_FTPArticle.FTP')
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
     @data(
@@ -69,10 +64,10 @@ class TestFTPArticle(unittest.TestCase):
     @unpack
     def test_do_activity_failure(self, workflow, elife_id, expected_result,
                                  fake_sftp_to_endpoint, fake_ftp,
-                                 fake_download_pmc_zip_from_s3):
+                                 fake_download_files_from_s3):
         fake_sftp_to_endpoint = MagicMock()
         fake_ftp.return_value = FakeFTP()
-        fake_download_pmc_zip_from_s3 = MagicMock()
+        fake_download_files_from_s3 = MagicMock()
         # Cause an exception by setting elife_id as non numeric for now
         activity_data = {
             'data': {

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -38,7 +38,7 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.article_versions")
     @patch("boto.swf.layer1.Layer1")
-    @patch.object(activity_PubRouterDeposit, "does_source_zip_exist_from_s3")
+    @patch.object(activity_PubRouterDeposit, "archive_zip_file_name")
     @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(article, "was_ever_published")
@@ -49,7 +49,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_was_ever_published,
         fake_storage_context,
         fake_outbox_key_names,
-        fake_zip_exists,
+        fake_zip_file_name,
         fake_conn,
         fake_article_versions,
         fake_email_smtp_connect,
@@ -62,7 +62,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_get_s3_keys.return_value = None
         fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
-        fake_zip_exists.return_value = True
+        fake_zip_file_name.return_value = True
         fake_conn.return_value = FakeLayer1()
         fake_article_versions.return_value = (
             200,


### PR DESCRIPTION
A blocker for issue https://github.com/elifesciences/issues/issues/7077

The logic in the sending of files to other repositories is the `FTPArticle` activity would often use the PMC zip file as the input. This was because the PMC zip file already had the version numbers removed from the file names and the XML.

For old articles, there was no PMC zip file in the bucket it checked (since in-house sending to PMC came later than year 1), and in this case there was existing logic to use the archived article zip as the input. The `FTPArticle` activity would just transform it into a PMC zip-like file by removing all the version numbers from the file names and the XML.

There is an issue raised (https://github.com/elifesciences/issues/issues/7077) to temporarily alter the XML PMC receives. To avoid sending this altered PMC XML to other downstream recipients, the code changes in this PR will de-couple the PMC zip from all the other pub router workflows.