### PR TITLE
Format cleaner log into production comments.

### DIFF
--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -1,7 +1,7 @@
 import json
 import time
 from provider.execution_context import get_session
-from provider import email_provider, utils
+from provider import cleaner, email_provider, utils
 from activity.objects import Activity
 
 
@@ -40,10 +40,11 @@ class activity_EmailAcceptedSubmissionOutput(Activity):
 
         # format the email body content
         body_content = ""
-        if cleaner_log:
+        comments = cleaner.production_comments(cleaner_log)
+        if comments:
             body_content = "Warnings found in the log file for zip file %s\n\n%s" % (
                 input_filename,
-                cleaner_log,
+                "\n".join(comments),
             )
         # Send email
         self.email_status = self.send_email(input_filename, body_content)

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -36,7 +36,7 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
                 "Subject: eLife accepted submission: 30-01-2019-RA-eLife-45644.zip"
             ),
             "expected_email_from": "From: sender@example.org",
-            "expected_email_body": b"cleaner log content",
+            "expected_email_body": b"Warnings found in the log file",
         },
     )
     def test_do_activity(
@@ -47,7 +47,14 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
     ):
         session = FakeSession(copy.copy(test_activity_data.accepted_session_example))
         # add some cleaner_log content
-        session.store_value("cleaner_log", test_data.get("expected_email_body"))
+        session.store_value(
+            "cleaner_log",
+            (
+                b"2022-03-31 11:11:39,706 WARNING elifecleaner:parse:check_multi_page_figure_pdf: "
+                b"12-08-2021-RA-eLife-73010.zip multiple page PDF figure file: "
+                b"12-08-2021-RA-eLife-73010/Figure 1.pdf"
+            ),
+        )
         fake_session.return_value = session
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -151,3 +151,25 @@ class TestBucketAssetFileNameMap(unittest.TestCase):
             settings_mock, bucket_name, expanded_folder
         )
         self.assertEqual(asset_file_name_map, expected)
+
+
+class TestProductionComments(unittest.TestCase):
+    def test_production_comments(self):
+        cleaner_log = (
+            "2022-03-31 11:11:39,632 INFO elifecleaner:parse:check_multi_page_figure_pdf: "
+            "12-08-2021-RA-eLife-73010.zip using pdfimages to check PDF figure file: 12-08-2021-RA-eLife-73010/Figure 1.pdf\n"
+            "2022-03-31 11:11:39,705 INFO elifecleaner:parse:check_multi_page_figure_pdf: 12-08-2021-RA-eLife-73010.zip pdfimages found images on pages {1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14} in PDF figure file: 12-08-2021-RA-eLife-73010/Figure 1.pdf\n"
+            "2022-03-31 11:11:39,706 WARNING elifecleaner:parse:check_multi_page_figure_pdf: 12-08-2021-RA-eLife-73010.zip multiple page PDF figure file: 12-08-2021-RA-eLife-73010/Figure 1.pdf\n"
+            "2022-03-17 11:10:06,722 WARNING elifecleaner:parse:check_missing_files: 20-12-2021-FA-eLife-76559.zip does not contain a file in the manifest: manuscript.tex\n"
+            "2022-03-17 11:10:06,722 WARNING elifecleaner:parse:check_extra_files: 20-12-2021-FA-eLife-76559.zip has file not listed in the manifest: 76559 correct version.tex\n"
+            "2022-02-22 13:10:15,942 WARNING elifecleaner:parse:check_missing_files_by_name: 22-02-2022-CR-eLife-78088.zip has file missing from expected numeric sequence: Figure 3"
+        )
+        expected = [
+            'Exeter: "Figure 1.pdf" is a PDF file made up of more than one page. Please check if there are images on numerous pages. If that\'s the case, please add the following author query: "Please provide this figure in a single-page format. If this would render the figure unreadable, please provide this as separate figures or figure supplements."',
+            "20-12-2021-FA-eLife-76559.zip does not contain a file in the manifest: manuscript.tex",
+            "20-12-2021-FA-eLife-76559.zip has file not listed in the manifest: 76559 correct version.tex",
+            "22-02-2022-CR-eLife-78088.zip has file missing from expected numeric sequence: Figure 3",
+        ]
+
+        comments = cleaner.production_comments(cleaner_log)
+        self.assertEqual(comments, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7306, filter and format the log messages to only include warnings in the email sent as part of the `IngestAcceptedSubmission` workflow.