### PR TITLE
Enhance FakeStorageContext and fix tests.

### DIFF
--- a/tests/activity/test_activity_archive_article.py
+++ b/tests/activity/test_activity_archive_article.py
@@ -2,12 +2,12 @@ import os
 import unittest
 import zipfile
 from mock import mock, patch
+from testfixtures import TempDirectory
 import activity.activity_ArchiveArticle as activity_module
 from activity.activity_ArchiveArticle import activity_ArchiveArticle as activity_object
-import tests.activity.settings_mock as settings_mock
+from tests.activity import settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 import tests.activity.test_activity_data as activity_test_data
-import tests.activity.helpers as helpers
 
 
 def outbox_files(folder):
@@ -32,9 +32,7 @@ class TestArchiveArticle(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
+        TempDirectory.cleanup_all()
 
     def zip_assertions(self, zip_file_path, expected_zip_file_name, expected_zip_files):
         zip_file_name = None
@@ -58,8 +56,11 @@ class TestArchiveArticle(unittest.TestCase):
             "elife-00353-v1.xml",
             "elife-00353-v1.pdf",
         ]
-        test_destination_folder = activity_test_data.ExpandArticle_files_dest_folder
-        fake_storage_context.return_value = FakeStorageContext()
+        directory = TempDirectory()
+        test_destination_folder = directory.path
+        fake_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
         self.activity.emit_monitor_event = mock.MagicMock()
 
         success = self.activity.do_activity(

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -1,10 +1,9 @@
 import unittest
 from mock import patch, MagicMock
+from testfixtures import TempDirectory
 from activity.activity_CopyGlencoeStillImages import activity_CopyGlencoeStillImages
-import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeSession, FakeStorageContext, FakeLogger
-import tests.activity.test_activity_data as test_activity_data
-import tests.activity.helpers as helpers
+from tests.activity import settings_mock, test_activity_data
 
 
 class TestCopyGlencoeStillImages(unittest.TestCase):
@@ -15,9 +14,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
         self.copyglencoestillimages.logger = FakeLogger()
 
     def tearDown(self):
-        helpers.delete_files_in_folder(
-            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
+        TempDirectory.cleanup_all()
 
     @patch("provider.article_processing.storage_context")
     @patch("provider.lax_provider.get_xml_file_name")
@@ -309,8 +306,9 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
     def test_store_file_according_to_the_current_article_id_whatever_is_the_filename_on_glencoe(
         self, fake_storage_context, fake_requests_get
     ):
+        directory = TempDirectory()
         fake_storage_context.return_value = FakeStorageContext(
-            test_activity_data.ExpandArticle_files_dest_folder
+            directory.path, dest_folder=directory.path
         )
         fake_requests_get.return_value = MagicMock()
         fake_requests_get.return_value.status_code = 200

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -9,9 +9,7 @@ import activity.activity_DepositCrossref as activity_module
 from activity.activity_DepositCrossref import activity_DepositCrossref
 from tests.classes_mock import FakeSMTPServer
 from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
-import tests.activity.settings_mock as settings_mock
-import tests.activity.test_activity_data as activity_test_data
-import tests.activity.helpers as helpers
+from tests.activity import helpers, settings_mock
 import tests.test_data as test_case_data
 
 
@@ -27,9 +25,6 @@ class TestDepositCrossref(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
@@ -138,7 +133,7 @@ class TestDepositCrossref(unittest.TestCase):
             sub_dir="crossref/outbox",
         )
         fake_storage_context.return_value = FakeStorageContext(
-            directory.path, resources
+            directory.path, resources, dest_folder=directory.path
         )
         # mock the POST to endpoint
         fake_request.return_value = FakeResponse(test_data.get("post_status_code"))

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -16,9 +16,8 @@ from tests.classes_mock import (
     FakeBigQueryRowIterator,
 )
 from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 import tests.activity.test_activity_data as activity_test_data
-import tests.activity.helpers as helpers
 
 
 @ddt
@@ -33,9 +32,6 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
@@ -105,8 +101,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
             sub_dir="crossref_peer_review/outbox",
         )
         fake_storage_context.return_value = FakeStorageContext(
-            directory.path,
-            resources,
+            directory.path, resources, dest_folder=directory.path
         )
         rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
         client = FakeBigQueryClient(rows)

--- a/tests/activity/test_activity_deposit_crossref_pending_publication.py
+++ b/tests/activity/test_activity_deposit_crossref_pending_publication.py
@@ -11,9 +11,8 @@ from activity.activity_DepositCrossrefPendingPublication import (
 )
 from tests.classes_mock import FakeSMTPServer
 from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 import tests.activity.test_activity_data as activity_test_data
-import tests.activity.helpers as helpers
 
 
 class TestDepositCrossrefPendingPublication(unittest.TestCase):
@@ -28,9 +27,6 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def tmp_dir(self):
         "return the tmp dir name for the activity"
@@ -82,8 +78,7 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
             sub_dir="crossref_pending_publication/outbox",
         )
         fake_storage_context.return_value = FakeStorageContext(
-            directory.path,
-            resources,
+            directory.path, resources, dest_folder=directory.path
         )
         # mock the POST to endpoint
         fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))

--- a/tests/activity/test_activity_deposit_digest_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_digest_ingest_assets.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 from ddt import ddt, data
 from provider import digest_provider, download_helper
 from activity.activity_DepositDigestIngestAssets import (
@@ -13,7 +14,6 @@ from tests.activity.classes_mock import FakeLogger
 import tests.test_data as test_case_data
 from tests.activity.classes_mock import FakeStorageContext
 import tests.activity.test_activity_data as testdata
-import tests.activity.helpers as helpers
 
 
 def input_data(file_name_to_change=None):
@@ -30,12 +30,9 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
-        # clean out the bucket destination folder
-        helpers.delete_files_in_folder(
-            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch.object(download_helper, "storage_context")
     @patch.object(digest_provider, "storage_context")
@@ -44,6 +41,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         {
             "comment": "digest docx file example",
             "filename": "DIGEST+99999.docx",
+            "msid": "99999",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": "https://doi.org/10.7554/eLife.99999",
             "expected_digest_image_file": None,
@@ -53,6 +51,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         {
             "comment": "digest zip file example",
             "filename": "DIGEST+99999.zip",
+            "msid": "99999",
             "expected_result": activity_object.ACTIVITY_SUCCESS,
             "expected_digest_doi": "https://doi.org/10.7554/eLife.99999",
             "expected_digest_image_file": "IMAGE 99999.jpeg",
@@ -62,6 +61,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         {
             "comment": "digest file does not exist example",
             "filename": "",
+            "msid": "99999",
             "expected_digest_doi": None,
             "expected_digest_image_file": None,
             "expected_dest_resource": None,
@@ -71,6 +71,7 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         {
             "comment": "bad digest docx file example",
             "filename": "DIGEST+99998.docx",
+            "msid": "99998",
             "expected_digest_doi": None,
             "expected_digest_image_file": None,
             "expected_dest_resource": None,
@@ -85,8 +86,11 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
         fake_provider_storage_context,
         fake_download_storage_context,
     ):
+        directory = TempDirectory()
+        dest_folder = os.path.join(directory.path, "files_dest")
+        os.mkdir(dest_folder)
         # copy XML files into the input directory using the storage context
-        fake_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(dest_folder=dest_folder)
         fake_provider_storage_context.return_value = FakeStorageContext()
         fake_download_storage_context.return_value = FakeStorageContext()
         # do the activity
@@ -127,7 +131,11 @@ class TestDepositDigestIngestAssets(unittest.TestCase):
             "failed in {comment}".format(comment=test_data.get("comment")),
         )
         # Check destination folder as a list
-        files = sorted(os.listdir(testdata.ExpandArticle_files_dest_folder))
+        bucket_folder_path = os.path.join(dest_folder, "digests", test_data.get("msid"))
+        if os.path.exists(bucket_folder_path):
+            files = sorted(os.listdir(bucket_folder_path))
+        else:
+            files = []
         compare_files = [file_name for file_name in files if file_name != ".gitkeep"]
         self.assertEqual(
             compare_files,

--- a/tests/activity/test_activity_generate_decision_letter_jats.py
+++ b/tests/activity/test_activity_generate_decision_letter_jats.py
@@ -2,17 +2,15 @@
 
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 from ddt import ddt, data
 import activity.activity_GenerateDecisionLetterJATS as activity_module
 from activity.activity_GenerateDecisionLetterJATS import (
     activity_GenerateDecisionLetterJATS as activity_object,
 )
-import tests.activity.settings_mock as settings_mock
-from tests.activity.classes_mock import FakeLogger
+from tests.activity import settings_mock
 import tests.test_data as test_case_data
-from tests.activity.classes_mock import FakeSession, FakeStorageContext
-import tests.activity.test_activity_data as test_activity_data
-import tests.activity.helpers as helpers
+from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext
 
 
 def input_data(file_name_to_change=""):
@@ -28,11 +26,9 @@ class TestGenerateDecisionLetterJATS(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")
@@ -52,12 +48,13 @@ class TestGenerateDecisionLetterJATS(unittest.TestCase):
         fake_storage_context,
         mock_session,
     ):
+        directory = TempDirectory()
         activity_input_data = input_data(test_data.get("filename"))
         # copy XML files into the input directory using the storage context
         fake_download_storage_context.return_value = FakeStorageContext()
         # activity storage context
         fake_storage_context.return_value = FakeStorageContext(
-            test_activity_data.ExpandArticle_files_dest_folder
+            directory.path, dest_folder=directory.path
         )
         # mock the session
         fake_session = FakeSession({})

--- a/tests/activity/test_activity_generate_swh_readme.py
+++ b/tests/activity/test_activity_generate_swh_readme.py
@@ -2,19 +2,19 @@ import os
 import shutil
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 import activity.activity_GenerateSWHReadme as activity_module
 from activity.activity_GenerateSWHReadme import (
     activity_GenerateSWHReadme as activity_object,
 )
 from provider.article import article
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import (
     FakeLogger,
     FakeStorageContext,
     FakeSession,
 )
 import tests.activity.test_activity_data as testdata
-import tests.activity.helpers as helpers
 
 
 def fake_download_xml(filename, to_dir):
@@ -35,10 +35,8 @@ class TestGenerateSWHReadme(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
-        helpers.delete_files_in_folder(
-            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch.object(article, "download_article_xml_from_s3")
     @patch.object(activity_module, "get_session")
@@ -46,9 +44,10 @@ class TestGenerateSWHReadme(unittest.TestCase):
     def test_do_activity(
         self, mock_storage_context, mock_session, fake_download_article_xml
     ):
+        directory = TempDirectory()
         article_xml_file = "elife-30274-v2.xml"
         mock_storage_context.return_value = FakeStorageContext(
-            testdata.ExpandArticle_files_dest_folder
+            directory.path, dest_folder=directory.path
         )
         mock_session.return_value = FakeSession(
             testdata.SoftwareHeritageDeposit_session_example
@@ -63,16 +62,14 @@ class TestGenerateSWHReadme(unittest.TestCase):
         self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
 
         # look at the file contents
-        files = os.listdir(testdata.ExpandArticle_files_dest_folder)
+        files = os.listdir(directory.path)
         readme_files = [
             file_name
             for file_name in files
             if file_name != ".gitkeep" and file_name.startswith("README")
         ]
         readme_file = readme_files[0]
-        with open(
-            os.path.join(testdata.ExpandArticle_files_dest_folder, readme_file), "rb"
-        ) as open_file:
+        with open(os.path.join(directory.path, readme_file), "rb") as open_file:
             readme_string = open_file.read()
             self.assertTrue(
                 b'# Executable Research Article for "Replication Study: Transcriptional '

--- a/tests/activity/test_activity_output_accepted_submission.py
+++ b/tests/activity/test_activity_output_accepted_submission.py
@@ -30,10 +30,6 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
         TempDirectory.cleanup_all()
         # clean the temporary directory, including the cleaner.log file
         helpers.delete_files_in_folder(self.activity.get_tmp_dir())
-        # clean folder used by storage context
-        helpers.delete_files_in_folder(
-            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
@@ -59,8 +55,10 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
             test_activity_data.accepted_session_example.get("expanded_folder"),
             zip_file_path,
         )
+        dest_folder = os.path.join(directory.path, "files_dest")
+        os.mkdir(dest_folder)
         fake_storage_context.return_value = FakeStorageContext(
-            directory.path, resources
+            directory.path, resources, dest_folder=dest_folder
         )
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources
@@ -99,9 +97,7 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
         # check output bucket folder contents
         output_bucket_list = [
             file_name
-            for file_name in os.listdir(
-                test_activity_data.ExpandArticle_files_dest_folder
-            )
+            for file_name in os.listdir(dest_folder)
             if file_name != ".gitkeep"
         ]
         self.assertEqual(
@@ -110,7 +106,7 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
         )
         # check the contents of the zip file
         zip_file_path = os.path.join(
-            test_activity_data.ExpandArticle_files_dest_folder,
+            dest_folder,
             test_data.get("filename"),
         )
         with zipfile.ZipFile(zip_file_path, "r") as open_zipfile:

--- a/tests/activity/test_activity_package_swh.py
+++ b/tests/activity/test_activity_package_swh.py
@@ -2,9 +2,11 @@ import os
 import zipfile
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
+from provider import software_heritage
 import activity.activity_PackageSWH as activity_module
 from activity.activity_PackageSWH import activity_PackageSWH as activity_object
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import (
     FakeLogger,
     FakeResponse,
@@ -12,7 +14,6 @@ from tests.activity.classes_mock import (
     FakeSession,
 )
 import tests.activity.test_activity_data as testdata
-import tests.activity.helpers as helpers
 
 
 class TestPackageSWH(unittest.TestCase):
@@ -21,18 +22,19 @@ class TestPackageSWH(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
-        helpers.delete_files_in_folder(
-            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch("requests.get")
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")
     def test_do_activity(self, mock_storage_context, mock_session, fake_requests_get):
+        directory = TempDirectory()
         expected_zip_file_name = "elife-30274-v1-era.zip"
         expected_zip_file_size = 1161501
-        mock_storage_context.return_value = FakeStorageContext()
+        mock_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
         mock_session.return_value = FakeSession(
             testdata.SoftwareHeritageDeposit_session_example
         )
@@ -50,13 +52,18 @@ class TestPackageSWH(unittest.TestCase):
         self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
 
         # Check destination folder file
-        files = sorted(os.listdir(testdata.ExpandArticle_files_dest_folder))
+        bucket_folder_path = os.path.join(
+            directory.path,
+            software_heritage.BUCKET_FOLDER,
+            testdata.SoftwareHeritageDeposit_data_example.get("run"),
+        )
+        files = sorted(os.listdir(bucket_folder_path))
 
         index = 0
         compare_files = [file_name for file_name in files if file_name != ".gitkeep"]
         for file in compare_files:
             self.assertEqual(expected_zip_file_name, file)
-            statinfo = os.stat(testdata.ExpandArticle_files_dest_folder + "/" + file)
+            statinfo = os.stat(bucket_folder_path + "/" + file)
             self.assertEqual(
                 expected_zip_file_size,
                 statinfo.st_size,

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -7,7 +7,7 @@ from ddt import ddt, data, unpack
 from testfixtures import TempDirectory
 import activity.activity_PMCDeposit as activity_module
 from activity.activity_PMCDeposit import activity_PMCDeposit
-import tests.activity.settings_mock as settings_mock
+from tests.activity import settings_mock
 from tests.classes_mock import FakeSMTPServer
 from tests.activity.classes_mock import (
     FakeLogger,
@@ -15,8 +15,6 @@ from tests.activity.classes_mock import (
     FakeStorageContext,
     FakeFTP,
 )
-import tests.activity.test_activity_data as activity_test_data
-import tests.activity.helpers as helpers
 
 
 @ddt
@@ -130,10 +128,8 @@ class TestPMCDeposit(unittest.TestCase):
         )
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def zip_file_list(self, zip_file_name):
         file_list = None
@@ -157,14 +153,14 @@ class TestPMCDeposit(unittest.TestCase):
         mock_article_related,
         fake_clean_tmp_dir,
     ):
-
+        directory = TempDirectory()
         fake_ftp.return_value = FakeFTP()
         fake_clean_tmp_dir.return_value = None
 
         for test_data in self.do_activity_passes:
 
             fake_storage_context.return_value = FakeStorageContext(
-                directory=self.test_data_dir
+                directory=self.test_data_dir, dest_folder=directory.path
             )
             fake_list_resources.return_value = test_data["pmc_zip_key_names"]
             mock_article_related.return_value = 200, test_data["related_article_json"]

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -13,7 +13,6 @@ from activity.activity_PublishFinalPOA import activity_PublishFinalPOA
 from tests.classes_mock import FakeSMTPServer
 from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
-import tests.activity.test_activity_data as activity_test_data
 
 
 class TestPublishFinalPOA(unittest.TestCase):
@@ -235,9 +234,6 @@ class TestPublishFinalPOA(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.poa.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def remove_files_from_tmp_dir_subfolders(self):
         """
@@ -268,13 +264,15 @@ class TestPublishFinalPOA(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(self.poa.get_tmp_dir())
         fake_clean_tmp_dir.return_value = None
 
-        fake_storage_context.return_value = FakeStorageContext()
         fake_next_revision_number.return_value = 1
         # fake_upload_files_to_s3.return_value = True
         fake_get_pub_date_str_from_lax.return_value = "20160704000000"
 
         for test_data in self.do_activity_passes:
             directory = TempDirectory()
+            fake_storage_context.return_value = FakeStorageContext(
+                dest_folder=directory.path
+            )
             resources = helpers.populate_storage(
                 from_dir="tests/test_data/poa/outbox/",
                 to_dir=directory.path,

--- a/tests/activity/test_activity_push_swh_deposit.py
+++ b/tests/activity/test_activity_push_swh_deposit.py
@@ -7,7 +7,7 @@ import activity.activity_PushSWHDeposit as activity_module
 from activity.activity_PushSWHDeposit import (
     activity_PushSWHDeposit as activity_object,
 )
-import tests.activity.settings_mock as settings_mock
+from tests.activity import settings_mock
 from tests.activity.classes_mock import (
     FakeLogger,
     FakeResponse,
@@ -15,7 +15,6 @@ from tests.activity.classes_mock import (
     FakeSession,
 )
 import tests.activity.test_activity_data as testdata
-import tests.activity.helpers as helpers
 
 
 class TestPushSWHDeposit(unittest.TestCase):
@@ -27,9 +26,6 @@ class TestPushSWHDeposit(unittest.TestCase):
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
-        helpers.delete_files_in_folder(
-            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch("requests.post")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_rename_accepted_submission_videos.py
+++ b/tests/activity/test_activity_rename_accepted_submission_videos.py
@@ -104,7 +104,7 @@ class TestRenameAcceptedSubmissionVideos(unittest.TestCase):
             zip_file_path,
         )
         fake_storage_context.return_value = FakeStorageContext(
-            directory.path, resources
+            directory.path, resources, dest_folder=directory.path
         )
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -10,7 +10,7 @@ from tests.activity.classes_mock import (
     FakeSession,
     FakeStorageContext,
 )
-from tests.activity import helpers, settings_mock
+from tests.activity import settings_mock
 import tests.activity.test_activity_data as testdata
 
 
@@ -23,9 +23,7 @@ class TestScheduleCrossref(unittest.TestCase):
         )
 
     def tearDown(self):
-        helpers.delete_files_in_folder(
-            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
+        pass
 
     @patch("provider.lax_provider.get_xml_file_name")
     @patch("activity.activity_ScheduleCrossref.get_session")

--- a/tests/activity/test_activity_schedule_crossref_pending_publication.py
+++ b/tests/activity/test_activity_schedule_crossref_pending_publication.py
@@ -31,10 +31,6 @@ class TestScheduleCrossrefPendingPublication(unittest.TestCase):
         TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
-        # clean out the bucket destination folder
-        helpers.delete_files_in_folder(
-            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch("provider.outbox_provider.storage_context")
     @patch.object(cleaner, "storage_context")
@@ -69,7 +65,9 @@ class TestScheduleCrossrefPendingPublication(unittest.TestCase):
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources=resources
         )
-        fake_outbox_storage_context.return_value = FakeStorageContext()
+        fake_outbox_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
         fake_session.return_value = FakeSession(
             test_activity_data.accepted_session_example
         )

--- a/tests/activity/test_activity_send_dashboard_properties.py
+++ b/tests/activity/test_activity_send_dashboard_properties.py
@@ -3,7 +3,7 @@ from mock import patch, ANY
 from testfixtures import TempDirectory
 from activity import activity_SendDashboardProperties as activity_module
 from activity.activity_SendDashboardProperties import activity_SendDashboardProperties
-from tests.activity import helpers, settings_mock
+from tests.activity import settings_mock
 from tests.activity.classes_mock import (
     FakeSession,
     FakeStorageContext,
@@ -23,9 +23,6 @@ class TestSendDashboardEvents(unittest.TestCase):
     def tearDown(self):
         self.directory.cleanup()
         TempDirectory.cleanup_all()
-        helpers.delete_files_in_folder(
-            test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     @patch("provider.lax_provider.get_xml_file_name")
     @patch.object(activity_module, "storage_context")

--- a/tests/activity/test_activity_verify_image_server.py
+++ b/tests/activity/test_activity_verify_image_server.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch, MagicMock
-from tests.activity import helpers, settings_mock
+from testfixtures import TempDirectory
+from tests.activity import settings_mock
 from tests.activity.classes_mock import FakeSession, FakeStorageContext
 from activity.activity_VerifyImageServer import activity_VerifyImageServer
 import tests.activity.test_activity_data as test_data
@@ -22,9 +23,7 @@ class TestVerifyImageServer(unittest.TestCase):
         ]
 
     def tearDown(self):
-        helpers.delete_files_in_folder(
-            test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
+        TempDirectory.cleanup_all()
 
     @patch("activity.activity_VerifyImageServer.storage_context")
     @patch("activity.activity_VerifyImageServer.get_session")
@@ -32,12 +31,13 @@ class TestVerifyImageServer(unittest.TestCase):
     def test_do_activity_success(
         self, fake_retrieve_endpoints_check, fake_session, fake_storage_context
     ):
+        directory = TempDirectory()
         # Given
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.return_value = [(True, "test.path")]
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext(
-            test_data.ExpandArticle_files_dest_folder, self.resources
+            directory.path, self.resources
         )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()
@@ -52,12 +52,13 @@ class TestVerifyImageServer(unittest.TestCase):
     def test_do_activity_failure(
         self, fake_retrieve_endpoints_check, fake_session, fake_storage_context
     ):
+        directory = TempDirectory()
         # Given
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.return_value = [(False, "test.path")]
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext(
-            test_data.ExpandArticle_files_dest_folder, self.resources
+            directory.path, self.resources
         )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()
@@ -72,12 +73,13 @@ class TestVerifyImageServer(unittest.TestCase):
     def test_do_activity_error(
         self, fake_retrieve_endpoints_check, fake_session, fake_storage_context
     ):
+        directory = TempDirectory()
         # Given
         data = test_data.data_example_before_publish
         fake_retrieve_endpoints_check.side_effect = Exception("Error!")
         fake_session.return_value = FakeSession(test_data.session_example)
         fake_storage_context.return_value = FakeStorageContext(
-            test_data.ExpandArticle_files_dest_folder, self.resources
+            directory.path, self.resources
         )
         self.verifyimageserver.emit_monitor_event = MagicMock()
         self.verifyimageserver.logger = MagicMock()

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -4,12 +4,10 @@ from collections import OrderedDict
 from mock import patch
 from testfixtures import TempDirectory
 from elifearticle.article import ArticleDate
-import provider.crossref as crossref
-import tests.settings_mock as settings_mock
+from provider import crossref
+from tests import settings_mock
 import tests.test_data as test_case_data
 from tests.activity.classes_mock import FakeLogger, FakeResponse
-import tests.activity.helpers as helpers
-import tests.activity.test_activity_data as activity_test_data
 
 
 def expected_http_detail(file_name, status_code):
@@ -28,9 +26,6 @@ class TestCrossrefProvider(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        helpers.delete_files_in_folder(
-            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
-        )
 
     def test_elifecrossref_config(self):
         """test reading the crossref config file"""


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7383

`FakeStorageContext` class, in `tests/activity/classes_mock.py` is changed so the output folder can be passed as an argument, and when writing objects to the fake bucket, path names are preserved.

Existing tests are updated to pass in a temporary directory for bucket "output", so read the contents from subfolders, and to use the `files_dest` folder (specified in the `ExpandArticle_files_dest_folder` variable) as little as possible, to use the `TempDirectory` instead.