### PR TITLE
Fix import boto in cron_NewS3POA.py

### DIFF
--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -1,3 +1,4 @@
+import boto
 from provider import utils
 import starter.starter_helper as helper
 from starter.objects import Starter


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1405

Removing `import boto.swf` from this module caused `boto.sqs.connect_to_region()` to fail. Add back `import boto` to fix it.