### PR TITLE
Use pad_msid and pad_volume, not zfill.

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -88,7 +88,17 @@ class activity_FTPArticle(Activity):
         self.download_files_from_s3(elife_id, workflow)
 
         # Set FTP settings
-        self.set_ftp_settings(elife_id, workflow)
+        try:
+            self.set_ftp_settings(elife_id, workflow)
+        except:
+            # Something went wrong, fail
+            if self.logger:
+                self.logger.exception(
+                    "exception in FTPArticle when invoking set_ftp_settings(), data: %s"
+                    % json.dumps(data, sort_keys=True, indent=4)
+                )
+            self.clean_tmp_dir()
+            return False
 
         # FTP to endpoint
         try:
@@ -163,7 +173,7 @@ class activity_FTPArticle(Activity):
             self.FTP_PASSWORD = self.settings.HEFCE_FTP_PASSWORD
             self.FTP_CWD = self.settings.HEFCE_FTP_CWD
             # Subfolders to create when FTPing
-            self.FTP_SUBDIR.append(str(doi_id).zfill(5))
+            self.FTP_SUBDIR.append(utils.pad_msid(doi_id))
 
             # SFTP settings
 
@@ -485,7 +495,7 @@ def zip_file_suffix(file_types):
 
 
 def new_zip_file_name(doi_id, prefix, suffix):
-    return "%s%s%s" % (prefix, str(doi_id).zfill(5), suffix)
+    return "%s%s%s" % (prefix, utils.pad_msid(doi_id), suffix)
 
 
 def file_type_matches(file_types):

--- a/activity/activity_LensArticle.py
+++ b/activity/activity_LensArticle.py
@@ -1,6 +1,7 @@
 import json
 import os
 import codecs
+from provider import utils
 from provider.storage_provider import storage_context
 import provider.templates as templatelib
 import provider.article as articlelib
@@ -114,7 +115,7 @@ class activity_LensArticle(Activity):
         Given an eLife article DOI ID (5 digits) assemble the
         S3 key name for where to save the article index.html page
         """
-        article_s3key = str(article_id).zfill(5) + "/index.html"
+        article_s3key = utils.pad_msid(article_id) + "/index.html"
 
         return article_s3key
 

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -354,8 +354,8 @@ def article_xml_file(folders):
 def new_zip_filename(journal, volume, fid, revision=None):
 
     filename = journal
-    filename = filename + "-" + str(volume).zfill(2)
-    filename = filename + "-" + str(fid).zfill(5)
+    filename = filename + "-" + utils.pad_volume(volume)
+    filename = filename + "-" + utils.pad_msid(fid)
     if revision:
         filename = filename + ".r" + str(revision)
     filename += ".zip"

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 from provider.storage_provider import storage_context
-from provider import lax_provider, outbox_provider
+from provider import lax_provider, outbox_provider, utils
 from activity.objects import Activity
 
 """
@@ -121,7 +121,7 @@ class activity_ScheduleDownstream(Activity):
         """
         # Rename the XML file to match what is used already
         new_key_name = new_outbox_xml_name(
-            prefix=prefix, journal="elife", article_id=str(article_id).zfill(5)
+            prefix=prefix, journal="elife", article_id=utils.pad_msid(article_id)
         )
 
         self.copy_article_xml_to_outbox(

--- a/provider/fastly_provider.py
+++ b/provider/fastly_provider.py
@@ -1,4 +1,5 @@
 import requests
+from provider import utils
 
 
 class FastlyApi:
@@ -32,7 +33,9 @@ def purge(article_id, version, settings):
     api = FastlyApi(settings.fastly_api_key)
     for service_id in settings.fastly_service_ids:
         for key in KEYS:
-            surrogate_key = key.format(article_id=article_id.zfill(5), version=version)
+            surrogate_key = key.format(
+                article_id=utils.pad_msid(article_id), version=version
+            )
             responses.append(api.purge(surrogate_key, service_id))
 
     return responses

--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -1,7 +1,7 @@
 import sys
 import re
 import requests
-from provider.utils import unicode_encode
+from provider.utils import pad_msid, unicode_encode
 
 
 """
@@ -57,8 +57,7 @@ def validate_sources(gc_data):
 
 
 def metadata(msid, settings):
-    padded_msid = str(msid).zfill(5)
-    doi = "10.7554/eLife." + padded_msid
+    doi = "10.7554/eLife." + pad_msid(msid)
     url = settings.video_url + doi
 
     resp = requests.get(url)
@@ -82,10 +81,6 @@ def has_videos(xml_str):
     if re.search(r'<media[^>]*mimetype="video".*?>', unicode_encode(xml_str)):
         return True
     return False
-
-
-def pad_msid(msid):
-    return str(int(msid)).zfill(5)
 
 
 def check_msid(msid):

--- a/provider/s3lib.py
+++ b/provider/s3lib.py
@@ -1,4 +1,5 @@
 import re
+from provider import utils
 
 
 """
@@ -36,7 +37,7 @@ def latest_pmc_zip_revision(doi_id, s3_key_names):
 
     name_matches = []
     for key_name in s3_key_names:
-        name_match = "-" + str(doi_id).zfill(5)
+        name_match = "-" + utils.pad_msid(doi_id)
         if name_match in key_name:
             name_matches.append(key_name)
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7448 to not use `zfill()` when formatting manuscript ID or volume numbers, remove a duplicate in `provider/glencoe_check.py`, and fix an existing test case to catch an exception.