### PR TITLE
Old S3 bucket code cleanup

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -236,17 +236,6 @@ class FakeFileInfo:
         self.key = None
 
 
-class FakeBucket:
-    def get_key(
-        self, key
-    ):  # key will be u'00353.1/7d5fa403-cba9-486c-8273-3078a98a0b98/elife-00353-fig1-v1.tif' for example
-        return key
-
-    def list(self, prefix="", delimiter="", headers=""):
-        "stub for mocking"
-        pass
-
-
 class FakeLogger:
     def __init__(self):
         self.logdebug = "First logger debug"

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -133,7 +133,7 @@ class FakeStorageContext:
     def get_resource_as_key(self, resource):
         bucket, s3_key = self.get_bucket_and_key(resource)
         attributes = {"last_modified": "2021-01-01T00:00:01.000Z"}
-        return FakeKey(None, s3_key, **attributes)
+        return FakeKey(**attributes)
 
     def resource_exists(self, resource):
         "check if a key exists"
@@ -225,38 +225,10 @@ class FakeResponse:
 
 
 class FakeKey:
-    def __init__(self, directory=None, destination=None, source=None, **kwargs):
-        self.d = directory
-        if destination is None:
-            destination = data.bucket_origin_file_name
-        if source is None:
-            source = data.xml_content_for_xml_key
-
-        if directory and destination and source:
-            self.d.write(destination, source)
-
-        self.destination = destination
-
-        # set object attributes from remaining keyword arguments
+    def __init__(self, **kwargs):
+        # set object attributes from keyword arguments
         for key, value in kwargs.items():
             setattr(self, key, value)
-
-    def get_contents_as_string(self):
-        return self.d.read(self.destination)
-
-    def set_contents_from_string(self, json_output):
-        self.d.write(self.destination, json_output)
-
-    def set_contents_from_filename(self, filename, replace=None):
-        file_destination = str(self.destination) + filename.split("/")[-1]
-        with open(filename, "rb") as fp:
-            self.d.write(file_destination, fp.read())
-
-    def check_file_contents(self, directory, file):
-        return directory.read(file)
-
-    def cleanup_fake_directories(self):
-        self.d.cleanup()
 
 
 class FakeFileInfo:

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -28,20 +28,6 @@ class FakeSession:
         return execution_id + "__" + key
 
 
-class FakeS3Connection:
-    def __init__(self):
-        self.buckets_dict = {
-            "origin_bucket": data.bucket_origin_file_name,
-            "dest_bucket": data.bucket_dest_file_name,
-        }
-
-    def get_bucket(self, mock_bucket_name):
-        return self.buckets_dict[mock_bucket_name]
-
-    def lookup(self, mock_bucket_name):
-        return self.get_bucket(mock_bucket_name)
-
-
 class FakeSQSClient:
     def __init__(self, directory=None, queues=None):
         self.dir = directory

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -6,16 +6,8 @@ from mock import patch, MagicMock
 from ddt import ddt, data, unpack
 import activity.activity_FTPArticle as activity_module
 from activity.activity_FTPArticle import activity_FTPArticle
-from tests.activity.classes_mock import FakeFTP, FakeLogger, FakeStorageContext
+from tests.activity.classes_mock import FakeFTP, FakeKey, FakeLogger, FakeStorageContext
 from tests.activity import settings_mock, test_activity_data
-
-
-class FakeKey:
-    "just want a fake key object which can have properties set"
-
-    def __init__(self, name=None, last_modified=None):
-        self.name = name
-        self.last_modified = last_modified
 
 
 @ddt
@@ -95,7 +87,9 @@ class TestFTPArticle(unittest.TestCase):
         # create mock Key object with name and last_modified value
         doi_id = "353"
         zip_file_name = "elife-00353-vor-v1-20121213000000.zip"
-        resources = [FakeKey(zip_file_name, "2019-05-31T00:00:00.000Z")]
+        resources = [
+            FakeKey(name=zip_file_name, last_modified="2019-05-31T00:00:00.000Z")
+        ]
         fake_storage_context.return_value = FakeStorageContext(
             test_activity_data.ExpandArticle_files_source_folder, resources
         )

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -6,7 +6,7 @@ import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
 from tests.classes_mock import FakeSWFClient, FakeSMTPServer
 import tests.test_data as test_case_data
-from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity.classes_mock import FakeKey, FakeLogger, FakeStorageContext
 from tests.activity import settings_mock, test_activity_data
 
 
@@ -20,14 +20,6 @@ ARCHIVE_ZIP_BUCKET_S3_KEYS = [
         "last_modified": "2020-02-05T09:04:11.000Z",
     },
 ]
-
-
-class FakeKey:
-    "just want a fake key object which can have properties set"
-
-    def __init__(self, name=None, last_modified=None):
-        self.name = name
-        self.last_modified = last_modified
 
 
 @ddt
@@ -180,7 +172,9 @@ class TestPubRouterDeposit(unittest.TestCase):
         # create mock Key object with name and last_modified value
         zip_file_name = "elife-00353-vor-v1-20121213000000.zip"
         last_modified = "2019-05-31T00:00:00.000Z"
-        resources = [FakeKey(zip_file_name, "2019-05-31T00:00:00.000Z")]
+        resources = [
+            FakeKey(name=zip_file_name, last_modified="2019-05-31T00:00:00.000Z")
+        ]
         fake_storage_context.return_value = FakeStorageContext(
             test_activity_data.ExpandArticle_files_source_folder, resources
         )

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -17,7 +17,7 @@ import tests.test_data as test_data
 from tests.classes_mock import FakeSMTPServer
 import tests.activity.helpers as helpers
 import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger, FakeKey, FakeStorageContext
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 
 
 LAX_ARTICLE_VERSIONS_RESPONSE_DATA_1 = test_data.lax_article_versions_response_data[:1]
@@ -1107,17 +1107,6 @@ class TestAuthorsFromXML(unittest.TestCase):
         article_object.parse_article_file(full_filename)
         authors = activity_module.authors_from_xml(article_object)
         self.assertEqual(authors, test_data.get("expected"))
-
-
-def fake_get_s3key(directory, to_dir, document, source_doc):
-    """
-    EJP data do two things, copy the CSV file to where it should be
-    and also set the fake S3 key object
-    """
-    dest_doc = os.path.join(to_dir, document)
-    shutil.copy(source_doc, dest_doc)
-    with open(source_doc, "rb") as open_file:
-        return FakeKey(directory, document, open_file.read())
 
 
 if __name__ == "__main__":

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -14,13 +14,6 @@ from tests.activity import helpers, settings_mock
 import tests.activity.test_activity_data as testdata
 
 
-class FakeKey:
-    "just want a fake key object which can have a property set"
-
-    def __init__(self):
-        self.name = None
-
-
 @ddt
 class TestScheduleCrossref(unittest.TestCase):
     def setUp(self):

--- a/tests/activity/test_activity_verify_image_server.py
+++ b/tests/activity/test_activity_verify_image_server.py
@@ -1,15 +1,17 @@
 import unittest
 from mock import patch, MagicMock
-from ddt import ddt, data
-import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeSession
+from tests.activity import helpers, settings_mock
+from tests.activity.classes_mock import FakeSession, FakeStorageContext
 from activity.activity_VerifyImageServer import activity_VerifyImageServer
 import tests.activity.test_activity_data as test_data
 
 
-class FakeStorageContext:
-    def list_resources(self, resource):
-        return [
+class TestVerifyImageServer(unittest.TestCase):
+    def setUp(self):
+        self.verifyimageserver = activity_VerifyImageServer(
+            settings_mock, None, None, None, None
+        )
+        self.resources = [
             "elife-003530-fig1-v1-1022w.jpg",
             "elife-003530-fig1-v1-80w.jpg",
             "elife-003530-fig1-v1-1022w.gif",
@@ -19,11 +21,9 @@ class FakeStorageContext:
             "elife-003530-fig1-v1-download.xml",
         ]
 
-
-class TestVerifyImageServer(unittest.TestCase):
-    def setUp(self):
-        self.verifyimageserver = activity_VerifyImageServer(
-            settings_mock, None, None, None, None
+    def tearDown(self):
+        helpers.delete_files_in_folder(
+            test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
         )
 
     @patch("activity.activity_VerifyImageServer.storage_context")
@@ -36,7 +36,9 @@ class TestVerifyImageServer(unittest.TestCase):
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.return_value = [(True, "test.path")]
         fake_session.return_value = FakeSession(test_data.session_example)
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            test_data.ExpandArticle_files_dest_folder, self.resources
+        )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()
         # When
@@ -54,7 +56,9 @@ class TestVerifyImageServer(unittest.TestCase):
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.return_value = [(False, "test.path")]
         fake_session.return_value = FakeSession(test_data.session_example)
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            test_data.ExpandArticle_files_dest_folder, self.resources
+        )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()
         # When
@@ -72,7 +76,9 @@ class TestVerifyImageServer(unittest.TestCase):
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.side_effect = Exception("Error!")
         fake_session.return_value = FakeSession(test_data.session_example)
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            test_data.ExpandArticle_files_dest_folder, self.resources
+        )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()
         # When

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -10,15 +10,7 @@ from mock import patch
 from ddt import ddt, data, unpack
 from provider.ejp import EJP
 from tests import settings_mock
-from tests.activity.classes_mock import FakeStorageContext
-
-
-class FakeKey:
-    "just want a fake key object which can have properties set"
-
-    def __init__(self, name=None, last_modified=None):
-        self.name = name
-        self.last_modified = last_modified
+from tests.activity.classes_mock import FakeKey, FakeStorageContext
 
 
 @ddt
@@ -416,10 +408,7 @@ class TestProviderEJP(unittest.TestCase):
         ejp_bucket_file_list = []
         with open(bucket_list_file_new, "r") as open_file:
             ejp_bucket_file_list += json.loads(open_file.read())
-        resources = [
-            FakeKey(s3_file.get("name"), s3_file.get("last_modified"))
-            for s3_file in ejp_bucket_file_list
-        ]
+        resources = [FakeKey(**s3_file) for s3_file in ejp_bucket_file_list]
         fake_storage_context.return_value = FakeStorageContext(
             self.directory.path, resources
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7161

Prior to implementing `boto3` bucket support, remove old test code no longer used, and refactor other code to be more simple.