### PR TITLE
Use elifecleaner==0.11.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,10 +43,9 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.10.0"
+elifecleaner = "~=0.11.0"
 
 [dev-packages]
-elifecleaner = "~=0.10.0"
 pylint = "~=2.11"
 testfixtures = "~=6.18"
 pytest = "~=6.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cddd0ae6b8cf26288cba6759bcb378c7e68e9a8d0f93a7966f0178c578afca43"
+            "sha256": "78aaa13d27111a0205cfbb1e902b8d538cef42ad9e05449f5fb49b14e75ec2fa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -236,13 +236,15 @@
             "hashes": [
                 "sha256:19d8702892b0d1e0914b3d8051a8bee73974c7c8d51ee3682858d6c56bb2faf2",
                 "sha256:2c4d20d3baa70ab33c794e6c224754cad355a962f182d6ca047b60df11fa0298",
+                "sha256:3e8041c1a331dfef974db73b12caf36f10611ab1eb1795d44461a4cbc887dad7",
                 "sha256:7237a68c333fbeb27be048a01d6f684e337579f6ce687c779966c931374040c0",
                 "sha256:9679ba90fa998e18e4465acccf6c5c6157c6013394c0c0ca2d5b4a9929f816bd",
                 "sha256:9f8c33e60b5d688df65ba18c20ef07513d6eed9c171aa2b6ab6c1c281f1da1de",
+                "sha256:ee93b84283ddfacc818e4871e11e8ab718f37cb76c08765969e3e8ee347f8bad",
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.11.0"
         },
         "elifecrossref": {
             "hashes": [
@@ -1108,17 +1110,27 @@
             "index": "pypi",
             "version": "==4.10.0"
         },
+        "dill": {
+            "hashes": [
+                "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f",
+                "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0'",
+            "version": "==0.3.4"
+        },
         "elifecleaner": {
             "hashes": [
                 "sha256:19d8702892b0d1e0914b3d8051a8bee73974c7c8d51ee3682858d6c56bb2faf2",
                 "sha256:2c4d20d3baa70ab33c794e6c224754cad355a962f182d6ca047b60df11fa0298",
+                "sha256:3e8041c1a331dfef974db73b12caf36f10611ab1eb1795d44461a4cbc887dad7",
                 "sha256:7237a68c333fbeb27be048a01d6f684e337579f6ce687c779966c931374040c0",
                 "sha256:9679ba90fa998e18e4465acccf6c5c6157c6013394c0c0ca2d5b4a9929f816bd",
                 "sha256:9f8c33e60b5d688df65ba18c20ef07513d6eed9c171aa2b6ab6c1c281f1da1de",
+                "sha256:ee93b84283ddfacc818e4871e11e8ab718f37cb76c08765969e3e8ee347f8bad",
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.11.0"
         },
         "elifetools": {
             "hashes": [
@@ -1370,6 +1382,14 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "typed-ast": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-03-22 - see update-dependencies.sh
+# file generated 2022-03-30 - see update-dependencies.sh
 arrow==1.2.2
 astroid==2.9.3
 attrs==21.4.0
@@ -19,7 +19,7 @@ dill==0.3.4
 docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
-elifecleaner==0.10.0
+elifecleaner==0.11.0
 elifecrossref==0.11.0
 elifepubmed==0.4.0
 elifetools==0.15.0

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -122,15 +122,15 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
             )
         )
         self.assertTrue(
-            log_infos[4].endswith("30-01-2019-RA-eLife-45644.zip rewriting xml tags")
+            log_infos[5].endswith("30-01-2019-RA-eLife-45644.zip rewriting xml tags")
         )
         self.assertTrue(
-            log_infos[5].endswith(
+            log_infos[7].endswith(
                 "30-01-2019-RA-eLife-45644.zip article_type research-article, display_channel ['Research Article']"
             )
         )
         self.assertTrue(
-            log_infos[6].endswith(
+            log_infos[8].endswith(
                 (
                     "30-01-2019-RA-eLife-45644.zip writing xml to file "
                     "%s/30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml"
@@ -139,7 +139,7 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
             )
         )
         self.assertTrue(
-            log_infos[7].endswith(
+            log_infos[9].endswith(
                 (
                     "30-01-2019-RA-eLife-45644.zip writing new zip file "
                     "%s/30-01-2019-RA-eLife-45644.zip"


### PR DESCRIPTION
Invoking `transform.transform_ejp_zip()` from the `elifecleaner` library should work the same except the log messages are slightly different.