### PR TITLE
Refactor log handlers in accepted submission steps

### DIFF
--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -51,20 +51,10 @@ class activity_TransformAcceptedSubmission(Activity):
         self.make_activity_directories()
 
         # configure log files for the cleaner provider
-        cleaner_log_handers = []
-        format_string = (
-            "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
-        )
-        # log to a common log file
-        cleaner_log_handers.append(cleaner.log_to_file(format_string=format_string))
-        # log file for this activity only
-        log_file_path = os.path.join(self.get_tmp_dir(), self.activity_log_file)
-        cleaner_log_handers.append(
-            cleaner.log_to_file(
-                log_file_path,
-                format_string=format_string,
-            )
-        )
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
 
         # parse the input data
         real_filename, bucket_name, bucket_folder = parse_activity_data(data)

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -61,20 +61,10 @@ class activity_ValidateAcceptedSubmission(Activity):
         storage = storage_context(self.settings)
 
         # configure log files for the cleaner provider
-        cleaner_log_handers = []
-        format_string = (
-            "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
-        )
-        # log to a common log file
-        cleaner_log_handers.append(cleaner.log_to_file(format_string=format_string))
-        # log file for this activity only
-        log_file_path = os.path.join(self.get_tmp_dir(), self.activity_log_file)
-        cleaner_log_handers.append(
-            cleaner.log_to_file(
-                log_file_path,
-                format_string=format_string,
-            )
-        )
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
 
         expanded_folder = session.get_value("expanded_folder")
         input_filename = session.get_value("input_filename")

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -5,6 +5,9 @@ from elifecleaner import LOGGER, configure_logging, parse, transform, zip_lib
 from provider.storage_provider import storage_context
 
 LOG_FILENAME = "elifecleaner.log"
+LOG_FORMAT_STRING = (
+    "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
+)
 
 
 def article_id_from_zip_file(zip_file):
@@ -21,6 +24,21 @@ def log_to_file(filename=None, level=logging.INFO, format_string=None):
     if not filename:
         filename = LOG_FILENAME
     return configure_logging(filename, level, format_string)
+
+
+def configure_activity_log_handlers(log_file_path):
+    "for a workflow activity configure where to log messages"
+    cleaner_log_handers = []
+    # log to a common log file
+    cleaner_log_handers.append(log_to_file(format_string=LOG_FORMAT_STRING))
+
+    cleaner_log_handers.append(
+        log_to_file(
+            log_file_path,
+            format_string=LOG_FORMAT_STRING,
+        )
+    )
+    return cleaner_log_handers
 
 
 def log_remove_handler(handler):


### PR DESCRIPTION
Reduce some code duplication for where log handlers of the `elifecleaner` library are set in activity code.