### PR TITLE
PubRouterDeposit tests improved and code refactoring

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -249,7 +249,7 @@ class activity_PubRouterDeposit(Activity):
 
         # Try and start a workflow
         try:
-            response = self.client.start_workflow_execution(**kwargs)
+            response = client.start_workflow_execution(**kwargs)
             starter_status = True
         except Exception as exception:
             # There is already a running workflow with that ID, cannot start another
@@ -339,7 +339,7 @@ class activity_PubRouterDeposit(Activity):
 
         # Try and start a workflow
         try:
-            response = self.client.start_workflow_execution(**kwargs)
+            response = client.start_workflow_execution(**kwargs)
             starter_status = True
         except Exception as exception:
             # There is already a running workflow with that ID, cannot start another

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -420,7 +420,7 @@ class activity_PubRouterDeposit(Activity):
                     remove_doi_list.append(article.doi)
 
         # Check article type for OA Switchboard recipient
-        if workflow == "OASwitchboard":
+        if check_approve_by_article_type(workflow):
             for article in articles:
                 if not approve_for_oa_switchboard(article):
                     if self.logger:
@@ -434,7 +434,7 @@ class activity_PubRouterDeposit(Activity):
                         remove_doi_list.append(article.doi)
 
         # Check if article is a resupply
-        if workflow not in ["CLOCKSS", "OVID", "PMC", "Zendy"]:
+        if check_approve_by_was_ever_published(workflow):
             for article in articles:
                 was_ever_published = blank_article.was_ever_published(
                     article.doi, workflow
@@ -451,7 +451,7 @@ class activity_PubRouterDeposit(Activity):
                         remove_doi_list.append(article.doi)
 
         # Check a vor archive zip file exists
-        if workflow not in ["OVID", "Zendy"]:
+        if check_approve_by_archive_zip_exists(workflow):
             for article in articles:
                 # Get the file name of the most recent archive zip from the archive bucket
                 zip_file_name = self.get_latest_archive_zip_name(article)
@@ -559,6 +559,21 @@ class activity_PubRouterDeposit(Activity):
         return True
 
 
+def check_approve_by_article_type(workflow):
+    "whether to check the OASwitchboard status when approving an article to send"
+    return bool(workflow == "OASwitchboard")
+
+
+def check_approve_by_was_ever_published(workflow):
+    "whether to check the article has been sent previously when approving an article to send"
+    return bool(workflow not in ["CLOCKSS", "OVID", "PMC", "Zendy"])
+
+
+def check_approve_by_archive_zip_exists(workflow):
+    "whether to check if a VoR article zip exists when approving an article to send"
+    return bool(workflow not in ["OVID", "Zendy"])
+
+
 def get_friendly_email_recipients(settings, workflow):
 
     recipient_email_list = []
@@ -634,7 +649,7 @@ def get_friendly_email_body(current_time, approved_articles):
 
 
 def approve_for_oa_switchboard(article):
-    "check article tyep and display channel to only sent particular types of articles"
+    "check article type and display channel to only sent particular types of articles"
     allowed_article_type = "research-article"
     allowed_display_channel_values = [
         "Research Advance",

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -378,27 +378,11 @@ class activity_PubRouterDeposit(Activity):
 
         return articles
 
-    def create_article(self, doi_id=None):
-        """
-        Instantiate an article object and optionally populate it with
-        data for the doi_id (int) supplied
-        """
+    def create_article(self):
+        "Instantiate an article object"
 
         # Instantiate a new article object
-        article = articlelib.article(self.settings)
-
-        if doi_id:
-            # Get and parse the article XML for data
-            # Convert the doi_id to 5 digit string in case it was an integer
-            if isinstance(doi_id, int):
-                doi_id = utils.pad_msid(doi_id)
-            article_xml_filename = article.download_article_xml_from_s3(
-                self.get_tmp_dir(), doi_id
-            )
-            article.parse_article_file(
-                self.get_tmp_dir() + os.sep + article_xml_filename
-            )
-        return article
+        return articlelib.article(self.settings)
 
     def approve_articles(self, articles, workflow):
         """

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -604,7 +604,7 @@ def get_friendly_email_recipients(settings, workflow):
     except:
         pass
 
-    if recipients and type(recipients) == list:
+    if recipients and isinstance(recipients, list):
         recipient_email_list = recipients
     elif recipients:
         recipient_email_list.append(recipients)

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -535,7 +535,7 @@ class activity_PubRouterDeposit(Activity):
         sender_email = self.settings.ses_poa_sender_email
 
         # Get pub router recipients
-        recipient_email_list = self.get_friendly_email_recipients(workflow)
+        recipient_email_list = get_friendly_email_recipients(self.settings, workflow)
 
         # Add admin email recipients
         recipient_email_list += email_provider.list_email_recipients(
@@ -558,42 +558,43 @@ class activity_PubRouterDeposit(Activity):
 
         return True
 
-    def get_friendly_email_recipients(self, workflow):
 
-        recipient_email_list = []
+def get_friendly_email_recipients(settings, workflow):
 
-        recipients = None
-        try:
-            # Get the email recipient list
-            if workflow == "HEFCE":
-                recipients = self.settings.HEFCE_EMAIL
-            elif workflow == "Cengage":
-                recipients = self.settings.CENGAGE_EMAIL
-            elif workflow == "GoOA":
-                recipients = self.settings.GOOA_EMAIL
-            elif workflow == "WoS":
-                recipients = self.settings.WOS_EMAIL
-            elif workflow == "CNPIEC":
-                recipients = self.settings.CNPIEC_EMAIL
-            elif workflow == "CNKI":
-                recipients = self.settings.CNKI_EMAIL
-            elif workflow == "CLOCKSS":
-                recipients = self.settings.CLOCKSS_EMAIL
-            elif workflow == "OVID":
-                recipients = self.settings.OVID_EMAIL
-            elif workflow == "Zendy":
-                recipients = self.settings.ZENDY_EMAIL
-            elif workflow == "OASwitchboard":
-                recipients = self.settings.OASWITCHBOARD_EMAIL
-        except:
-            pass
+    recipient_email_list = []
 
-        if recipients and type(recipients) == list:
-            recipient_email_list = recipients
-        elif recipients:
-            recipient_email_list.append(recipients)
+    recipients = None
+    try:
+        # Get the email recipient list
+        if workflow == "HEFCE":
+            recipients = settings.HEFCE_EMAIL
+        elif workflow == "Cengage":
+            recipients = settings.CENGAGE_EMAIL
+        elif workflow == "GoOA":
+            recipients = settings.GOOA_EMAIL
+        elif workflow == "WoS":
+            recipients = settings.WOS_EMAIL
+        elif workflow == "CNPIEC":
+            recipients = settings.CNPIEC_EMAIL
+        elif workflow == "CNKI":
+            recipients = settings.CNKI_EMAIL
+        elif workflow == "CLOCKSS":
+            recipients = settings.CLOCKSS_EMAIL
+        elif workflow == "OVID":
+            recipients = settings.OVID_EMAIL
+        elif workflow == "Zendy":
+            recipients = settings.ZENDY_EMAIL
+        elif workflow == "OASwitchboard":
+            recipients = settings.OASWITCHBOARD_EMAIL
+    except:
+        pass
 
-        return recipient_email_list
+    if recipients and type(recipients) == list:
+        recipient_email_list = recipients
+    elif recipients:
+        recipient_email_list.append(recipients)
+
+    return recipient_email_list
 
 
 def get_friendly_email_subject(current_time, workflow):

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -351,15 +351,17 @@ class TestApproveArticles(unittest.TestCase):
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
     @data(
-        "HEFCE",
         "Cengage",
-        "GoOA",
-        "WoS",
-        "CNPIEC",
-        "CNKI",
         "CLOCKSS",
-        "OVID",
+        "CNKI",
+        "CNPIEC",
+        "GoOA",
+        "HEFCE",
         "OASwitchboard",
+        "OVID",
+        "PMC",
+        "WoS",
+        "Zendy",
     )
     def test_approve_articles(
         self,
@@ -391,15 +393,18 @@ class TestApproveArticles(unittest.TestCase):
     @patch("provider.article.article.was_ever_published")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
+    @data(
+        "OASwitchboard",
+    )
     def test_approve_articles_oaswitchboard(
         self,
+        workflow_name,
         fake_article_versions,
         fake_was_ever_poa,
         fake_was_ever_published,
         fake_get_latest_archive_zip_name,
     ):
         "test when OASwitchboard is not approved"
-        workflow_name = "OASwitchboard"
         fake_was_ever_poa.return_value = True
         fake_was_ever_published.return_value = False
         fake_get_latest_archive_zip_name.return_value = "test.zip"
@@ -422,15 +427,25 @@ class TestApproveArticles(unittest.TestCase):
     @patch("provider.article.article.was_ever_published")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
+    @data(
+        "Cengage",
+        "CNKI",
+        "CNPIEC",
+        "GoOA",
+        "HEFCE",
+        "OASwitchboard",
+        "WoS",
+    )
     def test_approve_articles_was_ever_published(
         self,
+        workflow_name,
         fake_article_versions,
         fake_was_ever_poa,
         fake_was_ever_published,
         fake_get_latest_archive_zip_name,
     ):
         "test when was_ever_published is True for coverage adding the article to the remove list"
-        workflow_name = "HEFCE"
+
         fake_was_ever_poa.return_value = True
         fake_was_ever_published.return_value = True
         fake_get_latest_archive_zip_name.return_value = "test.zip"
@@ -451,15 +466,26 @@ class TestApproveArticles(unittest.TestCase):
     @patch("provider.article.article.was_ever_published")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
+    @data(
+        "Cengage",
+        "CLOCKSS",
+        "CNKI",
+        "CNPIEC",
+        "GoOA",
+        "HEFCE",
+        "OASwitchboard",
+        "PMC",
+        "WoS",
+    )
     def test_approve_articles_archive_zip_does_not_exist(
         self,
+        workflow_name,
         fake_article_versions,
         fake_was_ever_poa,
         fake_was_ever_published,
         fake_get_latest_archive_zip_name,
     ):
         "test when was_ever_published is False for coverage"
-        workflow_name = "HEFCE"
         fake_was_ever_poa.return_value = True
         fake_was_ever_published.return_value = False
         fake_get_latest_archive_zip_name.return_value = None

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -387,6 +387,7 @@ class TestApproveArticles(unittest.TestCase):
         self.assertEqual(approved_article_dois, expected_approved_article_dois)
         self.assertEqual(remove_doi_list, expected_remove_doi_list)
 
+    @patch.object(activity_PubRouterDeposit, "get_latest_archive_zip_name")
     @patch("provider.article.article.was_ever_published")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
@@ -395,11 +396,13 @@ class TestApproveArticles(unittest.TestCase):
         fake_article_versions,
         fake_was_ever_poa,
         fake_was_ever_published,
+        fake_get_latest_archive_zip_name,
     ):
         "test when OASwitchboard is not approved"
         workflow_name = "OASwitchboard"
         fake_was_ever_poa.return_value = True
-        fake_was_ever_published.return_value = True
+        fake_was_ever_published.return_value = False
+        fake_get_latest_archive_zip_name.return_value = "test.zip"
         fake_article_versions.return_value = (
             200,
             test_case_data.lax_article_versions_response_data,
@@ -415,6 +418,7 @@ class TestApproveArticles(unittest.TestCase):
         self.assertEqual(approved_article_dois, expected_approved_article_dois)
         self.assertEqual(remove_doi_list, expected_remove_doi_list)
 
+    @patch.object(activity_PubRouterDeposit, "get_latest_archive_zip_name")
     @patch("provider.article.article.was_ever_published")
     @patch("provider.lax_provider.was_ever_poa")
     @patch("provider.lax_provider.article_versions")
@@ -423,11 +427,13 @@ class TestApproveArticles(unittest.TestCase):
         fake_article_versions,
         fake_was_ever_poa,
         fake_was_ever_published,
+        fake_get_latest_archive_zip_name,
     ):
         "test when was_ever_published is True for coverage adding the article to the remove list"
         workflow_name = "HEFCE"
         fake_was_ever_poa.return_value = True
         fake_was_ever_published.return_value = True
+        fake_get_latest_archive_zip_name.return_value = "test.zip"
         fake_article_versions.return_value = (
             200,
             test_case_data.lax_article_versions_response_data,

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -308,8 +308,19 @@ class TestStartPmcDepositWorkflow(unittest.TestCase):
             settings_mock, FakeLogger(), None, None, None
         )
         self.pubrouterdeposit.workflow = "HEFCE"
+        # test overriding the workflow timeout
+        self.workflow_timeout_original = (
+            activity_module.PMC_DEPOSIT_WORKFLOW_EXECUTION_START_TO_CLOSE_TIMEOUT
+        )
+        activity_module.PMC_DEPOSIT_WORKFLOW_EXECUTION_START_TO_CLOSE_TIMEOUT = 1
         self.article = article()
         self.article.doi_id = "00666"
+
+    def tearDown(self):
+        # reset the workflow timeout value
+        activity_module.PMC_DEPOSIT_WORKFLOW_EXECUTION_START_TO_CLOSE_TIMEOUT = (
+            self.workflow_timeout_original
+        )
 
     @patch("boto3.client")
     def test_start_pmc_deposit_workflow(self, fake_client):

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -380,11 +380,20 @@ class TestGetFriendlyEmailRecipients(unittest.TestCase):
         "CNKI",
         "CLOCKSS",
         "OVID",
+        "Zendy",
+        "OASwitchboard",
     )
     def test_workflow_specific_values(self, workflow):
         "test functions that look at the workflow name"
         self.assertIsNotNone(
             self.pubrouterdeposit.get_friendly_email_recipients(workflow)
+        )
+
+    def test_recipients_string(self):
+        "test when the recipients is just a string and not a list"
+        self.pubrouterdeposit.settings.HEFCE_EMAIL = "email@example.org"
+        self.assertIsNotNone(
+            self.pubrouterdeposit.get_friendly_email_recipients("HEFCE")
         )
 
 

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -475,11 +475,6 @@ class TestApproveArticles(unittest.TestCase):
 
 @ddt
 class TestGetFriendlyEmailRecipients(unittest.TestCase):
-    def setUp(self):
-        self.pubrouterdeposit = activity_PubRouterDeposit(
-            settings_mock, FakeLogger(), None, None, None
-        )
-
     @data(
         "HEFCE",
         "Cengage",
@@ -495,14 +490,18 @@ class TestGetFriendlyEmailRecipients(unittest.TestCase):
     def test_workflow_specific_values(self, workflow):
         "test functions that look at the workflow name"
         self.assertIsNotNone(
-            self.pubrouterdeposit.get_friendly_email_recipients(workflow)
+            activity_module.get_friendly_email_recipients(settings_mock, workflow)
         )
 
     def test_recipients_string(self):
         "test when the recipients is just a string and not a list"
-        self.pubrouterdeposit.settings.HEFCE_EMAIL = "email@example.org"
+
+        class TestSettings:
+            HEFCE_EMAIL = "email@example.org"
+
+        test_settings = TestSettings()
         self.assertIsNotNone(
-            self.pubrouterdeposit.get_friendly_email_recipients("HEFCE")
+            activity_module.get_friendly_email_recipients(test_settings, "HEFCE")
         )
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7655

Firstly increased test coverage, then the module was refactored a bit to make it easier to switch over to a YAML file later which defines all the downstream recipients of article zip files.