### PR TITLE
ejp provider refactoring

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -531,20 +531,21 @@ class activity_PublicationEmail(Activity):
 
         return True
 
-    def get_authors(self, doi_id=None, corresponding=None, local_document=None):
+    def get_authors(self, doi_id=None):
         """
         Using the EJP data provider, get the column headings
         and author data, and reassemble into a list of authors
-        document is only provided when running tests, otherwise just specify the doi_id
+        for the article with doi_id
         """
-        author_list = []
+
         # EJP data provider
         ejp_object = ejp.EJP(self.settings, self.get_tmp_dir())
 
-        (column_headings, authors) = ejp_object.get_authors(
-            doi_id=doi_id, corresponding=corresponding, local_document=local_document
-        )
+        (column_headings, authors) = ejp_object.get_authors(doi_id=doi_id)
+        return self.get_author_list(column_headings, authors, doi_id)
 
+    def get_author_list(self, column_headings, authors, doi_id):
+        author_list = []
         # Authors will be none if there is not data
         if authors is None:
             log_info = "No authors found for article doi id " + str(doi_id)

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -84,30 +84,10 @@ class EJP:
 
         return (column_headings, author_rows)
 
-    def get_authors(self, doi_id=None, corresponding=None):
-        """
-        Get a list of authors for an article
-          If doi_id is None, return all authors
-          If corresponding is
-            True, return corresponding authors
-            False, return all but corresponding authors
-            None, return all authors
-        """
-        authors = []
+    def author_detail_list(self, document, doi_id=None, corresponding=None):
+        "get author details from the document as a list"
 
-        # Find the document on S3, save the content to
-        #  the tmp_dir
-        storage = storage_context(self.settings)
-        s3_key_name = self.find_latest_s3_file_name(file_type="author")
-        s3_resource = (
-            self.settings.storage_provider
-            + "://"
-            + self.bucket_name
-            + "/"
-            + s3_key_name
-        )
-        contents = storage.get_resource_as_string(s3_resource)
-        document = self.write_content_to_file(self.author_default_filename, contents)
+        authors = []
 
         # Parse the author file
         (column_headings, author_rows) = self.parse_author_file(document)
@@ -145,6 +125,32 @@ class EJP:
             authors = None
 
         return (column_headings, authors)
+
+    def get_authors(self, doi_id=None, corresponding=None):
+        """
+        Get a list of authors for an article
+          If doi_id is None, return all authors
+          If corresponding is
+            True, return corresponding authors
+            False, return all but corresponding authors
+            None, return all authors
+        """
+
+        # Find the document on S3, save the content to
+        #  the tmp_dir
+        storage = storage_context(self.settings)
+        s3_key_name = self.find_latest_s3_file_name(file_type="author")
+        s3_resource = (
+            self.settings.storage_provider
+            + "://"
+            + self.bucket_name
+            + "/"
+            + s3_key_name
+        )
+        contents = storage.get_resource_as_string(s3_resource)
+        document = self.write_content_to_file(self.author_default_filename, contents)
+
+        return self.author_detail_list(document, doi_id, corresponding)
 
     def is_corresponding_author(self, author_type_cde, dual_corr_author_ind):
         """

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -27,7 +27,6 @@ class EJP:
 
         # Some EJP file types we expect
         self.author_default_filename = "authors.csv"
-        self.editor_default_filename = "editors.csv"
 
     def write_content_to_file(self, filename, content, mode="wb"):
         "write the content to a file in the tmp_dir"

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -16,12 +16,9 @@ Connects to S3, discovers, downloads, and parses files exported by EJP
 
 
 class EJP:
-    def __init__(self, settings=None, tmp_dir=None):
+    def __init__(self, settings, tmp_dir):
         self.settings = settings
         self.tmp_dir = tmp_dir
-
-        # Default tmp_dir if not specified
-        self.tmp_dir_default = "ejp_provider"
 
         # Default S3 bucket name
         self.bucket_name = None
@@ -37,7 +34,7 @@ class EJP:
         document = None
         # set the document path
         try:
-            document_path = os.path.join(self.get_tmp_dir(), filename)
+            document_path = os.path.join(self.tmp_dir, filename)
         except TypeError:
             document_path = None
         # write the content to the file
@@ -376,15 +373,3 @@ class EJP:
             file_list = None
 
         return file_list
-
-    def get_tmp_dir(self):
-        """
-        Get the temporary file directory, but if not set
-        then make the directory
-        """
-        if self.tmp_dir:
-            return self.tmp_dir
-        else:
-            self.tmp_dir = self.tmp_dir_default
-
-        return self.tmp_dir

--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -85,7 +85,7 @@ class EJP:
 
         return (column_headings, author_rows)
 
-    def get_authors(self, doi_id=None, corresponding=None, local_document=None):
+    def get_authors(self, doi_id=None, corresponding=None):
         """
         Get a list of authors for an article
           If doi_id is None, return all authors
@@ -93,32 +93,22 @@ class EJP:
             True, return corresponding authors
             False, return all but corresponding authors
             None, return all authors
-          If document is None, find the most recent authors file
         """
         authors = []
-        # Check for the document
-        if local_document is None:
-            # No document? Find it on S3, save the content to
-            #  the tmp_dir
-            storage = storage_context(self.settings)
-            s3_key_name = self.find_latest_s3_file_name(file_type="author")
-            s3_resource = (
-                self.settings.storage_provider
-                + "://"
-                + self.bucket_name
-                + "/"
-                + s3_key_name
-            )
-            contents = storage.get_resource_as_string(s3_resource)
-            document = self.write_content_to_file(
-                self.author_default_filename, contents
-            )
-        else:
-            # copy the document to the tmp_dir if provided
-            with open(local_document, "rb") as fp:
-                document = self.write_content_to_file(
-                    self.author_default_filename, fp.read()
-                )
+
+        # Find the document on S3, save the content to
+        #  the tmp_dir
+        storage = storage_context(self.settings)
+        s3_key_name = self.find_latest_s3_file_name(file_type="author")
+        s3_resource = (
+            self.settings.storage_provider
+            + "://"
+            + self.bucket_name
+            + "/"
+            + s3_key_name
+        )
+        contents = storage.get_resource_as_string(s3_resource)
+        document = self.write_content_to_file(self.author_default_filename, contents)
 
         # Parse the author file
         (column_headings, author_rows) = self.parse_author_file(document)

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from testfixtures import TempDirectory
 from mock import patch
 from ddt import ddt, data, unpack
-from provider import pdf_cover_page
+from provider import ejp, pdf_cover_page
 from provider.templates import Templates
 import provider.article as articlelib
 from provider.ejp import EJP
@@ -38,8 +38,7 @@ LAX_ARTICLE_VERSIONS_RESPONSE_DATA_4 = test_data.lax_article_versions_response_d
 
 def fake_authors(activity_object, article_id=3):
     # parse author csv file or create test fixture data
-    ejp_object = EJP(None, None)
-    column_headings, authors = ejp_object.author_detail_list(
+    column_headings, authors = ejp.author_detail_list(
         "tests/test_data/ejp_author_file.csv", article_id
     )
     return activity_object.get_author_list(column_headings, authors, article_id)

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -37,9 +37,12 @@ LAX_ARTICLE_VERSIONS_RESPONSE_DATA_4 = test_data.lax_article_versions_response_d
 
 
 def fake_authors(activity_object, article_id=3):
-    return activity_object.get_authors(
-        article_id, None, "tests/test_data/ejp_author_file.csv"
+    # parse author csv file or create test fixture data
+    ejp_object = EJP(None, None)
+    column_headings, authors = ejp_object.author_detail_list(
+        "tests/test_data/ejp_author_file.csv", article_id
     )
+    return activity_object.get_author_list(column_headings, authors, article_id)
 
 
 @ddt

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -10,7 +10,7 @@ from testfixtures import tempdir
 from testfixtures import TempDirectory
 from mock import patch
 from ddt import ddt, data, unpack
-from provider import utils
+from provider import ejp, utils
 from provider.ejp import EJP
 from tests import settings_mock
 from tests.activity.classes_mock import FakeStorageContext
@@ -30,7 +30,6 @@ class TestProviderEJP(unittest.TestCase):
             "dual_corr_author_ind",
             "e_mail",
         ]
-        self.editor_column_headings = ["ms_no", "first_nm", "last_nm", "e_mail"]
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -57,13 +56,6 @@ class TestProviderEJP(unittest.TestCase):
             if exception_raised:
                 self.assertRaises(exception_raised)
 
-    def test_parse_author_file(self):
-        author_csv_file = os.path.join("tests", "test_data", "ejp_author_file.csv")
-        # call the function
-        (column_headings, authors) = self.ejp.parse_author_file(author_csv_file)
-        # assert results
-        self.assertEqual(column_headings, self.author_column_headings)
-
     @patch("provider.ejp.storage_context")
     @patch("provider.ejp.EJP.find_latest_s3_file_name")
     @data(
@@ -88,15 +80,6 @@ class TestProviderEJP(unittest.TestCase):
                     "Contributing Author",
                     " ",
                     "author02@example.org",
-                ],
-                [
-                    "3",
-                    "3",
-                    "Author",
-                    "Three",
-                    "Corresponding Author",
-                    " ",
-                    "author03@example.com",
                 ],
             ],
         ),
@@ -136,24 +119,6 @@ class TestProviderEJP(unittest.TestCase):
                     "Contributing Author",
                     " ",
                     "author13-02@example.com",
-                ],
-                [
-                    "13",
-                    "3",
-                    "Authoré",
-                    "Trés",
-                    "Contributing Author",
-                    "1",
-                    "author13-03@example.com",
-                ],
-                [
-                    "13",
-                    "4",
-                    "Author",
-                    "Cuatro",
-                    "Corresponding Author",
-                    " ",
-                    "author13-04@example.com",
                 ],
             ],
         ),
@@ -377,7 +342,7 @@ class TestProviderEJP(unittest.TestCase):
         )
         # mock things
         ejp_bucket_file_list = []
-        with open(bucket_list_file_new, "r") as open_file:
+        with open(bucket_list_file_new, "r", encoding="utf-8") as open_file:
             ejp_bucket_file_list += json.loads(open_file.read())
         fake_ejp_bucket_file_list.return_value = ejp_bucket_file_list
         # call the function
@@ -391,7 +356,7 @@ class TestProviderEJP(unittest.TestCase):
             "tests", "test_data", "ejp_bucket_list_new.json"
         )
         ejp_bucket_file_list = []
-        with open(bucket_list_file_new, "r") as open_file:
+        with open(bucket_list_file_new, "r", encoding="utf-8") as open_file:
             ejp_bucket_file_list += json.loads(open_file.read())
         resources = [
             {
@@ -418,5 +383,47 @@ class TestProviderEJP(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestAuthorDetailList(unittest.TestCase):
+    def setUp(self):
+        self.author_csv_file = os.path.join("tests", "test_data", "ejp_author_file.csv")
+
+    def test_author_detail_list(self):
+        corresponding = None
+        column_headings, authors = ejp.author_detail_list(
+            self.author_csv_file, 13, corresponding
+        )
+        self.assertEqual(len(authors), 4)
+
+    def test_author_detail_list_corresponding_true(self):
+        corresponding = True
+        author_csv_file = os.path.join("tests", "test_data", "ejp_author_file.csv")
+        column_headings, authors = ejp.author_detail_list(
+            self.author_csv_file, 13, corresponding
+        )
+        self.assertEqual(len(authors), 2)
+
+    def test_author_detail_list_corresponding_false(self):
+        corresponding = False
+        author_csv_file = os.path.join("tests", "test_data", "ejp_author_file.csv")
+        column_headings, authors = ejp.author_detail_list(
+            self.author_csv_file, 13, corresponding
+        )
+        self.assertEqual(len(authors), 2)
+
+
+class TestParseAuthorFile(unittest.TestCase):
+    def test_parse_author_file(self):
+        author_csv_file = os.path.join("tests", "test_data", "ejp_author_file.csv")
+        expected = [
+            "ms_no",
+            "author_seq",
+            "first_nm",
+            "last_nm",
+            "author_type_cde",
+            "dual_corr_author_ind",
+            "e_mail",
+        ]
+        # call the function
+        (column_headings, authors) = ejp.parse_author_file(author_csv_file)
+        # assert results
+        self.assertEqual(column_headings, expected)

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -252,45 +252,12 @@ class TestProviderEJP(unittest.TestCase):
         self.assertEqual(column_headings, self.author_column_headings)
         self.assertEqual(authors, expected_authors)
 
-    def test_parse_editor_file(self):
-        author_csv_file = os.path.join("tests", "test_data", "ejp_editor_file.csv")
-        # call the function
-        (column_headings, authors) = self.ejp.parse_editor_file(author_csv_file)
-        # assert results
-        self.assertEqual(column_headings, self.editor_column_headings)
-
-    @tempdir()
-    @data(
-        (3, [["3", "Editor", "One", "ed_one@example.com"]]),
-        ("00003", [["3", "Editor", "One", "ed_one@example.com"]]),
-        (666, None),
-        (
-            None,
-            [
-                ["3", "Editor", "One", "ed_one@example.com"],
-                ["13", "Editor", "Uno", "ed_uno@example.com"],
-            ],
-        ),
-    )
-    @unpack
-    def test_get_editors(self, doi_id, expected_editors):
-        editor_csv_file = os.path.join("tests", "test_data", "ejp_editor_file.csv")
-        # call the function
-        (column_headings, authors) = self.ejp.get_editors(doi_id, editor_csv_file)
-        # assert results
-        self.assertEqual(column_headings, self.editor_column_headings)
-        self.assertEqual(authors, expected_editors)
-
     @patch.object(arrow, "utcnow")
     @patch("provider.ejp.storage_context")
     @data(
         (
             "author",
             "ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_06_10_eLife.csv",
-        ),
-        (
-            "editor",
-            "ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_06_10_eLife.csv",
         ),
         (
             "poa_manuscript",
@@ -348,10 +315,6 @@ class TestProviderEJP(unittest.TestCase):
         (
             "author",
             "ejp_query_tool_query_id_15a)_Accepted_Paper_Details_2019_06_10_eLife.csv",
-        ),
-        (
-            "editor",
-            "ejp_query_tool_query_id_15b)_Accepted_Paper_Details_2019_06_10_eLife.csv",
         ),
         (
             "poa_manuscript",

--- a/tests/test_data/ejp_editor_file.csv
+++ b/tests/test_data/ejp_editor_file.csv
@@ -1,6 +1,0 @@
-"Query: 15b) Accepted Paper Details"
-"Generated on October 1, 2013"
-
-"ms_no","first_nm","last_nm","e_mail"
-"3","Editor","One","ed_one@example.com"
-"13","Editor","Uno","ed_uno@example.com"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7472

`provider/ejp.py` is changed to simplify how it uses a temporary directory, made easier to collect author data from CSV files when mocking in tests, linting changes, moved functions which had no self use, move the list used for matching CSV file names.

Two workflow activities use the EJP data, `PackagePOA` and `PublicationEmail`, and their logic and tests are updated as needed.