### PR TITLE
Refactor accepted submission transform.

### DIFF
--- a/activity/activity_OutputAcceptedSubmission.py
+++ b/activity/activity_OutputAcceptedSubmission.py
@@ -1,0 +1,156 @@
+import os
+import json
+import shutil
+from provider import article_processing, cleaner
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+class activity_OutputAcceptedSubmission(Activity):
+    "OutputAcceptedSubmission activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_OutputAcceptedSubmission, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "OutputAcceptedSubmission"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Download files from a bucket folder, zip them, "
+            "and copy to the output bucket."
+        )
+
+        # Track some values
+        self.input_file = None
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+            "OUTPUT_DIR": os.path.join(self.get_tmp_dir(), "output_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"download": None, "zip": None, "upload": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+
+        # download the all files from the bucket expanded folder
+        try:
+            download_all_files_from_bucket(
+                storage,
+                asset_file_name_map,
+                self.directories.get("INPUT_DIR"),
+                self.logger,
+            )
+            self.statuses["download"] = True
+        except:
+            log_message = (
+                "%s, exception in download_all_files_from_bucket" " for file %s"
+            ) % (
+                self.name,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            self.statuses["download"] = False
+
+        #  zip the files
+        if self.statuses.get("download"):
+            new_zip_file_path = cleaner.rezip(
+                asset_file_name_map, self.directories.get("OUTPUT_DIR"), input_filename
+            )
+            self.statuses["zip"] = True
+
+        if self.statuses.get("zip"):
+            # upload zip file to output bucket
+            self.upload_zip(
+                self.settings.accepted_submission_output_bucket, new_zip_file_path
+            )
+            self.statuses["upload"] = True
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)
+
+    def upload_zip(self, output_bucket_name, file_name_path):
+        "upload the zip to the bucket"
+        # Get the file name from the full file path
+        file_name = file_name_path.split(os.sep)[-1]
+
+        # Create S3 object and save
+        bucket_name = output_bucket_name
+        storage = storage_context(self.settings)
+        storage_provider = self.settings.storage_provider + "://"
+        s3_folder_name = ""
+        resource_dest = (
+            storage_provider + bucket_name + "/" + s3_folder_name + file_name
+        )
+        storage.set_resource_from_filename(resource_dest, file_name_path)
+        self.logger.info(
+            "%s, copied %s to %s", self.name, file_name_path, resource_dest
+        )
+
+
+def download_all_files_from_bucket(storage, asset_file_name_map, to_dir, logger):
+    "download files in asset_file_name_map from the S3 bucket expanded folder to the local disk"
+    s3_files = [
+        {"upload_file_nm": article_processing.file_name_from_name(key)}
+        for key in asset_file_name_map
+    ]
+    cleaner.download_asset_files_from_bucket(
+        storage, s3_files, asset_file_name_map, to_dir, logger
+    )

--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -1,10 +1,14 @@
 import os
 import json
 import shutil
-from S3utility.s3_notification_info import parse_activity_data
-from provider import cleaner, download_helper
+from xml.etree.ElementTree import ParseError
+from provider import article_processing, cleaner
+from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from activity.objects import Activity
+
+
+REPAIR_XML = False
 
 
 class activity_TransformAcceptedSubmission(Activity):
@@ -22,12 +26,12 @@ class activity_TransformAcceptedSubmission(Activity):
         self.default_task_schedule_to_start_timeout = 30
         self.default_task_start_to_close_timeout = 60 * 5
         self.description = (
-            "Download zip file input from the bucket, transform the files and the XML, "
-            + "and upload the new zip file to an output bucket."
+            "Download accepted submission files from a bucket folder, "
+            + "transform the files and the XML, "
+            + "and upload the modified files to the bucket folder."
         )
 
         # Track some values
-        self.input_file = None
         self.activity_log_file = "cleaner.log"
 
         # Local directory settings
@@ -38,7 +42,7 @@ class activity_TransformAcceptedSubmission(Activity):
         }
 
         # Track the success of some steps
-        self.statuses = {"transform": None, "upload": None}
+        self.statuses = {"download": None, "transform": None, "upload": None}
 
     def do_activity(self, data=None):
         """
@@ -48,7 +52,13 @@ class activity_TransformAcceptedSubmission(Activity):
             "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
         )
 
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
         self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
 
         # configure log files for the cleaner provider
         log_file_path = os.path.join(
@@ -56,78 +66,144 @@ class activity_TransformAcceptedSubmission(Activity):
         )  # log file for this activity only
         cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
 
-        # parse the input data
-        real_filename, bucket_name, bucket_folder = parse_activity_data(data)
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+
         self.logger.info(
-            "%s, real_filename: %s, bucket_name: %s, bucket_folder: %s"
-            % (self.name, real_filename, bucket_name, bucket_folder)
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
         )
 
-        # Download from S3
-        self.input_file = download_helper.download_file_from_s3(
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
             self.settings,
-            real_filename,
-            bucket_name,
-            bucket_folder,
+            asset_file_name_map,
             self.directories.get("INPUT_DIR"),
+            self.logger,
         )
 
-        self.logger.info("%s, downloaded file to %s" % (self.name, self.input_file))
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
 
-        # transform the zip file
-        self.logger.info(
-            "%s, starting to transform zip file %s", self.name, self.input_file
-        )
+        # download the code files so they can be modified
         try:
-            new_zip_file_path = cleaner.transform_ejp_zip(
-                self.input_file,
-                self.directories.get("TEMP_DIR"),
-                self.directories.get("OUTPUT_DIR"),
+            download_code_files_from_bucket(
+                storage,
+                xml_file_path,
+                asset_file_name_map,
+                self.directories.get("INPUT_DIR"),
+                self.logger,
             )
-            self.statuses["transform"] = True
-        except Exception:
+            self.statuses["download"] = True
+        except ParseError:
             log_message = (
-                "%s, unhandled exception in cleaner.transform_ejp_zip for file %s"
-                % (self.name, self.input_file)
+                "%s, XML ParseError exception in download_code_files_from_bucket"
+                " parsing XML file %s for file %s"
+            ) % (
+                self.name,
+                article_processing.file_name_from_name(xml_file_path),
+                input_filename,
             )
             self.logger.exception(log_message)
-            self.log_statuses(self.input_file)
-            return self.ACTIVITY_PERMANENT_FAILURE
+            cleaner.LOGGER.exception(log_message)
+            self.statuses["download"] = False
         finally:
-            # remove the log handlers
-            for log_handler in cleaner_log_handers:
-                cleaner.log_remove_handler(log_handler)
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
 
-        # upload zip file to output bucket
-        self.upload_zip(
-            self.settings.accepted_submission_output_bucket, new_zip_file_path
+        # transform the zip file
+        if self.statuses.get("download"):
+            self.logger.info(
+                "%s, starting to transform zip file %s", self.name, input_filename
+            )
+            try:
+                new_asset_file_name_map = cleaner.transform_ejp_files(
+                    asset_file_name_map,
+                    self.directories.get("TEMP_DIR"),
+                    input_filename,
+                )
+                self.statuses["transform"] = True
+            except Exception:
+                log_message = (
+                    "%s, unhandled exception in cleaner.transform_ejp_files for file %s"
+                    % (self.name, input_filename)
+                )
+                self.logger.exception(log_message)
+                self.statuses["transform"] = False
+                new_asset_file_name_map = {}
+            finally:
+                # remove the log handlers
+                for log_handler in cleaner_log_handers:
+                    cleaner.log_remove_handler(log_handler)
+
+            self.logger.info(
+                "%s, new_asset_file_name_map: %s" % (self.name, new_asset_file_name_map)
+            )
+
+        # files to upload and delete from the bucket folder is determined
+        # by comparing the keys of the old and new asset file name map
+        upload_keys = []
+        delete_keys = []
+        if self.statuses.get("transform"):
+            upload_keys = [
+                key
+                for key in new_asset_file_name_map
+                if key not in asset_file_name_map.keys()
+            ]
+            # also upload the XML file
+            upload_keys.append(cleaner.article_xml_asset(asset_file_name_map)[0])
+            delete_keys = [
+                key
+                for key in asset_file_name_map
+                if key not in new_asset_file_name_map.keys()
+            ]
+        self.logger.info("%s, bucket objects to delete: %s" % (self.name, delete_keys))
+        self.logger.info("%s, bucket objects to upload: %s" % (self.name, upload_keys))
+
+        # delete files from bucket folder
+        bucket_asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
         )
-        self.statuses["upload"] = True
+        for delete_key in delete_keys:
+            s3_resource = bucket_asset_file_name_map.get(delete_key)
+            # delete old key
+            storage.delete_resource(s3_resource)
+            self.logger.info("%s, deleted S3 object: %s" % (self.name, s3_resource))
 
-        self.log_statuses(self.input_file)
+        # upload files to bucket folder
+        for upload_key in upload_keys:
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            local_file_path = new_asset_file_name_map.get(upload_key)
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+            self.statuses["upload"] = True
+
+        self.log_statuses(input_filename)
 
         # Clean up disk
         self.clean_tmp_dir()
 
         return True
-
-    def upload_zip(self, output_bucket_name, file_name_path):
-        "upload the zip to the bucket"
-        # Get the file name from the full file path
-        file_name = file_name_path.split(os.sep)[-1]
-
-        # Create S3 object and save
-        bucket_name = output_bucket_name
-        storage = storage_context(self.settings)
-        storage_provider = self.settings.storage_provider + "://"
-        s3_folder_name = ""
-        resource_dest = (
-            storage_provider + bucket_name + "/" + s3_folder_name + file_name
-        )
-        storage.set_resource_from_filename(resource_dest, file_name_path)
-        self.logger.info(
-            "%s, copied %s to %s", self.name, file_name_path, resource_dest
-        )
 
     def log_statuses(self, input_file):
         "log the statuses value"
@@ -143,3 +219,13 @@ class activity_TransformAcceptedSubmission(Activity):
             if dir_name in keep_dirs or not os.path.exists(dir_path):
                 continue
             shutil.rmtree(dir_path)
+
+
+def download_code_files_from_bucket(
+    storage, xml_file_path, asset_file_name_map, to_dir, logger
+):
+    "download files from the S3 bucket expanded folder to the local disk"
+    code_files = cleaner.code_file_list(xml_file_path)
+    cleaner.download_asset_files_from_bucket(
+        storage, code_files, asset_file_name_map, to_dir, logger
+    )

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -63,6 +63,12 @@ def file_list(xml_file_path):
     return parse.file_list(root)
 
 
+def code_file_list(xml_file_path):
+    "get a list of code from the XML"
+    root = parse_article_xml(xml_file_path)
+    return transform.code_file_list(root)
+
+
 def files_by_extension(files, extension="pdf"):
     return [
         file_detail
@@ -77,6 +83,14 @@ def check_files(files, asset_file_name_map, identifier):
 
 def transform_ejp_zip(zip_file, tmp_dir, output_dir):
     return transform.transform_ejp_zip(zip_file, tmp_dir, output_dir)
+
+
+def transform_ejp_files(asset_file_name_map, output_dir, identifier):
+    return transform.transform_ejp_files(asset_file_name_map, output_dir, identifier)
+
+
+def rezip(asset_file_name_map, output_dir, zip_file_name):
+    return transform.rezip(asset_file_name_map, output_dir, zip_file_name)
 
 
 def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):

--- a/register.py
+++ b/register.py
@@ -126,6 +126,7 @@ def start(settings):
     activity_names.append("TransformAcceptedSubmission")
     activity_names.append("EmailAcceptedSubmissionOutput")
     activity_names.append("ValidateAcceptedSubmissionVideos")
+    activity_names.append("OutputAcceptedSubmission")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_output_accepted_submission.py
+++ b/tests/activity/test_activity_output_accepted_submission.py
@@ -1,0 +1,216 @@
+# coding=utf-8
+
+import os
+import unittest
+import zipfile
+from mock import patch
+from testfixtures import TempDirectory
+from provider import cleaner
+import activity.activity_OutputAcceptedSubmission as activity_module
+from activity.activity_OutputAcceptedSubmission import (
+    activity_OutputAcceptedSubmission as activity_object,
+)
+from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext
+from tests.activity import helpers, settings_mock, test_activity_data
+import tests.test_data as test_case_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+class TestOutputAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory, including the cleaner.log file
+        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+        # clean folder used by storage context
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity(
+        self, fake_storage_context, fake_cleaner_storage_context, fake_session
+    ):
+        test_data = {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_download_status": True,
+        }
+        directory = TempDirectory()
+        # copy files into the input directory using the storage context
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+
+        # mock the session
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("download"),
+            test_data.get("expected_download_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # check output bucket folder contents
+        output_bucket_list = [
+            file_name
+            for file_name in os.listdir(
+                test_activity_data.ExpandArticle_files_dest_folder
+            )
+            if file_name != ".gitkeep"
+        ]
+        self.assertEqual(
+            sorted(output_bucket_list),
+            [test_data.get("filename")],
+        )
+        # check the contents of the zip file
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_dest_folder,
+            test_data.get("filename"),
+        )
+        with zipfile.ZipFile(zip_file_path, "r") as open_zipfile:
+            resources = open_zipfile.namelist()
+        self.assertEqual(len(resources), 42)
+        self.assertEqual(
+            sorted(resources),
+            [
+                "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.pdf",
+                "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+                "30-01-2019-RA-eLife-45644/Answers for the eLife digest.docx",
+                "30-01-2019-RA-eLife-45644/Appendix 1.docx",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 1.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 11.pdf",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 12.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 13.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 14.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 15.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 2.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 3.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 4.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 5.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 6.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 7.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 8.png",
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 9.png",
+                "30-01-2019-RA-eLife-45644/Figure 1.tif",
+                "30-01-2019-RA-eLife-45644/Figure 2.tif",
+                "30-01-2019-RA-eLife-45644/Figure 3.png",
+                "30-01-2019-RA-eLife-45644/Figure 4.svg",
+                "30-01-2019-RA-eLife-45644/Figure 4source data 1.zip",
+                "30-01-2019-RA-eLife-45644/Figure 5.png",
+                "30-01-2019-RA-eLife-45644/Figure 5source code 1.c",
+                "30-01-2019-RA-eLife-45644/Figure 6.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 10_HorC.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 1_U crassus.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 2_U pictorum.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 3_M margaritifera.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 4_P auricularius.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 5_PesB.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 6_HavA.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 7_HavB.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 8_HavC.png",
+                "30-01-2019-RA-eLife-45644/Figure 6figure supplement 9_HorB.png",
+                "30-01-2019-RA-eLife-45644/Figure 6source data 1.pdf",
+                "30-01-2019-RA-eLife-45644/Manuscript.docx",
+                "30-01-2019-RA-eLife-45644/Potential striking image.tif",
+                "30-01-2019-RA-eLife-45644/Table 2source data 1.xlsx",
+                "30-01-2019-RA-eLife-45644/transparent_reporting_Sakalauskaite.docx",
+            ],
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "download_asset_files_from_bucket")
+    @patch.object(activity_module, "storage_context")
+    def test_do_activity_download_exception(
+        self,
+        fake_storage_context,
+        fake_download,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        directory = TempDirectory()
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+
+        zip_filename = "30-01-2019-RA-eLife-45644.zip"
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_filename,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        # mock the session
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+
+        fake_download.side_effect = Exception()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_filename))
+        self.assertEqual(result, True)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                (
+                    "OutputAcceptedSubmission, exception in "
+                    "download_all_files_from_bucket for file %s"
+                )
+                % zip_filename
+            ),
+        )

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -32,8 +32,8 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory, including the cleaner.log file
+        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -46,6 +46,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_short("ValidateAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
+                define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),
             ],
             "finish": {"requirements": None},


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7181

The `TransformAcceptedSubmission` activity is changed to use the expanded folder files as input, and it will modify the XML and the files in the expanded folder. A new activity `OutputAcceptedSubmission` will download the expanded files, create the final zip file, and upload it to the output bucket.

Any bugs detected when testing on the `continuumtest` environment may need to be fixed in the next code PR.