### PR TITLE
Set S3 ContenType when depositing some files to buckets

### DIFF
--- a/activity/activity_ApplyVersionNumber.py
+++ b/activity/activity_ApplyVersionNumber.py
@@ -3,6 +3,7 @@ import os
 import re
 from os import path
 from elifetools import xmlio
+from provider import utils
 from provider.execution_context import get_session
 from provider.article_structure import ArticleInfo
 import provider.article_structure as article_structure
@@ -210,7 +211,8 @@ class activity_ApplyVersionNumber(Activity):
             + filename
         )
         local_filename = path.join(self.get_tmp_dir(), filename)
-        storage.set_resource_from_filename(file_resource, local_filename)
+        metadata = {"ContentType": utils.content_type_from_file_name(filename)}
+        storage.set_resource_from_filename(file_resource, local_filename, metadata)
 
     def build_file_name_map(self, s3_key_names, version):
 

--- a/activity/activity_DepositAssets.py
+++ b/activity/activity_DepositAssets.py
@@ -1,6 +1,5 @@
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-from mimetypes import guess_type
 from provider import article_structure, utils
 from activity.objects import Activity
 
@@ -106,7 +105,7 @@ class activity_DepositAssets(Activity):
 
                 file_name_no_extension, extension = file_name.rsplit(".", 1)
                 if extension not in no_download_extensions:
-                    content_type = self.content_type_from_file_name(file_name)
+                    content_type = utils.content_type_from_file_name(file_name)
                     dict_metadata = {
                         "Content-Disposition": str(
                             "Content-Disposition: attachment; filename="
@@ -151,15 +150,6 @@ class activity_DepositAssets(Activity):
             return self.ACTIVITY_PERMANENT_FAILURE
 
         return self.ACTIVITY_SUCCESS
-
-    def content_type_from_file_name(self, file_name):
-        if file_name is None:
-            return None
-        content_type, encoding = guess_type(file_name)
-        if content_type is None:
-            return "binary/octet-stream"
-        else:
-            return content_type
 
     def get_no_download_extensions(self, no_download_extensions):
         return [x.strip() for x in no_download_extensions.split(",")]

--- a/activity/activity_DepositDigestIngestAssets.py
+++ b/activity/activity_DepositDigestIngestAssets.py
@@ -112,6 +112,9 @@ class activity_DepositDigestIngestAssets(Activity):
         storage = storage_context(self.settings)
         self.logger.info("Depositing digest image to S3 key %s", self.dest_resource)
         # set the bucket object resource from the local file
-        storage.set_resource_from_filename(self.dest_resource, digest.image.file)
+        metadata = {"ContentType": utils.content_type_from_file_name(digest.image.file)}
+        storage.set_resource_from_filename(
+            self.dest_resource, digest.image.file, metadata
+        )
         self.logger.info("Deposited digest image %s to S3", digest.image.file)
         return True

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -169,14 +169,6 @@ class activity_ExpandArticle(Activity):
 
         return True
 
-    def get_next_version(self, article_id):
-        version = lax_provider.article_highest_version(article_id, self.settings)
-        if isinstance(version, int) and version >= 1:
-            version = str(version + 1)
-        if version is None:
-            return "-1"
-        return version
-
     def check_filenames(self, filenames):
         xml_found = False
         for filename in filenames:

--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -130,7 +130,10 @@ class activity_ExpandArticle(Activity):
                     + "/"
                     + dest_path
                 )
-                storage.set_resource_from_filename(storage_resource_dest, source_path)
+                metadata = {"ContentType": utils.content_type_from_file_name(filename)}
+                storage.set_resource_from_filename(
+                    storage_resource_dest, source_path, metadata
+                )
 
             self.clean_tmp_dir()
 

--- a/activity/activity_ModifyArticleSubjects.py
+++ b/activity/activity_ModifyArticleSubjects.py
@@ -3,6 +3,7 @@ import os
 import csv
 from collections import OrderedDict
 from elifetools import parseJATS as parser
+from provider import utils
 from provider.storage_provider import storage_context
 from provider.execution_context import get_session
 from provider.article_structure import ArticleInfo
@@ -327,4 +328,5 @@ class activity_ModifyArticleSubjects(Activity):
             + "/"
             + s3_key_name
         )
-        storage.set_resource_from_filename(resource_dest, article_xml_file)
+        metadata = {"ContentType": utils.content_type_from_file_name(s3_key_name)}
+        storage.set_resource_from_filename(resource_dest, article_xml_file, metadata)

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -3,6 +3,7 @@ import urllib
 import base64
 from argparse import ArgumentParser
 import arrow
+from mimetypes import guess_type
 
 
 S3_DATE_FORMAT = "%Y%m%d%H%M%S"
@@ -222,3 +223,14 @@ def get_settings(env):
     import settings as settings_lib
 
     return settings_lib.get_settings(env)
+
+
+def content_type_from_file_name(file_name):
+    "for setting Content-Type headers on S3 objects, for example"
+    if file_name is None:
+        return None
+    content_type, encoding = guess_type(file_name)
+    if content_type is None:
+        return "binary/octet-stream"
+    else:
+        return content_type

--- a/tests/activity/test_activity_deposit_assets.py
+++ b/tests/activity/test_activity_deposit_assets.py
@@ -37,18 +37,6 @@ class TestDepositAssets(unittest.TestCase):
         result = self.depositassets.get_no_download_extensions(input)
         self.assertListEqual(result, expected)
 
-    @unpack
-    @data(
-        (None, None),
-        ("image.jpg", "image/jpeg"),
-        ("/folder/file.test.pdf", "application/pdf"),
-        ("/folder/weird_file.wdl", "binary/octet-stream"),
-        ("a_file", "binary/octet-stream"),
-    )
-    def test_content_type_from_file_name(self, input, expected):
-        result = self.depositassets.content_type_from_file_name(input)
-        self.assertEqual(result, expected)
-
     @patch("activity.activity_DepositAssets.get_session")
     @patch("activity.activity_DepositAssets.storage_context")
     @patch.object(activity_DepositAssets, "emit_monitor_event")

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -234,5 +234,20 @@ class TestConsoleStartEnvWorkflowDoiId(unittest.TestCase):
             self.assertEqual(utils.console_start_env_workflow_doi_id(), expected)
 
 
+@ddt
+class TestContentTypeFromFileName(unittest.TestCase):
+    @unpack
+    @data(
+        (None, None),
+        ("image.jpg", "image/jpeg"),
+        ("/folder/file.test.pdf", "application/pdf"),
+        ("/folder/weird_file.wdl", "binary/octet-stream"),
+        ("a_file", "binary/octet-stream"),
+    )
+    def test_content_type_from_file_name(self, input, expected):
+        result = utils.content_type_from_file_name(input)
+        self.assertEqual(result, expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7314

Fixing a bug with the transition to `boto3` to set the `Content-Type` head of some S3 objects to better values on files which are served by S3.