### PR TITLE
Activity object tests and linting

### DIFF
--- a/activity/activity_ExpandArticle.py
+++ b/activity/activity_ExpandArticle.py
@@ -92,9 +92,6 @@ class activity_ExpandArticle(Activity):
         try:
             # download zip to temp folder
             tmp = self.get_tmp_dir()
-            local_zip_file = self.open_file_from_tmp_dir(
-                filename_last_element, mode="wb"
-            )
             storage_resource_origin = (
                 self.settings.storage_provider
                 + "://"
@@ -102,8 +99,8 @@ class activity_ExpandArticle(Activity):
                 + "/"
                 + info.file_name
             )
-            storage.get_resource_to_file(storage_resource_origin, local_zip_file)
-            local_zip_file.close()
+            with open(os.path.join(tmp, filename_last_element), "wb") as local_zip_file:
+                storage.get_resource_to_file(storage_resource_origin, local_zip_file)
 
             # extract zip contents
             folder_name = path.join(article_version_id, run)

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -30,12 +30,12 @@ class Activity(object):
         # SWF Defaults, most are set in derived classes or at runtime
         try:
             self.domain = self.settings.domain
-        except KeyError:
+        except AttributeError:
             self.domain = None
 
         try:
             self.task_list = self.settings.default_task_list
-        except KeyError:
+        except AttributeError:
             self.task_list = None
 
         self.name = None

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -11,7 +11,7 @@ Amazon SWF activity base class
 """
 
 
-class Activity(object):
+class Activity:
 
     ACTIVITY_SUCCESS = "ActivitySuccess"
     ACTIVITY_TEMPORARY_FAILURE = "ActivityTemporaryFailure"
@@ -71,7 +71,7 @@ class Activity(object):
             response = self.client.describe_activity_type(
                 domain=self.domain, activityType=activity_type
             )
-        except botocore.exceptions.ClientError as exception:
+        except botocore.exceptions.ClientError:
             response = None
 
         return response
@@ -197,8 +197,8 @@ class Activity(object):
         """
         if self.tmp_dir:
             return self.tmp_dir
-        else:
-            self.make_tmp_dir()
+
+        self.make_tmp_dir()
 
         return self.tmp_dir
 
@@ -247,6 +247,7 @@ class Activity(object):
                 "Exception emitting %s message. Details: %s"
                 % (str(status), str(exception))
             )
+        return None
 
     def message_activity_name(self):
         "the name for the activity to use in emit messages"

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -223,20 +223,6 @@ class Activity(object):
                 raise
         return True
 
-    def open_file_from_tmp_dir(self, filename, mode="r"):
-        """
-        Read the file from the tmp_dir
-        """
-        tmp_dir = self.get_tmp_dir()
-
-        if tmp_dir:
-            full_filename = tmp_dir + os.sep + filename
-        else:
-            full_filename = filename
-
-        f = open(full_filename, mode)
-        return f
-
     def clean_tmp_dir(self):
 
         tmp_dir = self.get_tmp_dir()

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import re
 import dashboard_queue
+import botocore
 from provider import utils
 
 """
@@ -70,7 +71,7 @@ class Activity(object):
             response = self.client.describe_activity_type(
                 domain=self.domain, activityType=activity_type
             )
-        except self.client.exceptions.UnknownResourceFault:
+        except botocore.exceptions.ClientError as exception:
             response = None
 
         return response

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -2,8 +2,8 @@ import shutil
 import datetime
 import os
 import re
-import dashboard_queue
 import botocore
+import dashboard_queue
 from provider import utils
 
 """

--- a/tests/activity/test_activity_object.py
+++ b/tests/activity/test_activity_object.py
@@ -8,6 +8,17 @@ import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger
 
 
+class TestActivityInit(unittest.TestCase):
+    "tests instantiating an object"
+
+    def test_activity_init_with_no_settings(self):
+        "test an activity object where some settings are blank"
+        test_settings = object
+        activity_object = Activity(test_settings, None, None, None, None)
+        self.assertEqual(activity_object.domain, None)
+        self.assertEqual(activity_object.task_list, None)
+
+
 class TestActivity(unittest.TestCase):
     def setUp(self):
         fake_logger = FakeLogger()

--- a/tests/classes_mock.py
+++ b/tests/classes_mock.py
@@ -78,7 +78,8 @@ class FakeSWFClient:
         pass
 
     def describe_activity_type(self, domain, activityType):
-        pass
+        "return a partial fake response for when testing"
+        return {"typeInfo": "..."}
 
     def register_activity_type(self, **kwargs):
         pass


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7559

Mostly increasing test coverage for `activity/objects.py`, but also changed the boto3 client exception handling syntax, removed `open_file_from_tmp_dir()` and fixed the one remaining activity using it, and some code linting.