### PR TITLE
Remove unused functions from provider/s3lib.py

### DIFF
--- a/provider/s3lib.py
+++ b/provider/s3lib.py
@@ -1,67 +1,9 @@
 import re
-import boto.s3
 
 
 """
 Functions for reuse concerning Amazon s3 and buckets
 """
-
-
-def get_s3_key_names_from_bucket(
-    bucket,
-    key_type="key",
-    prefix=None,
-    delimiter="/",
-    headers=None,
-    file_extensions=None,
-):
-    """
-    Given a connected boto bucket object, and optional parameters,
-    from the prefix (folder name), get the s3 key names for
-    key_type objects, optionally that match a particular
-    list of file extensions
-    key_type = "key" then look for s3 objects
-    key_type = "prefix" then look for folders (also s3 objects of a different type)
-    """
-    s3_keys = get_s3_keys_from_bucket(
-        bucket, key_type, prefix, delimiter, headers, file_extensions
-    )
-    s3_key_names = []
-    # Convert to key names instead of objects to make it testable later
-    for key in s3_keys:
-        s3_key_names.append(key.name)
-
-    # Filter by file_extension
-    if file_extensions is not None:
-        s3_key_names = filter_list_by_file_extensions(s3_key_names, file_extensions)
-
-    return s3_key_names
-
-
-def get_s3_keys_from_bucket(
-    bucket,
-    key_type="key",
-    prefix=None,
-    delimiter="/",
-    headers=None,
-    file_extensions=None,
-):
-
-    s3_keys = []
-
-    # Get a list of S3 objects
-    bucketList = bucket.list(prefix=prefix, delimiter=delimiter, headers=headers)
-
-    for item in bucketList:
-        # Can loop through each item and search for objects
-        if key_type == "key":
-            if isinstance(item, boto.s3.key.Key):
-                s3_keys.append(item)
-        elif key_type == "prefix":
-            if isinstance(item, boto.s3.prefix.Prefix):
-                s3_keys.append(item)
-
-    return s3_keys
 
 
 def filter_list_by_file_extensions(s3_key_names, file_extensions):

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -1,7 +1,6 @@
 import unittest
 from mock import patch
 from ddt import ddt, data
-from provider import s3lib
 from provider.article import article
 import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
@@ -47,10 +46,8 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(article, "was_ever_published")
-    @patch.object(s3lib, "get_s3_keys_from_bucket")
     def test_do_activity(
         self,
-        fake_get_s3_keys,
         fake_was_ever_published,
         fake_storage_context,
         fake_archive_bucket_s3_keys,
@@ -63,7 +60,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         )
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
-        fake_get_s3_keys.return_value = None
         fake_storage_context.return_value = FakeStorageContext(
             "tests/test_data/", ["elife00013.xml", "elife09169.xml"]
         )
@@ -82,10 +78,8 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.storage_context")
     @patch.object(article, "was_ever_published")
-    @patch.object(s3lib, "get_s3_keys_from_bucket")
     def test_do_activity_not_published(
         self,
-        fake_get_s3_keys,
         fake_was_ever_published,
         fake_storage_context,
         fake_archive_bucket_s3_keys,
@@ -98,7 +92,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(tmp_dir)
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
-        fake_get_s3_keys.return_value = None
         fake_storage_context.return_value = FakeStorageContext(
             "tests/test_data/", ["elife00013.xml", "elife09169.xml"]
         )
@@ -153,12 +146,10 @@ class TestPubRouterDeposit(unittest.TestCase):
     @patch("boto3.client")
     @patch.object(activity_PubRouterDeposit, "get_archive_bucket_s3_keys")
     @patch("provider.outbox_provider.storage_context")
-    @patch.object(s3lib, "get_s3_keys_from_bucket")
     @data("PMC")
     def test_do_activity_pmc(
         self,
         workflow_name,
-        fake_get_s3_keys,
         fake_storage_context,
         fake_archive_bucket_s3_keys,
         fake_client,
@@ -176,7 +167,6 @@ class TestPubRouterDeposit(unittest.TestCase):
         )
         fake_archive_bucket_s3_keys.return_value = ARCHIVE_ZIP_BUCKET_S3_KEYS
         fake_was_ever_poa.return_value = False
-        fake_get_s3_keys.return_value = False
         fake_article_versions.return_value = (
             200,
             test_case_data.lax_article_versions_response_data,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7161

The old functions in `provider/s3lib.py` can be removed now since refactoring makes them obsolete.