### PR TITLE
FTPArticle tests and refactoring

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -248,7 +248,7 @@ class activity_FTPArticle(Activity):
         else:
             self.logger.info(
                 "FTPArticle running %s workflow for article %s, failed to package any zip files"
-                % (self.workflow, self.doi_id)
+                % (workflow, doi_id)
             )
 
     def download_archive_zip_from_s3(self, doi_id):

--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -52,13 +52,14 @@ class activity_FTPArticle(Activity):
         self.FTP_USERNAME = None
         self.FTP_PASSWORD = None
         self.FTP_CWD = None
-        self.FTP_SUBDIR = []
+        self.FTP_SUBDIR_LIST = []
 
         # SFTP settings
         self.SFTP_URI = None
         self.SFTP_USERNAME = None
         self.SFTP_PASSWORD = None
         self.SFTP_CWD = None
+        self.SFTP_SUBDIR = None
 
         # journal
         self.journal = JOURNAL
@@ -111,24 +112,35 @@ class activity_FTPArticle(Activity):
                     % (self.workflow, self.doi_id, zipfiles)
                 )
             if workflow == "HEFCE":
-                # self.ftp_to_endpoint(zipfiles, self.FTP_SUBDIR, passive=True)
-                # SFTP now
-                sub_dir = "{:05d}".format(int(elife_id))
-                self.sftp_to_endpoint(zipfiles, sub_dir)
+                self.sftp_to_endpoint(zipfiles, self.SFTP_SUBDIR)
             if workflow == "Cengage":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "WoS":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "GoOA":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "CNPIEC":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "CNKI":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "CLOCKSS":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "OVID":
-                self.ftp_to_endpoint(zipfiles, passive=True)
+                self.ftp_to_endpoint(
+                    zipfiles, sub_dir_list=self.FTP_SUBDIR_LIST, passive=True
+                )
             if workflow == "Zendy":
                 self.sftp_to_endpoint(zipfiles)
             if workflow == "OASwitchboard":
@@ -166,75 +178,10 @@ class activity_FTPArticle(Activity):
         Set the outgoing FTP server settings based on the
         workflow type specified
         """
-
-        if workflow == "HEFCE":
-            self.FTP_URI = self.settings.HEFCE_FTP_URI
-            self.FTP_USERNAME = self.settings.HEFCE_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.HEFCE_FTP_PASSWORD
-            self.FTP_CWD = self.settings.HEFCE_FTP_CWD
-            # Subfolders to create when FTPing
-            self.FTP_SUBDIR.append(utils.pad_msid(doi_id))
-
-            # SFTP settings
-
-            self.SFTP_URI = self.settings.HEFCE_SFTP_URI
-            self.SFTP_USERNAME = self.settings.HEFCE_SFTP_USERNAME
-            self.SFTP_PASSWORD = self.settings.HEFCE_SFTP_PASSWORD
-            self.SFTP_CWD = self.settings.HEFCE_SFTP_CWD
-
-        if workflow == "Cengage":
-            self.FTP_URI = self.settings.CENGAGE_FTP_URI
-            self.FTP_USERNAME = self.settings.CENGAGE_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.CENGAGE_FTP_PASSWORD
-            self.FTP_CWD = self.settings.CENGAGE_FTP_CWD
-
-        if workflow == "WoS":
-            self.FTP_URI = self.settings.WOS_FTP_URI
-            self.FTP_USERNAME = self.settings.WOS_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.WOS_FTP_PASSWORD
-            self.FTP_CWD = self.settings.WOS_FTP_CWD
-
-        if workflow == "GoOA":
-            self.FTP_URI = self.settings.GOOA_FTP_URI
-            self.FTP_USERNAME = self.settings.GOOA_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.GOOA_FTP_PASSWORD
-            self.FTP_CWD = self.settings.GOOA_FTP_CWD
-
-        if workflow == "CNPIEC":
-            self.FTP_URI = self.settings.CNPIEC_FTP_URI
-            self.FTP_USERNAME = self.settings.CNPIEC_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.CNPIEC_FTP_PASSWORD
-            self.FTP_CWD = self.settings.CNPIEC_FTP_CWD
-
-        if workflow == "CNKI":
-            self.FTP_URI = self.settings.CNKI_FTP_URI
-            self.FTP_USERNAME = self.settings.CNKI_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.CNKI_FTP_PASSWORD
-            self.FTP_CWD = self.settings.CNKI_FTP_CWD
-
-        if workflow == "CLOCKSS":
-            self.FTP_URI = self.settings.CLOCKSS_FTP_URI
-            self.FTP_USERNAME = self.settings.CLOCKSS_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.CLOCKSS_FTP_PASSWORD
-            self.FTP_CWD = self.settings.CLOCKSS_FTP_CWD
-
-        if workflow == "OVID":
-            self.FTP_URI = self.settings.OVID_FTP_URI
-            self.FTP_USERNAME = self.settings.OVID_FTP_USERNAME
-            self.FTP_PASSWORD = self.settings.OVID_FTP_PASSWORD
-            self.FTP_CWD = self.settings.OVID_FTP_CWD
-
-        if workflow == "Zendy":
-            self.SFTP_URI = self.settings.ZENDY_SFTP_URI
-            self.SFTP_USERNAME = self.settings.ZENDY_SFTP_USERNAME
-            self.SFTP_PASSWORD = self.settings.ZENDY_SFTP_PASSWORD
-            self.SFTP_CWD = self.settings.ZENDY_SFTP_CWD
-
-        if workflow == "OASwitchboard":
-            self.SFTP_URI = self.settings.OASWITCHBOARD_SFTP_URI
-            self.SFTP_USERNAME = self.settings.OASWITCHBOARD_SFTP_USERNAME
-            self.SFTP_PASSWORD = self.settings.OASWITCHBOARD_SFTP_PASSWORD
-            self.SFTP_CWD = self.settings.OASWITCHBOARD_SFTP_CWD
+        # temporary transitional method to support using class properties as credentials
+        credentials = collect_credentials(self.settings, doi_id, workflow)
+        for key, value in credentials.items():
+            setattr(self, key, value)
 
     def download_files_from_s3(self, doi_id, workflow):
 
@@ -504,3 +451,79 @@ def new_zip_file_name(doi_id, prefix, suffix):
 def file_type_matches(file_types):
     """wildcard file name matches for the file types to include"""
     return ["/*.%s" % file_type for file_type in file_types]
+
+
+def collect_credentials(settings, doi_id, workflow):
+    "Set the FTP and SFTP server settings based on the workflow type and article doi_id"
+
+    credentials = {}
+
+    if workflow == "HEFCE":
+        credentials["FTP_URI"] = settings.HEFCE_FTP_URI
+        credentials["FTP_USERNAME"] = settings.HEFCE_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.HEFCE_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.HEFCE_FTP_CWD
+        credentials["FTP_SUBDIR_LIST"] = [utils.pad_msid(doi_id)]
+
+        # SFTP settings
+        credentials["SFTP_URI"] = settings.HEFCE_SFTP_URI
+        credentials["SFTP_USERNAME"] = settings.HEFCE_SFTP_USERNAME
+        credentials["SFTP_PASSWORD"] = settings.HEFCE_SFTP_PASSWORD
+        credentials["SFTP_CWD"] = settings.HEFCE_SFTP_CWD
+        credentials["SFTP_SUBDIR"] = utils.pad_msid(doi_id)
+
+    if workflow == "Cengage":
+        credentials["FTP_URI"] = settings.CENGAGE_FTP_URI
+        credentials["FTP_USERNAME"] = settings.CENGAGE_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.CENGAGE_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.CENGAGE_FTP_CWD
+
+    if workflow == "WoS":
+        credentials["FTP_URI"] = settings.WOS_FTP_URI
+        credentials["FTP_USERNAME"] = settings.WOS_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.WOS_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.WOS_FTP_CWD
+
+    if workflow == "GoOA":
+        credentials["FTP_URI"] = settings.GOOA_FTP_URI
+        credentials["FTP_USERNAME"] = settings.GOOA_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.GOOA_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.GOOA_FTP_CWD
+
+    if workflow == "CNPIEC":
+        credentials["FTP_URI"] = settings.CNPIEC_FTP_URI
+        credentials["FTP_USERNAME"] = settings.CNPIEC_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.CNPIEC_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.CNPIEC_FTP_CWD
+
+    if workflow == "CNKI":
+        credentials["FTP_URI"] = settings.CNKI_FTP_URI
+        credentials["FTP_USERNAME"] = settings.CNKI_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.CNKI_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.CNKI_FTP_CWD
+
+    if workflow == "CLOCKSS":
+        credentials["FTP_URI"] = settings.CLOCKSS_FTP_URI
+        credentials["FTP_USERNAME"] = settings.CLOCKSS_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.CLOCKSS_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.CLOCKSS_FTP_CWD
+
+    if workflow == "OVID":
+        credentials["FTP_URI"] = settings.OVID_FTP_URI
+        credentials["FTP_USERNAME"] = settings.OVID_FTP_USERNAME
+        credentials["FTP_PASSWORD"] = settings.OVID_FTP_PASSWORD
+        credentials["FTP_CWD"] = settings.OVID_FTP_CWD
+
+    if workflow == "Zendy":
+        credentials["SFTP_URI"] = settings.ZENDY_SFTP_URI
+        credentials["SFTP_USERNAME"] = settings.ZENDY_SFTP_USERNAME
+        credentials["SFTP_PASSWORD"] = settings.ZENDY_SFTP_PASSWORD
+        credentials["SFTP_CWD"] = settings.ZENDY_SFTP_CWD
+
+    if workflow == "OASwitchboard":
+        credentials["SFTP_URI"] = settings.OASWITCHBOARD_SFTP_URI
+        credentials["SFTP_USERNAME"] = settings.OASWITCHBOARD_SFTP_USERNAME
+        credentials["SFTP_PASSWORD"] = settings.OASWITCHBOARD_SFTP_PASSWORD
+        credentials["SFTP_CWD"] = settings.OASWITCHBOARD_SFTP_CWD
+
+    return credentials

--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -7,7 +7,7 @@ import re
 from elifetools import parseJATS as parser
 from provider import article_processing, utils
 from provider.storage_provider import storage_context
-import provider.sftp as sftplib
+from provider.sftp import SFTP
 from provider.ftp import FTP
 from activity.objects import Activity
 
@@ -374,6 +374,7 @@ class activity_FTPArticle(Activity):
 
     def ftp_to_endpoint(self, uploadfiles, sub_dir_list=None, passive=True):
         "FTP files to endpoint"
+        self.logger.info("%s started ftp_to_endpoint()" % self.name)
         try:
             ftp_provider = FTP(self.logger)
             ftp_instance = ftp_provider.ftp_connect(
@@ -423,12 +424,14 @@ class activity_FTPArticle(Activity):
                 % (self.FTP_URI, exception)
             )
             raise
+        self.logger.info("%s finished ftp_to_endpoint()" % self.name)
 
     def sftp_to_endpoint(self, uploadfiles, sub_dir=None):
         """
         Using the sftp provider module, connect to sftp server and transmit files
         """
-        sftp = sftplib.SFTP(logger=self.logger)
+        self.logger.info("%s started sftp_to_endpoint()" % self.name)
+        sftp = SFTP(logger=self.logger)
         sftp_client = sftp.sftp_connect(
             self.SFTP_URI, self.SFTP_USERNAME, self.SFTP_PASSWORD
         )
@@ -437,6 +440,7 @@ class activity_FTPArticle(Activity):
             sftp.sftp_to_endpoint(sftp_client, uploadfiles, self.SFTP_CWD, sub_dir)
 
         sftp.disconnect()
+        self.logger.info("%s finished sftp_to_endpoint()" % self.name)
 
 
 def zip_file_suffix(file_types):

--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -397,12 +397,15 @@ class activity_FTPArticle(Activity):
             for file_type in file_type_matches(keep_file_types):
                 files = glob.glob(to_dir + file_type)
                 for to_dir_file in files:
+                    add_file = True
                     # Ignore some files that are PDF we do not want to include
                     for ignore in ignore_name_fragments:
                         if ignore in to_dir_file:
-                            continue
-                    filename = to_dir_file.split(os.sep)[-1]
-                    new_zipfile.write(to_dir_file, filename)
+                            add_file = False
+                            break
+                    if add_file:
+                        filename = to_dir_file.split(os.sep)[-1]
+                        new_zipfile.write(to_dir_file, filename)
 
         # Move the zip
         shutil.move(

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -93,6 +93,35 @@ class TestFTPArticle(unittest.TestCase):
         self.assertEqual(self.activity.do_activity(activity_data), expected_result)
 
 
+class TestDownloadFilesFromS3(unittest.TestCase):
+    def setUp(self):
+        self.activity = activity_FTPArticle(
+            settings_mock, FakeLogger(), None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_FTPArticle, "repackage_archive_zip_to_pmc_zip")
+    @patch.object(activity_FTPArticle, "download_archive_zip_from_s3")
+    def test_download_files_from_s3_failure(
+        self, fake_download_archive_zip, fake_repackage_archive_zip
+    ):
+        fake_download_archive_zip.return_value = True
+        fake_repackage_archive_zip.return_value = False
+        doi_id = "353"
+        workflow = "HEFCE"
+        # invoke the method being tested
+        self.activity.download_files_from_s3(doi_id, workflow)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "FTPArticle running %s workflow for article %s, failed to package any zip files"
+            )
+            % (workflow, doi_id),
+        )
+
+
 class TestDownloadArchiveZip(unittest.TestCase):
     def setUp(self):
         self.activity = activity_FTPArticle(

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -40,16 +40,17 @@ class TestFTPArticle(unittest.TestCase):
     @patch("activity.activity_FTPArticle.FTP")
     @patch("activity.activity_FTPArticle.SFTP")
     @data(
-        ("HEFCE", True, "hefce_ftp.localhost", "hefce_sftp.localhost", True),
-        ("Cengage", True, "cengage.localhost", None, True),
-        ("GoOA", True, "gooa.localhost", None, True),
-        ("WoS", True, "wos.localhost", None, True),
-        ("CNPIEC", True, "cnpiec.localhost", None, True),
-        ("CNKI", True, "cnki.localhost", None, True),
-        ("CLOCKSS", True, "clockss.localhost", None, True),
-        ("OVID", True, "ovid.localhost", None, True),
-        ("Zendy", True, None, "zendy.localhost", True),
-        ("OASwitchboard", True, None, "oaswitchboard.localhost", True),
+        ("HEFCE", True, "hefce_ftp.localhost", "hefce_sftp.localhost", 1, True),
+        ("Cengage", True, "cengage.localhost", None, 1, True),
+        ("GoOA", True, "gooa.localhost", None, 1, True),
+        ("WoS", True, "wos.localhost", None, 1, True),
+        ("CNPIEC", True, "cnpiec.localhost", None, 1, True),
+        ("CNKI", True, "cnki.localhost", None, 1, True),
+        ("CLOCKSS", True, "clockss.localhost", None, 1, True),
+        ("OVID", True, "ovid.localhost", None, 1, True),
+        ("Zendy", True, None, "zendy.localhost", 1, True),
+        ("OASwitchboard", True, None, "oaswitchboard.localhost", 1, True),
+        ("__unknown__", False, None, None, 0, False),
     )
     @unpack
     def test_do_activity(
@@ -58,6 +59,7 @@ class TestFTPArticle(unittest.TestCase):
         archive_zip_return_value,
         expected_ftp_uri,
         expected_sftp_uri,
+        expected_sending_started_messages,
         expected_result,
         fake_sftp,
         fake_ftp,
@@ -81,7 +83,7 @@ class TestFTPArticle(unittest.TestCase):
         ]
         self.assertEqual(
             len(log_sending_started_messages),
-            1,
+            expected_sending_started_messages,
             "info log did not contain started message for workflow %s" % workflow,
         )
 

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -82,6 +82,16 @@ class TestFTPArticle(unittest.TestCase):
         activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
         self.assertEqual(self.activity.do_activity(activity_data), expected_result)
 
+
+class TestDownloadArchiveZip(unittest.TestCase):
+    def setUp(self):
+        self.activity = activity_FTPArticle(
+            settings_mock, FakeLogger(), None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
     @patch.object(activity_module, "storage_context")
     def test_download_archive_zip_from_s3(self, fake_storage_context):
         self.activity.make_activity_directories()
@@ -104,6 +114,17 @@ class TestFTPArticle(unittest.TestCase):
             os.listdir(self.activity.directories.get("TMP_DIR")),
             [zip_file_name],
         )
+
+
+@ddt
+class TestMoveOrPackagePmcZip(unittest.TestCase):
+    def setUp(self):
+        self.activity = activity_FTPArticle(
+            settings_mock, FakeLogger(), None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     @data(
         (
@@ -161,6 +182,16 @@ class TestFTPArticle(unittest.TestCase):
             self.assertEqual(
                 sorted(zip_file.namelist()), sorted(expected_zip_file_contents)
             )
+
+
+class TestRepackageArchiveZip(unittest.TestCase):
+    def setUp(self):
+        self.activity = activity_FTPArticle(
+            settings_mock, FakeLogger(), None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
 
     def test_repackage_archive_zip_to_pmc_zip(self):
         input_zip_file_path = (
@@ -283,7 +314,3 @@ class TestFileTypeMatches(unittest.TestCase):
     @unpack
     def test_file_type_matches(self, file_types, expected):
         self.assertEqual(activity_module.file_type_matches(file_types), expected)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -60,24 +60,33 @@ class TestFTPArticle(unittest.TestCase):
         self.assertEqual(self.activity.SFTP_URI, expected_sftp_uri)
 
     @patch.object(activity_FTPArticle, "download_files_from_s3")
-    @patch("activity.activity_FTPArticle.FTP")
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
-    @data(
-        ("HEFCE", "non_numeric_raises_exception", False),
-    )
-    @unpack
     def test_do_activity_failure(
         self,
-        workflow,
-        elife_id,
-        expected_result,
         fake_sftp_to_endpoint,
-        fake_ftp,
         fake_download_files_from_s3,
     ):
         fake_sftp_to_endpoint.return_value = True
-        fake_ftp.return_value = FakeFTP()
         fake_download_files_from_s3.return_value = True
+        workflow = "HEFCE"
+        elife_id = "non_numeric_raises_exception"
+        expected_result = False
+        # Cause an exception by setting elife_id as non numeric for now
+        activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
+        self.assertEqual(self.activity.do_activity(activity_data), expected_result)
+
+    @patch.object(activity_FTPArticle, "download_files_from_s3")
+    @patch.object(activity_FTPArticle, "sftp_to_endpoint")
+    def test_do_activity_exception(
+        self,
+        fake_sftp_to_endpoint,
+        fake_download_files_from_s3,
+    ):
+        fake_sftp_to_endpoint.side_effect = Exception("An exception")
+        fake_download_files_from_s3.return_value = True
+        workflow = "HEFCE"
+        elife_id = "19405"
+        expected_result = False
         # Cause an exception by setting elife_id as non numeric for now
         activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
         self.assertEqual(self.activity.do_activity(activity_data), expected_result)

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import zipfile
 import datetime
-from mock import patch, MagicMock
+from mock import patch
 from ddt import ddt, data, unpack
 import activity.activity_FTPArticle as activity_module
 from activity.activity_FTPArticle import activity_FTPArticle
@@ -50,7 +50,7 @@ class TestFTPArticle(unittest.TestCase):
         fake_download_archive_zip_from_s3,
         fake_repackage_pmc_zip,
     ):
-        fake_sftp_to_endpoint = MagicMock()
+        fake_sftp_to_endpoint.return_value = True
         fake_ftp.return_value = FakeFTP()
         fake_download_archive_zip_from_s3.return_value = archive_zip_return_value
         fake_repackage_pmc_zip.return_value = True
@@ -75,9 +75,9 @@ class TestFTPArticle(unittest.TestCase):
         fake_ftp,
         fake_download_files_from_s3,
     ):
-        fake_sftp_to_endpoint = MagicMock()
+        fake_sftp_to_endpoint.return_value = True
         fake_ftp.return_value = FakeFTP()
-        fake_download_files_from_s3 = MagicMock()
+        fake_download_files_from_s3.return_value = True
         # Cause an exception by setting elife_id as non numeric for now
         activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
         self.assertEqual(self.activity.do_activity(activity_data), expected_result)
@@ -168,7 +168,7 @@ class TestMoveOrPackagePmcZip(unittest.TestCase):
         # copy in some sample data
         dest_input_zip_file_path = os.path.join(
             self.activity.directories.get("INPUT_DIR"),
-            input_zip_file_path.split("/")[-1],
+            input_zip_file_path.rsplit("/", 1)[-1],
         )
         shutil.copy(input_zip_file_path, dest_input_zip_file_path)
         # call the activity function
@@ -215,7 +215,7 @@ class TestRepackageArchiveZip(unittest.TestCase):
         ]
         # copy in some sample data
         dest_input_zip_file_path = os.path.join(
-            self.activity.directories.get("TMP_DIR"), input_zip_file_path.split("/")[-1]
+            self.activity.directories.get("TMP_DIR"), input_zip_file_path.rsplit("/", 1)[-1]
         )
         shutil.copy(input_zip_file_path, dest_input_zip_file_path)
         self.activity.repackage_archive_zip_to_pmc_zip(doi_id)

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -224,7 +224,8 @@ class TestRepackageArchiveZip(unittest.TestCase):
         ]
         # copy in some sample data
         dest_input_zip_file_path = os.path.join(
-            self.activity.directories.get("TMP_DIR"), input_zip_file_path.rsplit("/", 1)[-1]
+            self.activity.directories.get("TMP_DIR"),
+            input_zip_file_path.rsplit("/", 1)[-1],
         )
         shutil.copy(input_zip_file_path, dest_input_zip_file_path)
         self.activity.repackage_archive_zip_to_pmc_zip(doi_id)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7654

Test coverage improved for the `FTPArticle` activity, which allowed for refactoring of code where the workflow type or recipient name is used to set credentials and the sending protocol type (FTP or SFTP).

This will be changed again soon when it can load workflow-specific details from a YAML configuration files, in the meantime this transitional format is futher toward that plan.