### PR TITLE
Improve validate decision letter error email body.

### DIFF
--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -120,6 +120,8 @@ class activity_ValidateDecisionLetterInput(Activity):
             self.set_statuses(statuses)
             if not statuses.get("chars"):
                 error_messages.append(chars_error_messages)
+                # also add the JATS XML to the output
+                error_messages.append("\n%s" % self.xml_string)
 
         if (
             not self.statuses.get("valid")
@@ -127,9 +129,8 @@ class activity_ValidateDecisionLetterInput(Activity):
             or not self.statuses.get("chars")
         ):
             # Send error email
-            self.statuses["email"] = self.email_error_report(
-                real_filename, error_messages
-            )
+            email_body = "".join(error_messages)
+            self.statuses["email"] = self.email_error_report(real_filename, email_body)
             self.log_statuses(self.input_file)
             return self.ACTIVITY_PERMANENT_FAILURE
 
@@ -148,10 +149,10 @@ class activity_ValidateDecisionLetterInput(Activity):
             % (self.name, str(input_file), self.statuses)
         )
 
-    def email_error_report(self, filename, error_messages):
+    def email_error_report(self, filename, email_body):
         "send an email on error"
         datetime_string = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
-        body = email_provider.simple_email_body(datetime_string, error_messages)
+        body = email_provider.simple_email_body(datetime_string, email_body)
         subject = error_email_subject(filename)
         sender_email = self.settings.decision_letter_sender_email
 

--- a/tests/activity/test_activity_validate_decision_letter_input.py
+++ b/tests/activity/test_activity_validate_decision_letter_input.py
@@ -173,7 +173,7 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()
         )
-        fake_output_xml.return_value = True, "\u2028"
+        fake_output_xml.return_value = True, "<article><p>\u2028</p></article>"
         result = self.activity.do_activity(input_data("elife-39122.zip"))
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
         # check email files and contents
@@ -189,10 +189,12 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
                 "Error processing decision letter file: " in first_email_content
             )
             body = helpers.body_from_multipart_email_string(first_email_content)
+            print(body)
             self.assertTrue(
                 (
-                    b"Detected potentially incompatible characters in the JATS XML\\n\\n"
-                    b"\\u2028 (LINE SEPARATOR)\\n"
+                    b"Detected potentially incompatible characters in the JATS XML\n\n"
+                    b"\xe2\x80\xa8 (LINE SEPARATOR)\n"
+                    b"\n<article><p>\xe2\x80\xa8</p></article>"
                 )
                 in body
             )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7432

Format the list of error messages into a string in the body of the error email sent when validating a decision letter input, and also include the JATS XML output in the email if a problematic character was detected.