### PR TITLE
Unify the s3 outbox folder names.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -35,8 +35,8 @@ class activity_DepositCrossref(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "crossref/outbox/"
-        self.published_folder = "crossref/published/"
+        self.outbox_folder = outbox_provider.outbox_folder("crossref")
+        self.published_folder = outbox_provider.published_folder("crossref")
 
         # Track the success of some steps
         self.statuses = {}

--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -40,8 +40,8 @@ class activity_DepositCrossrefPeerReview(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "crossref_peer_review/outbox/"
-        self.published_folder = "crossref_peer_review/published/"
+        self.outbox_folder = outbox_provider.outbox_folder("crossref_peer_review")
+        self.published_folder = outbox_provider.published_folder("crossref_peer_review")
 
         # Track the success of some steps
         self.statuses = {}

--- a/activity/activity_DepositCrossrefPendingPublication.py
+++ b/activity/activity_DepositCrossrefPendingPublication.py
@@ -40,9 +40,15 @@ class activity_DepositCrossrefPendingPublication(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "crossref_pending_publication/outbox/"
-        self.published_folder = "crossref_pending_publication/published/"
-        self.not_published_folder = "crossref_pending_publication/not_published/"
+        self.outbox_folder = outbox_provider.outbox_folder(
+            "crossref_pending_publication"
+        )
+        self.published_folder = outbox_provider.published_folder(
+            "crossref_pending_publication"
+        )
+        self.not_published_folder = outbox_provider.not_published_folder(
+            "crossref_pending_publication"
+        )
 
         # Track the success of some steps
         self.statuses = {}

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -89,9 +89,10 @@ class activity_PubRouterDeposit(Activity):
             self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
 
         self.workflow = data["data"]["workflow"]
-        outbox_folder = get_outbox_folder(self.workflow)
-        published_folder = get_published_folder(self.workflow)
-        not_published_folder = get_not_published_folder(self.workflow)
+        workflow_folder = outbox_provider.workflow_foldername(self.workflow)
+        outbox_folder = outbox_provider.outbox_folder(workflow_folder)
+        published_folder = outbox_provider.published_folder(workflow_folder)
+        not_published_folder = outbox_provider.not_published_folder(workflow_folder)
 
         if outbox_folder is None or published_folder is None:
             # Total fail
@@ -631,96 +632,6 @@ def get_friendly_email_body(current_time, approved_articles):
     body += "\n\nSincerely\n\neLife bot"
 
     return body
-
-
-def get_outbox_folder(workflow):
-    """
-    S3 outbox, where files to be processed are
-    """
-    if workflow == "HEFCE":
-        return "pub_router/outbox/"
-    if workflow == "Cengage":
-        return "cengage/outbox/"
-    if workflow == "GoOA":
-        return "gooa/outbox/"
-    if workflow == "WoS":
-        return "wos/outbox/"
-    if workflow == "PMC":
-        return "pmc/outbox/"
-    if workflow == "CNPIEC":
-        return "cnpiec/outbox/"
-    if workflow == "CNKI":
-        return "cnki/outbox/"
-    if workflow == "CLOCKSS":
-        return "clockss/outbox/"
-    if workflow == "OVID":
-        return "ovid/outbox/"
-    if workflow == "Zendy":
-        return "zendy/outbox/"
-    if workflow == "OASwitchboard":
-        return "oaswitchboard/outbox/"
-
-    return None
-
-
-def get_published_folder(workflow):
-    """
-    S3 published folder, where processed files are copied to
-    """
-    if workflow == "HEFCE":
-        return "pub_router/published/"
-    if workflow == "Cengage":
-        return "cengage/published/"
-    if workflow == "GoOA":
-        return "gooa/published/"
-    if workflow == "WoS":
-        return "wos/published/"
-    if workflow == "PMC":
-        return "pmc/published/"
-    if workflow == "CNPIEC":
-        return "cnpiec/published/"
-    if workflow == "CNKI":
-        return "cnki/published/"
-    if workflow == "CLOCKSS":
-        return "clockss/published/"
-    if workflow == "OVID":
-        return "ovid/published/"
-    if workflow == "Zendy":
-        return "zendy/published/"
-    if workflow == "OASwitchboard":
-        return "oaswitchboard/published/"
-
-    return None
-
-
-def get_not_published_folder(workflow):
-    """
-    S3 published folder, where processed files are copied to
-    """
-    if workflow == "HEFCE":
-        return "pub_router/not_published/"
-    if workflow == "Cengage":
-        return "cengage/not_published/"
-    if workflow == "GoOA":
-        return "gooa/not_published/"
-    if workflow == "WoS":
-        return "wos/not_published/"
-    if workflow == "PMC":
-        return "pmc/not_published/"
-    if workflow == "CNPIEC":
-        return "cnpiec/not_published/"
-    if workflow == "CNKI":
-        return "cnki/not_published/"
-    if workflow == "CLOCKSS":
-        return "clockss/not_published/"
-    if workflow == "OVID":
-        return "ovid/not_published/"
-    if workflow == "Zendy":
-        return "zendy/not_published/"
-    if workflow == "OASwitchboard":
-        return "oaswitchboard/not_published/"
-
-    return None
 
 
 def approve_for_oa_switchboard(article):

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -46,8 +46,8 @@ class activity_PublicationEmail(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "publication_email/outbox/"
-        self.published_folder = "publication_email/published/"
+        self.outbox_folder = outbox_provider.outbox_folder("publication_email")
+        self.published_folder = outbox_provider.published_folder("publication_email")
 
         # Track XML files selected for publication
         self.insight_articles_to_remove_from_outbox = []

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -41,8 +41,8 @@ class activity_PubmedArticleDeposit(Activity):
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
-        self.outbox_folder = "pubmed/outbox/"
-        self.published_folder = "pubmed/published/"
+        self.outbox_folder = outbox_provider.outbox_folder("pubmed")
+        self.published_folder = outbox_provider.published_folder("pubmed")
 
         # Track the success of some steps
         self.statuses = OrderedDict(

--- a/activity/activity_ScheduleCrossref.py
+++ b/activity/activity_ScheduleCrossref.py
@@ -1,7 +1,7 @@
 import json
 
 from boto.s3.connection import S3Connection
-from provider import lax_provider
+from provider import lax_provider, outbox_provider
 from provider.execution_context import get_session
 from provider.article_structure import get_article_xml_key
 from activity.objects import Activity
@@ -25,7 +25,7 @@ class activity_ScheduleCrossref(Activity):
         self.logger = logger
 
         # For copying to crossref outbox from here for now
-        self.crossref_outbox_folder = "crossref/outbox/"
+        self.crossref_outbox_folder = outbox_provider.outbox_folder("crossref")
 
     def do_activity(self, data=None):
 

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -1,6 +1,6 @@
 import json
 
-from provider import crossref, lax_provider, utils
+from provider import crossref, lax_provider, outbox_provider, utils
 from provider.article_processing import download_jats
 from provider.storage_provider import storage_context
 from provider.execution_context import get_session
@@ -23,7 +23,7 @@ class activity_ScheduleCrossrefPeerReview(Activity):
         self.pretty_name = "Schedule Crossref Peer Review"
 
         # For copying to S3 bucket outbox
-        self.crossref_outbox_folder = "crossref_peer_review/outbox/"
+        self.crossref_outbox_folder = outbox_provider.outbox_folder("crossref_peer_review")
 
     def do_activity(self, data=None):
 

--- a/activity/activity_ScheduleCrossrefPendingPublication.py
+++ b/activity/activity_ScheduleCrossrefPendingPublication.py
@@ -31,7 +31,7 @@ class activity_ScheduleCrossrefPendingPublication(Activity):
         self.input_file = None
 
         # For copying to S3 bucket outbox
-        self.crossref_outbox_folder = "crossref_pending_publication/outbox/"
+        self.crossref_outbox_folder = outbox_provider.outbox_folder("crossref_pending_publication")
 
         # Local directory settings
         self.directories = {

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 from provider.storage_provider import storage_context
-import provider.lax_provider as lax_provider
+from provider import lax_provider, outbox_provider
 from activity.objects import Activity
 
 """
@@ -55,7 +55,7 @@ class activity_ScheduleDownstream(Activity):
             xml_file_name = lax_provider.get_xml_file_name(
                 self.settings, expanded_folder_name, expanded_bucket_name, version)
             xml_key_name = expanded_folder_name + "/" + xml_file_name
-            outbox_list = choose_outboxes(status, outbox_map(), first_by_status, run_type)
+            outbox_list = choose_outboxes(status, first_by_status, run_type)
 
             for outbox in outbox_list:
                 self.rename_and_copy_to_outbox(
@@ -104,50 +104,31 @@ class activity_ScheduleDownstream(Activity):
         storage.copy_resource(orig_resource, dest_resource)
 
 
-def outbox_map():
-    "map of outbox names to values"
-    outboxes = OrderedDict()
-    outboxes["pubmed"] = "pubmed/outbox/"
-    outboxes["pmc"] = "pmc/outbox/"
-    outboxes["publication_email"] = "publication_email/outbox/"
-    outboxes["pub_router"] = "pub_router/outbox/"
-    outboxes["cengage"] = "cengage/outbox/"
-    outboxes["gooa"] = "gooa/outbox/"
-    outboxes["wos"] = "wos/outbox/"
-    outboxes["cnpiec"] = "cnpiec/outbox/"
-    outboxes["cnki"] = "cnki/outbox/"
-    outboxes["clockss"] = "clockss/outbox/"
-    outboxes["ovid"] = "ovid/outbox/"
-    outboxes["zendy"] = "zendy/outbox/"
-    outboxes["oaswitchboard"] = "oaswitchboard/outbox/"
-    return outboxes
-
-
-def choose_outboxes(status, outbox_map, first_by_status, run_type=None):
+def choose_outboxes(status, first_by_status, run_type=None):
     outbox_list = []
 
     if run_type != "silent-correction":
         if first_by_status:
-            outbox_list.append(outbox_map.get("publication_email"))
+            outbox_list.append(outbox_provider.outbox_folder("publication_email"))
             if status == "vor":
-                outbox_list.append(outbox_map.get("oaswitchboard"))
-        outbox_list.append(outbox_map.get("pubmed"))
+                outbox_list.append(outbox_provider.outbox_folder("oaswitchboard"))
+        outbox_list.append(outbox_provider.outbox_folder("pubmed"))
 
-    outbox_list.append(outbox_map.get("ovid"))
-    outbox_list.append(outbox_map.get("zendy"))
+    outbox_list.append(outbox_provider.outbox_folder("ovid"))
+    outbox_list.append(outbox_provider.outbox_folder("zendy"))
 
     if status == "poa":
         pass
 
     elif status == "vor":
-        outbox_list.append(outbox_map.get("pmc"))
-        outbox_list.append(outbox_map.get("pub_router"))
-        outbox_list.append(outbox_map.get("cengage"))
-        outbox_list.append(outbox_map.get("gooa"))
-        outbox_list.append(outbox_map.get("wos"))
-        outbox_list.append(outbox_map.get("cnpiec"))
-        outbox_list.append(outbox_map.get("cnki"))
-        outbox_list.append(outbox_map.get("clockss"))
+        outbox_list.append(outbox_provider.outbox_folder("pmc"))
+        outbox_list.append(outbox_provider.outbox_folder("pub_router"))
+        outbox_list.append(outbox_provider.outbox_folder("cengage"))
+        outbox_list.append(outbox_provider.outbox_folder("gooa"))
+        outbox_list.append(outbox_provider.outbox_folder("wos"))
+        outbox_list.append(outbox_provider.outbox_folder("cnpiec"))
+        outbox_list.append(outbox_provider.outbox_folder("cnki"))
+        outbox_list.append(outbox_provider.outbox_folder("clockss"))
     return outbox_list
 
 

--- a/provider/article.py
+++ b/provider/article.py
@@ -10,6 +10,7 @@ from boto.s3.connection import S3Connection
 
 import provider.s3lib as s3lib
 from elifetools import parseJATS as parser
+from provider import outbox_provider
 from provider.article_structure import ArticleInfo
 from provider.storage_provider import storage_context
 from provider.utils import pad_msid, get_doi_url
@@ -245,24 +246,10 @@ class article(object):
 
         doi_ids = []
 
-        if workflow == "HEFCE":
-            published_folder = "pub_router/published/"
-        if workflow == "Cengage":
-            published_folder = "cengage/published/"
-        if workflow == "GoOA":
-            published_folder = "gooa/published/"
-        if workflow == "WoS":
-            published_folder = "wos/published/"
-        if workflow == "CNPIEC":
-            published_folder = "cnpiec/published/"
-        if workflow == "CNKI":
-            published_folder = "cnki/published/"
-        if workflow == "CLOCKSS":
-            published_folder = "clockss/published/"
-        if workflow == "OVID":
-            published_folder = "ovid/published/"
-        if workflow == "OASwitchboard":
-            published_folder = "oaswitchboard/published/"
+        # workflow e.g. "HEFCE"
+        workflow_folder = outbox_provider.workflow_foldername(workflow)
+        # published_folder e.g. "pub_router/published/""
+        published_folder = outbox_provider.published_folder(workflow_folder)
 
         file_extensions = []
         file_extensions.append(".xml")

--- a/provider/outbox_provider.py
+++ b/provider/outbox_provider.py
@@ -1,6 +1,30 @@
 import os
+from collections import OrderedDict
 from provider import article_processing
 from provider.storage_provider import storage_context
+
+
+# map of workflow name to s3 folder which holds outbox and other related folders
+DOWNSTREAM_WORKFLOW_MAP = OrderedDict(
+    [
+        ("Cengage", "cengage"),
+        ("CLOCKSS", "clockss"),
+        ("CNKI", "cnki"),
+        ("CNPIEC", "cnpiec"),
+        ("crossref", "crossref"),
+        ("crossref_peer_review", "crossref_peer_review"),
+        ("crossref_pending_publication", "crossref_pending_publication"),
+        ("GoOA", "gooa"),
+        ("HEFCE", "pub_router"),
+        ("OASwitchboard", "oaswitchboard"),
+        ("OVID", "ovid"),
+        ("PMC", "pmc"),
+        ("publication_email", "publication_email"),
+        ("pubmed", "pubmed"),
+        ("WoS", "wos"),
+        ("Zendy", "zendy"),
+    ]
+)
 
 
 def get_to_folder_name(folder_name, date_stamp):
@@ -98,3 +122,29 @@ def upload_files_to_s3_folder(settings, bucket_name, to_folder, file_names):
             + article_processing.file_name_from_name(file_name)
         )
         storage.set_resource_from_filename(resource_dest, file_name)
+
+
+def workflow_foldername(workflow):
+    "from workflow name return the s3 folder name"
+    return DOWNSTREAM_WORKFLOW_MAP.get(workflow)
+
+
+def outbox_folder(foldername):
+    "from s3 folder name return the outbox folder name"
+    if foldername not in DOWNSTREAM_WORKFLOW_MAP.values():
+        return None
+    return "%s/outbox/" % foldername
+
+
+def published_folder(foldername):
+    "from s3 folder name return the published folder name"
+    if foldername not in DOWNSTREAM_WORKFLOW_MAP.values():
+        return None
+    return "%s/published/" % foldername
+
+
+def not_published_folder(foldername):
+    "from s3 folder name return the not published folder name"
+    if foldername not in DOWNSTREAM_WORKFLOW_MAP.values():
+        return None
+    return "%s/not_published/" % foldername

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -11,19 +11,6 @@ import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 
 
-WORKFLOW_NAMES = [
-    "HEFCE",
-    "Cengage",
-    "WoS",
-    "GoOA",
-    "CNPIEC",
-    "CNKI",
-    "CLOCKSS",
-    "OVID",
-    "Zendy",
-    "OASwitchboard",
-]
-
 ARCHIVE_ZIP_BUCKET_S3_KEYS = [
     {
         "name": "elife-00013-vor-v1-20121015000000.zip",
@@ -207,36 +194,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         self.assertIsNotNone(
             self.pubrouterdeposit.get_friendly_email_recipients(workflow)
         )
-
-
-class TestGetOutboxFolder(unittest.TestCase):
-    def test_get_outbox_folder(self):
-        for workflow in WORKFLOW_NAMES:
-            self.assertIsNotNone(activity_module.get_outbox_folder(workflow))
-
-    def test_get_outbox_folder_undefined(self):
-        workflow = "foo"
-        self.assertIsNone(activity_module.get_outbox_folder(workflow))
-
-
-class TestGetPublishedFolder(unittest.TestCase):
-    def test_get_published_folder(self):
-        for workflow in WORKFLOW_NAMES:
-            self.assertIsNotNone(activity_module.get_published_folder(workflow))
-
-    def test_get_published_folder_undefined(self):
-        workflow = "foo"
-        self.assertIsNone(activity_module.get_published_folder(workflow))
-
-
-class TestGetNotPublishedFolder(unittest.TestCase):
-    def test_get_not_published_folder(self):
-        for workflow in WORKFLOW_NAMES:
-            self.assertIsNotNone(activity_module.get_not_published_folder(workflow))
-
-    def test_get_not_published_folder_undefined(self):
-        workflow = "foo"
-        self.assertIsNone(activity_module.get_not_published_folder(workflow))
 
 
 class TestApproveForOaSwitchboard(unittest.TestCase):

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -42,14 +42,14 @@ class TestScheduleDownstream(unittest.TestCase):
 
     def test_choose_outboxes_poa_first(self):
         """first poa version"""
-        outbox_list = activity_module.choose_outboxes("poa", activity_module.outbox_map(), True)
+        outbox_list = activity_module.choose_outboxes("poa", True)
         self.assertTrue("pubmed/outbox/" in outbox_list)
         self.assertTrue("publication_email/outbox/" in outbox_list)
         self.assertFalse("pmc/outbox/" in outbox_list)
 
     def test_choose_outboxes_poa_not_first(self):
         """poa but not the first poa"""
-        outbox_list = activity_module.choose_outboxes("poa", activity_module.outbox_map(), False)
+        outbox_list = activity_module.choose_outboxes("poa", False)
         self.assertTrue("pubmed/outbox/" in outbox_list)
         # do not send to pmc
         self.assertFalse("pmc/outbox/" in outbox_list)
@@ -58,7 +58,7 @@ class TestScheduleDownstream(unittest.TestCase):
 
     def test_choose_outboxes_vor_first(self):
         """first vor version"""
-        outbox_list = activity_module.choose_outboxes("vor", activity_module.outbox_map(), True)
+        outbox_list = activity_module.choose_outboxes("vor", True)
         self.assertTrue("pmc/outbox/" in outbox_list)
         self.assertTrue("pubmed/outbox/" in outbox_list)
         self.assertTrue("publication_email/outbox/" in outbox_list)
@@ -66,7 +66,7 @@ class TestScheduleDownstream(unittest.TestCase):
 
     def test_choose_outboxes_vor_not_first(self):
         """vor but not the first vor"""
-        outbox_list = activity_module.choose_outboxes("vor", activity_module.outbox_map(), False)
+        outbox_list = activity_module.choose_outboxes("vor", False)
         self.assertTrue("pmc/outbox/" in outbox_list)
         self.assertTrue("pubmed/outbox/" in outbox_list)
         self.assertTrue("pub_router/outbox/" in outbox_list)
@@ -74,8 +74,7 @@ class TestScheduleDownstream(unittest.TestCase):
         self.assertFalse("publication_email/outbox/" in outbox_list)
 
     def test_choose_outboxes_vor_silent_first(self):
-        outbox_list = activity_module.choose_outboxes(
-            "vor", activity_module.outbox_map(), True, "silent-correction")
+        outbox_list = activity_module.choose_outboxes("vor", True, "silent-correction")
         self.assertTrue("pmc/outbox/" in outbox_list)
         # do not send publication_email
         self.assertFalse("publication_email/outbox/" in outbox_list)

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -109,3 +109,36 @@ class TestOutboxProvider(unittest.TestCase):
             if file_name.endswith(".xml")
         ]
         self.assertEqual(uploaded_files, expected)
+
+
+class TestGetOutboxFolder(unittest.TestCase):
+    def test_outbox_folder(self):
+        for workflow in outbox_provider.DOWNSTREAM_WORKFLOW_MAP:
+            foldername = outbox_provider.workflow_foldername(workflow)
+            self.assertIsNotNone(outbox_provider.outbox_folder(foldername))
+
+    def test_outbox_folder_undefined(self):
+        foldername = "foo"
+        self.assertIsNone(outbox_provider.outbox_folder(foldername))
+
+
+class TestGetPublishedFolder(unittest.TestCase):
+    def test_published_folder(self):
+        for workflow in outbox_provider.DOWNSTREAM_WORKFLOW_MAP:
+            foldername = outbox_provider.workflow_foldername(workflow)
+            self.assertIsNotNone(outbox_provider.published_folder(foldername))
+
+    def test_published_folder_undefined(self):
+        foldername = "foo"
+        self.assertIsNone(outbox_provider.published_folder(foldername))
+
+
+class TestGetNotPublishedFolder(unittest.TestCase):
+    def test_not_published_folder(self):
+        for workflow in outbox_provider.DOWNSTREAM_WORKFLOW_MAP:
+            foldername = outbox_provider.workflow_foldername(workflow)
+            self.assertIsNotNone(outbox_provider.not_published_folder(foldername))
+
+    def test_not_published_folder_undefined(self):
+        foldername = "foo"
+        self.assertIsNone(outbox_provider.not_published_folder(foldername))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-bot/issues/911

A better consolidation of s3 bucket outbox folder names for the downstream workflows. The names are specified in `provider/outbox_provider.py` and then activities and the `article` provider go there for outbox, published, and not_published folder name paths.