### PR TITLE
Refactor FTPArticle to use storage_provider.

### DIFF
--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -103,7 +103,7 @@ class S3StorageContext:
         fp = open(file_path, mode="rb")
         return fp
 
-    def list_resources(self, folder):
+    def list_resources(self, folder, return_keys=False):
         bucket, s3_key = self.s3_storage_objects(folder)
         folder = s3_key[1:] if s3_key[:1] == "/" else s3_key
         if not folder:
@@ -112,6 +112,10 @@ class S3StorageContext:
         else:
             # list files from the folder and its subfolders and return full object path
             bucketlist = bucket.list(prefix=folder + "/")
+        if return_keys:
+            # return a list of key objects
+            return bucketlist
+        # by default return a list of key names only
         return [key.name for key in bucketlist]
 
     def copy_resource(

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -175,7 +175,7 @@ class FakeStorageContext:
         with open(file_name, "wb") as open_file:
             open_file.write(data)
 
-    def list_resources(self, resource):
+    def list_resources(self, resource, return_keys=False):
         return self.resources
 
     def copy_resource(self, origin, destination, additional_dict_metadata=None):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7161

`FTPArticle` changed to use `storage_provider.py` module and not to use `s3lib.py` or `S3Connection`.

A change to `storage_provider.py` is to accept a `return_keys` argument, so it can optionally return a list of `Key` objects instead of just key names, so later the `last_modified` property can continue to be used to filter archive zip objects.