### PR TITLE
Decode XML bytes to string for DL error email.

### DIFF
--- a/activity/activity_ValidateDecisionLetterInput.py
+++ b/activity/activity_ValidateDecisionLetterInput.py
@@ -2,7 +2,7 @@ import os
 import json
 import time
 from S3utility.s3_notification_info import parse_activity_data
-from provider import download_helper, email_provider, letterparser_provider
+from provider import download_helper, email_provider, letterparser_provider, utils
 from activity.objects import Activity
 
 
@@ -121,7 +121,7 @@ class activity_ValidateDecisionLetterInput(Activity):
             if not statuses.get("chars"):
                 error_messages.append(chars_error_messages)
                 # also add the JATS XML to the output
-                error_messages.append("\n%s" % self.xml_string)
+                error_messages.append("\n%s" % utils.bytes_decode(self.xml_string))
 
         if (
             not self.statuses.get("valid")

--- a/tests/activity/test_activity_validate_decision_letter_input.py
+++ b/tests/activity/test_activity_validate_decision_letter_input.py
@@ -173,7 +173,7 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()
         )
-        fake_output_xml.return_value = True, "<article><p>\u2028</p></article>"
+        fake_output_xml.return_value = True, b"<article><p>\xe2\x80\xa8</p></article>"
         result = self.activity.do_activity(input_data("elife-39122.zip"))
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
         # check email files and contents
@@ -189,7 +189,6 @@ class TestValidateDecisionLetterInput(unittest.TestCase):
                 "Error processing decision letter file: " in first_email_content
             )
             body = helpers.body_from_multipart_email_string(first_email_content)
-            print(body)
             self.assertTrue(
                 (
                     b"Detected potentially incompatible characters in the JATS XML\n\n"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7432

The XML included in the error email is improved here to display the unicode characters in a string decoded format instead of the harder to locate binary character representations when validating a decision letter (DL) input.