### PR TITLE
Dependency `elifecleaner` pinned to `0.12.0 `

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.11.0"
+elifecleaner = "~=0.12.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78aaa13d27111a0205cfbb1e902b8d538cef42ad9e05449f5fb49b14e75ec2fa"
+            "sha256": "ce1d22cc69defb2eb0e18db023eca3f0347fa2b515b632e145940994bf0bac16"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -244,7 +244,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.11.0"
+            "version": "==0.12.0"
         },
         "elifecrossref": {
             "hashes": [
@@ -1008,7 +1008,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         },
         "wand": {
@@ -1130,7 +1130,7 @@
                 "sha256:fe301a89ad8e2843c7131cfb00a493f0231b54c658001072c9c1dcddb0b4cf1a"
             ],
             "index": "pypi",
-            "version": "==0.11.0"
+            "version": "==0.12.0"
         },
         "elifetools": {
             "hashes": [
@@ -1351,6 +1351,14 @@
             ],
             "index": "pypi",
             "version": "==5.0.2"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
         },
         "soupsieve": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-03-30 - see update-dependencies.sh
+# file generated 2022-04-08 - see update-dependencies.sh
 arrow==1.2.2
 astroid==2.9.3
 attrs==21.4.0
@@ -19,7 +19,7 @@ dill==0.3.4
 docker==5.0.3
 ejpcsvparser==0.1.2
 elifearticle==0.7.0
-elifecleaner==0.11.0
+elifecleaner==0.12.0
 elifecrossref==0.11.0
 elifepubmed==0.4.0
 elifetools==0.15.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/16/display/redirect which resulted in this pull request.