### PR TITLE
Extend SilentCorrectionsIngest workflow timeout.

### DIFF
--- a/starter/starter_SilentCorrectionsIngest.py
+++ b/starter/starter_SilentCorrectionsIngest.py
@@ -26,6 +26,7 @@ class starter_SilentCorrectionsIngest(Starter):
         )
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
+        workflow_params["execution_start_to_close_timeout"] = str(60 * 60)
 
         input_data = S3NotificationInfo.to_dict(info)
         input_data["run"] = run

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -26,7 +26,7 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
                 ("workflow_name", "SilentCorrectionsIngest"),
                 ("workflow_version", "1"),
                 ("child_policy", None),
-                ("execution_start_to_close_timeout", None),
+                ("execution_start_to_close_timeout", "3600"),
                 (
                     "input",
                     (


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7230

A large zip file when procesesd in the `SilentCorrectionsIngest` workflow exceeds the default workflow start to close execution timeout of 5 minutes. Change the timeout to be 60 minutes, the same as is currently used in the `IngestArticleZip` workflow.