### PR TITLE
Dependency `pyjwt` pinned to `2.4.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-05-14 - see update-dependencies.sh
+# file generated 2022-05-25 - see update-dependencies.sh
 arrow==1.2.2
 astroid==2.9.3
 attrs==21.4.0
@@ -64,7 +64,7 @@ pyasn1-modules==0.2.8
 pycparser==2.21
 pyfunctional==1.4.3
 PyGithub==1.55
-PyJWT==2.3.0
+PyJWT==2.4.0
 pylint==2.12.2
 PyNaCl==1.5.0
 pypandoc==1.7.4


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/27/display/redirect which resulted in this pull request.