### PR TITLE
PubRouterDeposit move unsent files to a not_published folder in S3 bucket

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -90,6 +90,7 @@ class activity_PubRouterDeposit(Activity):
         self.workflow = data["data"]["workflow"]
         outbox_folder = get_outbox_folder(self.workflow)
         published_folder = get_published_folder(self.workflow)
+        not_published_folder = get_not_published_folder(self.workflow)
 
         if outbox_folder is None or published_folder is None:
             # Total fail
@@ -111,7 +112,9 @@ class activity_PubRouterDeposit(Activity):
         # Parse the XML
         self.articles = self.parse_article_xml(self.article_xml_filenames)
         # Approve the articles to be sent
-        self.articles_approved = self.approve_articles(self.articles, self.workflow)
+        self.articles_approved, remove_doi_list = self.approve_articles(
+            self.articles, self.workflow
+        )
 
         for article in self.articles_approved:
             # Start a workflow for each article this is approved to publish
@@ -162,6 +165,29 @@ class activity_PubRouterDeposit(Activity):
             published_file_names,
         )
         self.outbox_status = True
+
+        # move file for a remove DOI article out of the outbox folder
+        self.logger.info("Moving files from outbox folder to the not_published folder")
+        not_published_to_folder = outbox_provider.get_to_folder_name(
+            not_published_folder, date_stamp
+        )
+        not_published_xml_files = []
+        for article_doi, file_name in self.xml_file_to_doi_map.items():
+            if article_doi in remove_doi_list:
+                log_message = (
+                    "DOI %s, %s to move file %s to the not_published folder"
+                    % (article_doi, self.name, file_name)
+                )
+                self.logger.info(log_message)
+                self.admin_email_content += "\n" + log_message
+                not_published_xml_files.append(file_name)
+        outbox_provider.clean_outbox(
+            self.settings,
+            self.publish_bucket,
+            outbox_folder,
+            not_published_to_folder,
+            not_published_xml_files,
+        )
 
         # Send email to admins with the status
         self.activity_status = True
@@ -360,7 +386,7 @@ class activity_PubRouterDeposit(Activity):
         approved_articles = []
 
         # Keep track of which articles to remove at the end
-        remove_article_doi = []
+        remove_doi_list = []
 
         # Create a blank article object to use its functions
         blank_article = self.create_article()
@@ -384,7 +410,8 @@ class activity_PubRouterDeposit(Activity):
                     log_info = "Removing because it is not published " + article.doi
                     self.admin_email_content += "\n" + log_info
                     self.logger.info(log_info)
-                remove_article_doi.append(article.doi)
+                if article.doi not in remove_doi_list:
+                    remove_doi_list.append(article.doi)
 
         # Check article type for OA Switchboard recipient
         if workflow == "OASwitchboard":
@@ -397,7 +424,8 @@ class activity_PubRouterDeposit(Activity):
                         )
                         self.admin_email_content += "\n" + log_info
                         self.logger.info(log_info)
-                    remove_article_doi.append(article.doi)
+                    if article.doi not in remove_doi_list:
+                        remove_doi_list.append(article.doi)
 
         # Check if article is a resupply
         if workflow not in ["CLOCKSS", "OVID", "PMC", "Zendy"]:
@@ -413,7 +441,8 @@ class activity_PubRouterDeposit(Activity):
                         )
                         self.admin_email_content += "\n" + log_info
                         self.logger.info(log_info)
-                    remove_article_doi.append(article.doi)
+                    if article.doi not in remove_doi_list:
+                        remove_doi_list.append(article.doi)
 
         # Check a vor archive zip file exists
         if workflow not in ["OVID", "Zendy"]:
@@ -427,14 +456,15 @@ class activity_PubRouterDeposit(Activity):
                         )
                         self.admin_email_content += "\n" + log_info
                         self.logger.info(log_info)
-                    remove_article_doi.append(article.doi)
+                    if article.doi not in remove_doi_list:
+                        remove_doi_list.append(article.doi)
 
         # Can remove the articles now without affecting the loops using del
         for article in articles:
-            if article.doi not in remove_article_doi:
+            if article.doi not in remove_doi_list:
                 approved_articles.append(article)
 
-        return approved_articles
+        return approved_articles, remove_doi_list
 
     def send_admin_email(self):
         """
@@ -651,6 +681,36 @@ def get_published_folder(workflow):
         return "zendy/published/"
     if workflow == "OASwitchboard":
         return "oaswitchboard/published/"
+
+    return None
+
+
+def get_not_published_folder(workflow):
+    """
+    S3 published folder, where processed files are copied to
+    """
+    if workflow == "HEFCE":
+        return "pub_router/not_published/"
+    if workflow == "Cengage":
+        return "cengage/not_published/"
+    if workflow == "GoOA":
+        return "gooa/not_published/"
+    if workflow == "WoS":
+        return "wos/not_published/"
+    if workflow == "PMC":
+        return "pmc/not_published/"
+    if workflow == "CNPIEC":
+        return "cnpiec/not_published/"
+    if workflow == "CNKI":
+        return "cnki/not_published/"
+    if workflow == "CLOCKSS":
+        return "clockss/not_published/"
+    if workflow == "OVID":
+        return "ovid/not_published/"
+    if workflow == "Zendy":
+        return "zendy/not_published/"
+    if workflow == "OASwitchboard":
+        return "oaswitchboard/not_published/"
 
     return None
 

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -72,6 +72,80 @@ class TestPubRouterDeposit(unittest.TestCase):
         self.assertTrue(result)
 
     @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch("provider.lax_provider.article_versions")
+    @patch("boto.swf.layer1.Layer1")
+    @patch.object(activity_PubRouterDeposit, "archive_zip_file_name")
+    @patch("provider.outbox_provider.get_outbox_s3_key_names")
+    @patch("provider.outbox_provider.storage_context")
+    @patch.object(article, "was_ever_published")
+    @patch.object(s3lib, "get_s3_keys_from_bucket")
+    def test_do_activity_not_published(
+        self,
+        fake_get_s3_keys,
+        fake_was_ever_published,
+        fake_storage_context,
+        fake_outbox_key_names,
+        fake_zip_file_name,
+        fake_conn,
+        fake_article_versions,
+        fake_email_smtp_connect,
+    ):
+        "test not_published logic by mocking Lax does not have version data"
+        tmp_dir = self.pubrouterdeposit.get_tmp_dir()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            tmp_dir
+        )
+        activity_data = {"data": {"workflow": "HEFCE"}}
+        fake_was_ever_published.return_value = None
+        fake_get_s3_keys.return_value = None
+        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
+        fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
+        fake_zip_file_name.return_value = True
+        fake_conn.return_value = FakeLayer1()
+        fake_article_versions.return_value = (
+            200,
+            [{}],
+        )
+        result = self.pubrouterdeposit.do_activity(activity_data)
+        self.assertTrue(result)
+        self.assertTrue(
+            "Parsed https://doi.org/10.7554/eLife.09169"
+            in self.pubrouterdeposit.admin_email_content
+        )
+        self.assertTrue(
+            "Parsed https://doi.org/10.7554/eLife.00013"
+            in self.pubrouterdeposit.admin_email_content
+        )
+        self.assertTrue(
+            "Removing because it is not published 10.7554/eLife.09169"
+            in self.pubrouterdeposit.admin_email_content
+        )
+        self.assertTrue(
+            "Removing because it is not published 10.7554/eLife.00013"
+            in self.pubrouterdeposit.admin_email_content
+        )
+        self.assertTrue(
+            (
+                (
+                    "DOI 10.7554/eLife.09169, PubRouterDeposit to move file "
+                    "%s/elife09169.xml to the not_published folder"
+                )
+                % tmp_dir
+            )
+            in self.pubrouterdeposit.admin_email_content
+        )
+        self.assertTrue(
+            (
+                (
+                    "DOI 10.7554/eLife.00013, PubRouterDeposit to move file "
+                    "%s/elife00013.xml to the not_published folder"
+                )
+                % tmp_dir
+            )
+            in self.pubrouterdeposit.admin_email_content
+        )
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
     @patch("boto.swf.layer1.Layer1")
@@ -144,6 +218,16 @@ class TestGetPublishedFolder(unittest.TestCase):
     def test_get_published_folder_undefined(self):
         workflow = "foo"
         self.assertIsNone(activity_module.get_published_folder(workflow))
+
+
+class TestGetNotPublishedFolder(unittest.TestCase):
+    def test_get_not_published_folder(self):
+        for workflow in WORKFLOW_NAMES:
+            self.assertIsNotNone(activity_module.get_not_published_folder(workflow))
+
+    def test_get_not_published_folder_undefined(self):
+        workflow = "foo"
+        self.assertIsNone(activity_module.get_not_published_folder(workflow))
 
 
 class TestApproveForOaSwitchboard(unittest.TestCase):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7013

This enhancement should automatically move article XML files from the S3 outbox for each workflow into a `not_published` folder when the file is not sent due to unsuitability. In most cases the ignored files can be removed from the outbox since they would only be added to the queue when the expectation is they are ready to send.

It is loosely based on the logic added to the https://github.com/elifesciences/elife-bot/blob/develop/activity/activity_DepositCrossrefPendingPublication.py activity to move files out of the outbox folder so they are not processed again.

The logic may be tweaked later for special situations if they can be identified. For now, this first revision can be tried out to see how it performs.