### PR TITLE
Refactor schedule crossref pending publication

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -80,7 +80,8 @@ class activity_ValidateAcceptedSubmission(Activity):
         input_filename = session.get_value("input_filename")
 
         self.logger.info(
-            "%s, input_filename: %s, expanded_folder: %s" % (self.name, input_filename, expanded_folder)
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
         )
 
         # get list of bucket objects from expanded folder
@@ -92,8 +93,8 @@ class activity_ValidateAcceptedSubmission(Activity):
         )
 
         # find S3 object for article XML and download it
-        xml_file_path = download_xml_file_from_bucket(
-            storage,
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
             asset_file_name_map,
             self.directories.get("TEMP_DIR"),
             self.logger,
@@ -216,21 +217,6 @@ def error_email_subject(filename):
     return "Error validating accepted submission file: {filename}".format(
         filename=filename
     )
-
-
-def download_xml_file_from_bucket(storage, asset_file_name_map, to_dir, logger):
-    "download article XML file from the S3 bucket expanded folder to the local disk"
-    xml_file_asset = cleaner.article_xml_asset(asset_file_name_map)
-    asset_key, asset_resource = xml_file_asset
-    xml_file_path = os.path.join(to_dir, asset_key)
-    logger.info("Downloading XML file from %s to %s" % (asset_resource, xml_file_path))
-    # create folders if they do not exist
-    os.makedirs(os.path.dirname(xml_file_path), exist_ok=True)
-    with open(xml_file_path, "wb") as open_file:
-        storage.get_resource_to_file(asset_resource, open_file)
-        # rewrite asset_file_name_map to the local value
-        asset_file_name_map[asset_key] = xml_file_path
-    return xml_file_path
 
 
 def download_pdf_files_from_bucket(storage, files, asset_file_name_map, to_dir, logger):

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import re
 from elifecleaner import LOGGER, configure_logging, parse, transform, zip_lib
@@ -71,3 +72,19 @@ def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):
         key_name.replace(expanded_folder, "").lstrip("/") for key_name in s3_key_names
     ]
     return {key_name: orig_resource + "/" + key_name for key_name in short_s3_key_names}
+
+
+def download_xml_file_from_bucket(settings, asset_file_name_map, to_dir, logger):
+    "download article XML file from the S3 bucket expanded folder to the local disk"
+    storage = storage_context(settings)
+    xml_file_asset = article_xml_asset(asset_file_name_map)
+    asset_key, asset_resource = xml_file_asset
+    xml_file_path = os.path.join(to_dir, asset_key)
+    logger.info("Downloading XML file from %s to %s" % (asset_resource, xml_file_path))
+    # create folders if they do not exist
+    os.makedirs(os.path.dirname(xml_file_path), exist_ok=True)
+    with open(xml_file_path, "wb") as open_file:
+        storage.get_resource_to_file(asset_resource, open_file)
+        # rewrite asset_file_name_map to the local value
+        asset_file_name_map[asset_key] = xml_file_path
+    return xml_file_path

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -1,6 +1,7 @@
 import email
 import os
 import shutil
+import zipfile
 from digestparser.objects import Digest, Image
 from provider import utils
 from provider.article import article
@@ -86,3 +87,11 @@ def body_from_multipart_email_string(email_string):
         for payload in email_message.get_payload():
             body = payload.get_payload(decode=True)
     return body
+
+
+def expanded_folder_resources(zip_file_path, directory):
+    "expand the zip file to the directory and return a list resources"
+    with zipfile.ZipFile(zip_file_path, "r") as open_zipfile:
+        open_zipfile.extractall(path=directory)
+        resources = open_zipfile.namelist()
+    return resources

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -2,7 +2,6 @@
 
 import os
 import glob
-import zipfile
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -23,14 +22,6 @@ def input_data(file_name_to_change=""):
     activity_data = test_case_data.ingest_accepted_submission_data
     activity_data["file_name"] = file_name_to_change
     return activity_data
-
-
-def expanded_folder_resources(zip_file_path, directory):
-    "expand the zip file to the directory and return a list resources"
-    with zipfile.ZipFile(zip_file_path, "r") as open_zipfile:
-        open_zipfile.extractall(path=directory)
-        resources = open_zipfile.namelist()
-    return resources
 
 
 @ddt
@@ -98,7 +89,9 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             test_activity_data.accepted_session_example.get("expanded_folder"),
         )
 
-        resources = expanded_folder_resources(zip_file_path, directory_s3_folder_path)
+        resources = helpers.expanded_folder_resources(
+            zip_file_path, directory_s3_folder_path
+        )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources
         )
@@ -217,7 +210,9 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             directory.path,
             test_activity_data.accepted_session_example.get("expanded_folder"),
         )
-        resources = expanded_folder_resources(zip_file_path, directory_s3_folder_path)
+        resources = helpers.expanded_folder_resources(
+            zip_file_path, directory_s3_folder_path
+        )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources
         )
@@ -271,7 +266,9 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             directory.path,
             test_activity_data.accepted_session_example.get("expanded_folder"),
         )
-        resources = expanded_folder_resources(zip_file_path, directory_s3_folder_path)
+        resources = helpers.expanded_folder_resources(
+            zip_file_path, directory_s3_folder_path
+        )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7181

The `ScheduleCrossrefPendingPublication` activity can download the accepted article XML from the S3 bucket expanded folder now, instead of having to download the full zip file.

Some refactoring for code re-use in activity code and test scenarios.