### PR TITLE
Run cron_NewS3POA at :20, :25 and :30 minutes.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -184,7 +184,23 @@ def conditional_starts(current_datetime):
         # Jobs to start at 20 minutes past the hour
         LOGGER.info("Twenty minutes past the hour")
 
-        # POA Packaging at UK local time, hourly between 6:20 and 15:20
+        # POA Packaging at UK local time, run between 6:20 and 15:30
+        if local_current_time.tm_hour >= 6 and local_current_time.tm_hour <= 15:
+            conditional_start_list.append(
+                OrderedDict(
+                    [
+                        ("starter_name", "cron_NewS3POA"),
+                        ("workflow_id", "cron_NewS3POA"),
+                        ("start_seconds", 60 * 3),
+                    ]
+                )
+            )
+
+    elif current_time.tm_min >= 30 and current_time.tm_min <= 44:
+        # Jobs to start at the half past to quarter to the hour
+        LOGGER.info("half past to quarter to the hour")
+
+        # POA Packaging at UK local time, run between 6:20 and 15:30
         if local_current_time.tm_hour >= 6 and local_current_time.tm_hour <= 15:
             conditional_start_list.append(
                 OrderedDict(
@@ -195,10 +211,6 @@ def conditional_starts(current_datetime):
                     ]
                 )
             )
-
-    elif current_time.tm_min >= 30 and current_time.tm_min <= 44:
-        # Jobs to start at the half past to quarter to the hour
-        LOGGER.info("half past to quarter to the hour")
 
         conditional_start_list.append(
             OrderedDict(

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -193,6 +193,23 @@ class TestConditionalStarts(unittest.TestCase):
 
     @data(
         {
+            "comment": "06:25 UTC",
+            "date_time": "1970-01-01 06:25:00 UTC",
+            "expected_starter_names": [
+                "cron_FiveMinute",
+                "cron_NewS3POA",
+            ],
+            "expected_workflow_ids": [
+                "cron_FiveMinute",
+                "cron_NewS3POA",
+            ],
+        },
+    )
+    def test_conditional_starts_06_25_utc(self, test_data):
+        self.conditional_start_test_run(test_data)
+
+    @data(
+        {
             "comment": "10:45 UTC",
             "date_time": "1970-01-01 10:45:00 UTC",
             "expected_starter_names": [
@@ -216,10 +233,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-08-19 11:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "cron_NewS3POA",
                 "starter_DepositCrossrefPeerReview",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "cron_NewS3POA",
                 "DepositCrossrefPeerReview",
             ],
         },
@@ -233,10 +252,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-10-27 12:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "cron_NewS3POA",
                 "starter_DepositCrossrefPeerReview",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "cron_NewS3POA",
                 "DepositCrossrefPeerReview",
             ],
         },


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7276

Due to some later arriving PoA zip files, read the queue for messages 20 minutes, 25 minutes, and 30 minutes past the hour for the selected hours in `cron.py`.