### PR TITLE
boto3 SQS client to communicate with Lax.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -42,21 +42,6 @@ class FakeS3Connection:
         return self.get_bucket(mock_bucket_name)
 
 
-class FakeSQSMessage:
-    def __init__(self, directory):
-        self.dir = directory
-
-    def set_body(self, body):
-        # write bytes
-        self.dir.write("fake_sqs_body", bytes(body, "utf-8"))
-
-    def get_body(self):
-        return self.dir.read("fake_sqs_body")
-
-    def delete(self):
-        pass
-
-
 class FakeSQSClient:
     def __init__(self, directory=None, queues=None):
         self.dir = directory
@@ -93,40 +78,12 @@ class FakeSQSClient:
             ]
 
 
-class FakeSQSConn:
-    def __init__(self, directory):
-        self.dir = directory
-
-    def get_queue(self, queue):
-        return FakeSQSQueue(self.dir)  # self.get_object('FakeSQSQueue', self.dir)
-
-
 class FakeSQSQueue:
     def __init__(self, directory, messages=None):
         self.dir = directory
         self.messages = []
         if messages:
             self.messages = messages
-
-    # def write(self, body_dir):
-    #     self.dir.write("fake_sqs_queue_container", body_dir.read("fake_sqs_body"))
-    def write(self, message):
-        self.dir.write("fake_sqs_queue_container", message.dir.read("fake_sqs_body"))
-
-    def read(self, dir_name):
-        return self.dir.read(dir_name)
-
-    def get_messages(self, num_messages=1):
-        "for mocking return a list of messages"
-        return self.messages
-
-    def delete_message(self, message):
-        self.messages = [
-            q_message for q_message in self.messages if message != q_message
-        ]
-
-    def set_message_class(self, message_class):
-        pass
 
 
 class FakeFTP:


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7160

Final parts to be converted over to use `boto3` for SQS communication are the two activities which write queue messages for Lax to read.

This also allows for the deletion of old test classes and methods which are no longer present in the `boto3` library.

`end2end` tests will be expected to catch any bugs when sending messages to Lax.