### PR TITLE
Use boto3 in register.py, plus changes to allow it

### DIFF
--- a/activity/activity_AdminEmailHistory.py
+++ b/activity/activity_AdminEmailHistory.py
@@ -13,9 +13,11 @@ AdminEmailHistory activity
 
 
 class activity_AdminEmailHistory(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_AdminEmailHistory, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "AdminEmailHistory"

--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -18,9 +18,11 @@ ApplyVersionNumber.py activity
 
 
 class activity_ApplyVersionNumber(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ApplyVersionNumber, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ApplyVersionNumber"

--- a/activity/activity_ArchiveArticle.py
+++ b/activity/activity_ArchiveArticle.py
@@ -12,9 +12,11 @@ activity_ArchiveArticle.py activity
 
 
 class activity_ArchiveArticle(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ArchiveArticle, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ArchiveArticle"

--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -7,9 +7,11 @@ from provider import article_structure, image_conversion, utils
 
 
 class activity_ConvertImagesToJPG(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ConvertImagesToJPG, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ConvertImagesToJPG"

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -13,9 +13,11 @@ activity_CopyDigestToOutbox.py activity
 
 
 class activity_CopyDigestToOutbox(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_CopyDigestToOutbox, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "CopyDigestToOutbox"

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -18,9 +18,11 @@ class ValidationException(RuntimeError):
 
 
 class activity_CopyGlencoeStillImages(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_CopyGlencoeStillImages, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "CopyGlencoeStillImages"

--- a/activity/activity_CreateDigestMediumPost.py
+++ b/activity/activity_CreateDigestMediumPost.py
@@ -8,9 +8,11 @@ from activity.objects import Activity
 
 
 class activity_CreateDigestMediumPost(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_CreateDigestMediumPost, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "CreateDigestMediumPost"

--- a/activity/activity_DecisionLetterReceipt.py
+++ b/activity/activity_DecisionLetterReceipt.py
@@ -8,9 +8,11 @@ from activity.objects import Activity
 class activity_DecisionLetterReceipt(Activity):
     "DecisionLetterReceipt activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DecisionLetterReceipt, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DecisionLetterReceipt"

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -11,9 +11,11 @@ DepositAssets.py activity
 
 
 class activity_DepositAssets(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositAssets, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositAssets"

--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -11,9 +11,11 @@ DepositCrossref activity
 
 
 class activity_DepositCrossref(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositCrossref, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositCrossref"

--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -16,9 +16,11 @@ from provider import (
 
 
 class activity_DepositCrossrefPeerReview(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositCrossrefPeerReview, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositCrossrefPeerReview"

--- a/activity/activity_DepositCrossrefPendingPublication.py
+++ b/activity/activity_DepositCrossrefPendingPublication.py
@@ -16,9 +16,11 @@ PLACEHOLDER_ARTICLE_TITLE = "Title to be confirmed"
 
 
 class activity_DepositCrossrefPendingPublication(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositCrossrefPendingPublication, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositCrossrefPendingPublication"

--- a/activity/activity_DepositDOAJ.py
+++ b/activity/activity_DepositDOAJ.py
@@ -5,9 +5,11 @@ from activity.objects import Activity
 
 
 class activity_DepositDOAJ(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositDOAJ, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositDOAJ"

--- a/activity/activity_DepositDecisionLetterIngestAssets.py
+++ b/activity/activity_DepositDecisionLetterIngestAssets.py
@@ -11,9 +11,11 @@ DepositDecisionLetterIngestAssets.py activity
 
 
 class activity_DepositDecisionLetterIngestAssets(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositDecisionLetterIngestAssets, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositDecisionLetterIngestAssets"

--- a/activity/activity_DepositDigestIngestAssets.py
+++ b/activity/activity_DepositDigestIngestAssets.py
@@ -12,9 +12,11 @@ DepositDigestIngestAssets.py activity
 
 
 class activity_DepositDigestIngestAssets(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositDigestIngestAssets, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositDigestIngestAssets"

--- a/activity/activity_DepositIngestAssets.py
+++ b/activity/activity_DepositIngestAssets.py
@@ -10,9 +10,11 @@ DepositIngestAssets.py activity
 
 
 class activity_DepositIngestAssets(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DepositIngestAssets, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DepositIngestAssets"

--- a/activity/activity_DownstreamStart.py
+++ b/activity/activity_DownstreamStart.py
@@ -3,9 +3,11 @@ from activity.objects import Activity
 
 
 class activity_DownstreamStart(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_DownstreamStart, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "DownstreamStart"

--- a/activity/activity_EmailDigest.py
+++ b/activity/activity_EmailDigest.py
@@ -11,9 +11,11 @@ from activity.objects import Activity
 class activity_EmailDigest(Activity):
     "EmailDigest activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_EmailDigest, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "EmailDigest"

--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -11,9 +11,11 @@ from activity.objects import Activity
 class activity_EmailVideoArticlePublished(Activity):
     "EmailVideoArticlePublished activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_EmailVideoArticlePublished, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "EmailVideoArticlePublished"

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -21,9 +21,11 @@ ExpandArticle.py activity
 
 
 class activity_ExpandArticle(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ExpandArticle, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ExpandArticle"

--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -20,9 +20,11 @@ ZIP_FILE_PREFIX = "%s-" % JOURNAL
 
 
 class activity_FTPArticle(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_FTPArticle, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "FTPArticle"

--- a/activity/activity_GenerateDecisionLetterJATS.py
+++ b/activity/activity_GenerateDecisionLetterJATS.py
@@ -10,9 +10,11 @@ from activity.objects import Activity
 class activity_GenerateDecisionLetterJATS(Activity):
     "ValidateDecisionLetter activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_GenerateDecisionLetterJATS, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "GenerateDecisionLetterJATS"

--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -8,9 +8,11 @@ activity_GeneratePDFCovers.py activity
 
 
 class activity_GeneratePDFCovers(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_GeneratePDFCovers, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "GeneratePDFCovers"

--- a/activity/activity_GenerateSWHMetadata.py
+++ b/activity/activity_GenerateSWHMetadata.py
@@ -11,9 +11,11 @@ DESCRIPTION_PATTERN = 'ERA complement for "%s", %s'
 
 
 class activity_GenerateSWHMetadata(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_GenerateSWHMetadata, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "GenerateSWHMetadata"

--- a/activity/activity_GenerateSWHReadme.py
+++ b/activity/activity_GenerateSWHReadme.py
@@ -12,9 +12,11 @@ README_FILENAME = "README.md"
 
 
 class activity_GenerateSWHReadme(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_GenerateSWHReadme, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "GenerateSWHReadme"

--- a/activity/activity_IngestDigestToEndpoint.py
+++ b/activity/activity_IngestDigestToEndpoint.py
@@ -10,9 +10,11 @@ from activity.objects import Activity
 
 
 class activity_IngestDigestToEndpoint(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_IngestDigestToEndpoint, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "IngestDigestToEndpoint"

--- a/activity/activity_IngestToLax.py
+++ b/activity/activity_IngestToLax.py
@@ -18,9 +18,11 @@ activity_IngestToLax.py activity
 
 
 class activity_IngestToLax(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_IngestToLax, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "IngestToLax"

--- a/activity/activity_InvalidateCdn.py
+++ b/activity/activity_InvalidateCdn.py
@@ -8,9 +8,11 @@ activity_InvalidateCdn.py activity
 
 
 class activity_InvalidateCdn(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_InvalidateCdn, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "InvalidateCdn"

--- a/activity/activity_LensArticle.py
+++ b/activity/activity_LensArticle.py
@@ -14,9 +14,11 @@ LensArticle activity
 
 
 class activity_LensArticle(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_LensArticle, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "LensArticle"

--- a/activity/activity_ModifyArticleSubjects.py
+++ b/activity/activity_ModifyArticleSubjects.py
@@ -15,9 +15,11 @@ ModifyArticleSubjects.py activity
 
 
 class activity_ModifyArticleSubjects(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ModifyArticleSubjects, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ModifyArticleSubjects"

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -16,9 +16,11 @@ from activity.objects import Activity
 
 
 class activity_PMCDeposit(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PMCDeposit, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PMCDeposit"

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -23,9 +23,11 @@ from activity.objects import Activity
 class activity_PackagePOA(Activity):
     "PackagePOA activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PackagePOA, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PackagePOA"

--- a/activity/activity_PackageSWH.py
+++ b/activity/activity_PackageSWH.py
@@ -9,9 +9,11 @@ from activity.objects import Activity
 
 
 class activity_PackageSWH(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PackageSWH, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PackageSWH"

--- a/activity/activity_PingWorker.py
+++ b/activity/activity_PingWorker.py
@@ -6,9 +6,11 @@ PingWorker activity
 
 
 class activity_PingWorker(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PingWorker, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PingWorker"

--- a/activity/activity_PostDecisionLetterJATS.py
+++ b/activity/activity_PostDecisionLetterJATS.py
@@ -14,9 +14,11 @@ from activity.objects import Activity
 
 
 class activity_PostDecisionLetterJATS(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PostDecisionLetterJATS, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PostDecisionLetterJATS"

--- a/activity/activity_PostDigestJATS.py
+++ b/activity/activity_PostDigestJATS.py
@@ -15,9 +15,11 @@ from activity.objects import Activity
 
 
 class activity_PostDigestJATS(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PostDigestJATS, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PostDigestJATS"

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -25,9 +25,11 @@ PubRouterDeposit activity
 
 
 class activity_PubRouterDeposit(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PubRouterDeposit, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PubRouterDeposit"

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -28,9 +28,11 @@ SENDING_RETRY = 3
 
 
 class activity_PublicationEmail(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PublicationEmail, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PublicationEmail"

--- a/activity/activity_PublishDigest.py
+++ b/activity/activity_PublishDigest.py
@@ -4,9 +4,11 @@ from activity.objects import Activity
 
 
 class activity_PublishDigest(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PublishDigest, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PublishDigest"

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -18,9 +18,11 @@ PublishFinalPOA activity
 
 
 class activity_PublishFinalPOA(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PublishFinalPOA, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PublishFinalPOA"

--- a/activity/activity_PublishToLax.py
+++ b/activity/activity_PublishToLax.py
@@ -12,9 +12,11 @@ activity_PublishToLax.py activity
 
 
 class activity_PublishToLax(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PublishToLax, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PublishToLax"

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -12,9 +12,11 @@ from activity.objects import Activity
 
 
 class activity_PubmedArticleDeposit(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PubmedArticleDeposit, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PubmedArticleDeposit"

--- a/activity/activity_PushSWHDeposit.py
+++ b/activity/activity_PushSWHDeposit.py
@@ -14,9 +14,11 @@ MAX_ZIP_SIZE_IN_BYTES = 50000000
 
 
 class activity_PushSWHDeposit(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_PushSWHDeposit, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "PushSWHDeposit"

--- a/activity/activity_ReadyToPublish.py
+++ b/activity/activity_ReadyToPublish.py
@@ -6,9 +6,11 @@ from activity.objects import Activity
 
 
 class activity_ReadyToPublish(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ReadyToPublish, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ReadyToPublish"

--- a/activity/activity_ScheduleCrossref.py
+++ b/activity/activity_ScheduleCrossref.py
@@ -12,9 +12,11 @@ ScheduleCrossref.py activity
 
 
 class activity_ScheduleCrossref(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ScheduleCrossref, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ScheduleCrossref"

--- a/activity/activity_ScheduleCrossrefPeerReview.py
+++ b/activity/activity_ScheduleCrossrefPeerReview.py
@@ -8,9 +8,11 @@ from activity.objects import Activity
 
 
 class activity_ScheduleCrossrefPeerReview(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ScheduleCrossrefPeerReview, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ScheduleCrossrefPeerReview"

--- a/activity/activity_ScheduleCrossrefPendingPublication.py
+++ b/activity/activity_ScheduleCrossrefPendingPublication.py
@@ -9,9 +9,11 @@ from activity.objects import Activity
 
 
 class activity_ScheduleCrossrefPendingPublication(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ScheduleCrossrefPendingPublication, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ScheduleCrossrefPendingPublication"

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -10,9 +10,11 @@ ScheduleDownstream.py activity
 
 
 class activity_ScheduleDownstream(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ScheduleDownstream, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ScheduleDownstream"

--- a/activity/activity_SendDashboardProperties.py
+++ b/activity/activity_SendDashboardProperties.py
@@ -16,9 +16,11 @@ SendDashboardProperties.py activity
 
 
 class activity_SendDashboardProperties(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_SendDashboardProperties, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "SendDashboardProperties"

--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -10,9 +10,11 @@ from activity.objects import Activity
 class activity_TransformAcceptedSubmission(Activity):
     "TransformAcceptedSubmission activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_TransformAcceptedSubmission, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "TransformAcceptedSubmission"

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -18,9 +18,11 @@ class RetryException(RuntimeError):
 
 
 class activity_UpdateRepository(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_UpdateRepository, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "UpdateRepository"

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -14,9 +14,11 @@ REPAIR_XML = False
 class activity_ValidateAcceptedSubmission(Activity):
     "ValidateAcceptedSubmission activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ValidateAcceptedSubmission, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ValidateAcceptedSubmission"

--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -9,9 +9,11 @@ from activity.objects import Activity
 class activity_ValidateDecisionLetterInput(Activity):
     "ValidateDecisionLetter activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ValidateDecisionLetterInput, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ValidateDecisionLetterInput"

--- a/activity/activity_ValidateDigestInput.py
+++ b/activity/activity_ValidateDigestInput.py
@@ -9,9 +9,11 @@ from activity.objects import Activity
 class activity_ValidateDigestInput(Activity):
     "ValidateDigestInput activity"
 
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_ValidateDigestInput, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "ValidateDigestInput"

--- a/activity/activity_VerifyGlencoe.py
+++ b/activity/activity_VerifyGlencoe.py
@@ -12,9 +12,11 @@ class ValidationException(RuntimeError):
 
 
 class activity_VerifyGlencoe(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VerifyGlencoe, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VerifyGlencoe"

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -15,9 +15,11 @@ class ValidationException(RuntimeError):
 
 
 class activity_VerifyImageServer(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VerifyImageServer, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VerifyImageServer"

--- a/activity/activity_VerifyLaxResponse.py
+++ b/activity/activity_VerifyLaxResponse.py
@@ -14,9 +14,11 @@ class ValidationException(RuntimeError):
 
 
 class activity_VerifyLaxResponse(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VerifyLaxResponse, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VerifyLaxResponse"

--- a/activity/activity_VerifyPublishResponse.py
+++ b/activity/activity_VerifyPublishResponse.py
@@ -8,9 +8,11 @@ activity_VerifyPublishResponse.py activity
 
 
 class activity_VerifyPublishResponse(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VerifyPublishResponse, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VerifyPublishResponse"

--- a/activity/activity_VersionDateLookup.py
+++ b/activity/activity_VersionDateLookup.py
@@ -16,9 +16,11 @@ from activity.objects import Activity
 
 
 class activity_VersionDateLookup(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VersionDateLookup, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VersionDateLookup"

--- a/activity/activity_VersionLookup.py
+++ b/activity/activity_VersionLookup.py
@@ -12,9 +12,11 @@ lookup_functions = {
 
 
 class activity_VersionLookup(Activity):
-    def __init__(self, settings, logger, conn=None, token=None, activity_task=None):
+    def __init__(
+        self, settings, logger, conn=None, token=None, activity_task=None, client=None
+    ):
         super(activity_VersionLookup, self).__init__(
-            settings, logger, conn, token, activity_task
+            settings, logger, conn, token, activity_task, client=client
         )
 
         self.name = "VersionLookup"

--- a/register.py
+++ b/register.py
@@ -1,6 +1,6 @@
 import json
 import importlib
-import boto.swf
+import boto3
 import workflow
 import activity
 from provider import utils
@@ -12,9 +12,12 @@ Amazon SWF register workflow or activity utility
 
 def start(settings):
 
-    # Simple connect
-    conn = boto.swf.layer1.Layer1(
-        settings.aws_access_key_id, settings.aws_secret_access_key
+    # Connect to SWF to get client
+    swf_client = boto3.client(
+        "swf",
+        aws_access_key_id=settings.aws_access_key_id,
+        aws_secret_access_key=settings.aws_secret_access_key,
+        region_name=settings.swf_region,
     )
 
     workflow_names = []
@@ -52,7 +55,7 @@ def start(settings):
         workflow_class = getattr(module_object, class_name)
         # Create the workflow object
         logger = None
-        workflow_object = workflow_class(settings, logger, conn)
+        workflow_object = workflow_class(settings, logger, client=swf_client)
 
         # Now register it
         response = workflow_object.register()
@@ -129,7 +132,7 @@ def start(settings):
         activity_class = getattr(module_object, class_name)
         # Create the workflow object
         logger = None
-        activity_object = activity_class(settings, logger, conn)
+        activity_object = activity_class(settings, logger, client=swf_client)
 
         # Now register it
         response = activity_object.register()

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -12,11 +12,21 @@ class FakeBotoConnection:
         self.start_called = True
 
 
+class FakeSWFUnknownResourceFault(Exception):
+    pass
+
+
+class FakeSWFClientExceptions:
+    def __init__(self):
+        self.UnknownResourceFault = FakeSWFUnknownResourceFault()
+
+
 class FakeSWFClient:
     def __init__(self, *args, **kwargs):
         # infos is JSON format infos in SWF format for workflow executions
         self.infos = []
         self.infos_counter = 0
+        self.exceptions = FakeSWFClientExceptions()
 
     def add_infos(self, infos):
         "add an infos, to allow it to return more than one infos in succession"
@@ -78,6 +88,18 @@ class FakeSWFClient:
         if infos and infos.get("executionInfos"):
             count = len(infos.get("executionInfos"))
         return {"count": count, "truncated": False}
+
+    def describe_workflow_type(self, domain, workflowType):
+        pass
+
+    def register_workflow_type(self, **kwargs):
+        pass
+
+    def describe_activity_type(self, domain, activityType):
+        pass
+
+    def register_activity_type(self, **kwargs):
+        pass
 
 
 class FakeLayer1:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,22 +1,12 @@
 import unittest
 from mock import patch
-from testfixtures import TempDirectory
-import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeLayer1
-from tests.activity.classes_mock import FakeSQSConn, FakeSQSQueue
+from tests import settings_mock
+from tests.classes_mock import FakeSWFClient
 import register
 
 
 class TestRegister(unittest.TestCase):
-    def tearDown(self):
-        TempDirectory.cleanup_all()
-
-    @patch("boto.sqs.connection.SQSConnection.get_queue")
-    @patch("boto.sqs.connect_to_region")
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_layer, fake_sqs_conn, mock_queue):
-        directory = TempDirectory()
-        fake_sqs_conn.return_value = FakeSQSConn(directory)
-        mock_queue.return_value = FakeSQSQueue(directory)
-        fake_layer.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(register.start(settings_mock))

--- a/workflow/workflow_AdminEmail.py
+++ b/workflow/workflow_AdminEmail.py
@@ -11,10 +11,10 @@ class workflow_AdminEmail(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
-        definition=None,
+        client=None,
     ):
         super(workflow_AdminEmail, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_ApproveArticlePublication.py
+++ b/workflow/workflow_ApproveArticlePublication.py
@@ -11,9 +11,10 @@ class workflow_ApproveArticlePublication(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_ApproveArticlePublication, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_CopyGlencoeStillImages.py
+++ b/workflow/workflow_CopyGlencoeStillImages.py
@@ -11,9 +11,10 @@ class workflow_CopyGlencoeStillImages(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_CopyGlencoeStillImages, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_DepositCrossref.py
+++ b/workflow/workflow_DepositCrossref.py
@@ -11,9 +11,10 @@ class workflow_DepositCrossref(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_DepositCrossref, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_DepositCrossrefPeerReview.py
+++ b/workflow/workflow_DepositCrossrefPeerReview.py
@@ -11,9 +11,10 @@ class workflow_DepositCrossrefPeerReview(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_DepositCrossrefPeerReview, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_DepositCrossrefPendingPublication.py
+++ b/workflow/workflow_DepositCrossrefPendingPublication.py
@@ -11,9 +11,10 @@ class workflow_DepositCrossrefPendingPublication(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_DepositCrossrefPendingPublication, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_DepositDOAJ.py
+++ b/workflow/workflow_DepositDOAJ.py
@@ -11,9 +11,10 @@ class workflow_DepositDOAJ(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_DepositDOAJ, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_FTPArticle.py
+++ b/workflow/workflow_FTPArticle.py
@@ -11,9 +11,10 @@ class workflow_FTPArticle(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_FTPArticle, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -15,9 +15,10 @@ class workflow_IngestAcceptedSubmission(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_IngestAcceptedSubmission, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_IngestArticleZip.py
+++ b/workflow/workflow_IngestArticleZip.py
@@ -15,9 +15,10 @@ class workflow_IngestArticleZip(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_IngestArticleZip, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_IngestDecisionLetter.py
+++ b/workflow/workflow_IngestDecisionLetter.py
@@ -11,9 +11,10 @@ class workflow_IngestDecisionLetter(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_IngestDecisionLetter, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_IngestDigest.py
+++ b/workflow/workflow_IngestDigest.py
@@ -11,9 +11,10 @@ class workflow_IngestDigest(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_IngestDigest, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_LensArticlePublish.py
+++ b/workflow/workflow_LensArticlePublish.py
@@ -11,10 +11,10 @@ class workflow_LensArticlePublish(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
-        definition=None,
+        client=None,
     ):
         super(workflow_LensArticlePublish, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PMCDeposit.py
+++ b/workflow/workflow_PMCDeposit.py
@@ -11,9 +11,10 @@ class workflow_PMCDeposit(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PMCDeposit, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PackagePOA.py
+++ b/workflow/workflow_PackagePOA.py
@@ -11,9 +11,10 @@ class workflow_PackagePOA(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PackagePOA, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_Ping.py
+++ b/workflow/workflow_Ping.py
@@ -11,9 +11,10 @@ class workflow_Ping(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_Ping, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PostPerfectPublication.py
+++ b/workflow/workflow_PostPerfectPublication.py
@@ -11,9 +11,10 @@ class workflow_PostPerfectPublication(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PostPerfectPublication, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -11,9 +11,10 @@ class workflow_ProcessArticleZip(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_ProcessArticleZip, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PubRouterDeposit.py
+++ b/workflow/workflow_PubRouterDeposit.py
@@ -11,9 +11,10 @@ class workflow_PubRouterDeposit(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PubRouterDeposit, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PublicationEmail.py
+++ b/workflow/workflow_PublicationEmail.py
@@ -11,9 +11,10 @@ class workflow_PublicationEmail(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PublicationEmail, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PublishPOA.py
+++ b/workflow/workflow_PublishPOA.py
@@ -11,9 +11,10 @@ class workflow_PublishPOA(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PublishPOA, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_PubmedArticleDeposit.py
+++ b/workflow/workflow_PubmedArticleDeposit.py
@@ -11,9 +11,10 @@ class workflow_PubmedArticleDeposit(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_PubmedArticleDeposit, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_SilentCorrectionsIngest.py
+++ b/workflow/workflow_SilentCorrectionsIngest.py
@@ -15,9 +15,10 @@ class workflow_SilentCorrectionsIngest(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_SilentCorrectionsIngest, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_SilentCorrectionsProcess.py
+++ b/workflow/workflow_SilentCorrectionsProcess.py
@@ -11,9 +11,10 @@ class workflow_SilentCorrectionsProcess(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_SilentCorrectionsProcess, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults

--- a/workflow/workflow_SoftwareHeritageDeposit.py
+++ b/workflow/workflow_SoftwareHeritageDeposit.py
@@ -11,9 +11,10 @@ class workflow_SoftwareHeritageDeposit(Workflow):
         token=None,
         decision=None,
         maximum_page_size=100,
+        client=None,
     ):
         super(workflow_SoftwareHeritageDeposit, self).__init__(
-            settings, logger, conn, token, decision, maximum_page_size
+            settings, logger, conn, token, decision, maximum_page_size, client=client
         )
 
         # SWF Defaults


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7158

The aim is for `register.py` to use `boto3`. Since it loads each activity class and workflow class for each to register itself, they need to accept an SWF client when instantiated, so they can describe and register themselves at SWF.