### PR TITLE
Extend timeouts in IngestAcceptedSubmission.

### DIFF
--- a/starter/starter_IngestAcceptedSubmission.py
+++ b/starter/starter_IngestAcceptedSubmission.py
@@ -22,7 +22,7 @@ class starter_IngestAcceptedSubmission(Starter):
         )
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
-        workflow_params["execution_start_to_close_timeout"] = str(60 * 15)
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 30)
 
         input_data = S3NotificationInfo.to_dict(info)
         input_data["run"] = run

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -1,5 +1,5 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step
+from workflow.helper import define_workflow_step, define_workflow_step_short
 
 
 class workflow_IngestAcceptedSubmission(Workflow):
@@ -37,9 +37,9 @@ class workflow_IngestAcceptedSubmission(Workflow):
             "start": {"requirements": None},
             "steps": [
                 define_workflow_step("PingWorker", data),
-                define_workflow_step("ValidateAcceptedSubmission", data),
-                define_workflow_step("ScheduleCrossrefPendingPublication", data),
-                define_workflow_step("TransformAcceptedSubmission", data),
+                define_workflow_step_short("ValidateAcceptedSubmission", data),
+                define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
+                define_workflow_step_short("TransformAcceptedSubmission", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7140

Large zip files in the accepted submission workflow are taking almost five minutes to finish an activity, so extend their timeouts to ten minutes.