### PR TITLE
dashboard_queue.py boto3 sns client ; tests added

### DIFF
--- a/dashboard_queue.py
+++ b/dashboard_queue.py
@@ -1,19 +1,20 @@
-import boto.sqs
-import boto.sns
 import json
 import uuid
+import boto3
 from provider.utils import unicode_encode
 
 
 def send_message(message, settings):
 
-    conn = boto.sns.connect_to_region(
-        settings.sqs_region,
+    sns_client = boto3.client(
+        "sns",
         aws_access_key_id=settings.aws_access_key_id,
         aws_secret_access_key=settings.aws_secret_access_key,
+        region_name=settings.sqs_region,
     )
+
     payload = unicode_encode(json.dumps(message))
-    conn.publish(topic=settings.event_monitor_topic, message=payload)
+    sns_client.publish(TopicArn=settings.event_monitor_topic, Message=payload)
 
 
 def build_event_message(

--- a/tests/test_dashboard_queue.py
+++ b/tests/test_dashboard_queue.py
@@ -1,0 +1,71 @@
+import unittest
+import datetime
+from mock import patch
+import dashboard_queue
+
+
+class TestDashboardQueue(unittest.TestCase):
+    @patch("uuid.uuid4")
+    def test_build_event_message(self, fake_uuid4):
+        fake_uuid4.return_value = "uuid"
+        now = datetime.datetime.now()
+        item_identifier = "00666"
+        version = "1"
+        run = "run"
+        event_type = "PingWorker"
+        status = "start"
+        message = "Started PingWorker"
+        message_returned = dashboard_queue.build_event_message(
+            item_identifier, version, run, event_type, now, status, message
+        )
+        expected = {
+            "message_type": "event",
+            "item_identifier": item_identifier,
+            "version": version,
+            "run": run,
+            "event_type": event_type,
+            "timestamp": now.isoformat(),
+            "status": status,
+            "message": message,
+            "message_id": "uuid",
+        }
+        self.assertDictEqual(message_returned, expected)
+
+    def test_build_event_message_timestamp_exception(self):
+        """
+        test an unacceptable timestamp value:
+        AttributeError: 'str' object has no attribute 'isoformat'
+        """
+        with self.assertRaises(AttributeError):
+            dashboard_queue.build_event_message(
+                item_identifier="",
+                version="",
+                run="",
+                event_type="",
+                timestamp="",
+                status="",
+                message="",
+            )
+
+    @patch("uuid.uuid4")
+    def test_build_property_message(self, fake_uuid4):
+        fake_uuid4.return_value = "uuid"
+        item_identifier = "00666"
+        version = "1"
+        name = "publication-status"
+        value = "ready to publish"
+        property_type = "text"
+        message_returned = dashboard_queue.build_property_message(
+            item_identifier, version, name, value, property_type
+        )
+        expected = {
+            "message_type": "property",
+            "item_identifier": item_identifier,
+            "version": version,
+            "name": name,
+            "value": value,
+            "property_type": property_type,
+            "message_id": "uuid",
+        }
+
+        self.assertDictEqual(message_returned, expected)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/7159

Update the one place where it connects to SNS to use boto3 library. Added some test scenarios for message generation functions. `end2end` testing should hopefully indicate whether the SNS client works properly.