### PR TITLE
Add RenameAcceptedSubmissionVideos activity.

### DIFF
--- a/activity/activity_RenameAcceptedSubmissionVideos.py
+++ b/activity/activity_RenameAcceptedSubmissionVideos.py
@@ -1,0 +1,248 @@
+import os
+import json
+import shutil
+from xml.etree.ElementTree import ParseError
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner
+from activity.objects import Activity
+
+
+REPAIR_XML = False
+
+
+class activity_RenameAcceptedSubmissionVideos(Activity):
+    "RenameAcceptedSubmissionVideos activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_RenameAcceptedSubmissionVideos, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "RenameAcceptedSubmissionVideos"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Rename the accepted submission videos in the bucket folder"
+            " and in the XML file."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"rename_videos": None, "modify_xml": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+        article_id = session.get_value("article_id")
+        deposit_videos = session.get_value("deposit_videos")
+
+        if not deposit_videos:
+            self.logger.info(
+                "%s, %s deposit_videos session value is %s, activity returning True"
+                % (self.name, input_filename, deposit_videos)
+            )
+            return True
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("TEMP_DIR"),
+            self.logger,
+        )
+
+        # get the file list from the XML
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
+
+        # get list of files from the article XML
+        files = []
+        try:
+            files = cleaner.file_list(xml_file_path)
+            self.logger.info("%s, %s files: %s" % (self.name, input_filename, files))
+        except ParseError:
+            log_message = "%s, XML ParseError exception parsing file %s for file %s" % (
+                self.name,
+                xml_file_path,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
+        # generate new file names for the videos
+        generated_video_data = []
+        try:
+            generated_video_data = cleaner.video_data_from_files(files, article_id)
+        except ParseError:
+            log_message = "%s, exception invoking video_data_from_files for file %s" % (
+                self.name,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+        file_transformations = []
+        for video_data in generated_video_data:
+            from_file_name = video_data.get("upload_file_nm")
+            from_file = cleaner.ArticleZipFile(from_file_name)
+            to_file_name = video_data.get("video_filename")
+            to_file = cleaner.ArticleZipFile(to_file_name)
+            file_transformations.append((from_file, to_file))
+        self.logger.info(
+            "%s, %s file_transformations: %s"
+            % (self.name, input_filename, file_transformations)
+        )
+
+        # rewrite the XML file with the renamed video files
+        if file_transformations:
+            try:
+                cleaner.xml_rewrite_file_tags(
+                    xml_file_path, file_transformations, input_filename
+                )
+                self.logger.info(
+                    "%s, %s file_transformations rewriting XML completed"
+                    % (self.name, input_filename)
+                )
+                self.statuses["modify_xml"] = True
+            except:
+                log_message = (
+                    "%s, exception invoking xml_rewrite_file_tags for file %s"
+                    % (
+                        self.name,
+                        input_filename,
+                    )
+                )
+                self.logger.exception(log_message)
+
+        # rename the video files in the expanded folder
+        if self.statuses.get("modify_xml"):
+            # map values without folder names to match them later
+            asset_key_map = {key.rsplit("/", 1)[-1]: key for key in asset_file_name_map}
+            resource_prefix = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+            )
+            for file_transform in file_transformations:
+                old_s3_resource = (
+                    resource_prefix
+                    + "/"
+                    + asset_key_map.get(file_transform[0].xml_name)
+                )
+                # get the subfolder of the old resource to prepend to the new resource
+                new_resource_subfolder = old_s3_resource.rsplit(resource_prefix, 1)[
+                    -1
+                ].rsplit("/", 1)[0]
+                new_s3_resource = (
+                    resource_prefix
+                    + new_resource_subfolder
+                    + "/"
+                    + file_transform[1].xml_name
+                )
+                # copy old key to new key
+                self.logger.info(
+                    "%s, copying old S3 key %s to %s"
+                    % (self.name, old_s3_resource, new_s3_resource)
+                )
+                storage.copy_resource(old_s3_resource, new_s3_resource)
+                # delete old key
+                self.logger.info(
+                    "%s, deleting old S3 key %s" % (self.name, old_s3_resource)
+                )
+                storage.delete_resource(old_s3_resource)
+            self.statuses["rename_videos"] = True
+
+        # upload the modified XML file to the expanded folder
+        if self.statuses.get("rename_videos"):
+            upload_key = cleaner.article_xml_asset(asset_file_name_map)[0]
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            local_file_path = asset_file_name_map.get(upload_key)
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+            self.statuses["upload_xml"] = True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -1,7 +1,8 @@
 import os
 import logging
 import re
-from elifecleaner import LOGGER, configure_logging, parse, transform, zip_lib
+from elifecleaner import LOGGER, configure_logging, parse, transform, video, zip_lib
+from elifecleaner.transform import ArticleZipFile
 from provider.storage_provider import storage_context
 
 LOG_FILENAME = "elifecleaner.log"
@@ -91,6 +92,14 @@ def transform_ejp_files(asset_file_name_map, output_dir, identifier):
 
 def rezip(asset_file_name_map, output_dir, zip_file_name):
     return transform.rezip(asset_file_name_map, output_dir, zip_file_name)
+
+
+def video_data_from_files(files, article_id):
+    return video.video_data_from_files(files, article_id)
+
+
+def xml_rewrite_file_tags(xml_file_path, file_transformations, identifier):
+    transform.xml_rewrite_file_tags(xml_file_path, file_transformations, identifier)
 
 
 def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):

--- a/register.py
+++ b/register.py
@@ -126,6 +126,7 @@ def start(settings):
     activity_names.append("TransformAcceptedSubmission")
     activity_names.append("EmailAcceptedSubmissionOutput")
     activity_names.append("ValidateAcceptedSubmissionVideos")
+    activity_names.append("RenameAcceptedSubmissionVideos")
     activity_names.append("OutputAcceptedSubmission")
 
     for activity_name in activity_names:

--- a/tests/activity/test_activity_rename_accepted_submission_videos.py
+++ b/tests/activity/test_activity_rename_accepted_submission_videos.py
@@ -1,0 +1,337 @@
+# coding=utf-8
+
+import os
+import glob
+import copy
+import unittest
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_RenameAcceptedSubmissionVideos as activity_module
+from activity.activity_RenameAcceptedSubmissionVideos import (
+    activity_RenameAcceptedSubmissionVideos as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+def session_data(filename=None, article_id=None, deposit_videos=None):
+    s_data = copy.copy(test_activity_data.accepted_session_example)
+    if filename:
+        s_data["input_filename"] = filename
+    if article_id:
+        s_data["article_id"] = article_id
+    if deposit_videos:
+        s_data["deposit_videos"] = deposit_videos
+    return s_data
+
+
+@ddt
+class TestRenameAcceptedSubmissionVideos(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission with videos",
+            "filename": "28-09-2020-RA-eLife-63532.zip",
+            "article_id": "63532",
+            "expected_xml_file_path": "28-09-2020-RA-eLife-63532/28-09-2020-RA-eLife-63532.xml",
+            "expected_result": True,
+            "expected_rename_videos_status": True,
+            "expected_modify_xml_status": True,
+            "expected_upload_xml_status": True,
+            "expected_file_count": 26,
+            "expected_files": ["elife-63532-video1.avi", "elife-63532-video2.avi"],
+        },
+        {
+            "comment": "accepted submission zip has no videos",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "article_id": "45644",
+            "expected_xml_file_path": "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+            "expected_result": True,
+            "expected_rename_videos_status": None,
+            "expected_modify_xml_status": None,
+            "expected_upload_xml_status": None,
+            "expected_file_count": 42,
+            "expected_files": [],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_storage_context,
+        fake_session,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        workflow_session_data = session_data(
+            filename=test_data.get("filename"),
+            article_id=test_data.get("article_id"),
+            deposit_videos=True,
+        )
+        fake_session.return_value = FakeSession(workflow_session_data)
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            test_data.get("expected_xml_file_path"),
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("rename_videos"),
+            test_data.get("expected_rename_videos_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("modify_xml"),
+            test_data.get("expected_modify_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # some assertions on the bucket folder contents and the XML <file> tag values
+        expanded_path = os.path.join(
+            directory.path,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            test_data.get("filename").rstrip(".zip"),
+        )
+        expanded_files = os.listdir(expanded_path)
+        self.assertEqual(len(expanded_files), test_data.get("expected_file_count"))
+        for expected_file in test_data.get("expected_files"):
+            self.assertTrue(
+                expected_file in expanded_files,
+                "file {expected_file} not found in expanded_files in {comment}".format(
+                    expected_file=expected_file, comment=test_data.get("comment")
+                ),
+            )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    def test_do_activity_deposit_videos_none(
+        self,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is no deposit_videos value in the session"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(session_data(zip_file, article_id))
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_loginfo = (
+            "RenameAcceptedSubmissionVideos, %s"
+            " deposit_videos session value is None, activity returning True"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.loginfo[-1], expected_loginfo)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "file_list")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_file_list,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an XML ParseError when getting a file list"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            xml_file,
+        )
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, deposit_videos=True)
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_file_list.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "RenameAcceptedSubmissionVideos, XML ParseError exception "
+            "parsing file %s for file %s"
+        ) % (xml_file_path, zip_file)
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "video_data_from_files")
+    def test_do_activity_video_data_exception(
+        self,
+        fake_video_data_from_files,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an exception generating video file names"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, deposit_videos=True)
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_video_data_from_files.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "RenameAcceptedSubmissionVideos, exception invoking video_data_from_files "
+            "for file %s"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "xml_rewrite_file_tags")
+    def test_do_activity_xml_rewrite_exception(
+        self,
+        fake_xml_rewrite_file_tags,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an exception rewriting the XML file"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, deposit_videos=True)
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_xml_rewrite_file_tags.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "RenameAcceptedSubmissionVideos, exception invoking xml_rewrite_file_tags "
+            "for file %s"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -45,6 +45,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("ValidateAcceptedSubmission", data),
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_short("ValidateAcceptedSubmissionVideos", data),
+                define_workflow_step_short("RenameAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7181

Rename the accepted submission video files using the logic from the `elifecleaner` library, if the videos are to be deposited according to the session variable. Catch exceptions when reading or writing the XML or when generating video data.