### PR TITLE
Cross-platform sed commands.

### DIFF
--- a/update-dependencies.sh
+++ b/update-dependencies.sh
@@ -24,12 +24,12 @@ if [ -n "$package" ]; then
     pip install -r requirements.txt
 
     # make Pipenv install exactly what we want (==).
-    sed --in-place --regexp-extended "s/$package = \".+\"/$package = \"==$version\"/" Pipfile
+    sed -i .bck -E "s/$package = \".+\"/$package = \"==$version\"/" Pipfile
     # the envvar is necessary otherwise Pipenv will use it's own .venv directory.
     VIRTUAL_ENV="venv" pipenv install --keep-outdated "$package==$version"
 
     # relax the constraint again (~=).
-    sed --in-place --regexp-extended "s/$package = \".+\"/$package = \"~=$version\"/" Pipfile
+    sed -i .bck -E "s/$package = \".+\"/$package = \"~=$version\"/" Pipfile
 
 else
     # updates the Pipfile.lock file and then installs the newly updated dependencies.

--- a/update-dependencies.sh
+++ b/update-dependencies.sh
@@ -24,18 +24,25 @@ if [ -n "$package" ]; then
     pip install -r requirements.txt
 
     # make Pipenv install exactly what we want (==).
-    sed -i .bck -E "s/$package = \".+\"/$package = \"==$version\"/" Pipfile
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sed --in-place --regexp-extended "s/$package = \".+\"/$package = \"==$version\"/" Pipfile
+    else
+        sed -i '' -E "s/$package = \".+\"/$package = \"==$version\"/" Pipfile
+    fi
+
     # the envvar is necessary otherwise Pipenv will use it's own .venv directory.
     VIRTUAL_ENV="venv" pipenv install --keep-outdated "$package==$version"
 
     # relax the constraint again (~=).
-    sed -i .bck -E "s/$package = \".+\"/$package = \"~=$version\"/" Pipfile
-
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sed --in-place --regexp-extended "s/$package = \".+\"/$package = \"~=$version\"/" Pipfile
+    else
+        sed -i '' -E "s/$package = \".+\"/$package = \"~=$version\"/" Pipfile
+    fi
 else
     # updates the Pipfile.lock file and then installs the newly updated dependencies.
     # the envvar is necessary otherwise Pipenv will use it's own .venv directory.
     VIRTUAL_ENV="venv" pipenv update --dev
-
 fi
 
 datestamp=$(date +"%Y-%m-%d") # long form to support linux + bsd


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6980

I tried running the script supplying a specific `elifetools` version, and on Mac which has BSD `sed` the result of the script was not expected. Here's some suggestions for changes which worked for me.

BSD `sed` does not accept any `--` arguments.

It looks like `-E` works on both GNU and BSD `sed` pretty well.

The in-place editing `-i` seems to require a file extension value, otherwise it takes the first character it can find as the file extension. Documentation on this has more details about special considerations for when writing a file in-place which doesn't have a file extension.

