### PR TITLE
Add video rename log content to cleaner email body

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -254,6 +254,16 @@ def production_comments(log_content):
         message_content = message_parts.group(2)
         if message_type == "parse_article_xml":
             comments.append(message_content)
+    # add messages related to video duplicate detection and renaming
+    video_info_match_pattern = re.compile(r"INFO elifecleaner:video:(.*?): (.*)")
+    for message in log_messages:
+        message_parts = video_info_match_pattern.search(message)
+        if not message_parts:
+            continue
+        message_type = message_parts.group(1)
+        message_content = message_parts.group(2)
+        if message_type in ["all_terms_map", "renumber", "renumber_term_map"]:
+            comments.append(message_content)
 
     return comments
 
@@ -266,5 +276,6 @@ def production_comments_for_xml(log_content):
         for line in log_messages
         if "WARNING elifecleaner:parse:check_art_file:" not in line
         and "INFO elifecleaner:parse:parse_article_xml:" not in line
+        and "INFO elifecleaner:video:" not in line
     ]
     return production_comments("\n".join(filtered_messages))

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -191,7 +191,10 @@ class TestProductionComments(unittest.TestCase):
             "2022-02-22 13:10:15,942 WARNING elifecleaner:parse:check_missing_files_by_name: 22-02-2022-CR-eLife-78088.zip has file missing from expected numeric sequence: Figure 3\n"
             "2022-02-22 13:10:15,942 WARNING elifecleaner:parse:check_art_file: 22-02-2022-CR-eLife-78088.zip could not find a word or latex article file in the package\n"
             "2022-06-29 13:10:15,942 INFO elifecleaner:transform:transform_xml_funding: 22-02-2022-CR-eLife-78088.zip adding the WELLCOME_FUNDING_STATEMENT to the funding-statement\n"
-            "2022-06-29 13:10:15,942 INFO elifecleaner:parse:parse_article_xml: Replacing character entities in the XML string: ['&#x001D;']"
+            "2022-06-29 13:10:15,942 INFO elifecleaner:parse:parse_article_xml: Replacing character entities in the XML string: ['&#x001D;']\n"
+            "2022-06-29 13:10:15,942 INFO elifecleaner:video:all_terms_map: found duplicate video term values\n"
+            "2022-06-29 13:10:15,942 INFO elifecleaner:video:renumber: duplicate values: ['fig1video2']\n"
+            "2022-06-29 13:10:15,942 INFO elifecleaner:video:renumber_term_map: replacing number 2 with 3 for term Supplementary Video 2.mp4\n"
         )
 
     def test_production_comments(self):
@@ -203,6 +206,9 @@ class TestProductionComments(unittest.TestCase):
             "22-02-2022-CR-eLife-78088.zip could not find a word or latex article file in the package",
             cleaner.WELLCOME_FUNDING_COMMENTS,
             "Replacing character entities in the XML string: ['&#x001D;']",
+            "found duplicate video term values",
+            "duplicate values: ['fig1video2']",
+            "replacing number 2 with 3 for term Supplementary Video 2.mp4",
         ]
 
         comments = cleaner.production_comments(self.cleaner_log)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7617

Add some of the duplicate video detection and renaming messages to the body of the email sent as part of an `IngestAcceptedSubmission` workflow.