### PR TITLE
lax_response_adapter.py using boto3 sqs client.

### DIFF
--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -13,6 +13,8 @@ s3_session_bucket = "origin_bucket"
 aws_access_key_id = ""
 aws_secret_access_key = ""
 
+lax_response_queue = "lax_response_queue"
+
 workflow_starter_queue = "workflow_starter_queue"
 sqs_region = ""
 S3_monitor_queue = "incoming_queue"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7160

Changes to the `queue_workflow_starter.py` in PR https://github.com/elifesciences/elife-bot/pull/1414 has caused `end2end` testing to fail due to what looks like a mismatch between `boto` and `boto3` message formats.

This should hopefully set things in the right direction so the messages added by the `lax_response_adapter.py` to the workflow starter queue are not encoded and the data is readable from the `Body` attribute of the message.

If `end2end` testing continue to fail, there will probably be another PR to try and fix any remaining bugs.