### PR TITLE
worker.py and decider.py client read_timeout

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -2,6 +2,7 @@ import os
 import copy
 import json
 import importlib
+from botocore.config import Config
 import boto3
 import newrelic.agent
 from provider import process, utils
@@ -24,6 +25,7 @@ def decide(settings, flag, debug=False):
         aws_access_key_id=settings.aws_access_key_id,
         aws_secret_access_key=settings.aws_secret_access_key,
         region_name=settings.swf_region,
+        config=Config(connect_timeout=50, read_timeout=70),
     )
 
     token = None

--- a/worker.py
+++ b/worker.py
@@ -1,6 +1,7 @@
 import json
 import os
 import importlib
+from botocore.config import Config
 import boto3
 import newrelic.agent
 import log
@@ -25,6 +26,7 @@ def work(settings, flag):
         aws_access_key_id=settings.aws_access_key_id,
         aws_secret_access_key=settings.aws_secret_access_key,
         region_name=settings.swf_region,
+        config=Config(connect_timeout=50, read_timeout=70),
     )
 
     token = None


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7644

It looks like since the transfer over to using `boto3`, the client was not waiting for the default response sent back after 60 seconds of long polling for activity tasks and decision tasks. Setting a `read_timeout` of at least 70 seconds will allow it to be processed as it used to be when using original `boto`.