### PR TITLE
Change storage_provider.py list_resources()

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -55,6 +55,8 @@ class activity_ConvertImagesToJPG(Activity):
 
             storage = storage_context(self.settings)
             files_in_bucket = storage.list_resources(orig_resource)
+            # remove the subfolder name from file names
+            files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
 
             figures = []
             figures += list(filter(article_structure.article_figure, files_in_bucket))
@@ -68,6 +70,7 @@ class activity_ConvertImagesToJPG(Activity):
 
             for file_name in figures:
                 figure_resource = orig_resource + "/" + file_name
+
                 file_path = self.get_tmp_dir() + os.sep + file_name
                 file_pointer = storage.get_resource_to_file_pointer(
                     figure_resource, file_path

--- a/activity/activity_CopyDigestToOutbox.py
+++ b/activity/activity_CopyDigestToOutbox.py
@@ -91,6 +91,8 @@ class activity_CopyDigestToOutbox(Activity):
         )
         storage = storage_context(self.settings)
         files_in_bucket = storage.list_resources(resource_path)
+        # remove the subfolder name from file names
+        files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
         for resource in files_in_bucket:
             orig_resource = resource_path + "/" + resource
             self.logger.info("Deleting %s from the outbox", orig_resource)

--- a/activity/activity_CopyGlencoeStillImages.py
+++ b/activity/activity_CopyGlencoeStillImages.py
@@ -300,7 +300,10 @@ class activity_CopyGlencoeStillImages(Activity):
             + "/"
             + utils.pad_msid(article_id)
         )
-        return storage.list_resources(article_path_in_cdn)
+        files_in_bucket = storage.list_resources(article_path_in_cdn)
+        # remove the subfolder name from file names
+        files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
+        return files_in_bucket
 
     def validate_jpgs_against_cdn(self, cdn_all_files, cdn_still_jpgs):
         """checks that for each element of cdn_still_jpgs there are two files in the CDN.

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -60,7 +60,8 @@ class activity_DepositAssets(Activity):
                 storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
             )
             files_in_bucket = storage.list_resources(orig_resource)
-
+            # remove the subfolder name from file names
+            files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
             # filter figures that have already been copied (see DepositIngestAssets activity)
             pre_ingest_assets = article_structure.pre_ingest_assets(files_in_bucket)
 

--- a/activity/activity_DepositIngestAssets.py
+++ b/activity/activity_DepositIngestAssets.py
@@ -60,7 +60,8 @@ class activity_DepositIngestAssets(Activity):
                 storage_provider + expanded_folder_bucket + "/" + expanded_folder_name
             )
             files_in_bucket = storage.list_resources(orig_resource)
-
+            # remove the subfolder name from file names
+            files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
             pre_ingest_assets = article_structure.pre_ingest_assets(files_in_bucket)
 
             for file_name in pre_ingest_assets:

--- a/activity/activity_ModifyArticleSubjects.py
+++ b/activity/activity_ModifyArticleSubjects.py
@@ -167,6 +167,8 @@ class activity_ModifyArticleSubjects(Activity):
         storage_provider = self.settings.storage_provider + "://"
         orig_resource = storage_provider + bucket_name + "/" + bucket_folder_name
         files_in_bucket = storage.list_resources(orig_resource)
+        # remove the subfolder name from file names
+        files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
         article_xml_s3_key_name = None
         for filename in files_in_bucket:
             info = ArticleInfo(filename)

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -287,7 +287,8 @@ class activity_PMCDeposit(Activity):
         )
 
         s3_key_names = storage.list_resources(orig_resource)
-
+        # remove the subfolder name from file names
+        s3_key_names = [filename.rsplit("/", 1)[-1] for filename in s3_key_names]
         return next_revision_number(fid, s3_key_names)
 
 

--- a/activity/activity_PublishFinalPOA.py
+++ b/activity/activity_PublishFinalPOA.py
@@ -188,7 +188,8 @@ class activity_PublishFinalPOA(Activity):
         orig_resource = storage_provider + bucket_name + "/"
 
         s3_key_names = storage.list_resources(orig_resource)
-
+        # remove the subfolder name from file names
+        s3_key_names = [filename.rsplit("/", 1)[-1] for filename in s3_key_names]
         max_revision_number = 0
         for key_name in s3_key_names:
 

--- a/activity/activity_VerifyImageServer.py
+++ b/activity/activity_VerifyImageServer.py
@@ -63,6 +63,8 @@ class activity_VerifyImageServer(Activity):
             )
 
             files_in_bucket = storage.list_resources(images_resource)
+            # remove the subfolder name from file names
+            files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
             original_figures = article_structure.get_figures_for_iiif(files_in_bucket)
 
             iiif_path_for_article = self.settings.iiif_resolver.replace(

--- a/provider/lax_provider.py
+++ b/provider/lax_provider.py
@@ -323,6 +323,8 @@ def get_xml_file_name(settings, expanded_folder, xml_bucket, version=None):
     storage = storage_context(settings)
     resource = settings.storage_provider + "://" + xml_bucket + "/" + expanded_folder
     files_in_bucket = storage.list_resources(resource)
+    # remove the subfolder name from file names
+    files_in_bucket = [filename.rsplit("/", 1)[-1] for filename in files_in_bucket]
     for filename in files_in_bucket:
         info = ArticleInfo(filename)
         if info.file_type == "ArticleXML":

--- a/provider/outbox_provider.py
+++ b/provider/outbox_provider.py
@@ -43,14 +43,10 @@ def get_outbox_s3_key_names(settings, bucket_name, outbox_folder_name, xml_only=
         storage_provider + bucket_name + "/" + outbox_folder_name.rstrip("/")
     )
     s3_key_names = storage.list_resources(orig_resource)
-    # add back the outbox_folder to the key names
-    full_s3_key_names = [
-        (outbox_folder_name.rstrip("/") + "/" + key_name) for key_name in s3_key_names
-    ]
     if xml_only:
         # return only the .xml files
-        return [key_name for key_name in full_s3_key_names if key_name.endswith(".xml")]
-    return full_s3_key_names
+        return [key_name for key_name in s3_key_names if key_name.endswith(".xml")]
+    return s3_key_names
 
 
 def download_files_from_s3_outbox(

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -106,20 +106,13 @@ class S3StorageContext:
     def list_resources(self, folder):
         bucket, s3_key = self.s3_storage_objects(folder)
         folder = s3_key[1:] if s3_key[:1] == "/" else s3_key
-        files = []
         if not folder:
             # get a list of all bucket contents if no folder is specified
             bucketlist = bucket.list()
-            for key in bucketlist:
-                files.append(key.name)
         else:
-            # list files from the folder and its subfolders and return object names only
+            # list files from the folder and its subfolders and return full object path
             bucketlist = bucket.list(prefix=folder + "/")
-            for key in bucketlist:
-                filename = key.name.rsplit("/", 1)[1]
-                files.append(filename)
-
-        return files
+        return [key.name for key in bucketlist]
 
     def copy_resource(
         self, orig_resource, dest_resource, additional_dict_metadata=None

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -118,7 +118,9 @@ class FakeStorageProviderConnection:
 
 
 class FakeStorageContext:
-    def __init__(self, directory=data.ExpandArticle_files_source_folder):
+    def __init__(
+        self, directory=data.ExpandArticle_files_source_folder, resources=None
+    ):
         "can instantiate specifying a data directory or use the default"
         self.dir = directory
         self.resources = [
@@ -126,6 +128,8 @@ class FakeStorageContext:
             "elife-00353-v1.pdf",
             "elife-00353-v1.xml",
         ]
+        if resources is not None:
+            self.resources = resources
 
     def get_bucket_and_key(self, resource):
         p = re.compile(r"(.*?)://(.*?)(/.*)")

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -35,7 +35,6 @@ class TestDepositCrossref(unittest.TestCase):
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("requests.post")
-    @patch.object(FakeStorageContext, "list_resources")
     @patch("provider.outbox_provider.storage_context")
     @data(
         {
@@ -122,16 +121,15 @@ class TestDepositCrossref(unittest.TestCase):
         self,
         test_data,
         fake_storage_context,
-        fake_list_resources,
         fake_request,
         fake_email_smtp_connect,
     ):
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()
         )
-        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
-        # copy XML files into the input directory
-        fake_list_resources.return_value = test_data["article_xml_filenames"]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/crossref/outbox/", test_data["article_xml_filenames"]
+        )
         # mock the POST to endpoint
         fake_request.return_value = FakeResponse(test_data.get("post_status_code"))
         # do the activity

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -37,7 +37,6 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch("provider.lax_provider.article_versions")
     @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
-    @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(article, "was_ever_published")
     @patch.object(s3lib, "get_s3_keys_from_bucket")
@@ -46,7 +45,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_get_s3_keys,
         fake_was_ever_published,
         fake_storage_context,
-        fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
         fake_client,
         fake_article_versions,
@@ -58,8 +56,9 @@ class TestPubRouterDeposit(unittest.TestCase):
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
         fake_get_s3_keys.return_value = None
-        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
-        fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/", ["elife00013.xml", "elife09169.xml"]
+        )
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
         fake_client.return_value = FakeSWFClient()
         fake_article_versions.return_value = (
@@ -73,7 +72,6 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch("provider.lax_provider.article_versions")
     @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
-    @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(article, "was_ever_published")
     @patch.object(s3lib, "get_s3_keys_from_bucket")
@@ -82,7 +80,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_get_s3_keys,
         fake_was_ever_published,
         fake_storage_context,
-        fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
         fake_client,
         fake_article_versions,
@@ -94,8 +91,9 @@ class TestPubRouterDeposit(unittest.TestCase):
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
         fake_get_s3_keys.return_value = None
-        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
-        fake_outbox_key_names.return_value = ["elife00013.xml", "elife09169.xml"]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/", ["elife00013.xml", "elife09169.xml"]
+        )
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
         fake_client.return_value = FakeSWFClient()
         fake_article_versions.return_value = (
@@ -146,7 +144,6 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch("provider.lax_provider.article_versions")
     @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
-    @patch("provider.outbox_provider.get_outbox_s3_key_names")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(s3lib, "get_s3_keys_from_bucket")
     @data("PMC")
@@ -155,7 +152,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         workflow_name,
         fake_get_s3_keys,
         fake_storage_context,
-        fake_outbox_key_names,
         fake_archive_bucket_s3_keys,
         fake_client,
         fake_article_versions,
@@ -167,8 +163,9 @@ class TestPubRouterDeposit(unittest.TestCase):
             self.pubrouterdeposit.get_tmp_dir()
         )
         activity_data = {"data": {"workflow": workflow_name}}
-        fake_storage_context.return_value = FakeStorageContext("tests/test_data/")
-        fake_outbox_key_names.return_value = ["elife00013.xml"]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/", ["elife00013.xml"]
+        )
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
         fake_was_ever_poa.return_value = False
         fake_get_s3_keys.return_value = False

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -40,7 +40,6 @@ class TestPubmedArticleDeposit(unittest.TestCase):
     @patch.object(lax_provider, "article_versions")
     @patch.object(activity_PubmedArticleDeposit, "sftp_files_to_endpoint")
     @patch("provider.outbox_provider.storage_context")
-    @patch.object(FakeStorageContext, "list_resources")
     @data(
         {
             "comment": "example PoA file will have an aheadofprint",
@@ -173,7 +172,6 @@ class TestPubmedArticleDeposit(unittest.TestCase):
     def test_do_activity(
         self,
         test_data,
-        fake_list_resources,
         fake_storage_context,
         fake_sftp_files_to_endpoint,
         fake_article_versions,
@@ -185,8 +183,13 @@ class TestPubmedArticleDeposit(unittest.TestCase):
         )
         fake_clean_tmp_dir.return_value = None
         # copy XML files into the input directory using the storage context
-        fake_storage_context.return_value = FakeStorageContext()
-        fake_list_resources.return_value = test_data.get("outbox_filenames")
+        resources = [
+            "pubmed/outbox/%s" % filename
+            for filename in test_data.get("outbox_filenames")
+        ]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/", resources
+        )
         # lax data overrides
         fake_article_versions.return_value = 200, test_data.get("article_versions_data")
         # ftp

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -32,11 +32,12 @@ class TestOutboxProvider(unittest.TestCase):
 
     @patch("provider.outbox_provider.storage_context")
     def test_get_outbox_s3_key_names(self, fake_storage_context):
-        fake_storage_context.return_value = FakeStorageContext(
-            "tests/test_data/crossref/outbox/"
-        )
         outbox_folder = "crossref/outbox/"
-        expected = [outbox_folder.rstrip("/") + "/" + "elife-00353-v1.xml"]
+        resources = ["%selife-00353-v1.xml" % outbox_folder]
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/%s" % outbox_folder, resources
+        )
+        expected = [outbox_folder + "elife-00353-v1.xml"]
         key_names = outbox_provider.get_outbox_s3_key_names(
             settings_mock, "", outbox_folder
         )
@@ -45,7 +46,9 @@ class TestOutboxProvider(unittest.TestCase):
 
     @patch("provider.outbox_provider.storage_context")
     def test_download_files_from_s3_outbox(self, fake_storage_context):
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/crossref/outbox/", ["elife-18753-v1.xml"]
+        )
         bucket_name = ""
         outbox_folder = ""
         key_names = outbox_provider.get_outbox_s3_key_names(
@@ -62,7 +65,9 @@ class TestOutboxProvider(unittest.TestCase):
         self, fake_storage_context, fake_get_resource
     ):
         """test IOError exception for coverage"""
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            "tests/test_data/crossref/outbox/", ["elife-18753-v1.xml"]
+        )
         fake_get_resource.side_effect = IOError
         bucket_name = ""
         outbox_folder = ""


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7227

The `list_resources()` method of `S3StorageContext` class defined in the storage_provider.py module returned inconsistent results; if no folder was specified, the object names returned were their full path, but if a folder name was specified, the object names were returned without the subfolder names, and all objects in subfolders were included with no path names to distiguish between them.

The primary changes here are to simplify `list_resources()` so the object names returned are always the full object path in the S3 bucket. Activity code which depended on using object names with no path are adapted to remove the path names from the values before continuing.

The test objects and test scenarios are changed to reflect the different `list_resources()` return values, including those which used the `outbox_provider.py` module to get the names of objects in S3 bucket folders for the "outbox" of some workflows.

`end2end` testing may uncover some bugs to be fixed in a subsequent PR. More manual testing of the PoA packaging and publishing workflow and others can be done on the `continuumtest` environment to increase confidence they are still working properly before this code is deployed to the `prod` environment.