### PR TITLE
More timeout for TransformAcceptedSubmission.

### DIFF
--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -1,5 +1,9 @@
 from workflow.objects import Workflow
-from workflow.helper import define_workflow_step, define_workflow_step_short
+from workflow.helper import (
+    define_workflow_step,
+    define_workflow_step_short,
+    define_workflow_step_medium,
+)
 
 
 class workflow_IngestAcceptedSubmission(Workflow):
@@ -39,7 +43,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step("PingWorker", data),
                 define_workflow_step_short("ValidateAcceptedSubmission", data),
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
-                define_workflow_step_short("TransformAcceptedSubmission", data),
+                define_workflow_step_medium("TransformAcceptedSubmission", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7140

A further change to PR https://github.com/elifesciences/elife-bot/pull/1391, extend the timeout for the `TransformAcceptedSubmission` activity, it can use just a little longer time to finish.