### PR TITLE
Add RepairAcceptedSubmission activity.

### DIFF
--- a/activity/activity_RepairAcceptedSubmission.py
+++ b/activity/activity_RepairAcceptedSubmission.py
@@ -1,0 +1,166 @@
+import os
+import json
+import shutil
+from xml.etree.ElementTree import ParseError
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import article_processing, cleaner
+from activity.objects import Activity
+
+
+REPAIR_XML = True
+
+
+class activity_RepairAcceptedSubmission(Activity):
+    "RepairAcceptedSubmission activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_RepairAcceptedSubmission, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "RepairAcceptedSubmission"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Download accepted submission XML from the bucket, repair it if required, "
+            + "and replace it in the bucket."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"repair_xml": None, "output_xml": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
+
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
+
+        # parse XML
+        try:
+            root = cleaner.parse_article_xml(xml_file_path)
+            self.statuses["repair_xml"] = True
+            self.logger.info("%s, %s XML root parsed" % (self.name, input_filename))
+        except ParseError:
+            log_message = "%s, XML ParseError exception parsing XML %s for file %s" % (
+                self.name,
+                xml_file_path,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            root = None
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
+        # write the repaired XML to disk
+        if self.statuses.get("repair_xml"):
+            local_file_path = os.path.join(
+                self.directories.get("TEMP_DIR"),
+                article_processing.file_name_from_name(xml_file_path),
+            )
+            cleaner.write_xml_file(root, local_file_path, input_filename)
+            self.logger.info("%s, written XML to %s" % (self.name, local_file_path))
+            self.statuses["output_xml"] = True
+
+        # upload the XML to the bucket
+        if self.statuses.get("output_xml"):
+            upload_key = cleaner.article_xml_asset(asset_file_name_map)[0]
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+            self.statuses["upload_xml"] = True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)

--- a/register.py
+++ b/register.py
@@ -122,6 +122,7 @@ def start(settings):
     activity_names.append("GenerateSWHReadme")
     activity_names.append("PushSWHDeposit")
     activity_names.append("ExpandAcceptedSubmission")
+    activity_names.append("RepairAcceptedSubmission")
     activity_names.append("ValidateAcceptedSubmission")
     activity_names.append("TransformAcceptedSubmission")
     activity_names.append("EmailAcceptedSubmissionOutput")

--- a/tests/activity/test_activity_repair_accepted_submission.py
+++ b/tests/activity/test_activity_repair_accepted_submission.py
@@ -1,0 +1,194 @@
+# coding=utf-8
+
+import os
+import glob
+import unittest
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_RepairAcceptedSubmission as activity_module
+from activity.activity_RepairAcceptedSubmission import (
+    activity_RepairAcceptedSubmission as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestRepairAcceptedSubmission(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory, including the cleaner.log file
+        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_repair_xml_status": True,
+            "expected_output_xml_status": True,
+            "expected_upload_xml_status": True,
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        directory = TempDirectory()
+
+        zip_file_base = test_data.get("filename").rstrip(".zip")
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        dest_folder = os.path.join(directory.path, "files_dest")
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=dest_folder
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+        temp_dir_files = glob.glob(self.activity.directories.get("INPUT_DIR") + "/*/*")
+
+        xml_file_path = os.path.join(
+            self.activity.directories.get("INPUT_DIR"),
+            zip_file_base,
+            "%s.xml" % zip_file_base,
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("repair_xml"),
+            test_data.get("expected_repair_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("output_xml"),
+            test_data.get("expected_output_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # the new XML file should include the repaired XML namespace
+        bucket_folder_path = os.path.join(
+            dest_folder,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_base,
+        )
+        repaired_xml_file_path = os.path.join(
+            bucket_folder_path, "%s.xml" % zip_file_base
+        )
+        with open(repaired_xml_file_path, "r", encoding="utf-8") as open_file:
+            self.assertEqual(
+                (
+                    '<?xml version="1.0" ?><article article-type="research-article"'
+                    ' xmlns:xlink="http://www.w3.org/1999/xlink">\n'
+                ),
+                open_file.readline(),
+            )
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "parse_article_xml")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_parse_article_xml,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        directory = TempDirectory()
+        zip_file_base = "30-01-2019-RA-eLife-45644"
+        zip_file = "%s.zip" % zip_file_base
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+        xml_file_path = os.path.join(
+            self.activity.directories.get("INPUT_DIR"),
+            xml_file,
+        )
+        fake_session.return_value = FakeSession(
+            test_activity_data.accepted_session_example
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_parse_article_xml.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "RepairAcceptedSubmission, XML ParseError exception parsing XML %s for file %s"
+            )
+            % (xml_file_path, zip_file),
+        )

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -42,6 +42,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
             "steps": [
                 define_workflow_step("PingWorker", data),
                 define_workflow_step_short("ExpandAcceptedSubmission", data),
+                define_workflow_step_short("RepairAcceptedSubmission", data),
                 define_workflow_step_short("ValidateAcceptedSubmission", data),
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_short("ValidateAcceptedSubmissionVideos", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7340

To replace some HTML entities which are not XML compatible, rely on the `elifecleaner` library to repair the XML, which includes character conversions. A new activity named `RepairAcceptedSubmission` is added to the `IngestAcceptedSubmission` workflow to do immediately after expanding the zip file to the bucket folder.