### PR TITLE
Validate accepted activity fix

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -79,6 +79,10 @@ class activity_ValidateAcceptedSubmission(Activity):
         expanded_folder = session.get_value("expanded_folder")
         input_filename = session.get_value("input_filename")
 
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s" % (self.name, input_filename, expanded_folder)
+        )
+
         # get list of bucket objects from expanded folder
         asset_file_name_map = cleaner.bucket_asset_file_name_map(
             self.settings, self.settings.bot_bucket, expanded_folder

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -66,4 +66,8 @@ def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):
     storage_provider = settings.storage_provider + "://"
     orig_resource = storage_provider + bucket_name + "/" + expanded_folder
     s3_key_names = storage.list_resources(orig_resource)
-    return {key_name: orig_resource + "/" + key_name for key_name in s3_key_names}
+    # remove the expanded_folder from the s3_key_names
+    short_s3_key_names = [
+        key_name.replace(expanded_folder, "").lstrip("/") for key_name in s3_key_names
+    ]
+    return {key_name: orig_resource + "/" + key_name for key_name in short_s3_key_names}


### PR DESCRIPTION
Bug fix to the previous PR https://github.com/elifesciences/elife-bot/pull/1423

The asset file name map gathered from the S3 bucket expanded folder had incorrect key values, the expanded_folder name must be removed before assembling the map. Added a test scenario for the function.