### PR TITLE
Add EmailAcceptedSubmissionOutput activity.

### DIFF
--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -1,0 +1,80 @@
+import json
+import time
+from provider.execution_context import get_session
+from provider import email_provider, utils
+from activity.objects import Activity
+
+
+class activity_EmailAcceptedSubmissionOutput(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_EmailAcceptedSubmissionOutput, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "EmailAcceptedSubmissionOutput"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Send an email notification after "
+            "accepted submission zip file output is produced."
+        )
+
+        # Track the success of some steps
+        self.email_status = None
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        if self.logger:
+            self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        input_filename = session.get_value("input_filename")
+
+        # Send email
+        self.email_status = self.send_email(input_filename)
+
+        # return a value based on the email_status
+        if self.email_status is True:
+            return True
+
+        return self.ACTIVITY_PERMANENT_FAILURE
+
+    def send_email(self, output_file):
+        "email the message to the recipients"
+        success = True
+
+        datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
+        body = email_provider.simple_email_body(datetime_string)
+        subject = accepted_submission_email_subject(output_file)
+        sender_email = self.settings.accepted_submission_sender_email
+
+        recipient_email_list = email_provider.list_email_recipients(
+            self.settings.accepted_submission_output_recipient_email
+        )
+
+        connection = email_provider.smtp_connect(self.settings, self.logger)
+        # send the emails
+        for recipient in recipient_email_list:
+            # create the email
+            email_message = email_provider.message(subject, sender_email, recipient)
+            email_provider.add_text(email_message, body)
+            # send the email
+            email_success = email_provider.smtp_send(
+                connection, sender_email, recipient, email_message, self.logger
+            )
+            if not email_success:
+                # for now any failure in sending a mail return False
+                success = False
+        return success
+
+
+def accepted_submission_email_subject(output_file):
+    "the email subject"
+    return "eLife accepted submission: %s" % output_file

--- a/register.py
+++ b/register.py
@@ -124,6 +124,7 @@ def start(settings):
     activity_names.append("ExpandAcceptedSubmission")
     activity_names.append("ValidateAcceptedSubmission")
     activity_names.append("TransformAcceptedSubmission")
+    activity_names.append("EmailAcceptedSubmissionOutput")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/settings-example.py
+++ b/settings-example.py
@@ -332,6 +332,7 @@ class exp:
         "life@example.org",
     ]
     accepted_submission_queue = ""
+    accepted_submission_output_recipient_email = "e@example.org"
 
 
 class dev:
@@ -650,6 +651,7 @@ class dev:
         "life@example.org",
     ]
     accepted_submission_queue = ""
+    accepted_submission_output_recipient_email = "e@example.org"
 
 
 class live:
@@ -973,6 +975,7 @@ class live:
         "life@example.org",
     ]
     accepted_submission_queue = "cleaning-queue"
+    accepted_submission_output_recipient_email = "e@example.org"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -228,3 +228,4 @@ accepted_submission_validate_error_recipient_email = [
     "e@example.org",
     "life@example.org",
 ]
+accepted_submission_output_recipient_email = "typesetter@example.org"

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -1,0 +1,127 @@
+import os
+import glob
+import unittest
+from mock import patch
+from ddt import ddt, data
+import activity.activity_EmailAcceptedSubmissionOutput as activity_module
+from activity.activity_EmailAcceptedSubmissionOutput import (
+    activity_EmailAcceptedSubmissionOutput as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.classes_mock import FakeSMTPServer
+from tests.activity.classes_mock import FakeLogger, FakeSession
+from tests.activity import settings_mock, test_activity_data
+
+
+@ddt
+class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "expected_result": True,
+            "expected_email_status": True,
+            "expected_email_count": 1,
+            "expected_email_subject": (
+                "Subject: eLife accepted submission: 30-01-2019-RA-eLife-45644.zip"
+            ),
+            "expected_email_from": "From: sender@example.org",
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_email_smtp_connect,
+        fake_session,
+    ):
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        # do the activity
+        result = self.activity.do_activity(
+            test_case_data.ingest_accepted_submission_data
+        )
+        filename_used = test_case_data.ingest_accepted_submission_data.get("file_name")
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            "failed in {comment}, got {result}, filename {filename}".format(
+                comment=test_data.get("comment"),
+                result=result,
+                filename=filename_used,
+            ),
+        )
+        self.assertEqual(
+            self.activity.email_status,
+            test_data.get("expected_email_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        # check email files and contents
+        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files = glob.glob(email_files_filter)
+        if "expected_email_count" in test_data:
+            # assert 0 or more emails sent
+            self.assertEqual(len(email_files), test_data.get("expected_email_count"))
+        if test_data.get("expected_email_count"):
+            # can look at the first email for the subject and sender
+            first_email_content = None
+            with open(email_files[0], "r", encoding="utf8") as open_file:
+                first_email_content = open_file.read()
+            if first_email_content:
+                if test_data.get("expected_email_subject"):
+                    self.assertTrue(
+                        test_data.get("expected_email_subject") in first_email_content
+                    )
+                if test_data.get("expected_email_from"):
+                    self.assertTrue(
+                        test_data.get("expected_email_from") in first_email_content
+                    )
+                if test_data.get("expected_email_body"):
+                    self.assertTrue(
+                        test_data.get("expected_email_body") in first_email_content
+                    )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module.email_provider, "smtp_send")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    def test_do_activity_send_email_false(
+        self,
+        fake_email_smtp_connect,
+        fake_smtp_send,
+        fake_session,
+    ):
+        "test if sending an email returns false"
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_smtp_send.return_value = False
+        # do the activity
+        result = self.activity.do_activity(
+            test_case_data.ingest_accepted_submission_data
+        )
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
+
+
+class TestEmailSubject(unittest.TestCase):
+    def test_accepted_submission_email_subject(self):
+        "email subject line with correct output_file value"
+        output_file = "file.zip"
+        expected = "eLife accepted submission: %s" % output_file
+        subject = activity_module.accepted_submission_email_subject(output_file)
+        self.assertEqual(subject, expected)

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -45,6 +45,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("ValidateAcceptedSubmission", data),
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
+                define_workflow_step_short("EmailAcceptedSubmissionOutput", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7248

At the end of an `IngestAcceptedSubmission` workflow, send an email to the recipients, the subject line containing the zip file name.