### PR TITLE
Add exact to update-dependencies.sh args

### DIFF
--- a/Jenkinsfile.update-dependency
+++ b/Jenkinsfile.update-dependency
@@ -4,7 +4,7 @@ elifeUpdatePipeline(
             // ensure elife-bot--ci is on master
             builderDeployRevision 'elife-bot--ci', commit
             // on the elife-bot--ci instance, activate venv, run the 'update single dependency' script
-            builderCmd "elife-bot--ci", "./update-dependencies.sh ${params.package} ${params.tag}", "/opt/elife-bot", true
+            builderCmd "elife-bot--ci", "./update-dependencies.sh ${params.package} ${params.tag} exact", "/opt/elife-bot", true
             // rsync remote elife-bot to a ... local elife-bot?
             builderSync "ci--bot.elife.internal", "/opt/elife-bot/"
             // add the modified files

--- a/Jenkinsfile.update-dependency
+++ b/Jenkinsfile.update-dependency
@@ -4,7 +4,7 @@ elifeUpdatePipeline(
             // ensure elife-bot--ci is on master
             builderDeployRevision 'elife-bot--ci', commit
             // on the elife-bot--ci instance, activate venv, run the 'update single dependency' script
-            builderCmd "elife-bot--ci", "./update-dependencies.sh ${params.package} ${params.tag} exact", "/opt/elife-bot", true
+            builderCmd "elife-bot--ci", sh "./update-dependencies.sh ${params.package} ${params.tag}", "/opt/elife-bot", true
             // rsync remote elife-bot to a ... local elife-bot?
             builderSync "ci--bot.elife.internal", "/opt/elife-bot/"
             // add the modified files


### PR DESCRIPTION
A failure of `dependencies-elife-bot-update-dependency` pipeline, I think I've tracked it down to where this Jenkinsfile needs the third argument `exact` to be added, @lsh-0 what do you think please?