### PR TITLE
Add video deposit and annotate activity steps.

### DIFF
--- a/activity/activity_AnnotateAcceptedSubmissionVideos.py
+++ b/activity/activity_AnnotateAcceptedSubmissionVideos.py
@@ -1,0 +1,268 @@
+import os
+import json
+import shutil
+from xml.etree.ElementTree import ParseError
+from provider import cleaner, glencoe_check
+from provider.cleaner import SettingsException
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+REPAIR_XML = False
+
+# session variable name to store the number of attempts
+SESSION_ATTEMPT_COUNTER_NAME = "video_metadata_attempt_count"
+
+MAX_ATTEMPTS = 12
+
+
+class activity_AnnotateAcceptedSubmissionVideos(Activity):
+    "AnnotateAcceptedSubmissionVideos activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AnnotateAcceptedSubmissionVideos, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AnnotateAcceptedSubmissionVideos"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Get video metadata from the API endpoint and"
+            " add metadata to accepted submission XML."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"get": None, "annotate": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+        article_id = session.get_value("article_id")
+        annotate_videos = session.get_value("annotate_videos")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # if there are no videos to annotate return True
+        if not annotate_videos:
+            self.logger.info(
+                "%s, %s annotate_videos session value is %s, activity returning True"
+                % (self.name, input_filename, annotate_videos)
+            )
+            return True
+
+        # if there are insufficient credentials return True
+        settings_required = [
+            "video_url",
+        ]
+        try:
+            cleaner.verify_settings(
+                self.settings, settings_required, self.name, input_filename
+            )
+        except SettingsException as exception:
+            self.logger.exception(str(exception))
+            return True
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
+
+        # get metadata from video service endpoint
+        try:
+            gc_data = glencoe_check.metadata(
+                glencoe_check.check_msid(article_id), self.settings
+            )
+            self.logger.info("gc_data: %s" % json.dumps(gc_data, indent=4))
+            self.statuses["get"] = True
+        except Exception as exception:
+            # handle Glencoe API responses
+            message = "%s, exception in glencoe_check metadata for file %s: %s" % (
+                self.name,
+                input_filename,
+                exception,
+            )
+            # log when an exception is raised
+            self.logger.exception(message)
+            # count the number of attempts
+            if not session.get_value(SESSION_ATTEMPT_COUNTER_NAME):
+                session.store_value(SESSION_ATTEMPT_COUNTER_NAME, 1)
+            else:
+                # increment
+                session.store_value(
+                    SESSION_ATTEMPT_COUNTER_NAME,
+                    int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) + 1,
+                )
+            self.logger.info(
+                "%s, glencoe_check metadata attempts for file %s: %s"
+                % (
+                    self.name,
+                    input_filename,
+                    session.get_value(SESSION_ATTEMPT_COUNTER_NAME),
+                )
+            )
+            self.log_statuses(input_filename)
+            # Clean up disk
+            self.clean_tmp_dir()
+            if int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) < MAX_ATTEMPTS:
+                # return a temporary failure
+                return self.ACTIVITY_TEMPORARY_FAILURE
+            if int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) >= MAX_ATTEMPTS:
+                # return success after the maximum number of attempts to continue the workflow
+                self.logger.info(
+                    "%s, glencoe_check metadata attempts reached MAX_ATTEMPTS of %s for file %s"
+                    % (self.name, MAX_ATTEMPTS, input_filename)
+                )
+                return True
+
+        # read the XML
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
+
+        # parse XML
+        try:
+            root = cleaner.parse_article_xml(xml_file_path)
+            video_files = cleaner.video_file_list(xml_file_path)
+            self.logger.info("%s, %s XML root parsed" % (self.name, input_filename))
+            generated_video_data = cleaner.video_data_from_files(
+                video_files, article_id
+            )
+        except ParseError:
+            log_message = "%s, XML ParseError exception parsing XML %s for file %s" % (
+                self.name,
+                xml_file_path,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            root = None
+
+            generated_video_data = []
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
+        if root:
+            # for each video_id, get the glencoe video metadata
+            annotate_xml(
+                root, xml_file_path, generated_video_data, gc_data, input_filename
+            )
+            self.statuses["annotate"] = True
+
+        # upload the modified XML file to the expanded folder
+        if self.statuses.get("annotate"):
+            upload_key = cleaner.article_xml_asset(asset_file_name_map)[0]
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            local_file_path = asset_file_name_map.get(upload_key)
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+            self.statuses["upload_xml"] = True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)
+
+def annotate_xml(
+    root, xml_file_path, generated_video_data, gc_data, input_filename
+):
+    # for each video_id, get the glencoe video metadata
+    for video_data in generated_video_data:
+        video_id = video_data.get("video_id")
+        gc_video_data = gc_data.get(video_id)
+        video_data["glencoe_mp4"] = gc_video_data.get("mp4_href")
+        video_data["glencoe_jpg"] = gc_video_data.get("jpg_href")
+    # modify the file tag attributes
+    file_name_data_map = {
+        video_data.get("upload_file_nm"): video_data
+        for video_data in generated_video_data
+    }
+    for file_tag in root.findall("./front/article-meta/files/file"):
+        for file_nm_tag in file_tag.findall("./upload_file_nm"):
+            if file_nm_tag.text in file_name_data_map:
+                video_data = file_name_data_map.get(file_nm_tag.text)
+                file_tag.set("id", video_data.get("video_id"))
+                file_tag.set("glencoe-mp4", video_data.get("glencoe_mp4"))
+                file_tag.set("glencoe-jpg", video_data.get("glencoe_jpg"))
+    # write the modified XML to disk
+    cleaner.write_xml_file(root, xml_file_path, input_filename)

--- a/activity/activity_DepositAcceptedSubmissionVideos.py
+++ b/activity/activity_DepositAcceptedSubmissionVideos.py
@@ -1,0 +1,345 @@
+import os
+import json
+import glob
+import shutil
+import zipfile
+from xml.etree.ElementTree import ParseError
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner
+from provider.cleaner import SettingsException
+from provider.ftp import FTP
+from activity.objects import Activity
+
+
+REPAIR_XML = False
+
+FILE_NAME_PREFIX = "elife_videos_"
+
+# session variable name to store the number of attempts
+SESSION_ATTEMPT_COUNTER_NAME = "video_deposit_ftp_attempt_count"
+
+MAX_ATTEMPTS = 3
+
+
+class activity_DepositAcceptedSubmissionVideos(Activity):
+    "DepositAcceptedSubmissionVideos activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_DepositAcceptedSubmissionVideos, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "DepositAcceptedSubmissionVideos"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Package video and XML into a zip file and deposit to a video service."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"generate": None, "zip": None, "deposit": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+        article_id = session.get_value("article_id")
+        deposit_videos = session.get_value("deposit_videos")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # if there are no videos to deposit return True
+        if not deposit_videos:
+            self.logger.info(
+                "%s, %s deposit_videos session value is %s, activity returning True"
+                % (self.name, input_filename, deposit_videos)
+            )
+            return True
+
+        # if there are insufficient deposit credentials return True
+        settings_required = [
+            "GLENCOE_FTP_URI",
+            "GLENCOE_FTP_USERNAME",
+            "GLENCOE_FTP_PASSWORD",
+        ]
+        try:
+            cleaner.verify_settings(
+                self.settings, settings_required, self.name, input_filename
+            )
+        except SettingsException as exception:
+            self.logger.exception(str(exception))
+            return True
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
+
+        # get the file list from the XML
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
+
+        # get a list of video files from the XML
+        try:
+            video_files = cleaner.video_file_list(xml_file_path)
+            self.logger.info(
+                "%s, %s video_files: %s" % (self.name, input_filename, video_files)
+            )
+        except ParseError:
+            log_message = (
+                "%s, XML ParseError exception parsing video file list from %s for file %s"
+                % (
+                    self.name,
+                    xml_file_path,
+                    input_filename,
+                )
+            )
+            self.logger.exception(log_message)
+            video_files = []
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
+        # download video files from the bucket folder
+        if video_files:
+            cleaner.download_asset_files_from_bucket(
+                storage,
+                video_files,
+                asset_file_name_map,
+                self.directories.get("INPUT_DIR"),
+                self.logger,
+            )
+            video_data = cleaner.video_data_from_files(video_files, article_id)
+
+        # generate glencoe XML
+        if video_files:
+            glencoe_xml_file_path = self.generate_video_xml(
+                input_filename, xml_file_path, video_data
+            )
+            self.statuses["generate"] = True
+
+        # zip up the files and XML
+        if self.statuses.get("generate"):
+            self.create_video_zip(
+                asset_file_name_map, input_filename, video_data, glencoe_xml_file_path
+            )
+            self.statuses["zip"] = True
+
+        # FTP the zip file to Glencoe
+        if self.statuses.get("zip"):
+
+            try:
+                self.statuses["deposit"] = self.ftp_to_endpoint(
+                    self.directories.get("TEMP_DIR")
+                )
+                # set session variable for whether to check for Glencoe metadata
+                session.store_value("annotate_videos", True)
+            except Exception as exception:
+                message = "%s, exception in ftp_to_endpoint sending file %s: %s" % (
+                    self.name,
+                    input_filename,
+                    exception,
+                )
+                # log when an exception is raised
+                self.logger.exception(message)
+
+                # count the number of attempts
+                if not session.get_value(SESSION_ATTEMPT_COUNTER_NAME):
+                    session.store_value(SESSION_ATTEMPT_COUNTER_NAME, 1)
+                else:
+                    # increment
+                    session.store_value(
+                        SESSION_ATTEMPT_COUNTER_NAME,
+                        int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) + 1,
+                    )
+                self.logger.info(
+                    "%s, ftp_to_endpoint attempts for file %s: %s"
+                    % (
+                        self.name,
+                        input_filename,
+                        session.get_value(SESSION_ATTEMPT_COUNTER_NAME),
+                    )
+                )
+                self.log_statuses(input_filename)
+                # Clean up disk
+                self.clean_tmp_dir()
+                if int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) < MAX_ATTEMPTS:
+                    # return a temporary failure
+                    return self.ACTIVITY_TEMPORARY_FAILURE
+                if int(session.get_value(SESSION_ATTEMPT_COUNTER_NAME)) >= MAX_ATTEMPTS:
+                    # return success after the maximum number of attempts to continue the workflow
+                    self.logger.info(
+                        "%s, ftp_to_endpoint attempts reached MAX_ATTEMPTS of %s for file %s"
+                        % (self.name, MAX_ATTEMPTS, input_filename)
+                    )
+                    return True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def generate_video_xml(self, input_filename, xml_file_path, video_data):
+        "generate a JATS XML file containing video deposit metadata"
+        glencoe_xml_file_name = "%s%s.xml" % (
+            FILE_NAME_PREFIX,
+            input_filename.rsplit(".", 1)[0],
+        )
+        xml_string = cleaner.glencoe_xml(xml_file_path, video_data)
+        glencoe_xml_file_path = os.path.join(
+            self.directories.get("TEMP_DIR"), glencoe_xml_file_name
+        )
+        self.logger.info(
+            "%s, writing video XML for %s to %s"
+            % (self.name, input_filename, glencoe_xml_file_path)
+        )
+        with open(glencoe_xml_file_path, "wb") as open_file:
+            open_file.write(xml_string)
+        return glencoe_xml_file_path
+
+    def create_video_zip(
+        self, asset_file_name_map, input_filename, video_data, glencoe_xml_file_path
+    ):
+        "create zip file containing video files and video XML"
+        # map of asset key names
+        asset_key_map = {key.rsplit("/", 1)[-1]: key for key in asset_file_name_map}
+        # zip file name
+        glencoe_zip_file_name = "%s%s" % (FILE_NAME_PREFIX, input_filename)
+        glencoe_zip_file_path = os.path.join(
+            self.directories.get("TEMP_DIR"), glencoe_zip_file_name
+        )
+        with zipfile.ZipFile(
+            glencoe_zip_file_path, "w", zipfile.ZIP_DEFLATED, allowZip64=True
+        ) as open_zip:
+            # add video files
+            for video in video_data:
+                video_asset_key = asset_key_map.get(video.get("video_filename"))
+                video_file_path = asset_file_name_map.get(video_asset_key)
+                self.logger.info(
+                    "%s, adding video file %s to zip file %s"
+                    % (self.name, video_file_path, glencoe_zip_file_path)
+                )
+                arcname = video_file_path.rsplit(os.sep, 1)[-1]
+                open_zip.write(video_file_path, arcname)
+            # add XML file
+            self.logger.info(
+                "%s, adding video XML file %s to zip file %s"
+                % (self.name, glencoe_xml_file_path, glencoe_zip_file_path)
+            )
+            arcname = glencoe_xml_file_path.rsplit(os.sep, 1)[-1]
+            open_zip.write(glencoe_xml_file_path, arcname)
+
+    def ftp_to_endpoint(self, from_dir, file_type="/*.zip", passive=True):
+        """
+        FTP files to endpoint
+        as specified by the file_type to use in the glob
+        e.g. "/*.zip"
+        """
+        try:
+            ftp_provider = FTP(self.logger)
+            ftp_instance = ftp_provider.ftp_connect(
+                uri=self.settings.GLENCOE_FTP_URI,
+                username=self.settings.GLENCOE_FTP_USERNAME,
+                password=self.settings.GLENCOE_FTP_PASSWORD,
+                passive=passive,
+            )
+        except Exception as exception:
+            self.logger.exception("Exception connecting to FTP server: %s" % exception)
+            raise
+
+        # collect the list of files
+        zipfiles = glob.glob(from_dir + file_type)
+
+        try:
+            # transfer them by FTP to the endpoint
+            ftp_provider.ftp_to_endpoint(
+                ftp_instance=ftp_instance,
+                uploadfiles=zipfiles,
+                sub_dir_list=[self.settings.GLENCOE_FTP_CWD],
+            )
+        except Exception as exception:
+            self.logger.exception(
+                "Exception in transfer of files by FTP: %s" % exception
+            )
+            ftp_provider.ftp_disconnect(ftp_instance)
+            raise
+
+        try:
+            # disconnect the FTP connection
+            ftp_provider.ftp_disconnect(ftp_instance)
+        except Exception as exception:
+            self.logger.exception(
+                "Exception disconnecting from FTP server: %s" % exception
+            )
+            raise
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)

--- a/activity/activity_RenameAcceptedSubmissionVideos.py
+++ b/activity/activity_RenameAcceptedSubmissionVideos.py
@@ -2,6 +2,7 @@ import os
 import json
 import shutil
 from xml.etree.ElementTree import ParseError
+from elifecleaner.transform import ArticleZipFile
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from provider import cleaner
@@ -131,9 +132,9 @@ class activity_RenameAcceptedSubmissionVideos(Activity):
         file_transformations = []
         for video_data in generated_video_data:
             from_file_name = video_data.get("upload_file_nm")
-            from_file = cleaner.ArticleZipFile(from_file_name)
+            from_file = ArticleZipFile(from_file_name)
             to_file_name = video_data.get("video_filename")
-            to_file = cleaner.ArticleZipFile(to_file_name)
+            to_file = ArticleZipFile(to_file_name)
             file_transformations.append((from_file, to_file))
         self.logger.info(
             "%s, %s file_transformations: %s"

--- a/register.py
+++ b/register.py
@@ -127,6 +127,8 @@ def start(settings):
     activity_names.append("EmailAcceptedSubmissionOutput")
     activity_names.append("ValidateAcceptedSubmissionVideos")
     activity_names.append("RenameAcceptedSubmissionVideos")
+    activity_names.append("DepositAcceptedSubmissionVideos")
+    activity_names.append("AnnotateAcceptedSubmissionVideos")
     activity_names.append("OutputAcceptedSubmission")
 
     for activity_name in activity_names:

--- a/settings-example.py
+++ b/settings-example.py
@@ -334,6 +334,12 @@ class exp:
     accepted_submission_queue = ""
     accepted_submission_output_recipient_email = "e@example.org"
 
+    # Glencoe video deposit FTP settings
+    GLENCOE_FTP_URI = ""
+    GLENCOE_FTP_USERNAME = ""
+    GLENCOE_FTP_PASSWORD = ""
+    GLENCOE_FTP_CWD = ""
+
 
 class dev:
     # AWS settings
@@ -652,6 +658,12 @@ class dev:
     ]
     accepted_submission_queue = ""
     accepted_submission_output_recipient_email = "e@example.org"
+
+    # Glencoe video deposit FTP settings
+    GLENCOE_FTP_URI = ""
+    GLENCOE_FTP_USERNAME = ""
+    GLENCOE_FTP_PASSWORD = ""
+    GLENCOE_FTP_CWD = ""
 
 
 class live:
@@ -976,6 +988,12 @@ class live:
     ]
     accepted_submission_queue = "cleaning-queue"
     accepted_submission_output_recipient_email = "e@example.org"
+
+    # Glencoe video deposit FTP settings
+    GLENCOE_FTP_URI = ""
+    GLENCOE_FTP_USERNAME = ""
+    GLENCOE_FTP_PASSWORD = ""
+    GLENCOE_FTP_CWD = ""
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -77,7 +77,7 @@ email_video_recipient_email = "features_team@example.org"
 
 xml_info_queue = "test-elife-xml-info"
 
-video_url = ""
+video_url = "https://videometadata/"
 
 crossref_url = ""
 crossref_login_id = ""
@@ -229,3 +229,9 @@ accepted_submission_validate_error_recipient_email = [
     "life@example.org",
 ]
 accepted_submission_output_recipient_email = "typesetter@example.org"
+
+# Glencoe video deposit FTP settings
+GLENCOE_FTP_URI = "glencoe.localhost"
+GLENCOE_FTP_USERNAME = "user"
+GLENCOE_FTP_PASSWORD = "pass"
+GLENCOE_FTP_CWD = "folder"

--- a/tests/activity/test_activity_annotate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_annotate_accepted_submission_videos.py
@@ -1,0 +1,575 @@
+# coding=utf-8
+
+import os
+import glob
+import copy
+import shutil
+import unittest
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner, glencoe_check
+import activity.activity_AnnotateAcceptedSubmissionVideos as activity_module
+from activity.activity_AnnotateAcceptedSubmissionVideos import (
+    activity_AnnotateAcceptedSubmissionVideos as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeResponse,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+GLENCOE_METADATA_ARTICLE_63532 = {
+    "video1": {
+        "source_href": (
+            "https://static-movie-usa.glencoesoftware.com/source/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.avi"
+        ),
+        "doi": "",
+        "flv_href": (
+            "https://static-movie-usa.glencoesoftware.com/flv/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.flv"
+        ),
+        "uuid": "6a2538e3-621a-4412-b037-bbb7db4bec36",
+        "title": "video1",
+        "video_id": "video1",
+        "solo_href": "https://movie-usa.glencoesoftware.com/video/10.7554/eLife.63532/video1",
+        "height": 473,
+        "ogv_href": (
+            "https://static-movie-usa.glencoesoftware.com/ogv/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.ogv"
+        ),
+        "width": 473,
+        "legend": "",
+        "href": "elife-63532-video1.avi",
+        "webm_href": (
+            "https://static-movie-usa.glencoesoftware.com/webm/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.webm"
+        ),
+        "jpg_href": (
+            "https://static-movie-usa.glencoesoftware.com/jpg/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.jpg"
+        ),
+        "duration": 8.714286,
+        "mp4_href": (
+            "https://static-movie-usa.glencoesoftware.com/mp4/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.mp4"
+        ),
+        "id": "",
+        "size": 40976840,
+    },
+    "video2": {
+        "source_href": (
+            "https://static-movie-usa.glencoesoftware.com/source/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.avi"
+        ),
+        "doi": "",
+        "flv_href": (
+            "https://static-movie-usa.glencoesoftware.com/flv/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.flv"
+        ),
+        "uuid": "86a0d2c8-d6f2-4aa8-b07f-4c089d0f5423",
+        "title": "video2",
+        "video_id": "video2",
+        "solo_href": "https://movie-usa.glencoesoftware.com/video/10.7554/eLife.63532/video2",
+        "height": 346,
+        "ogv_href": (
+            "https://static-movie-usa.glencoesoftware.com/ogv/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.ogv"
+        ),
+        "width": 502,
+        "legend": "",
+        "href": "elife-63532-video2.avi",
+        "webm_href": (
+            "https://static-movie-usa.glencoesoftware.com/webm/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.webm"
+        ),
+        "jpg_href": (
+            "https://static-movie-usa.glencoesoftware.com/jpg/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.jpg"
+        ),
+        "duration": 4.428571,
+        "mp4_href": (
+            "https://static-movie-usa.glencoesoftware.com/mp4/10.7554/202/"
+            "c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.mp4"
+        ),
+        "id": "",
+        "size": 520732,
+    },
+}
+
+
+def input_data(file_name_to_change=""):
+    activity_data = copy.copy(test_case_data.ingest_accepted_submission_data)
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+def session_data(
+    filename=None, article_id=None, deposit_videos=None, annotate_videos=None
+):
+    s_data = copy.copy(test_activity_data.accepted_session_example)
+    if filename:
+        s_data["input_filename"] = filename
+    if article_id:
+        s_data["article_id"] = article_id
+    if deposit_videos:
+        s_data["deposit_videos"] = deposit_videos
+    if annotate_videos:
+        s_data["annotate_videos"] = annotate_videos
+    return s_data
+
+
+def expanded_folder_renamed_video_resources(directory, expanded_folder, zip_file_path):
+    "populate the expanded folder with files and rename and modify them to match expected data"
+    resources = helpers.expanded_folder_bucket_resources(
+        directory, expanded_folder, zip_file_path
+    )
+    if zip_file_path.rsplit("/", 1)[-1] == "28-09-2020-RA-eLife-63532.zip":
+        sub_folder = "28-09-2020-RA-eLife-63532"
+        video_file_map = {
+            "Video 1 AVI.avi": "elife-63532-video1.avi",
+            "Video 2 AVI .avi": "elife-63532-video2.avi",
+        }
+        xml_file = "28-09-2020-RA-eLife-63532.xml"
+        xml_file_path = os.path.join(
+            directory.path, expanded_folder, sub_folder, xml_file
+        )
+        # read the XML file content
+        with open(xml_file_path, "r", encoding="utf-8") as open_file:
+            xml_content = open_file.read()
+        for from_file, to_file in video_file_map.items():
+            # rename the file on disk
+            shutil.move(
+                os.path.join(directory.path, expanded_folder, sub_folder, from_file),
+                os.path.join(directory.path, expanded_folder, sub_folder, to_file),
+            )
+            # replace in the XML content
+            xml_content = xml_content.replace(from_file, to_file)
+            # alter the resources list items
+            resources.remove("%s/%s" % (sub_folder, from_file))
+            resources.append("%s/%s" % (sub_folder, to_file))
+        # write the final XML out to the file
+        with open(xml_file_path, "w", encoding="utf-8") as open_file:
+            open_file.write(xml_content)
+    return resources
+
+
+@ddt
+class TestAnnotateAcceptedSubmissionVideos(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    @patch.object(cleaner, "storage_context")
+    @patch("requests.get")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission with videos",
+            "filename": "28-09-2020-RA-eLife-63532.zip",
+            "article_id": "63532",
+            "annotate_videos": True,
+            "expected_xml_file_path": "28-09-2020-RA-eLife-63532/28-09-2020-RA-eLife-63532.xml",
+            "expected_result": True,
+            "expected_get_status": True,
+            "expected_annotate_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml": [
+                '<file file-type="video" glencoe-jpg="https://static-movie-usa.glencoesoftware.com/jpg/10.7554/202/c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.jpg" glencoe-mp4="https://static-movie-usa.glencoesoftware.com/mp4/10.7554/202/c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video1.mp4" id="video1">',
+                '<file file-type="video" glencoe-jpg="https://static-movie-usa.glencoesoftware.com/jpg/10.7554/202/c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.jpg" glencoe-mp4="https://static-movie-usa.glencoesoftware.com/mp4/10.7554/202/c0f4d0de3cd6bcc603bf3ef7a9435a8475709023/elife-63532-video2.mp4" id="video2">',
+            ],
+        },
+        {
+            "comment": "accepted submission zip has no videos",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "article_id": "45644",
+            "annotate_videos": None,
+            "expected_xml_file_path": None,
+            "expected_result": True,
+            "expected_get_status": None,
+            "expected_annotate_status": None,
+            "expected_upload_xml_status": None,
+            "expected_xml": [],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_get,
+        fake_cleaner_storage_context,
+        fake_storage_context,
+        fake_session,
+    ):
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # video get metadata response
+        fake_get.return_value = FakeResponse(200, GLENCOE_METADATA_ARTICLE_63532)
+
+        workflow_session_data = session_data(
+            filename=test_data.get("filename"),
+            article_id=test_data.get("article_id"),
+            annotate_videos=test_data.get("annotate_videos"),
+        )
+        fake_session.return_value = FakeSession(workflow_session_data)
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = expanded_folder_renamed_video_resources(
+            directory,
+            workflow_session_data.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("get"),
+            test_data.get("expected_get_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("annotate"),
+            test_data.get("expected_annotate_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        expanded_folder = os.path.join(
+            directory.path, workflow_session_data.get("expanded_folder")
+        )
+        expanded_folder_files = glob.glob(expanded_folder + "/*/*")
+        xml_file_path = ""
+        if test_data.get("expected_xml_file_path"):
+            xml_file_path = os.path.join(
+                expanded_folder,
+                test_data.get("expected_xml_file_path"),
+            )
+            self.assertTrue(xml_file_path in expanded_folder_files)
+
+        if xml_file_path and test_data.get("expected_xml"):
+            # assert XML file was modified
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            for expected_xml in test_data.get("expected_xml"):
+                self.assertTrue(
+                    expected_xml in xml_string,
+                    "%s not found in xml_string" % expected_xml,
+                )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch("requests.get")
+    @patch.object(cleaner, "parse_article_xml")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_parse_article_xml,
+        fake_get,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an XML ParseError when getting a file list"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+        xml_file_path = os.path.join(
+            self.activity.directories.get("INPUT_DIR"),
+            xml_file,
+        )
+        # video get metadata response
+        fake_get.return_value = FakeResponse(200, None)
+        fake_session.return_value = FakeSession(
+            session_data(
+                zip_file, article_id, deposit_videos=True, annotate_videos=True
+            )
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = expanded_folder_renamed_video_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_parse_article_xml.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "AnnotateAcceptedSubmissionVideos, XML ParseError exception "
+            "parsing XML %s for file %s"
+        ) % (xml_file_path, zip_file)
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+
+class TestAnnotateAcceptedSubmissionVideosGlencoeExceptions(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        filename = "28-09-2020-RA-eLife-63532.zip"
+        article_id = "63532"
+        # expanded bucket files
+        self.directory = TempDirectory()
+
+        self.workflow_session_data = session_data(
+            filename=filename,
+            article_id=article_id,
+            annotate_videos=True,
+        )
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            filename,
+        )
+        self.resources = expanded_folder_renamed_video_resources(
+            self.directory,
+            self.workflow_session_data.get("expanded_folder"),
+            zip_file_path,
+        )
+        self.dest_folder = os.path.join(
+            self.directory.path, self.workflow_session_data.get("expanded_folder")
+        )
+        self.input_data = input_data(filename)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(glencoe_check, "metadata")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_metadata_exception(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_metadata,
+        fake_storage_context,
+    ):
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_metadata.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch("requests.get")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_metadata_404(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_get,
+        fake_storage_context,
+    ):
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_get.return_value = FakeResponse(404, None)
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch("requests.get")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_metadata_404_increment_attempts(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_get,
+        fake_storage_context,
+    ):
+        "test if session variable count of attempts already exists"
+        self.workflow_session_data[activity_module.SESSION_ATTEMPT_COUNTER_NAME] = 1
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_get.return_value = FakeResponse(404, None)
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch("requests.get")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_metadata_404_max_attempts(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_get,
+        fake_storage_context,
+    ):
+        "test if attempt count exceeds the max attempts"
+        self.workflow_session_data[
+            activity_module.SESSION_ATTEMPT_COUNTER_NAME
+        ] = 1000000
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_get.return_value = FakeResponse(404, None)
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, True)
+
+
+class TestAnnotateVideosAnnotateVideosNone(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_annotate_videos_none(
+        self,
+        fake_session,
+    ):
+        "test if there is no annotate_videos value in the session"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(session_data(zip_file, article_id))
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_loginfo = (
+            "AnnotateAcceptedSubmissionVideos, %s"
+            " annotate_videos session value is None, activity returning True"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.loginfo[-1], expected_loginfo)
+
+
+class TestAnnotateVideosNoCredentials(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # change settings value
+        self.video_url = self.activity.settings.video_url
+        del self.activity.settings.video_url
+
+    def tearDown(self):
+        # restore settings value
+        self.activity.settings.video_url = self.video_url
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_annotate_videos_no_credentials(
+        self,
+        fake_session,
+    ):
+        "test if there are no credentials in the settings"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, True, True)
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_exception_message = (
+            "AnnotateAcceptedSubmissionVideos, %s"
+            " settings credential video_url is missing"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_exception_message)
+
+
+class TestAnnotateVideosBlankCredentials(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # change settings value
+        self.video_url = self.activity.settings.video_url
+        self.activity.settings.video_url = ""
+
+    def tearDown(self):
+        # restore settings value
+        self.activity.settings.video_url = self.video_url
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_annotate_videos_blank_credentials(
+        self,
+        fake_session,
+    ):
+        "test if there are blank credentials in the settings"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, True, True)
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_exception_message = (
+            "AnnotateAcceptedSubmissionVideos, %s"
+            " settings credential video_url is blank"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_exception_message)

--- a/tests/activity/test_activity_deposit_accepted_submission_videos.py
+++ b/tests/activity/test_activity_deposit_accepted_submission_videos.py
@@ -1,0 +1,530 @@
+# coding=utf-8
+
+import os
+import glob
+import copy
+import shutil
+import unittest
+import zipfile
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_DepositAcceptedSubmissionVideos as activity_module
+from activity.activity_DepositAcceptedSubmissionVideos import (
+    activity_DepositAcceptedSubmissionVideos as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeFTP,
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = copy.copy(test_case_data.ingest_accepted_submission_data)
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+def session_data(filename=None, article_id=None, deposit_videos=None):
+    s_data = copy.copy(test_activity_data.accepted_session_example)
+    if filename:
+        s_data["input_filename"] = filename
+    if article_id:
+        s_data["article_id"] = article_id
+    if deposit_videos:
+        s_data["deposit_videos"] = deposit_videos
+    return s_data
+
+
+def expanded_folder_renamed_video_resources(directory, expanded_folder, zip_file_path):
+    "populate the expanded folder with files and rename and modify them to match expected data"
+    resources = helpers.expanded_folder_bucket_resources(
+        directory, expanded_folder, zip_file_path
+    )
+    if zip_file_path.rsplit("/", 1)[-1] == "28-09-2020-RA-eLife-63532.zip":
+        sub_folder = "28-09-2020-RA-eLife-63532"
+        video_file_map = {
+            "Video 1 AVI.avi": "elife-63532-video1.avi",
+            "Video 2 AVI .avi": "elife-63532-video2.avi",
+        }
+        xml_file = "28-09-2020-RA-eLife-63532.xml"
+        xml_file_path = os.path.join(
+            directory.path, expanded_folder, sub_folder, xml_file
+        )
+        # read the XML file content
+        with open(xml_file_path, "r", encoding="utf-8") as open_file:
+            xml_content = open_file.read()
+        for from_file, to_file in video_file_map.items():
+            # rename the file on disk
+            shutil.move(
+                os.path.join(directory.path, expanded_folder, sub_folder, from_file),
+                os.path.join(directory.path, expanded_folder, sub_folder, to_file),
+            )
+            # replace in the XML content
+            xml_content = xml_content.replace(from_file, to_file)
+            # alter the resources list items
+            resources.remove("%s/%s" % (sub_folder, from_file))
+            resources.append("%s/%s" % (sub_folder, to_file))
+        # write the final XML out to the file
+        with open(xml_file_path, "w", encoding="utf-8") as open_file:
+            open_file.write(xml_content)
+    return resources
+
+
+@ddt
+class TestDepositAcceptedSubmissionVideos(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission with videos",
+            "filename": "28-09-2020-RA-eLife-63532.zip",
+            "article_id": "63532",
+            "deposit_videos": True,
+            "expected_xml_file_path": "28-09-2020-RA-eLife-63532/28-09-2020-RA-eLife-63532.xml",
+            "expected_result": True,
+            "expected_generate_status": True,
+            "expected_zip_status": True,
+            "expected_deposit_status": True,
+            "expected_file_count": 26,
+            "expected_zip_file_name": "elife_videos_28-09-2020-RA-eLife-63532.zip",
+            "expected_zip_file_list": [
+                "elife-63532-video1.avi",
+                "elife-63532-video2.avi",
+                "elife_videos_28-09-2020-RA-eLife-63532.xml",
+            ],
+        },
+        {
+            "comment": "accepted submission zip has no videos",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "article_id": "45644",
+            "deposit_videos": None,
+            "expected_xml_file_path": None,
+            "expected_result": True,
+            "expected_generate_status": None,
+            "expected_zip_status": None,
+            "expected_deposit_status": None,
+            "expected_file_count": 42,
+            "expected_zip_file_name": None,
+            "expected_zip_file_list": [],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_storage_context,
+        fake_session,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = expanded_folder_renamed_video_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        workflow_session_data = session_data(
+            filename=test_data.get("filename"),
+            article_id=test_data.get("article_id"),
+            deposit_videos=test_data.get("deposit_videos"),
+        )
+        fake_ftp.return_value = FakeFTP()
+        fake_session.return_value = FakeSession(workflow_session_data)
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+        input_dir_files = glob.glob(self.activity.directories.get("INPUT_DIR") + "/*/*")
+
+        if test_data.get("expected_xml_file_path"):
+            xml_file_path = os.path.join(
+                self.activity.directories.get("INPUT_DIR"),
+                test_data.get("expected_xml_file_path"),
+            )
+            self.assertTrue(xml_file_path in input_dir_files)
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("generate"),
+            test_data.get("expected_generate_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("zip"),
+            test_data.get("expected_zip_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("deposit"),
+            test_data.get("expected_deposit_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # assert the video zip file was created
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*")
+        if test_data.get("expected_zip_file_name"):
+            video_zip_file_path = os.path.join(
+                self.activity.directories.get("TEMP_DIR"),
+                test_data.get("expected_zip_file_name"),
+            )
+            self.assertTrue(
+                video_zip_file_path in temp_dir_files,
+                "zip not found in temp dir files %s" % temp_dir_files,
+            )
+            # assert the contents of the video zip file
+            if test_data.get("expected_zip_file_list"):
+                with zipfile.ZipFile(video_zip_file_path, "r") as open_zip:
+                    zip_namelist = open_zip.namelist()
+                    self.assertEqual(
+                        sorted(zip_namelist),
+                        sorted(test_data.get("expected_zip_file_list")),
+                    )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "file_list")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_file_list,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an XML ParseError when getting a file list"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+        xml_file_path = os.path.join(
+            self.activity.directories.get("INPUT_DIR"),
+            xml_file,
+        )
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, deposit_videos=True)
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = expanded_folder_renamed_video_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_file_list.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "DepositAcceptedSubmissionVideos, XML ParseError exception "
+            "parsing video file list from %s for file %s"
+        ) % (xml_file_path, zip_file)
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+
+class TestDepositAcceptedSubmissionVideosFtpExceptions(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        filename = "28-09-2020-RA-eLife-63532.zip"
+        article_id = "63532"
+        # expanded bucket files
+        self.directory = TempDirectory()
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            filename,
+        )
+        self.resources = expanded_folder_renamed_video_resources(
+            self.directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        self.workflow_session_data = session_data(
+            filename=filename,
+            article_id=article_id,
+            deposit_videos=True,
+        )
+        self.input_data = input_data(filename)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(FakeFTP, "ftp_connect")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_ftp_connect_exception(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_ftp_connect,
+        fake_storage_context,
+    ):
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_connect.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(FakeFTP, "ftp_to_endpoint")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_ftp_to_endpoint_exception(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_ftp_to_endpoint,
+        fake_storage_context,
+    ):
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_to_endpoint.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(FakeFTP, "ftp_disconnect")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_ftp_disconnect_exception(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_ftp_disconnect,
+        fake_storage_context,
+    ):
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_disconnect.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(FakeFTP, "ftp_disconnect")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_ftp_exception_increment_attempts(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_ftp_disconnect,
+        fake_storage_context,
+    ):
+        "test if session variable count of attempts already exists"
+        self.workflow_session_data[activity_module.SESSION_ATTEMPT_COUNTER_NAME] = 1
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_disconnect.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(FakeFTP, "ftp_disconnect")
+    @patch.object(activity_module, "FTP")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_ftp_exception_max_attempts(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_ftp,
+        fake_ftp_disconnect,
+        fake_storage_context,
+    ):
+        "test if attempt count exceeds the max attempts"
+        self.workflow_session_data[
+            activity_module.SESSION_ATTEMPT_COUNTER_NAME
+        ] = 1000000
+        fake_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            self.directory.path, self.resources
+        )
+        fake_session.return_value = FakeSession(self.workflow_session_data)
+        fake_ftp.return_value = FakeFTP()
+        fake_ftp_disconnect.side_effect = Exception("An exception")
+        result = self.activity.do_activity(self.input_data)
+        self.assertEqual(result, True)
+
+
+class TestDepositVideosDepositVideosNone(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_deposit_videos_none(
+        self,
+        fake_session,
+    ):
+        "test if there is no deposit_videos value in the session"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(session_data(zip_file, article_id))
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_loginfo = (
+            "DepositAcceptedSubmissionVideos, %s"
+            " deposit_videos session value is None, activity returning True"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.loginfo[-1], expected_loginfo)
+
+
+class TestDepositVideosNoCredentials(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # change settings value
+        self.glencoe_ftp_uri = self.activity.settings.GLENCOE_FTP_URI
+        del self.activity.settings.GLENCOE_FTP_URI
+
+    def tearDown(self):
+        # restore settings value
+        self.activity.settings.GLENCOE_FTP_URI = self.glencoe_ftp_uri
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_deposit_videos_no_credentials(
+        self,
+        fake_session,
+    ):
+        "test if there are no credentials in the settings"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, True)
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_exception_message = (
+            "DepositAcceptedSubmissionVideos, %s"
+            " settings credential GLENCOE_FTP_URI is missing"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_exception_message)
+
+
+class TestDepositVideosBlankCredentials(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # change settings value
+        self.glencoe_ftp_uri = self.activity.settings.GLENCOE_FTP_URI
+        self.activity.settings.GLENCOE_FTP_URI = ""
+
+    def tearDown(self):
+        # restore settings value
+        self.activity.settings.GLENCOE_FTP_URI = self.glencoe_ftp_uri
+
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_deposit_videos_blank_credentials(
+        self,
+        fake_session,
+    ):
+        "test if there are blank credentials in the settings"
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+
+        fake_session.return_value = FakeSession(
+            session_data(zip_file, article_id, True)
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_exception_message = (
+            "DepositAcceptedSubmissionVideos, %s"
+            " settings credential GLENCOE_FTP_URI is blank"
+        ) % zip_file
+        self.assertEqual(self.activity.logger.logexception, expected_exception_message)

--- a/tests/activity/test_activity_verify_glencoe.py
+++ b/tests/activity/test_activity_verify_glencoe.py
@@ -111,7 +111,7 @@ class TestVerifyGlencoe(unittest.TestCase):
             self.verifyglencoe.pretty_name,
             "error",
             "Glencoe video is not available for article 7777777701234; message: "
-            "article has no videos - url requested: 10.7554/eLife.01234",
+            "article has no videos - url requested: https://videometadata/10.7554/eLife.01234",
         )
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_TEMPORARY_FAILURE)
 
@@ -146,7 +146,7 @@ class TestVerifyGlencoe(unittest.TestCase):
             "error",
             "Glencoe video is not available for article 353; message: "
             "unhandled status code from Glencoe: 500 - "
-            "url requested: 10.7554/eLife.00353",
+            "url requested: https://videometadata/10.7554/eLife.00353",
         )
         self.assertEqual(result, self.verifyglencoe.ACTIVITY_TEMPORARY_FAILURE)
 

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -46,6 +46,8 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_short("ValidateAcceptedSubmissionVideos", data),
                 define_workflow_step_short("RenameAcceptedSubmissionVideos", data),
+                define_workflow_step_short("DepositAcceptedSubmissionVideos", data),
+                define_workflow_step_short("AnnotateAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7181

Adding `DepositAcceptedSubmissionVideos` and `AnnotateAcceptedSubmissionVideos` workflow activities to the `IngestAcceptedSubmission` workflow. These will send video files and XML by FTP to the video service, wait to check for the video metadata which is added to the accepted submission XML file.

If the required settings to deposit by FTP are missing or blank these activities should not attempt the deposit and quickly return `True`.