### PR TITLE
Add ParseError to the cleaner log too.

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -154,7 +154,7 @@ class activity_ValidateAcceptedSubmission(Activity):
         # Send an email if the log has warnings
         with open(log_file_path, "r", encoding="utf8") as open_file:
             log_contents = open_file.read()
-        if "WARNING" in log_contents:
+        if "ERROR" in log_contents or "WARNING" in log_contents:
             # Send error email
             error_messages = (
                 "Warnings found in the log file for zip file %s\n\n" % input_filename

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -5,7 +5,7 @@ import time
 from xml.etree.ElementTree import ParseError
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-from provider import cleaner, email_provider
+from provider import article_processing, cleaner, email_provider
 from activity.objects import Activity
 
 
@@ -109,10 +109,15 @@ class activity_ValidateAcceptedSubmission(Activity):
             files = cleaner.file_list(xml_file_path)
         except ParseError:
             log_message = (
-                "%s, XML ParseError exception in cleaner.file_list for file %s"
-                % (self.name, input_filename)
+                "%s, XML ParseError exception in cleaner.file_list"
+                " parsing XML file %s for file %s"
+            ) % (
+                self.name,
+                article_processing.file_name_from_name(xml_file_path),
+                input_filename,
             )
             self.logger.exception(log_message)
+            cleaner.LOGGER.exception(log_message)
             files = []
         finally:
             # reset the parsing library flag

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -227,10 +227,20 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             self.activity.logger.logexception.startswith(
                 (
                     "ValidateAcceptedSubmission, XML ParseError exception"
-                    " in cleaner.file_list for file"
+                    " in cleaner.file_list parsing XML file"
+                    " 30-01-2019-RA-eLife-45644.xml for file"
                 )
             )
         )
+        log_file_path = os.path.join(
+            self.activity.get_tmp_dir(), self.activity.activity_log_file
+        )
+        with open(log_file_path, "r", encoding="utf8") as open_file:
+            log_contents = open_file.read()
+        log_errors = [
+            line for line in log_contents.split("\n") if "ERROR elifecleaner:" in line
+        ]
+        self.assertEqual(len(log_errors), 1)
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")


### PR DESCRIPTION
Code in PR https://github.com/elifesciences/elife-bot/pull/1449 continued. If there is an XML `ParseError`, add it to the cleaner log too so it will end up in the error email body.