### PR TITLE
Refactor ValidateAcceptedSubmission.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from elifecleaner import LOGGER, configure_logging, parse, transform, zip_lib
+from provider.storage_provider import storage_context
 
 LOG_FILENAME = "elifecleaner.log"
 
@@ -29,9 +30,40 @@ def unzip_zip(zip_file, tmp_dir):
     return zip_lib.unzip_zip(zip_file, tmp_dir)
 
 
-def check_ejp_zip(zip_file, tmp_dir):
-    return parse.check_ejp_zip(zip_file, tmp_dir)
+def article_xml_asset(asset_file_name_map):
+    return parse.article_xml_asset(asset_file_name_map)
+
+
+def parse_article_xml(xml_file_path):
+    return parse.parse_article_xml(xml_file_path)
+
+
+def file_list(xml_file_path):
+    "get a list of files and their details from the XML"
+    root = parse_article_xml(xml_file_path)
+    return parse.file_list(root)
+
+
+def files_by_extension(files, extension="pdf"):
+    return [
+        file_detail
+        for file_detail in files
+        if parse.file_extension(file_detail.get("upload_file_nm")) == extension
+    ]
+
+
+def check_files(files, asset_file_name_map, identifier):
+    return parse.check_files(files, asset_file_name_map, identifier)
 
 
 def transform_ejp_zip(zip_file, tmp_dir, output_dir):
     return transform.transform_ejp_zip(zip_file, tmp_dir, output_dir)
+
+
+def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):
+    "list of bucket objects in the expanded_folder and return a map of object to its S3 path"
+    storage = storage_context(settings)
+    storage_provider = settings.storage_provider + "://"
+    orig_resource = storage_provider + bucket_name + "/" + expanded_folder
+    s3_key_names = storage.list_resources(orig_resource)
+    return {key_name: orig_resource + "/" + key_name for key_name in s3_key_names}

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -39,6 +39,19 @@ bucket = {bucket_origin_file_name: xml_content_for_xml_key, bucket_dest_file_nam
 
 run_example = "1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
 
+# Accepted submission workflow
+
+accepted_session_example = {
+    "run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda",
+    "input_filename": "30-01-2019-RA-eLife-45644.zip",
+    "input_bucket_name": "elife-accepted-submission-cleaning",
+    "input_bucket_folder": "",
+    "expanded_folder": (
+        "expanded_submissions/45644/1ee54f9a-cb28-4c8e-8232-4b317cf4beda/expanded_files"
+    ),
+    "article_id": "45644",
+}
+
 # ExpandArticle
 
 ExpandArticle_data = {

--- a/tests/activity/test_activity_expand_accepted_submission.py
+++ b/tests/activity/test_activity_expand_accepted_submission.py
@@ -80,16 +80,7 @@ class TestExpandAcceptedSubmission(unittest.TestCase):
             "Table 2source data 1.xlsx",
             "transparent_reporting_Sakalauskaite.docx",
         ]
-        expected_session_dict = {
-            "run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda",
-            "input_filename": "30-01-2019-RA-eLife-45644.zip",
-            "input_bucket_name": "elife-accepted-submission-cleaning",
-            "input_bucket_folder": "",
-            "expanded_folder": (
-                "expanded_submissions/45644/1ee54f9a-cb28-4c8e-8232-4b317cf4beda/expanded_files"
-            ),
-            "article_id": "45644",
-        }
+        expected_session_dict = testdata.accepted_session_example
         # do the activity
         success = self.activity.do_activity(
             test_case_data.ingest_accepted_submission_data


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7181

Since the `ExpandAcceptedSubmission` activity extracts accepted submission zip file contents to a folder in an S3 bucket, the `ValidateAcceptedSubmission` activity is the first one to use the data, rather than downloading the entire zip file and extracting it to disk. 

The list of files from the S3 bucket expanded folder is mapped, the article XML file is found and downloaded, the XML is parsed. 

Next, PDF files are downloaded so their page numbers can be counted, as part of the checking logic.

The `provider/cleaner.py` module is changed to use the `elifecleaner=0.10.0` version library, and some addiitonal functions are there to help use bucket object lists for checking the contents.

This can be tested on the `continuumtest` environment after test pipelines have completed, prior to deploying this to the `prod` environment.