### PR TITLE
Improve tests for UpdateRepository and linting the code

### DIFF
--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -12,6 +12,11 @@ activity_UpdateRepository.py activity
 """
 
 
+def settings_environment(settings_object):
+    "get the environment name from the settings object class name"
+    return type(settings_object()).__name__
+
+
 class RetryException(RuntimeError):
     pass
 
@@ -50,13 +55,8 @@ class activity_UpdateRepository(Activity):
             self.settings.git_repo_name,
             self.settings.github_token,
         ):
-            import settings as settingsLib
-
-            if (
-                isinstance(self.settings(), settingsLib.live)
-                or isinstance(self.settings(), settingsLib.prod)
-                or isinstance(self.settings(), settingsLib.end2end)
-            ):
+            environment = settings_environment(self.settings)
+            if environment in ["live", "prod", "end2end"]:
                 self.emit_monitor_event(
                     self.settings,
                     data["article_id"],
@@ -204,7 +204,7 @@ class activity_UpdateRepository(Activity):
 
     def _retry_or_cancel(self, e):
         if e.status == 409:
-            self.logger.warning("Retrying because of exception: %s", e)
+            self.logger.warning("Retrying because of exception: %s" % e)
             raise RetryException(str(e))
         else:
             raise e

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -98,11 +98,7 @@ class activity_UpdateRepository(Activity):
             # download xml
             with tempfile.TemporaryFile(mode="w+b") as tmp:
                 storage_provider = self.settings.storage_provider + "://"
-                published_path = (
-                    storage_provider
-                    + self.settings.publishing_buckets_prefix
-                    + self.settings.ppp_cdn_bucket
-                )
+                published_path = storage_provider + bucket_name
 
                 resource = published_path + "/" + s3_file_path
 
@@ -138,11 +134,11 @@ class activity_UpdateRepository(Activity):
             if exception_message == "The read operation timed out":
                 self.logger.info(str(exception))
                 return self.ACTIVITY_TEMPORARY_FAILURE
-            else:
-                self.logger.exception("Exception in do_activity")
-                return self.ACTIVITY_PERMANENT_FAILURE
 
-        except Exception as e:
+            self.logger.exception("Exception in do_activity")
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        except Exception as exception:
             self.logger.exception("Exception in do_activity")
             self.emit_monitor_event(
                 self.settings,
@@ -151,20 +147,20 @@ class activity_UpdateRepository(Activity):
                 data["run"],
                 self.pretty_name,
                 "error",
-                "Error Updating repository for article. Details: " + str(e),
+                "Error Updating repository for article. Details: " + str(exception),
             )
             return self.ACTIVITY_PERMANENT_FAILURE
 
     def update_github(self, repo_file, content):
 
-        g = Github(self.settings.github_token)
-        user = g.get_user("elifesciences")
+        github_object = Github(self.settings.github_token)
+        user = github_object.get_user("elifesciences")
         article_xml_repo = user.get_repo(self.settings.git_repo_name)
 
         try:
             xml_file = article_xml_repo.get_contents(repo_file)
-        except GithubException as e:
-            self.logger.info("GithubException - description: " + str(e))
+        except GithubException as exception:
+            self.logger.info("GithubException - description: " + str(exception))
             self.logger.info(
                 "GithubException: file "
                 + repo_file
@@ -174,12 +170,14 @@ class activity_UpdateRepository(Activity):
                 response = article_xml_repo.create_file(
                     repo_file, "Creates XML", content
                 )
-            except GithubException as e:
-                self._retry_or_cancel(e)
+            except GithubException as inner_exception:
+                self._retry_or_cancel(inner_exception)
             return "File " + repo_file + " successfully added. Commit: " + str(response)
 
-        except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + str(e))
+        except Exception as exception:
+            self.logger.info(
+                "Exception: file " + repo_file + ". Error: " + str(exception)
+            )
             raise
 
         try:
@@ -192,19 +190,21 @@ class activity_UpdateRepository(Activity):
                 response = article_xml_repo.update_file(
                     repo_file, "Updates xml", content, xml_file.sha
                 )
-            except GithubException as e:
-                self._retry_or_cancel(e)
+            except GithubException as exception:
+                self._retry_or_cancel(exception)
             return (
                 "File " + repo_file + " successfully updated. Commit: " + str(response)
             )
 
-        except Exception as e:
-            self.logger.info("Exception: file " + repo_file + ". Error: " + str(e))
+        except Exception as exception:
+            self.logger.info(
+                "Exception: file " + repo_file + ". Error: " + str(exception)
+            )
             raise
 
-    def _retry_or_cancel(self, e):
-        if e.status == 409:
-            self.logger.warning("Retrying because of exception: %s" % e)
-            raise RetryException(str(e))
-        else:
-            raise e
+    def _retry_or_cancel(self, exception):
+        if exception.status == 409:
+            self.logger.warning("Retrying because of exception: %s" % exception)
+            raise RetryException(str(exception))
+
+        raise exception

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -32,7 +32,7 @@ class FakeGithubRepository:
     ):
         pass
 
-    def create_file(path, message, content, branch=None, committer=None, author=None):
+    def create_file(self, path, message, content, branch=None, committer=None, author=None):
         pass
 
 

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -1,9 +1,47 @@
 import unittest
 from ssl import SSLError
+from github import GithubException
 from mock import patch, MagicMock
-from activity.activity_UpdateRepository import activity_UpdateRepository
-import tests.activity.settings_mock as settings_mock
+from activity.activity_UpdateRepository import activity_UpdateRepository, RetryException
+from tests.activity import settings_mock
 from tests.activity.classes_mock import FakeStorageContext, FakeLogger, FakeLaxProvider
+
+
+class FakeGithub:
+    "mock object for github.Github"
+
+    def get_user(self, login):
+        return FakeGithubNamedUser()
+
+
+class FakeGithubNamedUser:
+    "mock object for github.NamedUser.NamedUser"
+
+    def get_repo(self, full_name_or_id):
+        return FakeGithubRepository()
+
+
+class FakeGithubRepository:
+    "mock object for github.Repository.Repository"
+
+    def get_contents(self, path):
+        return FakeGithubContentFile()
+
+    def update_file(
+        self, path, message, content, sha, branch=None, committer=None, author=None
+    ):
+        pass
+
+    def create_file(path, message, content, branch=None, committer=None, author=None):
+        pass
+
+
+class FakeGithubContentFile:
+    "mock object for github.ContentFile.ContentFile"
+
+    def __init__(self):
+        self.decoded_content = b"<article/>"
+        self.sha = "sha"
 
 
 @patch("activity.activity_UpdateRepository.provider")
@@ -11,31 +49,75 @@ from tests.activity.classes_mock import FakeStorageContext, FakeLogger, FakeLaxP
 @patch("dashboard_queue.send_message")
 class TestUpdateRepository(unittest.TestCase):
     def test_happy_path(self, dashboard_queue, mock_storage_context, provider):
-        a = activity_UpdateRepository(settings_mock, FakeLogger())
+        activity_object = activity_UpdateRepository(settings_mock, FakeLogger())
+        dashboard_queue.return_value = True
         mock_storage_context.return_value = FakeStorageContext()
         provider.lax_provider = FakeLaxProvider
-        a.update_github = MagicMock()
+        activity_object.update_github = MagicMock()
 
-        result = a.do_activity(
+        result = activity_object.do_activity(
             {
                 "article_id": "12345",
                 "version": 1,
                 "run": "123abc",
             }
         )
-        self.assertTrue(result)
+        self.assertEqual(result, True)
 
-    def test_ssl_timeout_error_leads_to_a_retry(
+    def test_missing_settings_value(
         self, dashboard_queue, mock_storage_context, provider
     ):
-        a = activity_UpdateRepository(settings_mock, FakeLogger())
+        "test for when settings values are None depending on the environment name"
+
+        class ci:
+            "mock settings object for testing"
+            domain = None
+            default_task_list = None
+            git_repo_path = None
+            git_repo_name = None
+            github_token = None
+
+        class end2end(ci):
+            pass
+
+        dashboard_queue.return_value = True
         mock_storage_context.return_value = FakeStorageContext()
         provider.lax_provider = FakeLaxProvider
-        a.update_github = MagicMock()
 
-        a.update_github.side_effect = SSLError("The read operation timed out")
+        # test ci environment
+        activity_object = activity_UpdateRepository(ci, FakeLogger())
+        result = activity_object.do_activity(
+            {
+                "article_id": "12345",
+                "version": 1,
+                "run": "123abc",
+            }
+        )
+        self.assertEqual(result, True)
 
-        result = a.do_activity(
+        # test end2end environment
+        activity_object = activity_UpdateRepository(end2end, FakeLogger())
+        result = activity_object.do_activity(
+            {
+                "article_id": "12345",
+                "version": 1,
+                "run": "123abc",
+            }
+        )
+        self.assertEqual(result, "ActivityPermanentFailure")
+
+    def test_retry_exception_leads_to_a_retry(
+        self, dashboard_queue, mock_storage_context, provider
+    ):
+        activity_object = activity_UpdateRepository(settings_mock, FakeLogger())
+        dashboard_queue.return_value = True
+        mock_storage_context.return_value = FakeStorageContext()
+        provider.lax_provider = FakeLaxProvider
+        activity_object.update_github = MagicMock()
+
+        activity_object.update_github.side_effect = RetryException("Retry")
+
+        result = activity_object.do_activity(
             {
                 "article_id": "12345",
                 "version": 1,
@@ -44,19 +126,40 @@ class TestUpdateRepository(unittest.TestCase):
         )
         self.assertEqual(result, "ActivityTemporaryFailure")
 
-    def test_generic_errors_we_dont_know_how_to_treat_lead_to_permanent_failures(
+    def test_ssl_timeout_error_leads_to_a_retry(
         self, dashboard_queue, mock_storage_context, provider
     ):
-        a = activity_UpdateRepository(settings_mock, FakeLogger())
+        activity_object = activity_UpdateRepository(settings_mock, FakeLogger())
+        dashboard_queue.return_value = True
         mock_storage_context.return_value = FakeStorageContext()
         provider.lax_provider = FakeLaxProvider
-        a.update_github = MagicMock()
+        activity_object.update_github = MagicMock()
 
-        a.update_github.side_effect = RuntimeError(
-            "One of the cross beams has gone out askew..."
+        activity_object.update_github.side_effect = SSLError(
+            "The read operation timed out"
         )
 
-        result = a.do_activity(
+        result = activity_object.do_activity(
+            {
+                "article_id": "12345",
+                "version": 1,
+                "run": "123abc",
+            }
+        )
+        self.assertEqual(result, "ActivityTemporaryFailure")
+
+    def test_ssl_timeout_error_leads_to_a_permanent_failure(
+        self, dashboard_queue, mock_storage_context, provider
+    ):
+        activity_object = activity_UpdateRepository(settings_mock, FakeLogger())
+        dashboard_queue.return_value = True
+        mock_storage_context.return_value = FakeStorageContext()
+        provider.lax_provider = FakeLaxProvider
+        activity_object.update_github = MagicMock()
+
+        activity_object.update_github.side_effect = SSLError("Unhandled error message")
+
+        result = activity_object.do_activity(
             {
                 "article_id": "12345",
                 "version": 1,
@@ -64,3 +167,126 @@ class TestUpdateRepository(unittest.TestCase):
             }
         )
         self.assertEqual(result, "ActivityPermanentFailure")
+
+    def test_generic_errors_we_dont_know_how_to_treat_lead_to_permanent_failures(
+        self, dashboard_queue, mock_storage_context, provider
+    ):
+        activity_object = activity_UpdateRepository(settings_mock, FakeLogger())
+        dashboard_queue.return_value = True
+        mock_storage_context.return_value = FakeStorageContext()
+        provider.lax_provider = FakeLaxProvider
+        activity_object.update_github = MagicMock()
+
+        activity_object.update_github.side_effect = RuntimeError(
+            "One of the cross beams has gone out askew..."
+        )
+
+        result = activity_object.do_activity(
+            {
+                "article_id": "12345",
+                "version": 1,
+                "run": "123abc",
+            }
+        )
+        self.assertEqual(result, "ActivityPermanentFailure")
+
+
+@patch("activity.activity_UpdateRepository.Github")
+class TestUpdateGithub(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
+
+    def test_no_changes_to_file(self, mock_github):
+        repo_file = "file.txt"
+        content = b"<article/>"
+        mock_github.return_value = FakeGithub()
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        result = activity_object.update_github(repo_file, content)
+        self.assertEqual(result, "No changes in file %s" % repo_file)
+
+    def test_updated_file(self, mock_github):
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        result = activity_object.update_github(repo_file, content)
+        self.assertEqual(
+            result, "File %s successfully updated. Commit: None" % repo_file
+        )
+
+    @patch.object(FakeGithubRepository, "get_contents")
+    def test_get_contents_exception(self, fake_get_contents, mock_github):
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        fake_get_contents.side_effect = GithubException(
+            status="status", data="data", headers="headers"
+        )
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        result = activity_object.update_github(repo_file, content)
+        self.assertEqual(result, "File %s successfully added. Commit: None" % repo_file)
+
+    @patch.object(FakeGithubRepository, "get_contents")
+    def test_get_contents_unhandled_exception(self, fake_get_contents, mock_github):
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        fake_get_contents.side_effect = Exception("An unhanded exception")
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        with self.assertRaises(Exception):
+            activity_object.update_github(repo_file, content)
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            "Exception: file %s. Error: An unhanded exception" % repo_file,
+        )
+
+    @patch.object(FakeGithubRepository, "create_file")
+    @patch.object(FakeGithubRepository, "get_contents")
+    def test_create_file_exception(
+        self, fake_get_contents, fake_create_file, mock_github
+    ):
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        fake_get_contents.side_effect = GithubException(
+            status="status", data="data", headers="headers"
+        )
+        fake_create_file.side_effect = GithubException(
+            status=409, data="data", headers="headers"
+        )
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        with self.assertRaises(Exception):
+            activity_object.update_github(repo_file, content)
+        self.assertEqual(
+            self.logger.logwarning, 'Retrying because of exception: 409 "data"'
+        )
+
+    @patch.object(FakeGithubRepository, "update_file")
+    def test_update_file_exception(self, fake_update_file, mock_github):
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        fake_update_file.side_effect = GithubException(
+            status=409, data="data", headers="headers"
+        )
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        with self.assertRaises(Exception):
+            activity_object.update_github(repo_file, content)
+        self.assertEqual(
+            self.logger.logwarning, 'Retrying because of exception: 409 "data"'
+        )
+
+    @patch.object(FakeGithubRepository, "update_file")
+    def test_update_file_exception_unhandled_status(
+        self, fake_update_file, mock_github
+    ):
+        "test for status 500 which currently does not result in a retry"
+        repo_file = "file.txt"
+        content = b"<article>Updated</article>"
+        mock_github.return_value = FakeGithub()
+        fake_update_file.side_effect = GithubException(
+            status=500, data="data", headers="headers"
+        )
+        activity_object = activity_UpdateRepository(settings_mock, self.logger)
+        with self.assertRaises(GithubException):
+            activity_object.update_github(repo_file, content)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7474

`UpdateRepository` activity had low code coverage, which is now improved. The method of how it checks the settings environment, to decide whether blank github settings and credentials should result in a warning, how checks the class name of the settings object and decides based on that. There are many places where various exceptions are caught, and now there are tests for each potential situation.