### PR TITLE
Fix Content-Type on Lens html page in S3.

### DIFF
--- a/activity/activity_LensArticle.py
+++ b/activity/activity_LensArticle.py
@@ -101,7 +101,8 @@ class activity_LensArticle(Activity):
             + "/"
             + self.article_s3key
         )
-        storage.set_resource_from_filename(s3_resource, filename_plus_path)
+        metadata = {"ContentType": "text/html"}
+        storage.set_resource_from_filename(s3_resource, filename_plus_path, metadata)
 
         if self.logger:
             self.logger.info("LensArticle created for: %s" % self.article_s3key)

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -89,15 +89,15 @@ class S3StorageContext:
     def set_resource_from_filename(self, resource, file, metadata=None):
         "create object from file data, metadata can include ContentType key"
         bucket_name, s3_key = self.s3_storage_objects(resource)
-        if metadata is None:
-            metadata = {}
+        kwargs = {
+            "Filename": file,
+            "Bucket": bucket_name,
+            "Key": s3_key.lstrip("/"),
+        }
+        if metadata:
+            kwargs["ExtraArgs"] = metadata
         client = self.get_client_from_cache()
-        client.upload_file(
-            Filename=file,
-            Bucket=bucket_name,
-            Key=s3_key.lstrip("/"),
-            ExtraArgs=metadata,
-        )
+        client.upload_file(**kwargs)
 
     def set_resource_from_string(self, resource, data, content_type=None):
         "create object and save data there"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7313

The switch to `boto3` does not automatically set the `Content-Type` of an S3 object with a file extension of `.html` to `text/html` as happened when using `boto`.