### PR TITLE
Validate cecision letter characters

### DIFF
--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -100,16 +100,17 @@ class activity_ValidateDecisionLetterInput(Activity):
 
         self.set_statuses(statuses)
 
-        # part 2 articles to XML
-        self.xml_string, statuses = letterparser_provider.process_articles_to_xml(
-            self.articles, self.directories.get("TEMP_DIR"), self.logger
-        )
-
-        self.set_statuses(statuses)
-
         # Additional error messages
         if not self.statuses.get("unzip"):
             error_messages.append("Unable to unzip decision letter")
+
+        if self.articles:
+            # part 2 articles to XML
+            self.xml_string, statuses = letterparser_provider.process_articles_to_xml(
+                self.articles, self.directories.get("TEMP_DIR"), self.logger
+            )
+
+            self.set_statuses(statuses)
 
         if not self.statuses.get("valid") or not self.statuses.get("output"):
             # Send error email

--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -44,6 +44,7 @@ class activity_ValidateDecisionLetterInput(Activity):
             "valid": None,
             "generate": None,
             "output": None,
+            "chars": None,
             "email": None,
         }
 
@@ -112,7 +113,19 @@ class activity_ValidateDecisionLetterInput(Activity):
 
             self.set_statuses(statuses)
 
-        if not self.statuses.get("valid") or not self.statuses.get("output"):
+            # check characters
+            statuses, chars_error_messages = letterparser_provider.validate_characters(
+                self.xml_string
+            )
+            self.set_statuses(statuses)
+            if not statuses.get("chars"):
+                error_messages.append(chars_error_messages)
+
+        if (
+            not self.statuses.get("valid")
+            or not self.statuses.get("output")
+            or not self.statuses.get("chars")
+        ):
             # Send error email
             self.statuses["email"] = self.email_error_report(
                 real_filename, error_messages

--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -7,7 +7,11 @@ import docker
 from elifetools import parseJATS as parser
 from letterparser import generate, parse, zip_lib
 from letterparser.conf import raw_config, parse_raw_config
-from letterparser.utils import manuscript_from_file_name
+from letterparser.utils import (
+    manuscript_from_file_name,
+    detect_problem_characters,
+    unicode_char_name,
+)
 from provider.article_processing import file_name_from_name
 import log
 
@@ -186,6 +190,23 @@ def validate_articles(articles, logger=LOGGER):
                 logger.info(error_message)
 
     return valid, error_messages
+
+
+def validate_characters(xml_string):
+    "detect problematic characters in the XML"
+    error_message = ""
+    statuses = {"chars": True}
+    valid = True
+    chars = detect_problem_characters(xml_string)
+    if chars:
+        statuses["chars"] = False
+        # compose the error message
+        error_message = (
+            "Detected potentially incompatible characters in the JATS XML\n\n"
+        )
+        for char in chars:
+            error_message += "%s (%s)\n" % (char, unicode_char_name(char))
+    return statuses, error_message
 
 
 def generate_root(articles, root_tag="root", temp_dir="tmp", logger=LOGGER):

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -101,6 +101,20 @@ class TestValidateArticles(unittest.TestCase):
         self.assertTrue(len(error_messages) == 0)
 
 
+class TestValidateCharacters(unittest.TestCase):
+    def test_validate_characters(self):
+        "test for potentially problematic characters in XML"
+        xml_string = "𝒜\u2028"
+        expected_error_message = (
+            "Detected potentially incompatible characters in the JATS XML\n\n"
+            "\u2028 (LINE SEPARATOR)\n"
+            "𝒜 (MATHEMATICAL SCRIPT CAPITAL A)\n"
+        )
+        statuses, error_message = letterparser_provider.validate_characters(xml_string)
+        self.assertFalse(statuses.get("chars"))
+        self.assertEqual(error_message, expected_error_message)
+
+
 class TestCheckInput(unittest.TestCase):
     def setUp(self):
         self.temp_directory = TempDirectory()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7432

In the `ValidateDecisionLetter` activity, also check for potentially problematic characters in the JATS XML, and send an error email with an error message if any are found.