### PR TITLE
Use 10 minute timeout for PostPerfectPublication.

### DIFF
--- a/starter/starter_PostPerfectPublication.py
+++ b/starter/starter_PostPerfectPublication.py
@@ -32,6 +32,7 @@ class starter_PostPerfectPublication(Starter):
         )
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 10)
 
         workflow_params["input"] = json.dumps(info, default=lambda ob: None)
 

--- a/tests/starter/test_starter_post_perfect_publication.py
+++ b/tests/starter/test_starter_post_perfect_publication.py
@@ -23,7 +23,7 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
                 ("workflow_name", "PostPerfectPublication"),
                 ("workflow_version", "1"),
                 ("child_policy", None),
-                ("execution_start_to_close_timeout", None),
+                ("execution_start_to_close_timeout", "600"),
                 (
                     "input",
                     (


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7230

Processing a large article zip file is taking at least six minutes, exceeding the default five minute workflow start to close timeout. Extend it to ten minutes.