### PR TITLE
Add swf_region to example settings and tests.

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -58,6 +58,7 @@ class exp:
     # end PPP settings
 
     # SWF queue settings
+    swf_region = "us-east-1"
     domain = "Publish.dev"
     default_task_list = "DefaultTaskList"
 
@@ -379,6 +380,7 @@ class dev:
     # end PPP settings
 
     # SWF queue settings
+    swf_region = "us-east-1"
     domain = "Publish.dev"
     default_task_list = "DefaultTaskList"
 
@@ -697,6 +699,7 @@ class live:
     # end PPP settings
 
     # SWF queue settings
+    swf_region = "us-east-1"
     domain = "Publish"
     default_task_list = "DefaultTaskList"
 

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -1,3 +1,4 @@
+swf_region = ""
 domain = ""
 default_task_list = ""
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -1,3 +1,4 @@
+swf_region = ""
 domain = ""
 default_task_list = ""
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7156

Settings for using in `boto3` SWF connections soon.