### PR TITLE
Update dependencies to use elifecrossref==0.11.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -224,11 +224,11 @@
         },
         "elifecrossref": {
             "hashes": [
-                "sha256:5fecd0b16857bac523a0ba5441364cb2b5ecea9b6e71de7c5fac681b57f2c087",
-                "sha256:b799a3c1e22d592f0c3b321ac15627bfba0a890b0614c2f5d4480349b911c90d"
+                "sha256:8ef16bb36802c2a7ff822dd9c4526c3f8b2cc145e882c26e180353b54099e446",
+                "sha256:c2b5f425725804c0bed12724b13fe3084357009143354dd37a32ab9ae2b9ba54"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.11.0"
         },
         "elifepubmed": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
 elifecleaner==0.7.0
-elifecrossref==0.10.0
+elifecrossref==0.11.0
 elifepubmed==0.3.0
 elifetools==0.13.1
 func-timeout==4.3.5


### PR DESCRIPTION
Using the latest version of the `elifecrossref` library, in combination with a recent version of `elifearticle`, author's affiliation ROR id value will be included in Crossref deposits when the value is available in the article XML.