### PR TITLE
Refactor tests using expanded folder resources.

### DIFF
--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -95,3 +95,14 @@ def expanded_folder_resources(zip_file_path, directory):
         open_zipfile.extractall(path=directory)
         resources = open_zipfile.namelist()
     return resources
+
+
+def expanded_folder_bucket_resources(directory, expanded_folder, zip_file_path):
+    "populate the TempDirectory with files from zip_filename to mock a bucket folder in tests"
+    directory.makedir(expanded_folder)
+    directory_s3_folder_path = os.path.join(
+        directory.path,
+        expanded_folder,
+    )
+    resources = expanded_folder_resources(zip_file_path, directory_s3_folder_path)
+    return resources

--- a/tests/activity/test_activity_schedule_crossref_pending_publication.py
+++ b/tests/activity/test_activity_schedule_crossref_pending_publication.py
@@ -59,15 +59,10 @@ class TestScheduleCrossrefPendingPublication(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             test_data.get("filename"),
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
 
         # copy files into the input directory using the storage context

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -81,16 +81,10 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             test_data.get("filename"),
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources
@@ -203,15 +197,10 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             "30-01-2019-RA-eLife-45644.zip",
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources
@@ -269,15 +258,10 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             "30-01-2019-RA-eLife-45644.zip",
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources

--- a/tests/activity/test_activity_validate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_validate_accepted_submission_videos.py
@@ -108,16 +108,10 @@ class TestValidateAcceptedSubmissionVideos(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             test_data.get("filename"),
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources
@@ -192,15 +186,10 @@ class TestValidateAcceptedSubmissionVideos(unittest.TestCase):
             test_activity_data.ExpandArticle_files_source_folder,
             zip_file,
         )
-        directory.makedir(
-            test_activity_data.accepted_session_example.get("expanded_folder")
-        )
-        directory_s3_folder_path = os.path.join(
-            directory.path,
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
             test_activity_data.accepted_session_example.get("expanded_folder"),
-        )
-        resources = helpers.expanded_folder_resources(
-            zip_file_path, directory_s3_folder_path
+            zip_file_path,
         )
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources


### PR DESCRIPTION
In some tests for accepted submission workflow activities, some code can be reused when populating a test bucket fixture with expanded folder resources.