### PR TITLE
Storage provider tests

### DIFF
--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -4,12 +4,6 @@ import boto3
 import log
 
 
-def StorageContext(*args):
-    logger = log.logger("deprecated.log", "INFO", __name__, loggerName=__name__)
-    logger.warning("provider.storage_provider.StorageContext() is deprecated")
-    return S3StorageContext(args[0])
-
-
 def storage_context(*args):
     return S3StorageContext(*args)
 

--- a/provider/storage_provider.py
+++ b/provider/storage_provider.py
@@ -1,6 +1,7 @@
 import re
 from io import BytesIO
 import boto3
+import botocore
 import log
 
 
@@ -51,7 +52,7 @@ class S3StorageContext:
         client = self.get_client_from_cache()
         try:
             client.head_object(Bucket=bucket_name, Key=s3_key.lstrip("/"))
-        except (client.exceptions.ClientError, client.exceptions.NoSuchKey):
+        except botocore.exceptions.ClientError:
             # if response is 403 or 404, or the key does not exist
             return False
         return True

--- a/tests/provider/test_storage.py
+++ b/tests/provider/test_storage.py
@@ -1,10 +1,248 @@
+import datetime
+import os
+from io import BytesIO
 import unittest
-from mock import MagicMock
-from provider.storage_provider import S3StorageContext
+from mock import MagicMock, patch
+from testfixtures import TempDirectory
+import botocore
+from provider.storage_provider import (
+    storage_context,
+    S3StorageContext,
+    UnsupportedResourceType,
+)
 from tests import settings_mock
 
 
-class TestProviderStorage(unittest.TestCase):
+class FakeS3Client:
+    def __init__(self, list_objects_responses=None):
+        self.object = BytesIO()
+        self.object_metadata = None
+        self.list_objects_responses = list_objects_responses
+        # to increment how many times list_objects_v2() is called
+        self.list_objects_counter = 0
+
+    def head_object(self, **kwargs):
+        "return an object response dict example"
+        return {"AcceptRanges": "string", "ContentLength": 123}
+
+    def download_fileobj(self, **kwargs):
+        if (
+            kwargs.get("Fileobj")
+            and hasattr(kwargs.get("Fileobj"), "writable")
+            and kwargs.get("Fileobj").writable()
+        ):
+            kwargs.get("Fileobj").write(b"example")
+
+    def upload_file(self, **kwargs):
+        if kwargs.get("Filename"):
+            with open(kwargs.get("Filename"), "rb") as open_file:
+                self.object.write(open_file.read())
+        self.object_metadata = kwargs.get("ExtraArgs")
+
+    def put_object(self, **kwargs):
+        if kwargs.get("Body"):
+            self.object.write(kwargs.get("Body"))
+        if kwargs.get("ContentType"):
+            self.object_metadata = {"Content-Type": kwargs.get("ContentType")}
+
+    def list_objects_v2(self, **kwargs):
+        if not self.list_objects_responses:
+            return {}
+        try:
+            response = self.list_objects_responses[self.list_objects_counter]
+            if kwargs.get("ContinuationToken"):
+                response["ContinuationToken"] = kwargs.get("ContinuationToken")
+            self.list_objects_counter += 1
+            return response
+        except IndexError:
+            return {}
+
+    def delete_object(self, **kwargs):
+        pass
+
+
+class TestStorageContext(unittest.TestCase):
+    def test_storage_context_instatiation(self):
+        storage = storage_context(settings_mock)
+        self.assertTrue(isinstance(storage, S3StorageContext))
+
+
+class TestGetClientFromCache(unittest.TestCase):
+    @patch.object(S3StorageContext, "get_client")
+    def test_get_client_from_cache(self, fake_get_client):
+        fake_get_client.return_value = True
+        storage = S3StorageContext(settings_mock)
+        storage.get_client_from_cache()
+        self.assertIsNotNone(storage.context.get("client"))
+
+
+class TestS3StorageObjects(unittest.TestCase):
+    def test_s3_storage_objects(self):
+        bucket = "bucket"
+        path = "/folder/file.txt"
+        resource = "s3://%s%s" % (bucket, path)
+        storage = S3StorageContext(settings_mock)
+        bucket_name, s3_key = storage.s3_storage_objects(resource)
+        self.assertEqual(bucket_name, bucket)
+        self.assertEqual(s3_key, path)
+
+    def test_s3_storage_objects_unsupported(self):
+        resource = "file://bucket/folder/file.txt"
+        storage = S3StorageContext(settings_mock)
+        with self.assertRaises(UnsupportedResourceType):
+            storage.s3_storage_objects(resource)
+
+
+class TestResourceExists(unittest.TestCase):
+    @patch("boto3.client")
+    def test_resource_exists(self, fake_s3_client):
+        fake_s3_client.return_value = FakeS3Client()
+        storage = S3StorageContext(settings_mock)
+        result = storage.resource_exists("s3://a/1")
+        self.assertEqual(result, True)
+
+    @patch.object(FakeS3Client, "head_object")
+    @patch("boto3.client")
+    def test_resource_exists_exception(self, fake_s3_client, fake_head_object):
+        fake_s3_client.return_value = FakeS3Client()
+        fake_head_object.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "NoSuchKey"}},
+            "operation_name",
+        )
+        storage = S3StorageContext(settings_mock)
+        result = storage.resource_exists("s3://a/1")
+        self.assertEqual(result, False)
+
+
+class TestGetResourceAsString(unittest.TestCase):
+    @patch("boto3.client")
+    def test_get_resource_as_string(self, fake_s3_client):
+        fake_s3_client.return_value = FakeS3Client()
+        storage = S3StorageContext(settings_mock)
+        result = storage.get_resource_as_string("s3://a/1")
+        self.assertEqual(result, b"example")
+
+
+class TestGetResourceToFile(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("boto3.client")
+    def test_get_resource_to_file(self, fake_s3_client):
+        directory = TempDirectory()
+        test_file_path = os.path.join(directory.path, "test_object")
+        fake_s3_client.return_value = FakeS3Client()
+        storage = S3StorageContext(settings_mock)
+        with open(test_file_path, "wb") as open_file:
+            storage.get_resource_to_file("s3://a/1", open_file)
+        with open(test_file_path, "rb") as open_file:
+            self.assertEqual(open_file.read(), b"example")
+
+
+class TestGetResourceAttributes(unittest.TestCase):
+    @patch("boto3.client")
+    def test_get_resource_attributes(self, fake_s3_client):
+        fake_s3_client.return_value = FakeS3Client()
+        storage = S3StorageContext(settings_mock)
+        result = storage.get_resource_attributes("s3://a/1")
+        self.assertTrue(isinstance(result, dict))
+
+
+class TestSetResourceFromFilename(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("boto3.client")
+    def test_set_resource_from_filename(self, fake_s3_client):
+        directory = TempDirectory()
+        test_file_path = os.path.join(directory.path, "test_object")
+        test_value = b"example"
+        test_metadata = {"ContentType": "image/jpeg"}
+        with open(test_file_path, "wb") as open_file:
+            open_file.write(test_value)
+        s3_client = FakeS3Client()
+        fake_s3_client.return_value = s3_client
+        storage = S3StorageContext(settings_mock)
+        storage.set_resource_from_filename("s3://a/1", test_file_path, test_metadata)
+        self.assertEqual(s3_client.object.getvalue(), test_value)
+        self.assertEqual(s3_client.object_metadata, test_metadata)
+
+
+class TestSetResourceFromString(unittest.TestCase):
+    @patch("boto3.client")
+    def test_set_resource_from_string(self, fake_s3_client):
+        test_value = b"example"
+        test_content_type = "image/jpeg"
+        s3_client = FakeS3Client()
+        fake_s3_client.return_value = s3_client
+        storage = S3StorageContext(settings_mock)
+        storage.set_resource_from_string("s3://a/1", test_value, test_content_type)
+        self.assertEqual(s3_client.object.getvalue(), test_value)
+        self.assertEqual(
+            s3_client.object_metadata, {"Content-Type": "%s" % test_content_type}
+        )
+
+
+class TestListResources(unittest.TestCase):
+    def setUp(self):
+        # multiple responses returned by the client
+        self.list_objects_responses = [
+            {
+                "IsTruncated": True,
+                "NextContinuationToken": "token",
+                "Contents": [
+                    {
+                        "Key": "key1",
+                        "LastModified": datetime.datetime(2015, 1, 1),
+                        "ETag": "etag1",
+                        "Size": 123,
+                    },
+                ],
+            },
+            {
+                "Contents": [
+                    {
+                        "Key": "key2",
+                        "LastModified": datetime.datetime(2015, 1, 1),
+                        "ETag": "etag2",
+                        "Size": 123,
+                    },
+                ],
+            },
+        ]
+
+    @patch("boto3.client")
+    def test_list_resources(self, fake_s3_client):
+        fake_s3_client.return_value = FakeS3Client(self.list_objects_responses)
+        storage = S3StorageContext(settings_mock)
+        result = storage.list_resources("s3://a/1")
+        self.assertEqual(result, ["key1", "key2"])
+
+    @patch("boto3.client")
+    def test_list_resources_return_keys(self, fake_s3_client):
+        fake_s3_client.return_value = FakeS3Client(self.list_objects_responses)
+        storage = S3StorageContext(settings_mock)
+        result = storage.list_resources("s3://a/1", return_keys=True)
+        self.assertEqual(
+            result,
+            [
+                {
+                    "Key": "key1",
+                    "LastModified": datetime.datetime(2015, 1, 1, 0, 0),
+                    "ETag": "etag1",
+                    "Size": 123,
+                },
+                {
+                    "Key": "key2",
+                    "LastModified": datetime.datetime(2015, 1, 1, 0, 0),
+                    "ETag": "etag2",
+                    "Size": 123,
+                },
+            ],
+        )
+
+
+class TestCopyResource(unittest.TestCase):
     def setUp(self):
         self.storage = S3StorageContext(settings_mock)
         self.storage.context["client"] = MagicMock()
@@ -41,3 +279,14 @@ class TestProviderStorage(unittest.TestCase):
             },
             self.storage.context["client"].copy_object.mock_calls[0][2],
         )
+
+
+class TestDeleteResourceFromString(unittest.TestCase):
+    @patch.object(FakeS3Client, "delete_object")
+    @patch("boto3.client")
+    def test_delete_resource(self, fake_s3_client, fake_delete_object):
+        fake_s3_client.return_value = FakeS3Client()
+        storage = S3StorageContext(settings_mock)
+        fake_delete_object.return_value = MagicMock()
+        storage.delete_resource("s3://a/1")
+        fake_delete_object.assert_called_with(Bucket="a", Key="1")


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7620

Added tests for `provider/storage_provider.py` to increase the test coverage. There are some small changes to the module itself, removing a deprecated unused function, and using a different method for catching boto3 client exceptions.