### PR TITLE
get_xml_file_name() from article to lax_provider.

### DIFF
--- a/provider/article.py
+++ b/provider/article.py
@@ -6,7 +6,6 @@ from boto.s3.connection import S3Connection
 from elifetools import parseJATS as parser
 import provider.s3lib as s3lib
 from provider import outbox_provider
-from provider.article_structure import ArticleInfo
 from provider.storage_provider import storage_context
 from provider.utils import pad_msid, get_doi_url
 
@@ -483,24 +482,3 @@ class article:
             return True
         else:
             return False
-
-    @staticmethod
-    def _get_bucket_files(settings, expanded_folder_name, xml_bucket):
-        storage = storage_context(settings)
-        resource = (
-            settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder_name
-        )
-        files_in_bucket = storage.list_resources(resource)
-        return files_in_bucket
-
-    def get_xml_file_name(self, settings, expanded_folder_name, xml_bucket, version):
-        files = self._get_bucket_files(settings, expanded_folder_name, xml_bucket)
-        for filename in files:
-            info = ArticleInfo(filename)
-            if info.file_type == "ArticleXML":
-                if version is None:
-                    return filename
-                v_number = "-v" + version + "."
-                if v_number in filename:
-                    return filename
-        return None

--- a/tests/activity/test_activity_create_digest_medium_post.py
+++ b/tests/activity/test_activity_create_digest_medium_post.py
@@ -52,7 +52,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
     @patch.object(lax_provider, "article_first_by_status")
     @patch.object(lax_provider, "article_highest_version")
     @patch.object(article_processing, "storage_context")
-    @patch.object(article, "storage_context")
+    @patch.object(lax_provider, "storage_context")
     @patch.object(digest_provider, "storage_context")
     @patch.object(activity_object, "emit_monitor_event")
     @data(
@@ -99,7 +99,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
         test_data,
         fake_emit,
         fake_storage_context,
-        fake_article_storage_context,
+        fake_lax_provider_storage_context,
         fake_processing_storage_context,
         fake_highest_version,
         fake_first,
@@ -112,7 +112,7 @@ class TestCreateDigestMediumPost(unittest.TestCase):
         named_storage_context = FakeStorageContext()
         if test_data.get("bucket_resources"):
             named_storage_context.resources = test_data.get("bucket_resources")
-        fake_article_storage_context.return_value = named_storage_context
+        fake_lax_provider_storage_context.return_value = named_storage_context
         bot_storage_context = FakeStorageContext()
         if test_data.get("bot_bucket_resources"):
             bot_storage_context.resources = test_data.get("bot_bucket_resources")

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -64,7 +64,7 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         self.activity.clean_tmp_dir()
 
     @patch("activity.activity_IngestDigestToEndpoint.json_output.requests.get")
-    @patch.object(article, "storage_context")
+    @patch.object(lax_provider, "storage_context")
     @patch.object(article_processing, "storage_context")
     @patch.object(lax_provider, "article_first_by_status")
     @patch.object(lax_provider, "article_snippet")
@@ -132,7 +132,7 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_article_snippet,
         fake_first,
         fake_processing_storage_context,
-        fake_article_storage_context,
+        fake_lax_provider_storage_context,
         fake_get,
     ):
         # copy files into the input directory using the storage context
@@ -140,7 +140,7 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         named_storage_context = FakeStorageContext()
         if test_data.get("bucket_resources"):
             named_storage_context.resources = test_data.get("bucket_resources")
-        fake_article_storage_context.return_value = named_storage_context
+        fake_lax_provider_storage_context.return_value = named_storage_context
         bot_storage_context = FakeStorageContext()
         if test_data.get("bot_bucket_resources"):
             bot_storage_context.resources = test_data.get("bot_bucket_resources")

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -18,7 +18,7 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     @patch("provider.lax_provider.article_highest_version")
-    @patch("provider.article.storage_context")
+    @patch("provider.lax_provider.storage_context")
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(activity_object, "xml_sub_article_exists")
@@ -29,13 +29,13 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_sub_article_exists,
         fake_session_mock,
         fake_storage_context,
-        fake_article_storage_context,
+        fake_lax_provider_storage_context,
         fake_highest_version,
     ):
         expected_result = True
         fake_session_mock.return_value = FakeSession(activity_test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext()
-        fake_article_storage_context.return_value = FakeStorageContext()
+        fake_lax_provider_storage_context.return_value = FakeStorageContext()
         fake_highest_version.return_value = 1
         fake_sub_article_exists.return_value = True
         self.activity.emit_monitor_event = mock.MagicMock()

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -4,7 +4,7 @@ import activity.activity_ScheduleDownstream as activity_module
 from activity.activity_ScheduleDownstream import (
     activity_ScheduleDownstream as activity_object,
 )
-from provider import article, lax_provider
+from provider import lax_provider
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 import tests.activity.test_activity_data as activity_test_data
@@ -16,7 +16,7 @@ class TestScheduleDownstream(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     @patch("provider.lax_provider.article_first_by_status")
-    @patch.object(article, "storage_context")
+    @patch.object(lax_provider, "storage_context")
     @patch.object(activity_module, "storage_context")
     def test_do_activity(
         self, fake_activity_storage_context, fake_storage_context, fake_first

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -11,24 +11,6 @@ class ObjectView(object):
         self.__dict__ = d
 
 
-BUCKET_FILES_MOCK_VERSION = [
-    "elife-06498-fig1-v1.tif",
-    "elife-06498-resp-fig1-v3-80w.gif",
-    "elife-06498-v1.xml",
-    "elife-06498-v2.pdf",
-    "elife-06498-v2.xml",
-    "elife-06498-v3-download.xml",
-]
-
-BUCKET_FILES_MOCK = [
-    "elife-06498-fig1-v1.tif",
-    "elife-06498-resp-fig1-v1-80w.gif",
-    "elife-06498-v1-download.xml",
-    "elife-06498-v1.xml",
-    "elife-06498-v1.pdf",
-]
-
-
 @ddt
 class TestProviderArticle(unittest.TestCase):
     def setUp(self):
@@ -55,18 +37,6 @@ class TestProviderArticle(unittest.TestCase):
         )
         result = self.articleprovider.download_article_xml_from_s3("08411")
         self.assertEqual(result, False)
-
-    @patch.object(article, "_get_bucket_files")
-    def test_get_xml_file_name_by_version(self, mock_get_bucket_files):
-        mock_get_bucket_files.return_value = BUCKET_FILES_MOCK_VERSION
-        result = self.articleprovider.get_xml_file_name(None, None, None, version="2")
-        self.assertEqual(result, "elife-06498-v2.xml")
-
-    @patch.object(article, "_get_bucket_files")
-    def test_get_xml_file_name_no_version(self, mock_get_bucket_files):
-        mock_get_bucket_files.return_value = BUCKET_FILES_MOCK
-        result = self.articleprovider.get_xml_file_name(None, None, None, version=None)
-        self.assertEqual(result, "elife-06498-v1.xml")
 
     def test_tweet_url(self):
         tweet_url = self.articleprovider.get_tweet_url("10.7554/eLife.08411")

--- a/tests/provider/test_lax_provider.py
+++ b/tests/provider/test_lax_provider.py
@@ -6,7 +6,7 @@ import base64
 import json
 import tests.test_data as test_data
 from provider.lax_provider import ErrorCallingLaxException
-
+from tests.activity.classes_mock import FakeStorageContext
 from mock import mock, patch, MagicMock
 from ddt import ddt, data, unpack
 
@@ -505,5 +505,57 @@ class TestLaxProvider(unittest.TestCase):
         self.assertEqual(first, expected)
 
 
-if __name__ == "__main__":
-    unittest.main()
+BUCKET_FILES_MOCK_VERSION = [
+    "elife-06498-fig1-v1.tif",
+    "elife-06498-resp-fig1-v3-80w.gif",
+    "elife-06498-v1.xml",
+    "elife-06498-v2.pdf",
+    "elife-06498-v2.xml",
+    "elife-06498-v3-download.xml",
+]
+
+BUCKET_FILES_MOCK = [
+    "elife-06498-fig1-v1.tif",
+    "elife-06498-resp-fig1-v1-80w.gif",
+    "elife-06498-v1-download.xml",
+    "elife-06498-v1.xml",
+    "elife-06498-v1.pdf",
+]
+
+
+class TestGetXmlFileName(unittest.TestCase):
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.lax_provider.storage_context")
+    def test_get_xml_file_name_by_version(
+        self, fake_storage_context, fake_list_resources
+    ):
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_list_resources.return_value = BUCKET_FILES_MOCK_VERSION
+        result = lax_provider.get_xml_file_name(
+            settings_mock, "folder", "bucket", version="2"
+        )
+        self.assertEqual(result, "elife-06498-v2.xml")
+
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.lax_provider.storage_context")
+    def test_get_xml_file_name_no_version(
+        self, fake_storage_context, fake_list_resources
+    ):
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_list_resources.return_value = BUCKET_FILES_MOCK
+        result = lax_provider.get_xml_file_name(
+            settings_mock, "folder", "bucket", version=None
+        )
+        self.assertEqual(result, "elife-06498-v1.xml")
+
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch("provider.lax_provider.storage_context")
+    def test_get_xml_file_name_no_bucket_files(
+        self, fake_storage_context, fake_list_resources
+    ):
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_list_resources.return_value = []
+        result = lax_provider.get_xml_file_name(
+            settings_mock, "folder", "bucket", version=None
+        )
+        self.assertEqual(result, None)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7143

First PR for refactoring the `provider/article.py` code, the `get_xml_file_name()` function was only used by `provider/lax_provider.py` so move it over to there. Adjust the imports and test cases. Hopefully this will also pass end2end tests.