### PR TITLE
Remove boto.ses functions, not currently used.

### DIFF
--- a/provider/email_provider.py
+++ b/provider/email_provider.py
@@ -8,17 +8,7 @@ from string import Template
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import boto.ses
 from provider.utils import bytes_decode, unicode_encode
-
-
-def ses_connect(settings):
-    "connect to SES"
-    return boto.ses.connect_to_region(
-        settings.ses_region,
-        aws_access_key_id=settings.aws_access_key_id,
-        aws_secret_access_key=settings.aws_secret_access_key,
-    )
 
 
 def smtp_setting(settings, name):
@@ -117,13 +107,6 @@ def message(subject, sender, recipient):
     email_message["From"] = sender
     email_message["To"] = recipient
     return email_message
-
-
-def ses_send(connection, sender, recipient, email_message):
-    "send a MIMEMultipart email to the recipient from sender"
-    return connection.send_raw_email(
-        email_message.as_string(), source=sender, destinations=recipient
-    )
 
 
 def smtp_send(connection, sender, recipient, email_message, logger=None):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/916

This project used to use `SES` for sending email and now it uses SMTP, we can remove the old SES code which is no longer used.