### PR TITLE
Article provider refactoring no-self-use functions

### DIFF
--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -68,8 +68,6 @@ class activity_GeneratePDFCovers(Activity):
                 "Starting check for generation of pdf cover.",
             )
 
-            article = articlelib.article()
-
             if (
                 not (hasattr(self.settings, "pdf_cover_generator"))
                 or (
@@ -95,7 +93,7 @@ class activity_GeneratePDFCovers(Activity):
                 )
                 return self.ACTIVITY_SUCCESS
 
-            pdf_cover = article.get_pdf_cover_link(
+            pdf_cover = articlelib.get_pdf_cover_link(
                 self.settings.pdf_cover_generator, article_id, self.logger
             )
 

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -246,7 +246,7 @@ class activity_PublicationEmail(Activity):
 
             article = articlelib.create_article(self.settings, self.get_tmp_dir)
             article.parse_article_file(article_xml_filename)
-            article.pdf_cover_link = article.get_pdf_cover_page(
+            article.pdf_cover_link = articlelib.get_pdf_cover_page(
                 article.doi_id, self.settings, self.logger
             )
             log_info = "Parsed " + article.doi_url

--- a/provider/article.py
+++ b/provider/article.py
@@ -7,7 +7,7 @@ from elifetools import parseJATS as parser
 import provider.s3lib as s3lib
 from provider import outbox_provider
 from provider.storage_provider import storage_context
-from provider.utils import pad_msid, get_doi_url
+from provider.utils import msid_from_doi, get_doi_url, pad_msid
 
 """
 Article data provider
@@ -76,7 +76,7 @@ class article:
             soup = parser.parse_document(document)
             self.doi = parser.doi(soup)
             if self.doi:
-                self.doi_id = get_doi_id(self.doi)
+                self.doi_id = pad_msid(msid_from_doi(self.doi))
                 self.doi_url = get_doi_url(self.doi)
                 self.lens_url = get_lens_url(self.doi)
                 self.tweet_url = get_tweet_url(self.doi)
@@ -183,7 +183,7 @@ class article:
         For an article DOI and workflow name, check if it ever went through that workflow
         """
 
-        doi_id = get_doi_id(doi)
+        doi_id = msid_from_doi(doi)
 
         if int(doi_id) in self.was_published_doi_ids(workflow):
             return True
@@ -366,20 +366,9 @@ def get_lens_url(doi):
     """
     Given a DOI, get the URL for the lens article
     """
-    doi_id = get_doi_id(doi)
+    doi_id = pad_msid(msid_from_doi(doi))
     lens_url = "https://lens.elifesciences.org/" + doi_id
     return lens_url
-
-
-def get_doi_id(doi):
-    """
-    Given a DOI, return the doi_id part of it
-    e.g. DOI 10.7554/eLife.00013
-    split on dot and the last list element is doi_id
-    """
-    x = doi.split(".")
-    doi_id = x[-1]
-    return doi_id
 
 
 def get_pdf_cover_link(pdf_cover_generator_url, doi_id, logger):

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -2,6 +2,7 @@ import email
 import os
 import shutil
 from digestparser.objects import Digest, Image
+from provider import utils
 from provider.article import article
 
 
@@ -43,7 +44,7 @@ def instantiate_article(article_type, doi, is_poa=None, was_ever_poa=None):
     article_object = article()
     article_object.article_type = article_type
     article_object.doi = doi
-    article_object.doi_id = article_object.get_doi_id(doi)
+    article_object.doi_id = utils.pad_msid(utils.msid_from_doi(doi))
     article_object.is_poa = is_poa
     article_object.was_ever_poa = was_ever_poa
     return article_object

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 from mock import patch
-from provider.article import article
+import provider.article as articlelib
 from provider import lax_provider
 from activity.activity_GeneratePDFCovers import activity_GeneratePDFCovers
 import tests.activity.settings_mock as settings_mock
@@ -67,7 +67,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         json.dumps(self.fake_logger.logerror)
 
     @patch.object(lax_provider, "article_snippet")
-    @patch.object(article, "get_pdf_cover_link")
+    @patch.object(articlelib, "get_pdf_cover_link")
     @patch.object(activity_GeneratePDFCovers, "emit_monitor_event")
     def test_do_activity_error_wrong_result_from_covers(
         self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet
@@ -84,7 +84,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         json.dumps(self.fake_logger.logerror)
 
     @patch.object(lax_provider, "article_snippet")
-    @patch.object(article, "get_pdf_cover_link")
+    @patch.object(articlelib, "get_pdf_cover_link")
     @patch.object(activity_GeneratePDFCovers, "emit_monitor_event")
     def test_do_activity_get_pdf_exception(
         self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -9,7 +9,7 @@ from testfixtures import TempDirectory
 from mock import mock, patch
 from ddt import ddt, data, unpack
 from provider.templates import Templates
-from provider.article import article
+import provider.article as articlelib
 from provider.ejp import EJP
 import activity.activity_PublicationEmail as activity_module
 from activity.activity_PublicationEmail import activity_PublicationEmail
@@ -271,7 +271,7 @@ class TestPublicationEmail(unittest.TestCase):
 
             # Prime the related article property for when needed
             if pass_test_data.get("related_article"):
-                related_article = article()
+                related_article = articlelib.article()
                 related_article.parse_article_file(
                     pass_test_data.get("related_article")
                 )
@@ -497,7 +497,7 @@ class TestPublicationEmail(unittest.TestCase):
 
         authors = fake_authors(self.activity, 13)
 
-        article_object = article()
+        article_object = articlelib.article()
         article_object.parse_article_file("tests/test_data/elife00013.xml")
         article_type = article_object.article_type
         feature_article = False
@@ -539,7 +539,7 @@ class TestPublicationEmail(unittest.TestCase):
 
         authors = fake_authors(self.activity)
 
-        article_object = article()
+        article_object = articlelib.article()
         article_object.parse_article_file("tests/test_data/elife-00353-v1.xml")
         article_object.pdf_cover_link = (
             "https://localhost.org/download-your-cover/00353"
@@ -582,9 +582,9 @@ class TestPublicationEmail(unittest.TestCase):
 
     def test_get_pdf_cover_page(self):
 
-        article_object = article()
+        article_object = articlelib.article()
         article_object.parse_article_file("tests/test_data/elife-00353-v1.xml")
-        article_object.pdf_cover_link = article_object.get_pdf_cover_page(
+        article_object.pdf_cover_link = articlelib.get_pdf_cover_page(
             article_object.doi_id, self.activity.settings, self.activity.logger
         )
         self.assertEqual(
@@ -756,7 +756,7 @@ class TestArticleAuthors(unittest.TestCase):
             ),
         ]
 
-        article_object = article()
+        article_object = articlelib.article()
         article_object.authors = self.article_xml_authors
         article_object.display_channel = display_channel
 
@@ -777,7 +777,7 @@ class TestArticleAuthors(unittest.TestCase):
             },
         ]
 
-        article_object = article()
+        article_object = articlelib.article()
         article_object.authors = self.article_xml_authors
         article_object.display_channel = display_channel
 
@@ -948,7 +948,7 @@ class TestGetRelatedArticle(unittest.TestCase):
         """get related article from existing list of related articles"""
         doi = "10.7554/eLife.15747"
         expected_doi = doi
-        related_article = article()
+        related_article = articlelib.article()
         related_article.parse_article_file("tests/test_data/elife-15747-v2.xml")
         return_value = activity_module.get_related_article(
             settings_mock, TempDirectory(), doi, [related_article], FakeLogger(), ""
@@ -960,7 +960,7 @@ class TestGetRelatedArticle(unittest.TestCase):
         """get related article from creating a new article for the doi"""
         doi = "10.7554/eLife.15747"
         expected_doi = doi
-        article_object = article()
+        article_object = articlelib.article()
         article_object.parse_article_file("tests/test_data/elife-15747-v2.xml")
         fake_create_article.return_value = article_object
         related_articles = []
@@ -1079,7 +1079,7 @@ class TestAuthorsFromXML(unittest.TestCase):
         },
     )
     def test_authors_from_xml(self, test_data):
-        article_object = article()
+        article_object = articlelib.article()
         full_filename = os.path.join(
             "tests/files_source/publication_email/outbox", test_data.get("filename")
         )

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -195,12 +195,6 @@ class TestGetLensUrl(unittest.TestCase):
         self.assertEqual(lens_url, "https://lens.elifesciences.org/08411")
 
 
-class TestGetDoiId(unittest.TestCase):
-    def test_get_doi_id(self):
-        doi_id = provider_module.get_doi_id("10.7554/eLife.08411")
-        self.assertEqual(doi_id, "08411")
-
-
 @ddt
 class TestIdFromPoaS3KeyName(unittest.TestCase):
     @data(

--- a/tests/provider/test_article.py
+++ b/tests/provider/test_article.py
@@ -1,4 +1,5 @@
 import unittest
+import provider.article as provider_module
 from provider.article import article
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
@@ -37,24 +38,6 @@ class TestProviderArticle(unittest.TestCase):
         )
         result = self.articleprovider.download_article_xml_from_s3("08411")
         self.assertEqual(result, False)
-
-    def test_tweet_url(self):
-        tweet_url = self.articleprovider.get_tweet_url("10.7554/eLife.08411")
-        self.assertEqual(
-            tweet_url,
-            (
-                "http://twitter.com/intent/tweet?text=https%3A%2F%2Fdoi.org"
-                + "%2F10.7554%2FeLife.08411+%40eLife"
-            ),
-        )
-
-    def test_get_lens_url(self):
-        lens_url = self.articleprovider.get_lens_url("10.7554/eLife.08411")
-        self.assertEqual(lens_url, "https://lens.elifesciences.org/08411")
-
-    def test_get_doi_id(self):
-        doi_id = self.articleprovider.get_doi_id("10.7554/eLife.08411")
-        self.assertEqual(doi_id, "08411")
 
     @data(
         {
@@ -193,21 +176,33 @@ class TestProviderArticle(unittest.TestCase):
         parse_result = self.articleprovider.parse_article_file(filename)
         self.assertFalse(parse_result)
 
-    @data(
-        {
-            "s3_key_name": "pubmed/published/20140923/elife02104.xml",
-            "expected_doi_id": 2104,
-        },
-        {
-            "s3_key_name": "pubmed/published/20141224/elife04034.xml",
-            "expected_doi_id": 4034,
-        },
-    )
-    @unpack
-    def test_get_doi_id_from_s3_key_name(self, s3_key_name, expected_doi_id):
-        doi_id = self.articleprovider.get_doi_id_from_s3_key_name(s3_key_name)
-        self.assertEqual(doi_id, expected_doi_id)
 
+class TestTweetUrl(unittest.TestCase):
+    def test_tweet_url(self):
+        tweet_url = provider_module.get_tweet_url("10.7554/eLife.08411")
+        self.assertEqual(
+            tweet_url,
+            (
+                "http://twitter.com/intent/tweet?text=https%3A%2F%2Fdoi.org"
+                + "%2F10.7554%2FeLife.08411+%40eLife"
+            ),
+        )
+
+
+class TestGetLensUrl(unittest.TestCase):
+    def test_get_lens_url(self):
+        lens_url = provider_module.get_lens_url("10.7554/eLife.08411")
+        self.assertEqual(lens_url, "https://lens.elifesciences.org/08411")
+
+
+class TestGetDoiId(unittest.TestCase):
+    def test_get_doi_id(self):
+        doi_id = provider_module.get_doi_id("10.7554/eLife.08411")
+        self.assertEqual(doi_id, "08411")
+
+
+@ddt
+class TestIdFromPoaS3KeyName(unittest.TestCase):
     @data(
         {
             "s3_key_name": "published/20140508/elife_poa_e02419.xml",
@@ -224,9 +219,23 @@ class TestProviderArticle(unittest.TestCase):
     )
     @unpack
     def test_get_doi_id_from_poa_s3_key_name(self, s3_key_name, expected_doi_id):
-        doi_id = self.articleprovider.get_doi_id_from_poa_s3_key_name(s3_key_name)
+        doi_id = provider_module.get_doi_id_from_poa_s3_key_name(s3_key_name)
         self.assertEqual(doi_id, expected_doi_id)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@ddt
+class TestIdFromS3KeyName(unittest.TestCase):
+    @data(
+        {
+            "s3_key_name": "pubmed/published/20140923/elife02104.xml",
+            "expected_doi_id": 2104,
+        },
+        {
+            "s3_key_name": "pubmed/published/20141224/elife04034.xml",
+            "expected_doi_id": 4034,
+        },
+    )
+    @unpack
+    def test_get_doi_id_from_s3_key_name(self, s3_key_name, expected_doi_id):
+        doi_id = provider_module.get_doi_id_from_s3_key_name(s3_key_name)
+        self.assertEqual(doi_id, expected_doi_id)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7143

Move no-self-use functions out of the `article` object, and change test scenarios and activities which depend on them.