### PR TITLE
Fix swfmeta get_closed_workflow_execution_count()

### DIFF
--- a/provider/swfmeta.py
+++ b/provider/swfmeta.py
@@ -62,7 +62,7 @@ class SWFMeta:
 
         result = self.client.count_closed_workflow_executions(**kwargs)
 
-        return result.get("count")
+        return result
 
     def get_closed_workflow_executionInfos(
         self,

--- a/tests/provider/test_swfmeta.py
+++ b/tests/provider/test_swfmeta.py
@@ -90,10 +90,11 @@ class TestProviderSWFMeta(unittest.TestCase):
         mock_swf_client = FakeSWFClient()
         mock_swf_client.add_infos(self.base_completed_infos)
         fake_client.return_value = mock_swf_client
-        count = self.swfmeta.get_closed_workflow_execution_count(
+        expected = {"count": 43, "truncated": False}
+        result = self.swfmeta.get_closed_workflow_execution_count(
             workflow_name="DepositCrossref"
         )
-        self.assertEqual(count, 43)
+        self.assertEqual(result, expected)
 
     @patch("boto3.client")
     def test_get_last_completed(self, fake_client):


### PR DESCRIPTION
Second bug fix to PR https://github.com/elifesciences/elife-bot/pull/1397

The return value of `boto3` `count_closed_workflow_executions()` is the same as it was in boto2, and when refactoring `swfmeta.py` it should not have been changed to return the `count` only. There's only one running part using this, the `AdminEmailHistory` activity, which was returning 0 for the count of each workflow execution type, incorrectly.