### PR TITLE
Add TransformAcceptedSubmission activity.

### DIFF
--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -1,0 +1,155 @@
+import os
+import json
+import shutil
+from S3utility.s3_notification_info import parse_activity_data
+from provider import cleaner, download_helper
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+class activity_TransformAcceptedSubmission(Activity):
+    "TransformAcceptedSubmission activity"
+
+    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+        super(activity_TransformAcceptedSubmission, self).__init__(
+            settings, logger, conn, token, activity_task
+        )
+
+        self.name = "TransformAcceptedSubmission"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Download zip file input from the bucket, transform the files and the XML, "
+            + "and upload the new zip file to an output bucket."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+            "OUTPUT_DIR": os.path.join(self.get_tmp_dir(), "output_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"transform": None, "upload": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        self.make_activity_directories()
+
+        # configure log files for the cleaner provider
+        cleaner_log_handers = []
+        format_string = (
+            "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
+        )
+        # log to a common log file
+        cleaner_log_handers.append(cleaner.log_to_file(format_string=format_string))
+        # log file for this activity only
+        log_file_path = os.path.join(self.get_tmp_dir(), self.activity_log_file)
+        cleaner_log_handers.append(
+            cleaner.log_to_file(
+                log_file_path,
+                format_string=format_string,
+            )
+        )
+
+        # parse the input data
+        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+        self.logger.info(
+            "%s, real_filename: %s, bucket_name: %s, bucket_folder: %s"
+            % (self.name, real_filename, bucket_name, bucket_folder)
+        )
+
+        # Download from S3
+        self.input_file = download_helper.download_file_from_s3(
+            self.settings,
+            real_filename,
+            bucket_name,
+            bucket_folder,
+            self.directories.get("INPUT_DIR"),
+        )
+
+        self.logger.info("%s, downloaded file to %s" % (self.name, self.input_file))
+
+        # transform the zip file
+        self.logger.info(
+            "%s, starting to transform zip file %s", self.name, self.input_file
+        )
+        try:
+            new_zip_file_path = cleaner.transform_ejp_zip(
+                self.input_file,
+                self.directories.get("TEMP_DIR"),
+                self.directories.get("OUTPUT_DIR"),
+            )
+            self.statuses["transform"] = True
+        except Exception:
+            log_message = (
+                "%s, unhandled exception in cleaner.transform_ejp_zip for file %s"
+                % (self.name, self.input_file)
+            )
+            self.logger.exception(log_message)
+            self.log_statuses(self.input_file)
+            return self.ACTIVITY_PERMANENT_FAILURE
+        finally:
+            # remove the log handlers
+            for log_handler in cleaner_log_handers:
+                cleaner.log_remove_handler(log_handler)
+
+        # upload zip file to output bucket
+        self.upload_zip(
+            self.settings.accepted_submission_output_bucket, new_zip_file_path
+        )
+        self.statuses["upload"] = True
+
+        self.log_statuses(self.input_file)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def upload_zip(self, output_bucket_name, file_name_path):
+        "upload the zip to the bucket"
+        # Get the file name from the full file path
+        file_name = file_name_path.split(os.sep)[-1]
+
+        # Create S3 object and save
+        bucket_name = output_bucket_name
+        storage = storage_context(self.settings)
+        storage_provider = self.settings.storage_provider + "://"
+        s3_folder_name = ""
+        resource_dest = (
+            storage_provider + bucket_name + "/" + s3_folder_name + file_name
+        )
+        storage.set_resource_from_filename(resource_dest, file_name_path)
+        self.logger.info(
+            "%s, copied %s to %s", self.name, file_name_path, resource_dest
+        )
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -1,5 +1,5 @@
 import logging
-from elifecleaner import LOGGER, configure_logging, parse
+from elifecleaner import LOGGER, configure_logging, parse, transform
 
 LOG_FILENAME = "elifecleaner.log"
 
@@ -17,3 +17,7 @@ def log_remove_handler(handler):
 
 def check_ejp_zip(zip_file, tmp_dir):
     return parse.check_ejp_zip(zip_file, tmp_dir)
+
+
+def transform_ejp_zip(zip_file, tmp_dir, output_dir):
+    return transform.transform_ejp_zip(zip_file, tmp_dir, output_dir)

--- a/register.py
+++ b/register.py
@@ -120,6 +120,7 @@ def start(settings):
     activity_names.append("GenerateSWHReadme")
     activity_names.append("PushSWHDeposit")
     activity_names.append("ValidateAcceptedSubmission")
+    activity_names.append("TransformAcceptedSubmission")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/settings-example.py
+++ b/settings-example.py
@@ -316,6 +316,7 @@ class exp():
     era_incoming_queue = "exp-era-incoming-queue"
 
     # Accepted submission workflow
+    accepted_submission_output_bucket = "exp-elife-bot-accepted-submission-cleaning-output"
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
     accepted_submission_queue = ""
@@ -621,6 +622,7 @@ class dev():
     era_incoming_queue = "dev-era-incoming-queue"
 
     # Accepted submission workflow
+    accepted_submission_output_bucket = "dev-elife-bot-accepted-submission-cleaning-output"
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
     accepted_submission_queue = ""
@@ -931,6 +933,7 @@ class live():
     era_incoming_queue = "prod-era-incoming-queue"
 
     # Accepted submission workflow
+    accepted_submission_output_bucket = "live-elife-bot-accepted-submission-cleaning-output"
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
     accepted_submission_queue = "cleaning-queue"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -220,5 +220,6 @@ software_heritage_auth_pass = "pass"
 software_heritage_api_get_origin_pattern = "https://archive.swh.example.org/api/1/origin/{origin}/get/"
 
 # Accepted submission workflow
+accepted_submission_output_bucket = "accepted-submission-cleaning-output"
 accepted_submission_sender_email = "sender@example.org"
 accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from provider import cleaner
+import activity.activity_TransformAcceptedSubmission as activity_module
+from activity.activity_TransformAcceptedSubmission import (
+    activity_TransformAcceptedSubmission as activity_object,
+)
+import tests.activity.settings_mock as settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+import tests.activity.helpers as helpers
+import tests.activity.test_activity_data as activity_test_data
+import tests.test_data as test_case_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+class TestTransformAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+        # clean folder used by storage context
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module.download_helper, "storage_context")
+    def test_do_activity(self, fake_download_storage_context, fake_storage_context):
+        test_data = {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_transform_status": True,
+        }
+
+        # copy files into the input directory using the storage context
+        fake_download_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext()
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("transform"),
+            test_data.get("expected_transform_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        log_file_path = os.path.join(
+            self.activity.get_tmp_dir(), self.activity.activity_log_file
+        )
+        with open(log_file_path, "r") as open_file:
+            log_contents = open_file.read()
+        log_infos = [
+            line
+            for line in log_contents.split("\n")
+            if "INFO elifecleaner:transform:" in line
+        ]
+        # check output bucket folder contents
+        self.assertTrue(
+            "30-01-2019-RA-eLife-45644.zip"
+            in os.listdir(activity_test_data.ExpandArticle_files_dest_folder)
+        )
+
+        # compare some log file values,
+        # these assertions can be removed if any are too hard to manage
+        self.assertTrue(
+            log_infos[0].endswith("30-01-2019-RA-eLife-45644.zip starting to transform")
+        )
+        self.assertTrue(
+            log_infos[1].endswith(
+                "30-01-2019-RA-eLife-45644.zip code_file_name: Figure 5source code 1.c"
+            )
+        )
+        self.assertTrue(
+            log_infos[2].endswith(
+                (
+                    "30-01-2019-RA-eLife-45644.zip from_file: "
+                    'ArticleZipFile("Figure 5source code 1.c", '
+                    '"30-01-2019-RA-eLife-45644/Figure 5source code 1.c", '
+                    '"%s/30-01-2019-RA-eLife-45644/Figure 5source code 1.c")'
+                )
+                % self.activity.directories.get("TEMP_DIR")
+            )
+        )
+        self.assertTrue(
+            log_infos[3].endswith(
+                (
+                    "30-01-2019-RA-eLife-45644.zip to_file: "
+                    'ArticleZipFile("Figure 5source code 1.c.zip", '
+                    '"30-01-2019-RA-eLife-45644/Figure 5source code 1.c.zip", '
+                    '"%s/Figure 5source code 1.c.zip")'
+                )
+                % self.activity.directories.get("OUTPUT_DIR")
+            )
+        )
+        self.assertTrue(
+            log_infos[4].endswith("30-01-2019-RA-eLife-45644.zip rewriting xml tags")
+        )
+        self.assertTrue(
+            log_infos[5].endswith(
+                (
+                    "30-01-2019-RA-eLife-45644.zip writing xml to file "
+                    "%s/30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml"
+                )
+                % self.activity.directories.get("TEMP_DIR")
+            )
+        )
+        self.assertTrue(
+            log_infos[6].endswith(
+                (
+                    "30-01-2019-RA-eLife-45644.zip writing new zip file "
+                    "%s/30-01-2019-RA-eLife-45644.zip"
+                )
+                % self.activity.directories.get("OUTPUT_DIR")
+            )
+        )
+
+    @patch.object(cleaner, "transform_ejp_zip")
+    @patch.object(activity_module.download_helper, "storage_context")
+    def test_do_activity_exception_unknown(
+        self, fake_download_storage_context, fake_transform_ejp_zip
+    ):
+        # copy files into the input directory using the storage context
+        fake_download_storage_context.return_value = FakeStorageContext()
+
+        fake_transform_ejp_zip.side_effect = Exception()
+        # do the activity
+        result = self.activity.do_activity(input_data("30-01-2019-RA-eLife-45644.zip"))
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                (
+                    "TransformAcceptedSubmission, unhandled exception in "
+                    "cleaner.transform_ejp_zip for file %s/30-01-2019-RA-eLife-45644.zip"
+                )
+                % self.activity.directories.get("INPUT_DIR")
+            ),
+        )

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -39,6 +39,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step("PingWorker", data),
                 define_workflow_step("ValidateAcceptedSubmission", data),
                 define_workflow_step("ScheduleCrossrefPendingPublication", data),
+                define_workflow_step("TransformAcceptedSubmission", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7000

A new activity added to the `IngestAcceptedSubmission` workflow, will download the zip, transform it, and upload to an output bucket. It uses the `elifecleaner` library for the transformation function.