### PR TITLE
Refactor PubRouterDeposit to use storage_provider.

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -4,16 +4,13 @@ import json
 import time
 import glob
 import boto3
-import boto.s3
-from boto.s3.connection import S3Connection
-
 import provider.article as articlelib
+from provider.storage_provider import storage_context
 from provider import (
     article_processing,
     email_provider,
     lax_provider,
     outbox_provider,
-    s3lib,
     utils,
 )
 
@@ -274,12 +271,9 @@ class activity_PubRouterDeposit(Activity):
         bucket_name = self.archive_bucket
 
         # Connect to S3 and bucket
-        s3_conn = S3Connection(
-            self.settings.aws_access_key_id, self.settings.aws_secret_access_key
-        )
-        bucket = s3_conn.lookup(bucket_name)
-
-        s3_keys_in_bucket = s3lib.get_s3_keys_from_bucket(bucket=bucket)
+        storage = storage_context(self.settings)
+        bucket_resource = self.settings.storage_provider + "://" + bucket_name + "/"
+        s3_keys_in_bucket = storage.list_resources(bucket_resource, return_keys=True)
 
         s3_keys = []
         for key in s3_keys_in_bucket:

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -7,8 +7,8 @@ import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
 from tests.classes_mock import FakeSWFClient, FakeSMTPServer
 import tests.test_data as test_case_data
-import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity import settings_mock, test_activity_data
 
 
 ARCHIVE_ZIP_BUCKET_S3_KEYS = [
@@ -21,6 +21,14 @@ ARCHIVE_ZIP_BUCKET_S3_KEYS = [
         "last_modified": "2020-02-05T09:04:11.000Z",
     },
 ]
+
+
+class FakeKey:
+    "just want a fake key object which can have properties set"
+
+    def __init__(self, name=None, last_modified=None):
+        self.name = name
+        self.last_modified = last_modified
 
 
 @ddt
@@ -176,6 +184,19 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_client.return_value = FakeSWFClient()
         result = self.pubrouterdeposit.do_activity(activity_data)
         self.assertTrue(result)
+
+    @patch.object(activity_module, "storage_context")
+    def test_get_archive_bucket_s3_keys(self, fake_storage_context):
+        # create mock Key object with name and last_modified value
+        zip_file_name = "elife-00353-vor-v1-20121213000000.zip"
+        last_modified = "2019-05-31T00:00:00.000Z"
+        resources = [FakeKey(zip_file_name, "2019-05-31T00:00:00.000Z")]
+        fake_storage_context.return_value = FakeStorageContext(
+            test_activity_data.ExpandArticle_files_source_folder, resources
+        )
+        expected = [{"name": zip_file_name, "last_modified": last_modified}]
+        s3_keys = self.pubrouterdeposit.get_archive_bucket_s3_keys()
+        self.assertEqual(s3_keys, expected)
 
     @data(
         "HEFCE",


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7161

Refactor `PubRouterDeposit` activity to use `storage_provider.py` instead of `s3lib` and `S3Connection`.