### PR TITLE
Enhance FakeStorageContext and fix tests.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -175,11 +175,21 @@ class FakeStorageContext:
         return self.resources
 
     def copy_resource(self, origin, destination, additional_dict_metadata=None):
-        pass
+        origin_bucket_name, s3_key = self.get_bucket_and_key(origin)
+        origin_file_name = s3_key.lstrip("/")
+        destination_bucket_name, s3_key = self.get_bucket_and_key(destination)
+        destination_file_name = s3_key.lstrip("/")
+        if origin_bucket_name == destination_bucket_name:
+            origin_path = os.path.join(self.dir, origin_file_name)
+            destination_path = os.path.join(self.dir, destination_file_name)
+            # create folders if they do not exist
+            os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+            copy(origin_path, destination_path)
 
     def delete_resource(self, resource):
-        # delete from the destination folder
-        file_name = data.ExpandArticle_files_dest_folder + "/" + resource.split("/")[-1]
+        "delete from the destination folder"
+        bucket_name, s3_key = self.get_bucket_and_key(resource)
+        file_name = self.dir + "/" + s3_key
         if os.path.exists(file_name):
             os.remove(file_name)
 

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -106,3 +106,17 @@ def expanded_folder_bucket_resources(directory, expanded_folder, zip_file_path):
     )
     resources = expanded_folder_resources(zip_file_path, directory_s3_folder_path)
     return resources
+
+
+def populate_storage(from_dir, to_dir, filenames, sub_dir=""):
+    "copy filesnames from from_dir to to_dir into the sub_dir for test bucket resources"
+    resources = []
+    for filename in filenames:
+        from_filename = os.path.join(from_dir, filename)
+        to_resource = os.path.join(sub_dir, filename)
+        to_filename = os.path.join(to_dir, to_resource)
+        resources.append(to_resource)
+        # create folders if they do not exist
+        os.makedirs(os.path.dirname(to_filename), exist_ok=True)
+        shutil.copy(from_filename, to_filename)
+    return resources

--- a/tests/activity/test_activity_deposit_crossref_pending_publication.py
+++ b/tests/activity/test_activity_deposit_crossref_pending_publication.py
@@ -2,6 +2,7 @@ import os
 import time
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 from elifearticle.article import Article
 from provider import crossref
 import activity.activity_DepositCrossrefPendingPublication as activity_module
@@ -25,6 +26,7 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
         self.outbox_folder = "tests/test_data/crossref_pending_publication/outbox/"
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
             activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
@@ -69,12 +71,19 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
                 "</pending_publication>",
             ],
         }
+        directory = TempDirectory()
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()
         )
+        resources = helpers.populate_storage(
+            from_dir=self.outbox_folder,
+            to_dir=directory.path,
+            filenames=test_data["article_xml_filenames"],
+            sub_dir="crossref_pending_publication/outbox",
+        )
         fake_storage_context.return_value = FakeStorageContext(
-            self.outbox_folder,
-            test_data["article_xml_filenames"],
+            directory.path,
+            resources,
         )
         # mock the POST to endpoint
         fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -81,15 +81,18 @@ class TestOutboxProvider(unittest.TestCase):
 
     @patch("provider.outbox_provider.storage_context")
     def test_clean_outbox(self, fake_storage_context):
-        fake_storage_context.return_value = FakeStorageContext(self.directory)
-        # copy two files in for cleaning
-        shutil.copy(self.good_xml_file, self.directory.path)
-        shutil.copy(self.bad_xml_file, self.directory.path)
-        # add outbox_folder name and one file to the list of published file names
+        fake_storage_context.return_value = FakeStorageContext(self.directory.path)
         bucket_name = "bucket"
-        outbox_folder = "crossref/outbox/"
         to_folder = "crossref/published/"
-        published_file_names = [outbox_folder, self.good_xml_file]
+        outbox_folder = "crossref/outbox/"
+        outbox_folder_directory = os.path.join(self.directory.path, outbox_folder)
+        # create folders if they do not exist
+        os.makedirs(os.path.dirname(outbox_folder_directory), exist_ok=True)
+        # copy two files in for cleaning
+        shutil.copy(self.good_xml_file, outbox_folder_directory)
+        shutil.copy(self.bad_xml_file, outbox_folder_directory)
+        # add one file to the list of published file names
+        published_file_names = [self.good_xml_file]
         # clean outbox
         outbox_provider.clean_outbox(
             settings_mock, bucket_name, outbox_folder, to_folder, published_file_names


### PR DESCRIPTION
Test class `FakeStorageContext` has methods for `copy_resource()` and `delete_resource()`, although they were either incomplete or inflexible. Here, those two methods are more functional to use the local file system to emulate S3 bucket objects.

Fixing `FakeStorageContext` required to change tests that copy or delete S3 bucket objects to use a temporary directory for test bucket data.