### PR TITLE
base64 decode messages in workflow starter queue.

### DIFF
--- a/queue_workflow_starter.py
+++ b/queue_workflow_starter.py
@@ -44,7 +44,7 @@ def main(settings, flag):
             WaitTimeSeconds=20,
         )
         if messages.get("Messages"):
-            logger.info(str(len(messages)) + " message received")
+            logger.info(str(len(messages.get("Messages"))) + " message received")
             message = messages.get("Messages")[0]
             logger.info("message contents: %s", message.get("Body"))
             process_message(settings, logger, message)
@@ -69,8 +69,15 @@ def connect(settings):
 
 
 def process_message(settings, logger, message):
+    message_payload = {}
     try:
         message_payload = json.loads(str(bytes_decode(message.get("Body"))))
+    except json.decoder.JSONDecodeError:
+        # decode messages from the dashboard queue
+        decoded_body = utils.base64_decode_string(message.get("Body"))
+        message_payload = json.loads(decoded_body)
+
+    try:
         name = message_payload.get("workflow_name")
         data = message_payload.get("workflow_data")
         start_workflow(settings, name, data)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7160

A potential bug fix to the previous two PRs. The workflow starter message added by the continuum dashboard to start an `ApproveArticlePublication` workflow has an encoded  body, which when switching away from `boto` `Message` objects to use `boto3`, the message is not getting decoded automatically. This will attempt to base64 decode the message if it fails to be parsed as a JSON string.