### PR TITLE
Article provider refactoring

### DIFF
--- a/activity/activity_EmailVideoArticlePublished.py
+++ b/activity/activity_EmailVideoArticlePublished.py
@@ -147,7 +147,7 @@ class activity_EmailVideoArticlePublished(Activity):
         Given a list of article XML filenames,
         parse the files and add the article object to our article map
         """
-        article_object = articlelib.article(self.settings, self.get_tmp_dir())
+        article_object = articlelib.article(self.settings)
         article_object.parse_article_file(xml_file)
         if self.logger:
             self.logger.info("Parsed %s" % article_object.doi_url)

--- a/activity/activity_GeneratePDFCovers.py
+++ b/activity/activity_GeneratePDFCovers.py
@@ -1,5 +1,4 @@
-import provider.article as articlelib
-from provider import lax_provider
+from provider import lax_provider, pdf_cover_page
 from activity.objects import Activity
 
 """
@@ -93,7 +92,7 @@ class activity_GeneratePDFCovers(Activity):
                 )
                 return self.ACTIVITY_SUCCESS
 
-            pdf_cover = articlelib.get_pdf_cover_link(
+            pdf_cover = pdf_cover_page.get_pdf_cover_link(
                 self.settings.pdf_cover_generator, article_id, self.logger
             )
 

--- a/activity/activity_GenerateSWHMetadata.py
+++ b/activity/activity_GenerateSWHMetadata.py
@@ -63,9 +63,9 @@ class activity_GenerateSWHMetadata(Activity):
 
         # download article XML file
         try:
-            bot_article = articlelib.article(self.settings, self.get_tmp_dir())
+            bot_article = articlelib.article(self.settings)
             article_xml_filename = bot_article.download_article_xml_from_s3(
-                utils.pad_msid(article_id)
+                self.get_tmp_dir(), utils.pad_msid(article_id)
             )
             self.logger.info(
                 "Downloaded article XML for %s to %s"

--- a/activity/activity_GenerateSWHReadme.py
+++ b/activity/activity_GenerateSWHReadme.py
@@ -65,9 +65,9 @@ class activity_GenerateSWHReadme(Activity):
 
         # download article XML file
         try:
-            bot_article = articlelib.article(self.settings, self.get_tmp_dir())
+            bot_article = articlelib.article(self.settings)
             article_xml_filename = bot_article.download_article_xml_from_s3(
-                utils.pad_msid(article_id)
+                self.get_tmp_dir(), utils.pad_msid(article_id)
             )
             self.logger.info(
                 "Downloaded article XML for %s to %s"

--- a/activity/activity_LensArticle.py
+++ b/activity/activity_LensArticle.py
@@ -32,7 +32,7 @@ class activity_LensArticle(Activity):
         self.templates = templatelib.Templates(settings, self.get_tmp_dir())
 
         # article data provider
-        self.article = articlelib.article(settings, self.get_tmp_dir())
+        self.article = articlelib.article(settings)
 
         # Default templates directory
         self.from_dir = "template"
@@ -57,7 +57,7 @@ class activity_LensArticle(Activity):
             article_id = data["article_id"]
 
         self.article_xml_filename = self.article.download_article_xml_from_s3(
-            doi_id=article_id
+            self.get_tmp_dir(), doi_id=article_id
         )
 
         if not self.article_xml_filename:

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -42,7 +42,7 @@ class activity_PubRouterDeposit(Activity):
         self.date_stamp = utils.set_datestamp()
 
         # Instantiate a new article object to provide some helper functions
-        self.article = articlelib.article(self.settings, self.get_tmp_dir())
+        self.article = articlelib.article(self.settings)
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket
@@ -385,14 +385,16 @@ class activity_PubRouterDeposit(Activity):
         """
 
         # Instantiate a new article object
-        article = articlelib.article(self.settings, self.get_tmp_dir())
+        article = articlelib.article(self.settings)
 
         if doi_id:
             # Get and parse the article XML for data
             # Convert the doi_id to 5 digit string in case it was an integer
             if isinstance(doi_id, int):
                 doi_id = utils.pad_msid(doi_id)
-            article_xml_filename = article.download_article_xml_from_s3(doi_id)
+            article_xml_filename = article.download_article_xml_from_s3(
+                self.get_tmp_dir(), doi_id
+            )
             article.parse_article_file(
                 self.get_tmp_dir() + os.sep + article_xml_filename
             )

--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -9,6 +9,7 @@ from provider import (
     email_provider,
     lax_provider,
     outbox_provider,
+    pdf_cover_page,
     templates,
     utils,
 )
@@ -246,7 +247,7 @@ class activity_PublicationEmail(Activity):
 
             article = articlelib.create_article(self.settings, self.get_tmp_dir)
             article.parse_article_file(article_xml_filename)
-            article.pdf_cover_link = articlelib.get_pdf_cover_page(
+            article.pdf_cover_link = pdf_cover_page.get_pdf_cover_page(
                 article.doi_id, self.settings, self.logger
             )
             log_info = "Parsed " + article.doi_url

--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -37,7 +37,7 @@ class activity_PubmedArticleDeposit(Activity):
         self.date_stamp = utils.set_datestamp()
 
         # Instantiate a new article object to provide some helper functions
-        self.article = articlelib.article(self.settings, self.get_tmp_dir())
+        self.article = articlelib.article(self.settings)
 
         # Bucket for outgoing files
         self.publish_bucket = settings.poa_packaging_bucket

--- a/provider/article.py
+++ b/provider/article.py
@@ -3,8 +3,8 @@ import re
 import urllib
 import requests
 from elifetools import parseJATS as parser
-import provider.s3lib as s3lib
-from provider import outbox_provider
+from provider import outbox_provider, s3lib
+from provider.lax_provider import article_highest_version
 from provider.storage_provider import storage_context
 from provider.utils import msid_from_doi, get_doi_url, pad_msid
 
@@ -21,13 +21,15 @@ def create_article(settings, tmp_dir, doi_id=None):
     """
 
     # Instantiate a new article object
-    article_object = article(settings, tmp_dir)
+    article_object = article(settings)
 
     if doi_id:
         # Get and parse the article XML for data
         # Convert the doi_id to 5 digit string in case it was an integer
         doi_id = pad_msid(doi_id)
-        article_xml_filename = article_object.download_article_xml_from_s3(doi_id)
+        article_xml_filename = article_object.download_article_xml_from_s3(
+            tmp_dir, doi_id
+        )
         try:
             article_object.parse_article_file(
                 os.path.join(tmp_dir, article_xml_filename)
@@ -40,12 +42,8 @@ def create_article(settings, tmp_dir, doi_id=None):
 
 
 class article:
-    def __init__(self, settings=None, tmp_dir=None):
+    def __init__(self, settings=None):
         self.settings = settings
-        self.tmp_dir = tmp_dir
-
-        # Default tmp_dir if not specified
-        self.tmp_dir_default = "article_provider"
 
         # Some defaults
         self.related_insight_article = None
@@ -101,12 +99,11 @@ class article:
         except:
             return False
 
-    def download_article_xml_from_s3(self, doi_id=None):
+    def download_article_xml_from_s3(self, to_dir, doi_id=None):
         """
         Return the article data for use in templates
         """
 
-        download_dir = "s3_download"
         xml_filename = None
         # Check for the document
 
@@ -116,9 +113,6 @@ class article:
         article_id = doi_id
         # Get the highest published version from lax
         try:
-            # hack: work around circular dependency between lax_provider.py and article.py
-            from provider.lax_provider import article_highest_version
-
             version = article_highest_version(article_id, self.settings)
             if not isinstance(version, int):
                 return False
@@ -145,30 +139,14 @@ class article:
             + ".xml"
         )
         xml_filename = xml_file_url.split("/")[-1]
-
-        r = requests.get(xml_file_url)
-        if r.status_code == 200:
-            filename_plus_path = self.get_tmp_dir() + os.sep + xml_filename
-            f = open(filename_plus_path, "wb")
-            f.write(r.content)
-            f.close()
+        response = requests.get(xml_file_url)
+        if response.status_code == 200:
+            filename_plus_path = to_dir + os.sep + xml_filename
+            with open(filename_plus_path, "wb") as open_file:
+                open_file.write(response.content)
             return xml_filename
-        else:
-            return False
 
-        return xml_filename
-
-    def get_tmp_dir(self):
-        """
-        Get the temporary file directory, but if not set
-        then make the directory
-        """
-        if self.tmp_dir:
-            return self.tmp_dir
-        else:
-            self.tmp_dir = self.tmp_dir_default
-
-        return self.tmp_dir
+        return False
 
     def set_related_insight_article(self, article_object):
         """
@@ -294,10 +272,7 @@ class article:
             # Display channel was never set
             return None
 
-        if display_channel in self.display_channel:
-            return True
-        else:
-            return False
+        return bool(display_channel in self.display_channel)
 
 
 def get_tweet_url(doi):
@@ -385,7 +360,6 @@ def get_doi_id_from_poa_s3_key_name(s3_key_name):
     """
 
     doi_id = None
-    delimiter = "/"
     file_name_prefix = "elife_poa_e"
 
     doi_id = get_doi_id_from_s3_key_name(s3_key_name, file_name_prefix)
@@ -402,7 +376,6 @@ def get_doi_id_from_vor_s3_key_name(s3_key_name):
     """
 
     doi_id = None
-    delimiter = "/"
     file_name_prefix = "elife"
 
     doi_id = get_doi_id_from_s3_key_name(s3_key_name, file_name_prefix)

--- a/provider/article.py
+++ b/provider/article.py
@@ -293,35 +293,6 @@ def get_lens_url(doi):
     return lens_url
 
 
-def get_pdf_cover_link(pdf_cover_generator_url, doi_id, logger):
-
-    url = pdf_cover_generator_url + pad_msid(doi_id)
-    logger.info("URL for PDF Generator %s", url)
-    resp = requests.post(url)
-    logger.info("Response code for PDF Generator %s", str(resp.status_code))
-    assert (
-        resp.status_code != 404
-    ), "PDF cover not found. Format: %s - url requested: %s" % (format, url)
-    assert resp.status_code in [200, 202], (
-        "unhandled status code from PDF cover service: %s . "
-        "Format: %s - url requested: %s" % (resp.status_code, format, url)
-    )
-    data = resp.json()
-    logger.info("PDF Generator Response %s", str(data))
-    return data["formats"]
-
-
-def get_pdf_cover_page(doi_id, settings, logger):
-    try:
-        assert hasattr(
-            settings, "pdf_cover_landing_page"
-        ), "pdf_cover_landing_page variable is missing from settings file!"
-        return settings.pdf_cover_landing_page + doi_id
-    except AssertionError as err:
-        logger.error(str(err))
-        return ""
-
-
 def get_doi_id_from_s3_key_name(s3_key_name, file_name_prefix="elife"):
     """
     Extract just the integer doi_id value from the S3 key name

--- a/provider/article.py
+++ b/provider/article.py
@@ -280,8 +280,8 @@ def get_tweet_url(doi):
     Given a DOI, return a tweet URL
     """
     doi_url = get_doi_url(doi)
-    f = {"text": doi_url + " @eLife"}
-    return "http://twitter.com/intent/tweet?" + urllib.parse.urlencode(f)
+    params = {"text": doi_url + " @eLife"}
+    return "http://twitter.com/intent/tweet?" + urllib.parse.urlencode(params)
 
 
 def get_lens_url(doi):

--- a/provider/pdf_cover_page.py
+++ b/provider/pdf_cover_page.py
@@ -1,0 +1,31 @@
+import requests
+from provider.utils import pad_msid
+
+
+def get_pdf_cover_link(pdf_cover_generator_url, doi_id, logger):
+
+    url = pdf_cover_generator_url + pad_msid(doi_id)
+    logger.info("URL for PDF Generator %s", url)
+    resp = requests.post(url)
+    logger.info("Response code for PDF Generator %s", str(resp.status_code))
+    assert (
+        resp.status_code != 404
+    ), "PDF cover not found. Format: %s - url requested: %s" % (format, url)
+    assert resp.status_code in [200, 202], (
+        "unhandled status code from PDF cover service: %s . "
+        "Format: %s - url requested: %s" % (resp.status_code, format, url)
+    )
+    data = resp.json()
+    logger.info("PDF Generator Response %s", str(data))
+    return data["formats"]
+
+
+def get_pdf_cover_page(doi_id, settings, logger):
+    try:
+        assert hasattr(
+            settings, "pdf_cover_landing_page"
+        ), "pdf_cover_landing_page variable is missing from settings file!"
+        return settings.pdf_cover_landing_page + doi_id
+    except AssertionError as err:
+        logger.error(str(err))
+        return ""

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -223,10 +223,10 @@ class FakeRequest:
 
 
 class FakeResponse:
-    def __init__(self, status_code, response_json=None, text=""):
+    def __init__(self, status_code, response_json=None, text="", content=None):
         self.status_code = status_code
         self.response_json = response_json
-        self.content = None
+        self.content = content
         self.text = text
         self.request = FakeRequest()
         self.headers = {}

--- a/tests/activity/test_activity_generate_pdf_covers.py
+++ b/tests/activity/test_activity_generate_pdf_covers.py
@@ -1,8 +1,7 @@
 import unittest
 import json
 from mock import patch
-import provider.article as articlelib
-from provider import lax_provider
+from provider import lax_provider, pdf_cover_page
 from activity.activity_GeneratePDFCovers import activity_GeneratePDFCovers
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeResponse
@@ -67,7 +66,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         json.dumps(self.fake_logger.logerror)
 
     @patch.object(lax_provider, "article_snippet")
-    @patch.object(articlelib, "get_pdf_cover_link")
+    @patch.object(pdf_cover_page, "get_pdf_cover_link")
     @patch.object(activity_GeneratePDFCovers, "emit_monitor_event")
     def test_do_activity_error_wrong_result_from_covers(
         self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet
@@ -84,7 +83,7 @@ class TestGeneratePDFCovers(unittest.TestCase):
         json.dumps(self.fake_logger.logerror)
 
     @patch.object(lax_provider, "article_snippet")
-    @patch.object(articlelib, "get_pdf_cover_link")
+    @patch.object(pdf_cover_page, "get_pdf_cover_link")
     @patch.object(activity_GeneratePDFCovers, "emit_monitor_event")
     def test_do_activity_get_pdf_exception(
         self, fake_monitor_event, fake_article_pdf_cover_link, fake_snippet

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from testfixtures import TempDirectory
 from mock import patch
 from ddt import ddt, data, unpack
+from provider import pdf_cover_page
 from provider.templates import Templates
 import provider.article as articlelib
 from provider.ejp import EJP
@@ -605,7 +606,7 @@ class TestPublicationEmail(unittest.TestCase):
 
         article_object = articlelib.article()
         article_object.parse_article_file("tests/test_data/elife-00353-v1.xml")
-        article_object.pdf_cover_link = articlelib.get_pdf_cover_page(
+        article_object.pdf_cover_link = pdf_cover_page.get_pdf_cover_page(
             article_object.doi_id, self.activity.settings, self.activity.logger
         )
         self.assertEqual(

--- a/tests/provider/test_templates.py
+++ b/tests/provider/test_templates.py
@@ -144,7 +144,7 @@ class TestProviderTemplates(unittest.TestCase):
     def test_lens_article_html(self, from_dir, expected_content):
         article_xml_filename = "elife03385.xml"
         article_xml_path = "tests/test_data/" + article_xml_filename
-        article_object = article(settings_mock, tmp_dir=self.directory.path)
+        article_object = article(settings_mock)
         article_object.parse_article_file(article_xml_path)
         cdn_bucket = "cdn-bucket"
         content = self.templates.get_lens_article_html(


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7449

The `provider/article.py` module is changed to not keep track of a directory when downloading XML from a bucket URL. Test coverage is increased. The PDF cover page functions are moved to a new module `provider/pdf_cover_page.py`.