### PR TITLE
Add comments to accepted submission XML.

### DIFF
--- a/activity/activity_AddCommentsToAcceptedSubmissionXml.py
+++ b/activity/activity_AddCommentsToAcceptedSubmissionXml.py
@@ -1,0 +1,195 @@
+import os
+import json
+import shutil
+from xml.etree.ElementTree import ParseError, SubElement
+from provider import cleaner
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+REPAIR_XML = False
+
+
+class activity_AddCommentsToAcceptedSubmissionXml(Activity):
+    "AddCommentsToAcceptedSubmissionXml activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AddCommentsToAcceptedSubmissionXml, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AddCommentsToAcceptedSubmissionXml"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Add production comments to the accepted submission XML."
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"add": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+        cleaner_log = session.get_value("cleaner_log")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # generate the production comments to see if there are any
+        comments = cleaner.production_comments(cleaner_log)
+        if not comments:
+            self.logger.info(
+                "%s, %s production_comments is %s, activity returning True"
+                % (self.name, input_filename, comments)
+            )
+            return True
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
+
+        # read the XML
+        # reset the REPAIR_XML constant
+        original_repair_xml = cleaner.parse.REPAIR_XML
+        cleaner.parse.REPAIR_XML = REPAIR_XML
+
+        # parse XML
+        try:
+            root = cleaner.parse_article_xml(xml_file_path)
+            self.logger.info("%s, %s XML root parsed" % (self.name, input_filename))
+        except ParseError:
+            log_message = "%s, XML ParseError exception parsing XML %s for file %s" % (
+                self.name,
+                xml_file_path,
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            root = None
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
+        if root:
+            try:
+                # todo!!!!
+                add_comments_to_xml(root, xml_file_path, comments, input_filename)
+                self.statuses["add"] = True
+            except:
+                log_message = "%s, exception in add_comments_to_xml %s for file %s" % (
+                    self.name,
+                    xml_file_path,
+                    input_filename,
+                )
+                self.logger.exception(log_message)
+
+        # upload the modified XML file to the expanded folder
+        if self.statuses.get("add"):
+            upload_key = cleaner.article_xml_asset(asset_file_name_map)[0]
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            local_file_path = asset_file_name_map.get(upload_key)
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+            self.statuses["upload_xml"] = True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)
+
+
+def add_comments_to_xml(root, xml_file_path, comments, input_filename):
+    "add each of the comments into a p tag inside a production-comments tag"
+    article_meta_tag = root.find("./front/article-meta")
+    # find or create the custom meta group tag
+    custom_meta_group_tag = article_meta_tag.find("./custom-meta-group")
+    if not custom_meta_group_tag:
+        custom_meta_group_tag = SubElement(article_meta_tag, "custom-meta-group")
+    # find or create the production comments tag
+    production_comments_tag = article_meta_tag.find("./production-comments")
+    if not production_comments_tag:
+        production_comments_tag = SubElement(custom_meta_group_tag, "production-comments")
+    # add each comment to a new p tag
+    for comment in comments:
+        p_tag = SubElement(production_comments_tag, "p")
+        p_tag.text = comment
+    # write the modified XML to disk
+    cleaner.write_xml_file(root, xml_file_path, input_filename)

--- a/register.py
+++ b/register.py
@@ -130,6 +130,7 @@ def start(settings):
     activity_names.append("RenameAcceptedSubmissionVideos")
     activity_names.append("DepositAcceptedSubmissionVideos")
     activity_names.append("AnnotateAcceptedSubmissionVideos")
+    activity_names.append("AddCommentsToAcceptedSubmissionXml")
     activity_names.append("OutputAcceptedSubmission")
 
     for activity_name in activity_names:

--- a/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
+++ b/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
@@ -1,0 +1,326 @@
+# coding=utf-8
+
+import os
+import glob
+import copy
+import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AddCommentsToAcceptedSubmissionXml as activity_module
+from activity.activity_AddCommentsToAcceptedSubmissionXml import (
+    activity_AddCommentsToAcceptedSubmissionXml as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = copy.copy(test_case_data.ingest_accepted_submission_data)
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+def session_data(filename=None, article_id=None, cleaner_log=None):
+    s_data = copy.copy(test_activity_data.accepted_session_example)
+    if filename:
+        s_data["input_filename"] = filename
+    if article_id:
+        s_data["article_id"] = article_id
+    if cleaner_log:
+        s_data["cleaner_log"] = cleaner_log
+    return s_data
+
+
+@ddt
+class TestAddCommentsToAcceptedSubmissionXml(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "storage_context")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission cleaner_log includes a warning",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "article_id": "45644",
+            "cleaner_log": (
+                "2022-03-31 11:11:39,706 "
+                "WARNING elifecleaner:parse:check_multi_page_figure_pdf: "
+                "30-01-2019-RA-eLife-45644.zip multiple page PDF figure file: "
+                "30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf\n"
+            ),
+            "expected_xml_file_path": "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+            "expected_result": True,
+            "expected_add_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml": [
+                (
+                    "<production-comments>"
+                    "<p>Exeter: &quot;Appendix 1figure 10.pdf&quot; is a PDF file made up of "
+                    "more than one page. Please check if there are images on numerous pages. "
+                    "If that's the case, please add the following author query: "
+                    "&quot;Please provide this figure in a single-page format. If this would "
+                    "render the figure unreadable, please provide this as separate figures or "
+                    "figure supplements.&quot;</p></production-comments>"
+                )
+            ],
+        },
+        {
+            "comment": "accepted submission cleaner_log is blank",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "article_id": "45644",
+            "cleaner_log": "",
+            "expected_xml_file_path": None,
+            "expected_result": True,
+            "expected_add_status": None,
+            "expected_upload_xml_status": None,
+            "expected_xml": [],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_storage_context,
+        fake_session,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        workflow_session_data = session_data(
+            filename=test_data.get("filename"),
+            article_id=test_data.get("article_id"),
+            cleaner_log=test_data.get("cleaner_log"),
+        )
+        fake_session.return_value = FakeSession(workflow_session_data)
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        filename_used = input_data(test_data.get("filename")).get("file_name")
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            (
+                "failed in {comment}, got {result}, filename {filename}, "
+                + "input_file {input_file}"
+            ).format(
+                comment=test_data.get("comment"),
+                result=result,
+                input_file=self.activity.input_file,
+                filename=filename_used,
+            ),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("add"),
+            test_data.get("expected_add_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        expanded_folder = os.path.join(
+            directory.path, workflow_session_data.get("expanded_folder")
+        )
+        expanded_folder_files = glob.glob(expanded_folder + "/*/*")
+        xml_file_path = ""
+        if test_data.get("expected_xml_file_path"):
+            xml_file_path = os.path.join(
+                expanded_folder,
+                test_data.get("expected_xml_file_path"),
+            )
+            self.assertTrue(xml_file_path in expanded_folder_files)
+
+        if xml_file_path and test_data.get("expected_xml"):
+            # assert XML file was modified
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            for expected_xml in test_data.get("expected_xml"):
+                self.assertTrue(
+                    expected_xml in xml_string,
+                    "%s not found in xml_string" % expected_xml,
+                )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "parse_article_xml")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_parse_article_xml,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an XML ParseError when parsing it"
+        directory = TempDirectory()
+        zip_file_base = "30-01-2019-RA-eLife-45644"
+        article_id = zip_file_base.rsplit("-", 1)[-1]
+        zip_file = "%s.zip" % zip_file_base
+        xml_file = "%s/%s.xml" % (zip_file_base, zip_file_base)
+        xml_file_path = os.path.join(
+            self.activity.directories.get("INPUT_DIR"),
+            xml_file,
+        )
+
+        fake_session.return_value = FakeSession(
+            session_data(
+                zip_file, article_id, cleaner_log=" WARNING elifecleaner:parse:foo: bar"
+            )
+        )
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_parse_article_xml.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "AddCommentsToAcceptedSubmissionXml, XML ParseError exception "
+            "parsing XML %s for file %s"
+        ) % (xml_file_path, zip_file)
+
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+
+class TestAddXmlException(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "add_comments_to_xml")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_xml_exception(
+        self,
+        fake_session,
+        fake_cleaner_storage_context,
+        fake_add_comments_to_xml,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+
+        directory = TempDirectory()
+        filename = "30-01-2019-RA-eLife-45644.zip"
+        article_id = "45644"
+
+        workflow_session_data = session_data(
+            filename=filename,
+            article_id=article_id,
+            cleaner_log=" WARNING elifecleaner:parse:foo: bar",
+        )
+        fake_session.return_value = FakeSession(workflow_session_data)
+
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            filename,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            workflow_session_data.get("expanded_folder"),
+            zip_file_path,
+        )
+
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+
+        fake_add_comments_to_xml.side_effect = Exception("An exception")
+        result = self.activity.do_activity(input_data(filename))
+        self.assertEqual(result, True)
+        self.assertTrue(
+            self.activity.logger.logexception.startswith(
+                "AddCommentsToAcceptedSubmissionXml, exception in add_comments_to_xml"
+            )
+        )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+
+class TestAddCommentsToXml(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_add_comments_to_xml(self):
+        "test adding missing tags to a basic XML file"
+        directory = TempDirectory()
+        xml_file_path = os.path.join(directory.path, "test.xml")
+        xml_string = "<article><front><article-meta/></front></article>"
+        comments = ["A comment"]
+        input_filename = "test.zip"
+        expected = (
+            '<?xml version="1.0" ?>'
+            "<article><front><article-meta>"
+            "<custom-meta-group>"
+            "<production-comments><p>A comment</p></production-comments>"
+            "</custom-meta-group>"
+            "</article-meta></front></article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        activity_module.add_comments_to_xml(
+            root, xml_file_path, comments, input_filename
+        )
+        with open(xml_file_path, "r", encoding="utf-8") as open_file:
+            output_xml = open_file.read()
+        self.assertEqual(output_xml, expected)

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -50,6 +50,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("DepositAcceptedSubmissionVideos", data),
                 define_workflow_step_short("AnnotateAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
+                define_workflow_step_short("AddCommentsToAcceptedSubmissionXml", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),
             ],


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7141

The new `AddCommentsToAcceptedSubmissionXml` activity added to the `IngestAcceptedSubmission` workflow will add comments to the XML file, currently found in the cleaner library log file content.