### PR TITLE
Use boto3 sqs client in queue workers.

### DIFF
--- a/S3utility/s3_sqs_message.py
+++ b/S3utility/s3_sqs_message.py
@@ -1,13 +1,12 @@
-from boto.sqs.message import Message
 import json
 from S3utility.s3_notification_info import S3NotificationInfo
 
 
-class S3SQSMessage(Message):
-    def __init__(self, queue=None, body="", xml_attrs=None):
-        Message.__init__(self, queue, body)
+class S3SQSMessage:
+    def __init__(self, body=""):
         self.payload = None
         self.notification_type = "S3Info"
+        self.set_body(body)
 
     def event_name(self):
         return self.payload["Records"][0]["eventName"]
@@ -39,4 +38,3 @@ class S3SQSMessage(Message):
             self.payload = json.loads(body)
         if body and "Records" in list(self.payload.keys()):
             self.notification_type = "S3Event"
-        super(Message, self).set_body(body)

--- a/starter/cron_NewS3POA.py
+++ b/starter/cron_NewS3POA.py
@@ -1,4 +1,4 @@
-import boto
+import boto3
 from provider import utils
 import starter.starter_helper as helper
 from starter.objects import Starter
@@ -31,33 +31,30 @@ class cron_NewS3POA(Starter):
         helper.start_ping_marker(ping_marker_id, self.settings, self.logger)
 
         # Get data from SQS queue
-        sqs_conn = sqs_connect(self.settings)
-        sqs_queue = get_sqs_queue(sqs_conn, self.settings)
-        process_queue(sqs_queue, self.settings, self.logger)
+        sqs_client = sqs_connect(self.settings)
+        process_queue(sqs_client, self.settings, self.logger)
 
 
 def sqs_connect(settings):
     """connect to the queue service"""
-    return boto.sqs.connect_to_region(
-        settings.sqs_region,
+    return boto3.client(
+        "sqs",
         aws_access_key_id=settings.aws_access_key_id,
         aws_secret_access_key=settings.aws_secret_access_key,
+        region_name=settings.sqs_region,
     )
 
 
-def get_sqs_queue(sqs_conn, settings):
-    """get the queue"""
-    queue = sqs_conn.get_queue(settings.poa_incoming_queue)
-    queue.set_message_class(S3SQSMessage)
-    return queue
-
-
-def process_queue(sqs_queue, settings, logger):
+def process_queue(sqs_client, settings, logger):
     """reach each message from the queue, start a workflow, then delete the message"""
     message_count = 0
+    queue_url_response = sqs_client.get_queue_url(QueueName=settings.poa_incoming_queue)
+    queue_url = queue_url_response.get("QueueUrl")
     while True:
         try:
-            messages = get_queue_messages(sqs_queue, MAX_MESSAGE_COUNT, logger)
+            messages = get_queue_messages(
+                sqs_client, queue_url, MAX_MESSAGE_COUNT, logger
+            )
         except:
             logger.exception(
                 "Breaking process queue read loop, failed to get messages from queue"
@@ -65,43 +62,53 @@ def process_queue(sqs_queue, settings, logger):
             break
 
         # check if any messages to process
-        if not messages:
+        if not messages.get("Messages"):
             logger.info("no messages available")
             break
         else:
             logger.info("Processing %s messages" % len(messages))
 
         # process each message, deleting each message when done
-        for message in messages:
+        for message in messages.get("Messages"):
             # increment count
             message_count += 1
             logger.info("Processing message number %s", message_count)
 
+            s3_message = S3SQSMessage(message.get("Body"))
             # check message type
-            if message.notification_type != "S3Event":
+            if s3_message.notification_type != "S3Event":
                 logger.info(
                     "Message not processed, deleting it from queue: %s"
-                    % message.get_body()
+                    % s3_message.payload
                 )
-                sqs_queue.delete_message(message)
+                sqs_client.delete_message(
+                    QueueUrl=queue_url,
+                    ReceiptHandle=message.get("ReceiptHandle"),
+                )
                 continue
 
             # start a workflow
             try:
-                logger.info("Starting workflow for message: %s" % message)
-                start_package_poa_workflow(message, settings, logger)
+                logger.info("Starting workflow for message: %s" % s3_message)
+                start_package_poa_workflow(s3_message, settings, logger)
             except:
                 logger.exception(
                     "Exception processing message, deleting it from queue: %s"
-                    % message.get_body()
+                    % s3_message.payload
                 )
             finally:
-                sqs_queue.delete_message(message)
+                sqs_client.delete_message(
+                    QueueUrl=queue_url,
+                    ReceiptHandle=message.get("ReceiptHandle"),
+                )
 
 
-def get_queue_messages(sqs_queue, num_messages, logger):
+def get_queue_messages(sqs_client, queue_url, num_messages, logger):
     try:
-        return sqs_queue.get_messages(num_messages)
+        return sqs_client.receive_message(
+            QueueUrl=queue_url,
+            MaxNumberOfMessages=num_messages,
+        )
     except:
         logger.exception("Exception in getting messages from SQS queue")
         raise

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -122,45 +122,6 @@ class FakeFlag:
         return return_value
 
 
-class FakeS3Event:
-    "object to test an S3 notification event from an SQS queue"
-
-    def __init__(self, bucket_name=None):
-        self.notification_type = "S3Event"
-        self.id = None
-        self.body = ""
-        # test data below
-        self._event_name = u"ObjectCreated:Put"
-        self._event_time = u"2016-07-28T16:14:27.809576Z"
-        self._bucket_name = u"jen-elife-production-final"
-        if bucket_name:
-            self._bucket_name = bucket_name
-        self._file_name = u"elife-00353-vor-r1.zip"
-        self._file_etag = u"e7f639f63171c097d4761e2d2efe8dc4"
-        self._file_size = 1097506
-
-    def get_body(self):
-        return self.body
-
-    def event_name(self):
-        return self._event_name
-
-    def event_time(self):
-        return self._event_time
-
-    def bucket_name(self):
-        return self._bucket_name
-
-    def file_name(self):
-        return self._file_name
-
-    def file_etag(self):
-        return self._file_etag
-
-    def file_size(self):
-        return self._file_size
-
-
 class FakeSMTPServer:
     def __init__(self, tmp_dir):
         self.number = 0

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -13,7 +13,7 @@ s3_session_bucket = "origin_bucket"
 aws_access_key_id = ""
 aws_secret_access_key = ""
 
-workflow_starter_queue = ""
+workflow_starter_queue = "workflow_starter_queue"
 sqs_region = ""
 S3_monitor_queue = "incoming_queue"
 
@@ -29,7 +29,7 @@ bot_bucket = "bot_bucket"
 lens_bucket = "dest_bucket"
 poa_packaging_bucket = "poa_packaging_bucket"
 poa_bucket = "poa_bucket"
-poa_incoming_queue = ""
+poa_incoming_queue = "poa_incoming_queue"
 ses_poa_sender_email = ""
 ses_poa_recipient_email = ""
 

--- a/tests/starter/test_cron_new_s3_poa.py
+++ b/tests/starter/test_cron_new_s3_poa.py
@@ -1,54 +1,71 @@
 import unittest
+import json
 from mock import patch
 import botocore
 from testfixtures import TempDirectory
+from S3utility.s3_sqs_message import S3SQSMessage
 import starter.cron_NewS3POA as starter_module
 from starter.cron_NewS3POA import cron_NewS3POA
-from tests.classes_mock import FakeSWFClient, FakeS3Event
-from tests.activity.classes_mock import FakeLogger, FakeSQSConn, FakeSQSQueue
-import tests.settings_mock as settings_mock
+from tests.classes_mock import FakeSWFClient
+from tests.activity.classes_mock import FakeLogger, FakeSQSClient, FakeSQSQueue
+from tests import settings_mock, test_data
 
 
 class TestCronNewS3POA(unittest.TestCase):
     def setUp(self):
         self.fake_logger = FakeLogger()
         self.starter = cron_NewS3POA(settings_mock, logger=self.fake_logger)
+        # queue data for reuse
+        # create an S3 event message
+        self.records = test_data.test_s3_event_records(
+            bucket="poa", key="18022_1_supp_mat_highwire_zip_268991_x75s4v.zip"
+        )
+        self.fake_queue_messages = [
+            {"Messages": [{"ReceiptHandle": "id", "Body": json.dumps(self.records)}]}
+        ]
 
     def tearDown(self):
         TempDirectory.cleanup_all()
 
-    @patch.object(starter_module, "get_sqs_queue")
-    @patch.object(starter_module, "sqs_connect")
-    @patch("boto3.client")
-    def test_start(self, fake_client, mock_sqs_connect, mock_queue):
+    @patch("starter.cron_NewS3POA.sqs_connect")
+    @patch("starter.objects.boto3.client")
+    def test_start(self, fake_swf_client, fake_sqs_client):
         directory = TempDirectory()
-        fake_client.return_value = FakeSWFClient()
-        mock_sqs_connect.return_value = FakeSQSConn(directory)
-        s3_event = FakeS3Event()
-        mock_queue.return_value = FakeSQSQueue(directory, messages=[s3_event])
+        fake_swf_client.return_value = FakeSWFClient()
+        # mock the SQS client and queues
+        fake_queues = {
+            settings_mock.poa_incoming_queue: FakeSQSQueue(
+                directory, self.fake_queue_messages
+            ),
+        }
+        fake_sqs_client.return_value = FakeSQSClient(directory, queues=fake_queues)
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch.object(starter_module, "get_sqs_queue")
-    @patch.object(starter_module, "sqs_connect")
-    @patch("boto3.client")
-    def test_start_no_messages(self, fake_client, mock_sqs_connect, mock_queue):
+    @patch("tests.activity.classes_mock.FakeSQSClient.receive_message")
+    @patch("starter.cron_NewS3POA.sqs_connect")
+    @patch("starter.objects.boto3.client")
+    def test_start_no_messages(
+        self, fake_swf_client, fake_sqs_client, fake_receive_message
+    ):
         directory = TempDirectory()
-        fake_client.return_value = FakeSWFClient()
-        mock_sqs_connect.return_value = FakeSQSConn(directory)
-        mock_queue.return_value = FakeSQSQueue(directory)
+        fake_swf_client.return_value = FakeSWFClient()
+        fake_sqs_client.return_value = FakeSQSClient(directory)
+        fake_receive_message.return_value = {}
+        # mock_queue.return_value = FakeSQSQueue(directory)
         self.assertIsNone(self.starter.start(settings_mock))
 
     @patch.object(FakeSWFClient, "start_workflow_execution")
-    @patch.object(starter_module, "get_sqs_queue")
-    @patch.object(starter_module, "sqs_connect")
-    @patch("boto3.client")
-    def test_start_exception(
-        self, fake_client, mock_sqs_connect, mock_queue, fake_start
-    ):
+    @patch("starter.cron_NewS3POA.sqs_connect")
+    @patch("starter.objects.boto3.client")
+    def test_start_exception_old(self, fake_swf_client, fake_sqs_client, fake_start):
         directory = TempDirectory()
-        fake_client.return_value = FakeSWFClient()
-        mock_sqs_connect.return_value = FakeSQSConn(directory)
-        mock_queue.return_value = FakeSQSQueue(directory)
+        fake_swf_client.return_value = FakeSWFClient()
+        fake_queues = {
+            settings_mock.poa_incoming_queue: FakeSQSQueue(
+                directory, self.fake_queue_messages
+            ),
+        }
+        fake_sqs_client.return_value = FakeSQSClient(directory, queues=fake_queues)
         mock_exception = botocore.exceptions.ClientError(
             {"Error": {"Code": "WorkflowExecutionAlreadyStartedFault"}},
             "operation_name",
@@ -56,21 +73,23 @@ class TestCronNewS3POA(unittest.TestCase):
         fake_start.side_effect = mock_exception
         self.assertIsNone(self.starter.start(settings_mock))
 
-    @patch.object(FakeSQSQueue, "get_messages")
-    def test_get_queue_messages_exception(self, fake_get_messages):
+    @patch.object(FakeSQSClient, "receive_message")
+    def test_get_queue_messages_exception(self, fake_receive_message):
         directory = TempDirectory()
-        fake_queue = FakeSQSQueue(directory)
-        fake_get_messages.side_effect = Exception("Get messages exception")
+        fake_sqs_client = FakeSQSClient(directory)
+        fake_receive_message.side_effect = Exception("Get messages exception")
         with self.assertRaises(Exception):
-            starter_module.get_queue_messages(fake_queue, 1, FakeLogger())
+            starter_module.get_queue_messages(
+                fake_sqs_client, "queue_url", 1, FakeLogger()
+            )
 
-    @patch.object(FakeSQSQueue, "get_messages")
-    def test_process_queue_exception(self, fake_get_messages):
+    @patch.object(FakeSQSClient, "receive_message")
+    def test_process_queue_exception(self, fake_receive_message):
         directory = TempDirectory()
-        fake_queue = FakeSQSQueue(directory)
-        fake_get_messages.side_effect = Exception("Get messages exception")
+        fake_sqs_client = FakeSQSClient(directory)
+        fake_receive_message.side_effect = Exception("Get messages exception")
         logger = FakeLogger()
-        starter_module.process_queue(fake_queue, settings_mock, logger)
+        starter_module.process_queue(fake_sqs_client, settings_mock, logger)
         self.assertEqual(
             logger.logexception,
             "Breaking process queue read loop, failed to get messages from queue",
@@ -78,38 +97,54 @@ class TestCronNewS3POA(unittest.TestCase):
 
     def test_process_queue_ignored_message(self):
         directory = TempDirectory()
-        s3_event = FakeS3Event()
         logger = FakeLogger()
-        # here change the event type so it is ignored
-        s3_event.notification_type = "foo"
-        fake_queue = FakeSQSQueue(directory, messages=[s3_event])
-        starter_module.process_queue(fake_queue, settings_mock, logger)
+        # change the message Body so it is not considered an S3Event
+        records = {"foo": "bar"}
+        fake_queue_messages = [
+            {"Messages": [{"ReceiptHandle": "id", "Body": json.dumps(records)}]}
+        ]
+        fake_queues = {
+            settings_mock.poa_incoming_queue: FakeSQSQueue(
+                directory, fake_queue_messages
+            ),
+        }
+        fake_sqs_client = FakeSQSClient(directory, queues=fake_queues)
+        starter_module.process_queue(fake_sqs_client, settings_mock, logger)
         self.assertEqual(
-            logger.loginfo[-2], "Message not processed, deleting it from queue: "
+            logger.loginfo[-2],
+            "Message not processed, deleting it from queue: %s" % records,
         )
         self.assertEqual(logger.loginfo[-1], "no messages available")
 
     @patch.object(starter_module, "start_package_poa_workflow")
     def test_process_queue_starter_exception(self, fake_start_workflow):
         directory = TempDirectory()
-        s3_event = FakeS3Event()
+
         logger = FakeLogger()
-        fake_queue = FakeSQSQueue(directory, messages=[s3_event])
+        fake_queues = {
+            settings_mock.poa_incoming_queue: FakeSQSQueue(
+                directory, self.fake_queue_messages
+            ),
+        }
+        fake_sqs_client = FakeSQSClient(directory, queues=fake_queues)
         fake_start_workflow.side_effect = Exception("Failed to start workflow")
-        starter_module.process_queue(fake_queue, settings_mock, logger)
+        starter_module.process_queue(fake_sqs_client, settings_mock, logger)
         self.assertEqual(
             logger.logexception,
-            "Exception processing message, deleting it from queue: ",
+            "Exception processing message, deleting it from queue: %s" % self.records,
         )
 
-    @patch("boto3.client")
-    def test_start_package_poa_workflow_exception(self, fake_client):
-        s3_event = FakeS3Event()
+    @patch("starter.objects.boto3.client")
+    def test_start_package_poa_workflow_exception(self, fake_swf_client):
+        s3_message = S3SQSMessage(body=json.dumps(self.records))
         logger = FakeLogger()
-        fake_client.side_effect = Exception("Failed to start workflow")
+        fake_swf_client.side_effect = Exception("Failed to start workflow")
         with self.assertRaises(Exception):
-            starter_module.start_package_poa_workflow(s3_event, settings_mock, logger)
+            starter_module.start_package_poa_workflow(s3_message, settings_mock, logger)
         self.assertEqual(
             logger.logexception,
-            "Error: starting starter_PackagePOA for document elife-00353-vor-r1.zip",
+            (
+                "Error: starting starter_PackagePOA for document "
+                "18022_1_supp_mat_highwire_zip_268991_x75s4v.zip"
+            ),
         )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -290,3 +290,29 @@ glencoe_metadata = {
         "size": 21300934,
     },
 }
+
+
+def test_s3_event_records(bucket=None, key=None):
+    "sample s3 notification records data"
+    if not bucket:
+        bucket = "continuumtest-elife-accepted-submission-cleaning"
+    if not key:
+        key = "02-09-2022-RA-eLife-99999.zip"
+    return {
+        "Records": [
+            {
+                "eventTime": "2022-02-09T01:43:07.709Z",
+                "eventName": "ObjectCreated:CompleteMultipartUpload",
+                "s3": {
+                    "bucket": {
+                        "name": bucket,
+                    },
+                    "object": {
+                        "key": key,
+                        "size": 19464507,
+                        "eTag": "28b76c025ab9bd3a967885302d413efa-3",
+                    },
+                },
+            }
+        ]
+    }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7160

First set of code changes to use `boto3` library to read SQS queues. The code here depended on the class `S3SQSMessage()` defined in this project which was used in `boto` to set the SQS queue message class. In `boto3`, there is no message class, and `S3SQSMessage` is refactored to accept a body argument and is no longer derived from a boto `Message` class.

The two parts reading S3 notificaitons from queues are the `queue_worker.py` and the `starter/cron_NewS3POA.py` module.

`queue_worker.py` was tested on a read AWS envrionment, a dev one, and it should confidently pass end2end tests.

The PoA queue listener will be tested on the `continuumtest` environment when the new code is available there, and code can be bug fixed, if required, before it is deployed to the `prod` environment.