### PR TITLE
Dependency `elifecleaner` pinned to `0.9.1 `

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,10 +42,10 @@ GitPython = "~=3.1"
 PyYAML = "~=5.4"
 Wand = "~=0.6"
 PyGithub = "~=1.55"
-elifecleaner = "~=0.9.0"
+elifecleaner = "~=0.9.1"
 
 [dev-packages]
-elifecleaner = "~=0.9.0"
+elifecleaner = "~=0.9.1"
 pylint = "~=2.11"
 testfixtures = "~=6.18"
 pytest = "~=6.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "86816ef06a812907f41bde662052d91bce7a7e404cf189aeb17cdd6967908065"
+            "sha256": "10ee55a2fbdd48ca2aad0db28496ec5caa649313bd6ff9fb3692499bfdfcd038"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,10 +26,13 @@
         },
         "bcrypt": {
             "hashes": [
+                "sha256:56e5da069a76470679f312a7d3d23deb3ac4519991a0361abc11da837087b61d",
                 "sha256:5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29",
                 "sha256:63d4e3ff96188e5898779b6057878fecf3f11cfe6ec3b313ea09955d587ec7a7",
                 "sha256:81fec756feff5b6818ea7ab031205e1d323d8943d237303baca2c5f9c7846f34",
+                "sha256:a0584a92329210fcd75eb8a3250c5a941633f8bfaf2a18f81009b097732839b7",
                 "sha256:a67fb841b35c28a59cebed05fbd3e80eea26e6d75851f0574a9273c80f3e9b55",
+                "sha256:b589229207630484aefe5899122fb938a5b017b0f4349f769b8c13e78d99a8fd",
                 "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6",
                 "sha256:cd1ea2ff3038509ea95f687256c46b79f5fc382ad0aa3664d200047546d511d1",
                 "sha256:cdcdcb3972027f83fe24a48b1e90ea4b584d35f1cc279d76de6fc4b13376239d"
@@ -228,7 +231,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==0.9.1"
         },
         "elifecrossref": {
             "hashes": [
@@ -976,7 +979,7 @@
                 "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
                 "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.8'",
             "version": "==4.0.1"
         },
         "urllib3": {
@@ -1100,7 +1103,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==0.9.1"
         },
         "elifetools": {
             "hashes": [
@@ -1375,7 +1378,7 @@
                 "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
                 "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.8'",
             "version": "==4.0.1"
         },
         "wand": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2021-12-20 - see update-dependencies.sh
+# file generated 2022-01-05 - see update-dependencies.sh
 arrow==1.2.1
 astroid==2.9.0
 attrs==21.2.0
@@ -18,7 +18,7 @@ dill==0.3.4
 docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
-elifecleaner==0.9.0
+elifecleaner==0.9.1
 elifecrossref==0.11.0
 elifepubmed==0.3.0
 elifetools==0.15.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/12/display/redirect which resulted in this pull request.