### PR TITLE
Refactor storage_provider.py to use boto3

### DIFF
--- a/activity/activity_ConvertImagesToJPG.py
+++ b/activity/activity_ConvertImagesToJPG.py
@@ -74,9 +74,8 @@ class activity_ConvertImagesToJPG(Activity):
                 figure_resource = orig_resource + "/" + file_name
 
                 file_path = self.get_tmp_dir() + os.sep + file_name
-                file_pointer = storage.get_resource_to_file_pointer(
-                    figure_resource, file_path
-                )
+                with open(file_path, "wb") as open_file:
+                    storage.get_resource_to_file(figure_resource, open_file)
 
                 cdn_bucket_name = (
                     self.settings.publishing_buckets_prefix
@@ -92,14 +91,15 @@ class activity_ConvertImagesToJPG(Activity):
 
                 publish_locations = [cdn_resource_path]
 
-                image_conversion.generate_images(
-                    self.settings,
-                    formats,
-                    file_pointer,
-                    article_structure.ArticleInfo(file_name),
-                    publish_locations,
-                    self.logger,
-                )
+                with open(file_path, "rb") as file_pointer:
+                    image_conversion.generate_images(
+                        self.settings,
+                        formats,
+                        file_pointer,
+                        article_structure.ArticleInfo(file_name),
+                        publish_locations,
+                        self.logger,
+                    )
 
             self.emit_monitor_event(
                 self.settings,

--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -5,7 +5,7 @@ import glob
 import shutil
 import re
 from elifetools import parseJATS as parser
-from provider import article_processing
+from provider import article_processing, utils
 from provider.storage_provider import storage_context
 import provider.sftp as sftplib
 from provider.ftp import FTP
@@ -251,7 +251,14 @@ class activity_FTPArticle(Activity):
 
         s3_keys = []
         for key in s3_keys_in_bucket:
-            s3_keys.append({"name": key.name, "last_modified": key.last_modified})
+            s3_keys.append(
+                {
+                    "name": key.get("Key"),
+                    "last_modified": key.get("LastModified").strftime(
+                        utils.DATE_TIME_FORMAT
+                    ),
+                }
+            )
 
         for status in ["vor", "poa"]:
             s3_key_name = article_processing.latest_archive_zip_revision(

--- a/activity/activity_PackagePOA.py
+++ b/activity/activity_PackagePOA.py
@@ -271,12 +271,17 @@ class activity_PackagePOA(Activity):
             with open(filename_plus_path, "wb") as open_file:
                 storage.get_resource_to_file(storage_resource_origin, open_file)
             # log last modified date if available
-            s3_key = storage.get_resource_as_key(storage_resource_origin)
+            s3_key_attributes = storage.get_resource_attributes(storage_resource_origin)
+            last_modified_string = "[unknown]"
+            if s3_key_attributes.get("LastModified"):
+                last_modified_string = s3_key_attributes.get("LastModified").strftime(
+                    utils.DATE_TIME_FORMAT
+                )
             self.logger.info(
                 "CSV file %s last_modified: %s"
                 % (
                     storage_resource_origin,
-                    getattr(s3_key, "last_modified", "[unknown]"),
+                    last_modified_string,
                 )
             )
 

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -277,7 +277,14 @@ class activity_PubRouterDeposit(Activity):
 
         s3_keys = []
         for key in s3_keys_in_bucket:
-            s3_keys.append({"name": key.name, "last_modified": key.last_modified})
+            s3_keys.append(
+                {
+                    "name": key.get("Key"),
+                    "last_modified": key.get("LastModified").strftime(
+                        utils.DATE_TIME_FORMAT
+                    ),
+                }
+            )
         return s3_keys
 
     def get_latest_archive_zip_name(self, article):

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -1,5 +1,4 @@
 import calendar
-import time
 from operator import itemgetter
 import csv
 import re
@@ -356,32 +355,18 @@ class EJP:
         # List bucket contents
         keys = storage.list_resources(resource, return_keys=True)
 
-        attr_list = ["name", "last_modified"]
         file_list = []
 
         for key in keys:
-
             item_attrs = {}
-
-            for attr_name in attr_list:
-
-                raw_value = getattr(key, attr_name, None)
-                if raw_value:
-                    string_value = str(raw_value)
-                    item_attrs[attr_name] = string_value
-
-                try:
-                    if item_attrs["last_modified"]:
-                        # Parse last_modified into a timestamp for easy computations
-                        date_format = utils.DATE_TIME_FORMAT
-                        date_str = time.strptime(
-                            item_attrs["last_modified"], date_format
-                        )
-                        timestamp = calendar.timegm(date_str)
-                        item_attrs["last_modified_timestamp"] = timestamp
-                except KeyError:
-                    pass
-
+            item_attrs["name"] = key.get("Key")
+            item_attrs["last_modified"] = key.get("LastModified").strftime(
+                utils.DATE_TIME_FORMAT
+            )
+            # Convert last_modified into a timestamp for easy computations
+            item_attrs["last_modified_timestamp"] = calendar.timegm(
+                key.get("LastModified").timetuple()
+            )
             # Finally, add to the file list
             if len(item_attrs) > 0:
                 file_list.append(item_attrs)

--- a/provider/image_conversion.py
+++ b/provider/image_conversion.py
@@ -41,8 +41,8 @@ def store_in_publish_locations(settings, filename, image, publish_locations, dow
         for resource in publish_locations:
             image.seek(0)
             content_type, encoding = guess_type(filename)
-            storage.set_resource_from_file(
-                resource + filename, image, metadata={"Content-Type": content_type}
+            storage.set_resource_from_filename(
+                resource + filename, image, metadata={"ContentType": content_type}
             )
 
             if download:

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -5,6 +5,7 @@ from shutil import copy
 import shutil
 import re
 import os
+from datetime import datetime
 from mock import MagicMock
 
 
@@ -130,10 +131,9 @@ class FakeStorageContext:
         s3_key = match.group(3)
         return bucket_name, s3_key
 
-    def get_resource_as_key(self, resource):
-        bucket, s3_key = self.get_bucket_and_key(resource)
-        attributes = {"last_modified": "2021-01-01T00:00:01.000Z"}
-        return FakeKey(**attributes)
+    def get_resource_attributes(self, resource):
+        attributes = {"LastModified": datetime(2021, 1, 1, 0, 0, 1)}
+        return attributes
 
     def resource_exists(self, resource):
         "check if a key exists"
@@ -156,7 +156,7 @@ class FakeStorageContext:
         # default used by verify glencoe tests
         return '<mock><media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="wmv" mimetype="video" xlink:href="elife-00569-media1.wmv"></media></mock>'
 
-    def set_resource_from_filename(self, resource, file_name):
+    def set_resource_from_filename(self, resource, file_name, metadata=None):
         "resource name can be different than the file name"
         to_file_name = resource.rsplit("/", 1)[-1]
         dest = data.ExpandArticle_files_dest_folder + "/" + to_file_name
@@ -182,12 +182,6 @@ class FakeStorageContext:
         file_name = data.ExpandArticle_files_dest_folder + "/" + resource.split("/")[-1]
         if os.path.exists(file_name):
             os.remove(file_name)
-
-    def get_resource_to_file_pointer(self, resource, file_path):
-        return None
-
-    # def set_contents_from_filename(self, storage_object, key, path):
-    #     copyfile(file, "tests\\" + storage_object + key)
 
 
 def fake_get_tmp_dir(path=None):
@@ -222,13 +216,6 @@ class FakeResponse:
 
     def json(self):
         return self.response_json
-
-
-class FakeKey:
-    def __init__(self, **kwargs):
-        # set object attributes from keyword arguments
-        for key, value in kwargs.items():
-            setattr(self, key, value)
 
 
 class FakeFileInfo:

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -2,11 +2,12 @@ import unittest
 import shutil
 import os
 import zipfile
+import datetime
 from mock import patch, MagicMock
 from ddt import ddt, data, unpack
 import activity.activity_FTPArticle as activity_module
 from activity.activity_FTPArticle import activity_FTPArticle
-from tests.activity.classes_mock import FakeFTP, FakeKey, FakeLogger, FakeStorageContext
+from tests.activity.classes_mock import FakeFTP, FakeLogger, FakeStorageContext
 from tests.activity import settings_mock, test_activity_data
 
 
@@ -88,7 +89,7 @@ class TestFTPArticle(unittest.TestCase):
         doi_id = "353"
         zip_file_name = "elife-00353-vor-v1-20121213000000.zip"
         resources = [
-            FakeKey(name=zip_file_name, last_modified="2019-05-31T00:00:00.000Z")
+            {"Key": zip_file_name, "LastModified": datetime.datetime(2019, 5, 31)}
         ]
         fake_storage_context.return_value = FakeStorageContext(
             test_activity_data.ExpandArticle_files_source_folder, resources

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -3,14 +3,16 @@
 import unittest
 import json
 import os
+import datetime
 import arrow
 from testfixtures import tempdir
 from testfixtures import TempDirectory
 from mock import patch
 from ddt import ddt, data, unpack
+from provider import utils
 from provider.ejp import EJP
 from tests import settings_mock
-from tests.activity.classes_mock import FakeKey, FakeStorageContext
+from tests.activity.classes_mock import FakeStorageContext
 
 
 @ddt
@@ -408,7 +410,16 @@ class TestProviderEJP(unittest.TestCase):
         ejp_bucket_file_list = []
         with open(bucket_list_file_new, "r") as open_file:
             ejp_bucket_file_list += json.loads(open_file.read())
-        resources = [FakeKey(**s3_file) for s3_file in ejp_bucket_file_list]
+        resources = [
+            {
+                "Key": s3_file.get("name"),
+                "LastModified": datetime.datetime.strptime(
+                    s3_file.get("last_modified"), utils.DATE_TIME_FORMAT
+                ),
+            }
+            for s3_file in ejp_bucket_file_list
+        ]
+
         fake_storage_context.return_value = FakeStorageContext(
             self.directory.path, resources
         )

--- a/tests/provider/test_storage.py
+++ b/tests/provider/test_storage.py
@@ -1,31 +1,43 @@
 import unittest
-from mock import MagicMock, call
+from mock import MagicMock
 from provider.storage_provider import S3StorageContext
+from tests import settings_mock
 
 
 class TestProviderStorage(unittest.TestCase):
     def setUp(self):
-        self.storage = S3StorageContext({})
-        self.storage.context["buckets"]["a"] = MagicMock()
-        self.storage.context["buckets"]["b"] = MagicMock()
-        self.storage.context["connection"] = MagicMock()
+        self.storage = S3StorageContext(settings_mock)
+        self.storage.context["client"] = MagicMock()
 
     def test_copy_without_any_metadata_to_override(self):
         original = "s3://a/1"
         destination = "s3://b/2"
         self.storage.copy_resource(original, destination, None)
+        self.storage.context["client"].copy_object.assert_called()
         self.assertEqual(
-            {"metadata": None},
-            self.storage.context["buckets"]["b"].copy_key.mock_calls[0][2],
+            {"Bucket": "b", "CopySource": {"Bucket": "a", "Key": "1"}, "Key": "2"},
+            self.storage.context["client"].copy_object.mock_calls[0][2],
         )
 
     def test_copy_and_specify_metadata(self):
         original = "s3://a/1"
         destination = "s3://b/2"
         self.storage.copy_resource(
-            original, destination, {"Content-Type": "application/json"}
+            original,
+            destination,
+            {
+                "Content-Type": "application/json",
+                "Content-Disposition": "Content-Disposition: attachment; filename=2;",
+            },
         )
         self.assertEqual(
-            {"metadata": {"Content-Type": "application/json"}},
-            self.storage.context["buckets"]["b"].copy_key.mock_calls[0][2],
+            {
+                "CopySource": {"Bucket": "a", "Key": "1"},
+                "Bucket": "b",
+                "Key": "2",
+                "MetadataDirective": "REPLACE",
+                "ContentType": "application/json",
+                "ContentDisposition": "Content-Disposition: attachment; filename=2;",
+            },
+            self.storage.context["client"].copy_object.mock_calls[0][2],
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7161

Many changes to `provider/storage_provider.py` to use `boto3` instead of `boto`. Some methods are removed or renamed and the code using them was refactored accordingly. Bucket object return value of `LastUpdated` is a `datetime` object instead of a string when using `boto3`.

Once `end2end` tests are passing, this can be tested a little more on the `continuumtest` environment prior to deploying it to the `prod` environment.