### PR TITLE
Clean up temp folders when running tests

### DIFF
--- a/provider/letterparser_provider.py
+++ b/provider/letterparser_provider.py
@@ -37,9 +37,9 @@ def letterparser_config(settings):
     )
 
 
-def parse_file(file_name, config):
+def parse_file(file_name, config, temp_dir="tmp"):
     try:
-        return parse.parse_file(file_name, config)
+        return parse.parse_file(file_name, config, temp_dir)
     except docker.errors.APIError:
         LOGGER.info("Error connecting to docker")
         raise

--- a/register.py
+++ b/register.py
@@ -1,5 +1,6 @@
 import json
 import importlib
+import os
 import boto3
 import workflow
 import activity
@@ -145,6 +146,10 @@ def start(settings):
 
         # Now register it
         response = activity_object.register()
+
+        # clean up temporary directory
+        activity_object.clean_tmp_dir()
+        os.rmdir(activity_object.get_tmp_dir())
 
         print(("got response: \n%s" % json.dumps(response, sort_keys=True, indent=4)))
 

--- a/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
+++ b/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import copy
+import shutil
 import unittest
 from xml.etree import ElementTree
 from xml.etree.ElementTree import ParseError
@@ -48,8 +49,8 @@ class TestAddCommentsToAcceptedSubmissionXml(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")
@@ -242,6 +243,8 @@ class TestAddXmlException(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "add_comments_to_xml")

--- a/tests/activity/test_activity_admin_email_history.py
+++ b/tests/activity/test_activity_admin_email_history.py
@@ -15,6 +15,9 @@ class TestAdminEmailHistory(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch.object(swfmetalib.SWFMeta, "connect")
     @patch.object(swfmetalib.SWFMeta, "get_closed_workflow_execution_count")
     @patch.object(activity_module.email_provider, "smtp_connect")

--- a/tests/activity/test_activity_annotate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_annotate_accepted_submission_videos.py
@@ -169,8 +169,8 @@ class TestAnnotateAcceptedSubmissionVideos(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")
@@ -395,6 +395,8 @@ class TestAnnotateAcceptedSubmissionVideosGlencoeExceptions(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(glencoe_check, "metadata")
@@ -549,6 +551,8 @@ class TestAnnotateAcceptedSubmissionAnnotateXmlException(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "annotate_xml")
@@ -626,6 +630,8 @@ class TestAnnotateVideosBlankCredentials(unittest.TestCase):
     def tearDown(self):
         # restore settings value
         self.activity.settings.video_url = self.video_url
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     def test_do_activity_annotate_videos_blank_credentials(

--- a/tests/activity/test_activity_apply_version_number.py
+++ b/tests/activity/test_activity_apply_version_number.py
@@ -122,6 +122,7 @@ class TestApplyVersionNumber(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        self.applyversionnumber.clean_tmp_dir()
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_ApplyVersionNumber, "emit_monitor_event")

--- a/tests/activity/test_activity_archive_article.py
+++ b/tests/activity/test_activity_archive_article.py
@@ -33,6 +33,7 @@ class TestArchiveArticle(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        self.activity.clean_tmp_dir()
 
     def zip_assertions(self, zip_file_path, expected_zip_file_name, expected_zip_files):
         zip_file_name = None

--- a/tests/activity/test_activity_copy_glencoe_still_images.py
+++ b/tests/activity/test_activity_copy_glencoe_still_images.py
@@ -15,6 +15,7 @@ class TestCopyGlencoeStillImages(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        self.copyglencoestillimages.clean_tmp_dir()
 
     @patch("provider.article_processing.storage_context")
     @patch("provider.lax_provider.get_xml_file_name")

--- a/tests/activity/test_activity_deposit_accepted_submission_videos.py
+++ b/tests/activity/test_activity_deposit_accepted_submission_videos.py
@@ -85,8 +85,8 @@ class TestDepositAcceptedSubmissionVideos(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")
@@ -302,6 +302,8 @@ class TestDepositAcceptedSubmissionVideosFtpExceptions(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(FakeFTP, "ftp_connect")
@@ -440,6 +442,10 @@ class TestDepositVideosDepositVideosNone(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
+    def tearDown(self):
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+
     @patch.object(activity_module, "get_session")
     def test_do_activity_deposit_videos_none(
         self,
@@ -472,6 +478,8 @@ class TestDepositVideosNoCredentials(unittest.TestCase):
     def tearDown(self):
         # restore settings value
         self.activity.settings.GLENCOE_FTP_URI = self.glencoe_ftp_uri
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     def test_do_activity_deposit_videos_no_credentials(
@@ -506,6 +514,8 @@ class TestDepositVideosBlankCredentials(unittest.TestCase):
     def tearDown(self):
         # restore settings value
         self.activity.settings.GLENCOE_FTP_URI = self.glencoe_ftp_uri
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     def test_do_activity_deposit_videos_blank_credentials(

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -238,6 +238,8 @@ class TestEmailDigestFileName(unittest.TestCase):
             digest_content, activity.digest_config
         )
         self.assertEqual(file_name, expected)
+        # clean the temporary directory
+        activity.clean_tmp_dir()
 
     def test_output_file_name_unicode(self):
         "docx output file name with unicode author name"

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -19,7 +19,9 @@ class TestExpandArticle(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        helpers.delete_directories_in_folder("tests/tmp")
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+        self.expandarticle.clean_tmp_dir()
 
     @patch.object(activity_ExpandArticle, "get_tmp_dir")
     @patch("activity.activity_ExpandArticle.get_session")

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -211,6 +211,9 @@ class TestFTPArticleFTPToEndpoint(unittest.TestCase):
         self.uploadfiles = ["zipfile.zip"]
         self.sub_dir_list = ["subfolder", "subsubfolder"]
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch.object(FakeFTP, "ftp_connect")
     @patch("activity.activity_FTPArticle.FTP")
     def test_ftp_connect_exception(self, fake_ftp, fake_ftp_connect):

--- a/tests/activity/test_activity_generate_swh_metadata.py
+++ b/tests/activity/test_activity_generate_swh_metadata.py
@@ -37,6 +37,7 @@ class TestGenerateSWHMetadata(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+        self.activity.clean_tmp_dir()
 
     @patch.object(article, "download_article_xml_from_s3")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_generate_swh_readme.py
+++ b/tests/activity/test_activity_generate_swh_readme.py
@@ -37,6 +37,7 @@ class TestGenerateSWHReadme(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+        self.activity.clean_tmp_dir()
 
     @patch.object(article, "download_article_xml_from_s3")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -552,6 +552,10 @@ class TestIngestDigestToEndpointGenerate(unittest.TestCase):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
 
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
     @patch.object(activity_object, "digest_json")
     def test_digest_json_exception(self, fake_digest_json):
         fake_digest_json.side_effect = Exception("Digest content exception")
@@ -584,6 +588,10 @@ class TestIngestDigestToEndpointDigestJson(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
 
     @patch("activity.activity_IngestDigestToEndpoint.json_output.requests.get")
     @data(
@@ -648,6 +656,10 @@ class TestIngestDigestToEndpointSession(unittest.TestCase):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
 
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
     def test_session_data_none_data(self):
         "test no data supplied"
         session_data = self.activity.session_data(None)
@@ -663,6 +675,10 @@ class TestIngestDigestToEndpointEmit(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
 
     def test_emit_start_message_none_data(self):
         "test missing data run attribute"
@@ -706,6 +722,10 @@ class TestIngestDigestToEndpointPreview(unittest.TestCase):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
 
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
     def test_digest_preview_link(self):
         "digest preview url from settings value and article_id"
         article_id = "353"
@@ -719,6 +739,10 @@ class TestIngestDigestToEndpointApprove(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
 
     @patch.object(digest_provider, "docx_exists_in_s3")
     @patch.object(lax_provider, "article_status_version_map")

--- a/tests/activity/test_activity_output_accepted_submission.py
+++ b/tests/activity/test_activity_output_accepted_submission.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+import shutil
 import zipfile
 from mock import patch
 from testfixtures import TempDirectory
@@ -28,8 +29,8 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory, including the cleaner.log file
-        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -33,7 +33,8 @@ class TestPackagePOA(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        self.poa.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.poa.get_tmp_dir())
 
     def fake_download_latest_csv(self):
         csv_files = glob.glob(self.test_data_dir + "/*.csv")

--- a/tests/activity/test_activity_package_swh.py
+++ b/tests/activity/test_activity_package_swh.py
@@ -24,6 +24,7 @@ class TestPackageSWH(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+        self.activity.clean_tmp_dir()
 
     @patch("requests.get")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -284,6 +284,9 @@ class TestFtpToEndpoint(unittest.TestCase):
         )
         self.test_data_dir = "tests/test_data/pmc/"
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch.object(activity_module.FTP, "ftp_connect")
     def test_ftp_to_endpoint_connect_exception(self, fake_ftp_connect):
         fake_ftp_connect.side_effect = Exception("An exception")

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -158,6 +158,10 @@ class TestPostDecisionLetterBadSettings(unittest.TestCase):
         )
         self.input_data = input_data("elife-39122.zip")
 
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
     @patch.object(activity_module, "get_session")
     def test_do_activity_missing_endpoint(self, mock_session):
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -433,6 +433,9 @@ class TestSendEmailsForArticles(unittest.TestCase):
         )
         self.articles = articles
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch.object(activity_PublicationEmail, "article_authors_by_article_type")
     def test_send_emails_for_articles_no_recipients(
         self,
@@ -526,6 +529,9 @@ class TestProcessArticles(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch("provider.article.article.download_article_xml_from_s3")
     @patch("provider.lax_provider.article_versions")
     @data(
@@ -592,6 +598,9 @@ class TestChooseEmailType(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @data(
         (
             "article-commentary",
@@ -635,6 +644,9 @@ class TestGetEmailHeaders(unittest.TestCase):
         self.activity = activity_PublicationEmail(
             settings_mock, fake_logger, None, None, None
         )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     def test_template_get_email_headers_00013(self):
 
@@ -685,6 +697,9 @@ class TestGetEmailBody(unittest.TestCase):
         self.activity = activity_PublicationEmail(
             settings_mock, fake_logger, None, None, None
         )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     def test_template_get_email_body_00353(self):
 
@@ -743,6 +758,9 @@ class TestGetPdfCoverPage(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     def test_get_pdf_cover_page(self):
 
         article_object = articlelib.article()
@@ -764,6 +782,9 @@ class TestSendEmail(unittest.TestCase):
         self.activity = activity_PublicationEmail(
             settings_mock, fake_logger, None, None, None
         )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     @patch.object(activity_PublicationEmail, "send_author_email")
     def test_send_email_bad_authors(self, fake_send_author_email):
@@ -865,6 +886,9 @@ class TestApproveArticles(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch("provider.lax_provider.article_versions")
     def test_removes_articles_based_on_article_type(self, fake_article_versions):
         "test removing articles based on article type"
@@ -918,6 +942,9 @@ class TestArticleAuthors(unittest.TestCase):
                 "email": ["article_csv_author@example.org"],
             }
         ]
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     @patch.object(activity_PublicationEmail, "get_authors")
     def test_article_authors(self, fake_get_authors):
@@ -976,6 +1003,9 @@ class TestChooseRecipientAuthors(unittest.TestCase):
         self.activity = activity_PublicationEmail(
             settings_mock, fake_logger, None, None, None
         )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     @data(
         (
@@ -1087,6 +1117,9 @@ class TestMergeRecipients(unittest.TestCase):
                 ]
             )
         ]
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     def test_merge_recipients_empty(self):
         list_one = None

--- a/tests/activity/test_activity_rename_accepted_submission_videos.py
+++ b/tests/activity/test_activity_rename_accepted_submission_videos.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import copy
+import shutil
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -47,8 +48,8 @@ class TestRenameAcceptedSubmissionVideos(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(activity_module, "storage_context")

--- a/tests/activity/test_activity_repair_accepted_submission.py
+++ b/tests/activity/test_activity_repair_accepted_submission.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import glob
+import shutil
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -32,8 +33,8 @@ class TestRepairAcceptedSubmission(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory, including the cleaner.log file
-        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -17,6 +17,9 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch("provider.lax_provider.article_highest_version")
     @patch("provider.lax_provider.storage_context")
     @patch.object(activity_module, "storage_context")

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import shutil
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -28,8 +29,8 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory, including the cleaner.log file
-        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -2,6 +2,7 @@
 
 import os
 import glob
+import shutil
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -33,8 +34,8 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory, including the cleaner.log file
-        helpers.delete_files_in_folder(self.activity.get_tmp_dir())
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
         # reset the session value
         self.session.store_value("cleaner_log", None)
 

--- a/tests/activity/test_activity_validate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_validate_accepted_submission_videos.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import copy
+import shutil
 import unittest
 from xml.etree.ElementTree import ParseError
 from mock import patch
@@ -47,8 +48,8 @@ class TestValidateAcceptedSubmissionVideos(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
-        # clean the temporary directory
-        self.activity.clean_tmp_dir()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
 
     @patch("provider.glencoe_check.requests.get")
     @patch.object(activity_module, "get_session")

--- a/tests/provider/test_digest_provider.py
+++ b/tests/provider/test_digest_provider.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import copy
 from mock import patch, MagicMock
+from testfixtures import TempDirectory
 from digestparser.objects import Digest, Image
 import provider.digest_provider as digest_provider
 from provider.digest_provider import (
@@ -223,15 +224,16 @@ class TestDigestProvider(unittest.TestCase):
 
 
 class TestBuildDigest(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = os.path.join("tests/tmp")
+    def tearDown(self):
+        TempDirectory.cleanup_all()
 
     def test_digest_unicode(self):
         """test a digest zip with a unicode docx file name"""
+        directory = TempDirectory()
         input_file = os.path.join("tests", "files_source", "DIGEST_35774.zip")
         expected_status = True
         expected_author = "Bayés"
-        build_status, digest = digest_provider.build_digest(input_file, self.temp_dir)
+        build_status, digest = digest_provider.build_digest(input_file, directory.path)
         self.assertEqual(build_status, expected_status)
         self.assertEqual(digest.author, expected_author)
 

--- a/tests/provider/test_letterparser_provider.py
+++ b/tests/provider/test_letterparser_provider.py
@@ -16,14 +16,18 @@ class TestLetterParserProvider(unittest.TestCase):
         self.file_name = "tests/fixtures/letterparser/sections.docx"
         self.blank_config = {}
 
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
     def test_letterparser_config(self):
-        """test reading the letterparser config file"""
+        "test reading the letterparser config file"
         config = letterparser_provider.letterparser_config(settings_mock)
         self.assertEqual(config.get("docker_image"), "elifesciences/pandoc:2.9.1.1")
 
     def test_parse_file(self):
         """test parsing docx file with pandoc which may be called via Docker"""
         # blank config will use pandoc executable if present, otherwise via Docker image default
+        directory = TempDirectory()
         expected = (
             "<p><bold>Preamble\n"
             "</bold></p>\n"
@@ -34,7 +38,7 @@ class TestLetterParserProvider(unittest.TestCase):
             "<p>Author response ....</p>\n"
         )
 
-        output = letterparser_provider.parse_file(self.file_name, self.blank_config)
+        output = letterparser_provider.parse_file(self.file_name, self.blank_config, directory.path)
         self.assertEqual(
             output, expected, "Docker pandoc output not equal, is Docker running?"
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7580

Folders and files were accumulating after running tests. Changes are made to remove these temporary files and folders after running the tests. Some minor changes to other modues for them to remove temporary files when invoked.