### PR TITLE
Dependency `elifecleaner` pinned to `0.8.1 `

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,10 +42,10 @@ GitPython = "~=3.1"
 PyYAML = "~=5.4"
 Wand = "~=0.6"
 PyGithub = "~=1.55"
-elifecleaner = "~=0.8.0"
+elifecleaner = "~=0.8.1"
 
 [dev-packages]
-elifecleaner = "~=0.8.0"
+elifecleaner = "~=0.8.1"
 pylint = "~=2.11"
 testfixtures = "~=6.18"
 pytest = "~=6.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4f6df3604a71dc54c9a214249c9e90cf0def471b6c35efbd6564f55b94b57ae"
+            "sha256": "74e43d8bbab7708ff8b3e6429b440ef3b878eba2060397063afca22bda78395d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -228,7 +228,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.8.0"
+            "version": "==0.8.1"
         },
         "elifecrossref": {
             "hashes": [
@@ -1100,7 +1100,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.8.0"
+            "version": "==0.8.1"
         },
         "elifetools": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2021-12-15 - see update-dependencies.sh
+# file generated 2021-12-17 - see update-dependencies.sh
 arrow==1.2.1
 astroid==2.9.0
 attrs==21.2.0
@@ -18,7 +18,7 @@ dill==0.3.4
 docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
-elifecleaner==0.8.0
+elifecleaner==0.8.1
 elifecrossref==0.11.0
 elifepubmed==0.3.0
 elifetools==0.14.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/10/display/redirect which resulted in this pull request.