### PR TITLE
Refactor starters to use boto3 library.

### DIFF
--- a/activity/activity_LensArticle.py
+++ b/activity/activity_LensArticle.py
@@ -1,4 +1,3 @@
-import boto.swf
 import json
 import os
 import codecs

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -1,4 +1,3 @@
-import boto.swf
 from provider import utils
 import starter.starter_helper as helper
 from starter.objects import Starter

--- a/starter/starter_PackagePOA.py
+++ b/starter/starter_PackagePOA.py
@@ -48,8 +48,6 @@ class starter_PackagePOA(Starter):
 
         self.start_workflow_execution(workflow_params)
 
-        self.connect_to_swf()
-
 
 if __name__ == "__main__":
 

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -5,7 +5,7 @@ from provider import s3lib
 from provider.article import article
 import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
-from tests.classes_mock import FakeLayer1, FakeSMTPServer
+from tests.classes_mock import FakeSWFClient, FakeSMTPServer
 import tests.test_data as test_case_data
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
@@ -35,7 +35,7 @@ class TestPubRouterDeposit(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.article_versions")
-    @patch("boto.swf.layer1.Layer1")
+    @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
@@ -48,7 +48,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_storage_context,
         fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
-        fake_conn,
+        fake_client,
         fake_article_versions,
         fake_email_smtp_connect,
     ):
@@ -61,7 +61,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         fake_article_versions.return_value = (
             200,
             test_case_data.lax_article_versions_response_data,
@@ -71,7 +71,7 @@ class TestPubRouterDeposit(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.article_versions")
-    @patch("boto.swf.layer1.Layer1")
+    @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
@@ -84,7 +84,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_storage_context,
         fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
-        fake_conn,
+        fake_client,
         fake_article_versions,
         fake_email_smtp_connect,
     ):
@@ -97,7 +97,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
         fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         fake_article_versions.return_value = (
             200,
             [{}],
@@ -144,7 +144,7 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
-    @patch("boto.swf.layer1.Layer1")
+    @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
@@ -157,7 +157,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_storage_context,
         fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
-        fake_conn,
+        fake_client,
         fake_article_versions,
         fake_was_ever_poa,
         fake_email_smtp_connect,
@@ -176,7 +176,7 @@ class TestPubRouterDeposit(unittest.TestCase):
             200,
             test_case_data.lax_article_versions_response_data,
         )
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         result = self.pubrouterdeposit.do_activity(activity_data)
         self.assertTrue(result)
 

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -4,29 +4,11 @@ import ftplib
 from datetime import datetime
 
 
-class FakeBotoConnection:
-    def __init__(self):
-        self.start_called = None
-
-    def start_workflow_execution(self, *args, **kwargs):
-        self.start_called = True
-
-
-class FakeSWFUnknownResourceFault(Exception):
-    pass
-
-
-class FakeSWFClientExceptions:
-    def __init__(self):
-        self.UnknownResourceFault = FakeSWFUnknownResourceFault()
-
-
 class FakeSWFClient:
     def __init__(self, *args, **kwargs):
         # infos is JSON format infos in SWF format for workflow executions
         self.infos = []
         self.infos_counter = 0
-        self.exceptions = FakeSWFClientExceptions()
 
     def add_infos(self, infos):
         "add an infos, to allow it to return more than one infos in succession"
@@ -119,82 +101,7 @@ class FakeSWFClient:
     def request_cancel_workflow_execution(self, **kwargs):
         pass
 
-
-class FakeLayer1:
-    def respond_decision_task_completed(
-        self, task_token, decisions=None, execution_context=None
-    ):
-        pass
-
-    def start_workflow_execution(
-        self,
-        domain,
-        workflow_id,
-        workflow_name,
-        workflow_version,
-        task_list=None,
-        child_policy=None,
-        execution_start_to_close_timeout=None,
-        input=None,
-        tag_list=None,
-        task_start_to_close_timeout=None,
-    ):
-        pass
-
-    def list_closed_workflow_executions(
-        self,
-        domain,
-        start_latest_date=None,
-        start_oldest_date=None,
-        close_latest_date=None,
-        close_oldest_date=None,
-        close_status=None,
-        tag=None,
-        workflow_id=None,
-        workflow_name=None,
-        workflow_version=None,
-        maximum_page_size=None,
-        next_page_token=None,
-        reverse_order=None,
-    ):
-        return {"executionInfos": []}
-
-    def describe_workflow_type(self, domain, workflow_name, workflow_version):
-        pass
-
-    def register_workflow_type(
-        self,
-        domain,
-        name,
-        version,
-        task_list=None,
-        default_child_policy=None,
-        default_execution_start_to_close_timeout=None,
-        default_task_start_to_close_timeout=None,
-        description=None,
-    ):
-        pass
-
-    def describe_activity_type(self, domain, activity_name, activity_version):
-        pass
-
-    def register_activity_type(
-        self,
-        domain,
-        name,
-        version,
-        task_list=None,
-        default_task_heartbeat_timeout=None,
-        default_task_schedule_to_close_timeout=None,
-        default_task_schedule_to_start_timeout=None,
-        default_task_start_to_close_timeout=None,
-        description=None,
-    ):
-        pass
-
-    def poll_for_decision_task(
-        domain, task_list, identity, maximum_page_size, next_page_token=None
-    ):
+    def start_workflow_execution(self, **kwargs):
         pass
 
 

--- a/tests/starter/test_cron_five_minute.py
+++ b/tests/starter/test_cron_five_minute.py
@@ -1,8 +1,7 @@
 import unittest
 from mock import patch
-from boto.swf.exceptions import SWFWorkflowExecutionAlreadyStartedError
 from starter.cron_FiveMinute import cron_FiveMinute
-from tests.classes_mock import FakeLayer1, FakeSWFClient
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 
@@ -13,23 +12,17 @@ class TestCronFiveMinute(unittest.TestCase):
         self.starter = cron_FiveMinute(settings_mock, logger=self.fake_logger)
 
     @patch("boto3.client")
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn, fake_client):
-        fake_conn.return_value = FakeLayer1()
+    def test_start(self, fake_client):
         mock_swf_client = FakeSWFClient()
         mock_swf_client.add_infos({"executionInfos": []})
         fake_client.return_value = mock_swf_client
         self.assertIsNone(self.starter.start(settings_mock))
 
     @patch("boto3.client")
-    @patch.object(FakeLayer1, "start_workflow_execution")
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_exception(self, fake_conn, fake_start, fake_client):
-        fake_conn.return_value = FakeLayer1()
-        fake_start.side_effect = SWFWorkflowExecutionAlreadyStartedError(
-            "message", None
-        )
+    @patch.object(FakeSWFClient, "start_workflow_execution")
+    def test_start_exception(self, fake_start, fake_client):
         mock_swf_client = FakeSWFClient()
+        fake_start.side_effect = Exception()
         mock_swf_client.add_infos({"executionInfos": []})
         fake_client.return_value = mock_swf_client
         self.assertIsNone(self.starter.start(settings_mock))

--- a/tests/starter/test_starter_admin_email.py
+++ b/tests/starter/test_starter_admin_email.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_AdminEmail import starter_AdminEmail
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterAdminEmail(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_AdminEmail(settings_mock, logger=self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_approve_article_publication.py
+++ b/tests/starter/test_starter_approve_article_publication.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from mock import patch
 from starter.starter_ApproveArticlePublication import starter_ApproveArticlePublication
 from starter.starter_helper import NullRequiredDataException
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
 from tests.activity.classes_mock import FakeLogger
@@ -54,9 +54,9 @@ class TestStarterApproveArticlePublication(unittest.TestCase):
             **invalid_data
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_approve_article_publication_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_approve_article_publication_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(
             settings=settings_mock, **test_data.ApprovePublication_data()
         )

--- a/tests/starter/test_starter_copy_glencoe_still_images.py
+++ b/tests/starter/test_starter_copy_glencoe_still_images.py
@@ -5,7 +5,7 @@ import starter.starter_CopyGlencoeStillImages as starter_module
 from starter.starter_CopyGlencoeStillImages import starter_CopyGlencoeStillImages
 from starter.starter_helper import NullRequiredDataException
 import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 
 
@@ -21,14 +21,14 @@ class TestStarterCopyGlencoeStillImages(unittest.TestCase):
             settings=settings_mock,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_copy_glencoe_still_images_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_copy_glencoe_still_images_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(settings=settings_mock, article_id="353")
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_main(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_main(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         env = "dev"
         doi_id = "7"
         testargs = ["starter_CopyGlencoeStillImages.py", "-e", env, "-a", doi_id, "-p"]

--- a/tests/starter/test_starter_deposit_crossref.py
+++ b/tests/starter/test_starter_deposit_crossref.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_DepositCrossref import starter_DepositCrossref
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterDepositCrossref(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_DepositCrossref(settings_mock, self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_deposit_crossref_peer_review.py
+++ b/tests/starter/test_starter_deposit_crossref_peer_review.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_DepositCrossrefPeerReview import starter_DepositCrossrefPeerReview
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -13,12 +13,12 @@ class TestStarterDepositCrossrefPeerReview(unittest.TestCase):
             settings_mock, self.fake_logger
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_deposit_crossref_pending_publication.py
+++ b/tests/starter/test_starter_deposit_crossref_pending_publication.py
@@ -4,7 +4,7 @@ from starter.starter_DepositCrossrefPendingPublication import (
     starter_DepositCrossrefPendingPublication,
 )
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -15,12 +15,12 @@ class TestStarterDepositCrossrefPendingPublication(unittest.TestCase):
             settings_mock, self.fake_logger
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_deposit_doaj.py
+++ b/tests/starter/test_starter_deposit_doaj.py
@@ -4,7 +4,7 @@ from starter.starter_DepositDOAJ import starter_DepositDOAJ
 from starter.starter_helper import NullRequiredDataException
 import tests.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 class TestStarterDepositDOAJ(unittest.TestCase):
@@ -20,15 +20,15 @@ class TestStarterDepositDOAJ(unittest.TestCase):
             info={},
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow_no_article_id(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow_no_article_id(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         info = {"article_id": ""}
         with self.assertRaises(NullRequiredDataException):
             self.starter.start(settings=settings_mock, info=info)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_deposit_doaj_start(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_deposit_doaj_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         info = {"article_id": "353"}
         self.starter.start(settings=settings_mock, info=info)

--- a/tests/starter/test_starter_ftp_article.py
+++ b/tests/starter/test_starter_ftp_article.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from mock import patch
 from starter.starter_FTPArticle import starter_FTPArticle
 from starter.starter_helper import NullRequiredDataException
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 
@@ -55,9 +55,9 @@ class TestStarterFTPArticle(unittest.TestCase):
             str(test_exception.exception), "Did not get a doi_id argument. Required."
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
+    @patch("boto3.client")
+    def test_start(self, fake_client):
         workflow = "HEFCE"
         doi_id = 3
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock, workflow, doi_id))

--- a/tests/starter/test_starter_helper.py
+++ b/tests/starter/test_starter_helper.py
@@ -1,8 +1,11 @@
 import unittest
 import json
 from ddt import ddt, data, unpack
-import starter.starter_helper as starter_helper
-import tests.test_data as test_data
+from mock import patch
+from starter import starter_helper
+from tests import test_data
+from tests.classes_mock import FakeSWFClient
+from tests.activity import settings_mock
 from tests.activity.classes_mock import FakeLogger
 
 
@@ -16,11 +19,11 @@ EXAMPLE_WORKFLOW_ID = (
 class TestStarterHelper(unittest.TestCase):
     @unpack
     @data(
-        {"data": test_data.data_published_lax, "execution": "lax"},
-        {"data": test_data.data_error_lax, "execution": "lax"},
-        {"data": test_data.data_published_website, "execution": "website"},
+        {"execution_data": test_data.data_published_lax, "execution": "lax"},
+        {"execution_data": test_data.data_error_lax, "execution": "lax"},
+        {"execution_data": test_data.data_published_website, "execution": "website"},
     )
-    def test_set_workflow_information_lax(self, data, execution):
+    def test_set_workflow_information_lax(self, execution_data, execution):
 
         (
             workflow_id,
@@ -33,19 +36,19 @@ class TestStarterHelper(unittest.TestCase):
             EXAMPLE_WORKFLOW_NAME,
             "1",
             None,
-            data,
-            "%s.%s" % (data.get("article_id"), data.get("version")),
+            execution_data,
+            "%s.%s" % (execution_data.get("article_id"), execution_data.get("version")),
             execution,
         )
 
         self.assertEqual(
-            EXAMPLE_WORKFLOW_ID(execution, data.get("version")), workflow_id
+            EXAMPLE_WORKFLOW_ID(execution, execution_data.get("version")), workflow_id
         )
         self.assertEqual(EXAMPLE_WORKFLOW_NAME, workflow_name)
         self.assertEqual("1", workflow_version)
         self.assertIsNone(child_policy)
         self.assertEqual("1800", execution_start_to_close_timeout)
-        self.assertEqual(json.dumps(data), workflow_input)
+        self.assertEqual(json.dumps(execution_data), workflow_input)
 
     def test_get_starter_module(self):
         "for coverage successful starter module import"
@@ -64,3 +67,10 @@ class TestStarterHelper(unittest.TestCase):
         starter_name = "not_a_starter"
         return_value = starter_helper.import_starter_module(starter_name, FakeLogger())
         self.assertFalse(return_value)
+
+    @patch("boto3.client")
+    def test_start_ping_marker(self, fake_client):
+        fake_logger = FakeLogger()
+        fake_client.return_value = FakeSWFClient()
+        starter_helper.start_ping_marker("workflow_id", settings_mock, fake_logger)
+        self.assertEqual(fake_logger.logexception, "First logger exception")

--- a/tests/starter/test_starter_ingest_accepted_submission.py
+++ b/tests/starter/test_starter_ingest_accepted_submission.py
@@ -6,7 +6,7 @@ from S3utility.s3_notification_info import S3NotificationInfo
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -26,9 +26,9 @@ class TestStarterIngestAcceptedSubmission(unittest.TestCase):
             info=test_data.data_error_lax,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start(
                 settings=settings_mock,
@@ -39,9 +39,9 @@ class TestStarterIngestAcceptedSubmission(unittest.TestCase):
             )
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start_workflow(
                 run=RUN_EXAMPLE,

--- a/tests/starter/test_starter_ingest_article_zip.py
+++ b/tests/starter/test_starter_ingest_article_zip.py
@@ -6,7 +6,7 @@ from S3utility.s3_notification_info import S3NotificationInfo
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -26,9 +26,9 @@ class TestStarterIngestArticleZip(unittest.TestCase):
             info={},
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_ingest_article_zip_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_ingest_article_zip_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(
             settings=settings_mock,
             run=RUN_EXAMPLE,

--- a/tests/starter/test_starter_ingest_decision_letter.py
+++ b/tests/starter/test_starter_ingest_decision_letter.py
@@ -6,7 +6,7 @@ from S3utility.s3_notification_info import S3NotificationInfo
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -26,9 +26,9 @@ class TestStarterIngestDecisionLetter(unittest.TestCase):
             info=test_data.data_error_lax,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_ingest_decision_letter_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_ingest_decision_letter_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start(
                 settings=settings_mock,
@@ -39,9 +39,9 @@ class TestStarterIngestDecisionLetter(unittest.TestCase):
             )
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start_workflow(
                 run=RUN_EXAMPLE,

--- a/tests/starter/test_starter_ingest_digest.py
+++ b/tests/starter/test_starter_ingest_digest.py
@@ -6,7 +6,7 @@ from S3utility.s3_notification_info import S3NotificationInfo
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -26,9 +26,9 @@ class TestStarterIngestDigest(unittest.TestCase):
             info=test_data.data_error_lax,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_ingest_digest_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_ingest_digest_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start(
                 settings=settings_mock,
@@ -37,9 +37,9 @@ class TestStarterIngestDigest(unittest.TestCase):
             )
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start_workflow(
                 run=RUN_EXAMPLE,

--- a/tests/starter/test_starter_lens_article_publish.py
+++ b/tests/starter/test_starter_lens_article_publish.py
@@ -4,7 +4,7 @@ from mock import patch
 from starter.starter_LensArticlePublish import starter_LensArticlePublish
 from starter.starter_helper import NullRequiredDataException
 import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 
 
@@ -38,8 +38,8 @@ class TestStarterLensArticlePublish(unittest.TestCase):
             "Did not get doi_id in starter LensArticlePublish",
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
+    @patch("boto3.client")
+    def test_start(self, fake_client):
         doi_id = 3
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock, doi_id))

--- a/tests/starter/test_starter_package_poa.py
+++ b/tests/starter/test_starter_package_poa.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_helper import NullRequiredDataException
 from starter.starter_PackagePOA import starter_PackagePOA
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 
@@ -20,8 +20,8 @@ class TestStarterPackagePOA(unittest.TestCase):
             document=None,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
+    @patch("boto3.client")
+    def test_start(self, fake_client):
         document = "document"
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock, document))

--- a/tests/starter/test_starter_ping.py
+++ b/tests/starter/test_starter_ping.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_Ping import starter_Ping
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterPing(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_Ping(settings_mock, self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_pmc_deposit.py
+++ b/tests/starter/test_starter_pmc_deposit.py
@@ -3,7 +3,7 @@ from mock import patch
 from starter.starter_helper import NullRequiredDataException
 from starter.starter_PMCDeposit import starter_PMCDeposit
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -20,8 +20,8 @@ class TestStarterPMCDeposit(unittest.TestCase):
             document=None,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
+    @patch("boto3.client")
+    def test_start(self, fake_client):
         document = "document"
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock, document))

--- a/tests/starter/test_starter_post_perfect_publication.py
+++ b/tests/starter/test_starter_post_perfect_publication.py
@@ -5,7 +5,7 @@ from starter.starter_PostPerfectPublication import starter_PostPerfectPublicatio
 from starter.starter_helper import NullRequiredDataException
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 
 
@@ -53,7 +53,7 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
             info=test_data.data_invalid_lax,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_post_perfect_publication_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_post_perfect_publication_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(info=test_data.data_error_lax, settings=settings_mock)

--- a/tests/starter/test_starter_process_article_zip.py
+++ b/tests/starter/test_starter_process_article_zip.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from mock import patch
 from starter.starter_ProcessArticleZip import starter_ProcessArticleZip
 from starter.starter_helper import NullRequiredDataException
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
@@ -55,7 +55,7 @@ class TestStarterProcessArticleZip(unittest.TestCase):
             **test_data.data_invalid_lax
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_process_article_zip_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_process_article_zip_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(settings=settings_mock, **test_data.data_ingested_lax)

--- a/tests/starter/test_starter_pub_router_deposit.py
+++ b/tests/starter/test_starter_pub_router_deposit.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from mock import patch
 from starter.starter_PubRouterDeposit import starter_PubRouterDeposit
 from starter.starter_helper import NullRequiredDataException
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger
 
@@ -36,8 +36,8 @@ class TestStarterPubRouterDeposit(unittest.TestCase):
             str(test_exception.exception), "Did not get a workflow argument. Required."
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
+    @patch("boto3.client")
+    def test_start(self, fake_client):
         workflow = "HEFCE"
-        fake_conn.return_value = FakeLayer1()
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock, workflow))

--- a/tests/starter/test_starter_publication_email.py
+++ b/tests/starter/test_starter_publication_email.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_PublicationEmail import starter_PublicationEmail
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterPublicationEmail(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_PublicationEmail(settings_mock, self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_publish_poa.py
+++ b/tests/starter/test_starter_publish_poa.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_PublishPOA import starter_PublishPOA
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterPublishPOA(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_PublishPOA(settings_mock, self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_pubmed_article_deposit.py
+++ b/tests/starter/test_starter_pubmed_article_deposit.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch
 from starter.starter_PubmedArticleDeposit import starter_PubmedArticleDeposit
 from tests.activity.classes_mock import FakeLogger
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import tests.settings_mock as settings_mock
 
 
@@ -11,12 +11,12 @@ class TestStarterPubmedArticleDeposit(unittest.TestCase):
         self.fake_logger = FakeLogger()
         self.starter = starter_PubmedArticleDeposit(settings_mock, self.fake_logger)
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_conn):
-        fake_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(self.starter.start_workflow())

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -6,7 +6,7 @@ from starter.starter_helper import NullRequiredDataException
 from S3utility.s3_notification_info import S3NotificationInfo
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -61,9 +61,9 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
             info={},
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_silent_corrections_ingest_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_silent_corrections_ingest_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(
             settings=settings_mock,
             run=RUN_EXAMPLE,

--- a/tests/starter/test_starter_silent_corrections_process.py
+++ b/tests/starter/test_starter_silent_corrections_process.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from mock import patch
 from starter.starter_SilentCorrectionsProcess import starter_SilentCorrectionsProcess
 from starter.starter_helper import NullRequiredDataException
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
 import tests.test_data as test_data
@@ -55,7 +55,7 @@ class TestStarterSilentCorrectionsProcess(unittest.TestCase):
             **test_data.data_invalid_lax
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_process_article_zip_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_process_article_zip_starter(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.starter.start(settings=settings_mock, **test_data.data_ingested_lax)

--- a/tests/starter/test_starter_software_heritage_deposit.py
+++ b/tests/starter/test_starter_software_heritage_deposit.py
@@ -5,7 +5,7 @@ from starter.starter_SoftwareHeritageDeposit import starter_SoftwareHeritageDepo
 from starter.starter_helper import NullRequiredDataException
 from tests.activity.classes_mock import FakeLogger
 import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 
 
 RUN_EXAMPLE = u"1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
@@ -41,9 +41,9 @@ class TestStarterSoftwareHeritageDeposit(unittest.TestCase):
             info=info,
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_ingest_decision_letter_starter_no_run_argument(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_software_heritage_start_no_run_argument(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start(
                 settings=settings_mock,
@@ -52,9 +52,9 @@ class TestStarterSoftwareHeritageDeposit(unittest.TestCase):
             )
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_ingest_decision_letter_starter(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_software_heritage_start(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start(
                 settings=settings_mock,
@@ -63,9 +63,9 @@ class TestStarterSoftwareHeritageDeposit(unittest.TestCase):
             )
         )
 
-    @patch("boto.swf.layer1.Layer1")
-    def test_start_workflow(self, fake_boto_conn):
-        fake_boto_conn.return_value = FakeLayer1()
+    @patch("boto3.client")
+    def test_start_workflow(self, fake_client):
+        fake_client.return_value = FakeSWFClient()
         self.assertIsNone(
             self.starter.start_workflow(
                 run=RUN_EXAMPLE,

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -4,7 +4,7 @@ from pytz import timezone
 from ddt import ddt, data
 from mock import patch
 import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeLayer1
+from tests.classes_mock import FakeSWFClient
 import cron
 
 
@@ -75,8 +75,8 @@ class TestCron(unittest.TestCase):
         )
         self.assertEqual(return_value, test_data.get("expected"))
 
-    @patch.object(FakeLayer1, "start_workflow_execution")
-    @patch("boto.swf.layer1.Layer1")
+    @patch.object(FakeSWFClient, "start_workflow_execution")
+    @patch("boto3.client")
     @data(
         {"starter_name": "starter_AdminEmail", "workflow_id": "AdminEmail"},
         {
@@ -89,8 +89,8 @@ class TestCron(unittest.TestCase):
         },
         {"starter_name": "starter_PublishPOA", "workflow_id": "PublishPOA"},
     )
-    def test_start_workflow(self, test_data, fake_conn, fake_start):
-        fake_conn.return_value = FakeLayer1()
+    def test_start_workflow(self, test_data, fake_client, fake_start):
+        fake_client.return_value = FakeSWFClient()
         fake_start.return_value = {}
         starter_name = test_data.get("starter_name")
         workflow_id = test_data.get("workflow_id")

--- a/tests/test_queue_workflow_starter.py
+++ b/tests/test_queue_workflow_starter.py
@@ -1,10 +1,9 @@
 import unittest
 import json
-import boto.swf.layer1
 from mock import patch
 from testfixtures import TempDirectory
-import tests.settings_mock as settings_mock
-from tests.classes_mock import FakeFlag, FakeBotoConnection
+from tests import settings_mock
+from tests.classes_mock import FakeFlag, FakeSWFClient
 from tests.activity.classes_mock import FakeSQSMessage, FakeSQSQueue, FakeLogger
 import queue_workflow_starter
 
@@ -18,61 +17,72 @@ class TestQueueWorkflowStarter(unittest.TestCase):
 
     @patch("tests.activity.classes_mock.FakeSQSQueue.get_messages")
     @patch("queue_workflow_starter.get_queue")
-    @patch.object(boto.swf.layer1, "Layer1")
-    def test_main(self, fake_boto_conn, mock_queue, mock_queue_read):
+    @patch("boto3.client")
+    @patch("log.logger")
+    def test_main(self, fake_logger, fake_client, mock_queue, mock_queue_read):
         directory = TempDirectory()
         message_body = json.dumps({"workflow_name": "Ping", "workflow_data": {}})
-        mock_boto_connection = FakeBotoConnection()
-        fake_boto_conn.return_value = mock_boto_connection
+        fake_client.return_value = FakeSWFClient()
+        mock_logger = FakeLogger()
+        fake_logger.return_value = mock_logger
         mock_queue.return_value = FakeSQSQueue(directory)
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         mock_queue_read.return_value = [fake_message]
         queue_workflow_starter.main(settings_mock, FakeFlag())
-        self.assertEqual(mock_boto_connection.start_called, True)
+        self.assertTrue("Starting workflow: Ping_" in str(mock_logger.loginfo))
 
-    @patch.object(boto.swf.layer1, "Layer1")
-    def test_process_message(self, fake_boto_conn):
+    @patch("boto3.client")
+    @patch("log.logger")
+    def test_process_message(self, fake_logger, fake_client):
         directory = TempDirectory()
         message_body = json.dumps(
             {"workflow_name": "PubmedArticleDeposit", "workflow_data": {}}
         )
-        mock_boto_connection = FakeBotoConnection()
-        fake_boto_conn.return_value = mock_boto_connection
+        fake_client.return_value = FakeSWFClient()
+        mock_logger = FakeLogger()
+        fake_logger.return_value = mock_logger
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         queue_workflow_starter.process_message(
             settings_mock, FakeLogger(), fake_message
         )
-        self.assertEqual(mock_boto_connection.start_called, True)
+        self.assertTrue(
+            "Starting workflow: PubmedArticleDeposit" in str(mock_logger.loginfo)
+        )
 
-    @patch.object(boto.swf.layer1, "Layer1")
-    def test_process_message_no_data_processor(self, fake_boto_conn):
+    @patch("boto3.client")
+    @patch("log.logger")
+    def test_process_message_no_data_processor(self, fake_logger, fake_client):
         directory = TempDirectory()
         message_body = json.dumps({"workflow_name": "Ping", "workflow_data": {}})
-        mock_boto_connection = FakeBotoConnection()
-        fake_boto_conn.return_value = mock_boto_connection
+        fake_client.return_value = FakeSWFClient()
+        mock_logger = FakeLogger()
+        fake_logger.return_value = mock_logger
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         queue_workflow_starter.process_message(
             settings_mock, FakeLogger(), fake_message
         )
-        self.assertEqual(mock_boto_connection.start_called, True)
+        self.assertTrue("Starting workflow: Ping_" in str(mock_logger.loginfo))
 
-    @patch.object(boto.swf.layer1, "Layer1")
-    def test_process_message_fail_to_start_workflow(self, fake_boto_conn):
+    @patch("boto3.client")
+    @patch("log.logger")
+    def test_process_message_fail_to_start_workflow(self, fake_logger, fake_client):
         directory = TempDirectory()
         message_body = json.dumps(
             {"workflow_name": "not_a_real_workflow", "workflow_data": {}}
         )
-        mock_boto_connection = FakeBotoConnection()
-        fake_boto_conn.return_value = mock_boto_connection
+        fake_client.return_value = FakeSWFClient()
+        mock_logger = FakeLogger()
+        fake_logger.return_value = mock_logger
         fake_message = FakeSQSMessage(directory)
         fake_message.set_body(message_body)
         queue_workflow_starter.process_message(
             settings_mock, FakeLogger(), fake_message
         )
-        self.assertEqual(mock_boto_connection.start_called, None)
+        # log only contains the First logger info message since no workflow was started
+        self.assertTrue(len(mock_logger.loginfo) == 1)
 
     def test_process_data_ingestarticlezip(self):
         workflow_data = {


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7158

Changing the starters and related code to use the `boto3` library, allows for the older Layer1 and boto.swf libraries to be removed completely.