### PR TITLE
Fail workflows if FTP_URI or SFTP_URI is blank.

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -65,6 +65,13 @@ class activity_PMCDeposit(Activity):
         # Create output directories
         self.make_activity_directories(list(self.directories.values()))
 
+        # Check the settings for suitability to send
+        if not self.settings.PMC_FTP_URI:
+            self.logger.info(
+                "%s settings PMC_FTP_URI value is blank, cannot send files", self.name
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
         # Download the S3 objects
         download_status = self.download_files_from_s3(self.document)
 

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -42,7 +42,7 @@ lax_article_related = "https://test/eLife.{article_id}/related"
 verify_ssl = False
 lax_auth_key = "an_auth_key"
 
-PMC_FTP_URI = ""
+PMC_FTP_URI = "pmc.localhost"
 PMC_FTP_USERNAME = ""
 PMC_FTP_PASSWORD = ""
 PMC_FTP_CWD = ""

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -87,6 +87,28 @@ class TestFTPArticle(unittest.TestCase):
             "info log did not contain started message for workflow %s" % workflow,
         )
 
+    def test_do_activity_no_ftp_uri(
+        self,
+    ):
+        "test for when the FTP_URI is blank"
+        self.activity.settings.CENGAGE_FTP_URI = ""
+        workflow = "Cengage"
+        elife_id = "19405"
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
+        self.assertEqual(self.activity.do_activity(activity_data), expected_result)
+
+    def test_do_activity_no_sftp_uri(
+        self,
+    ):
+        "test for when the SFTP_URI is blank"
+        self.activity.settings.HEFCE_SFTP_URI = ""
+        workflow = "HEFCE"
+        elife_id = "19405"
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        activity_data = {"data": {"elife_id": elife_id, "workflow": workflow}}
+        self.assertEqual(self.activity.do_activity(activity_data), expected_result)
+
     @patch.object(activity_FTPArticle, "download_files_from_s3")
     @patch.object(activity_FTPArticle, "sftp_to_endpoint")
     def test_do_activity_failure(

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -190,6 +190,23 @@ class TestPMCDeposit(unittest.TestCase):
     @patch.object(FakeStorageContext, "list_resources")
     @patch.object(activity_PMCDeposit, "ftp_to_endpoint")
     @patch("activity.activity_PMCDeposit.storage_context")
+    def test_do_activity_no_settings_uri(
+        self,
+        fake_storage_context,
+        fake_ftp_to_endpoint,
+        fake_list_resources,
+        mock_article_related,
+    ):
+        "test for when the PMC_FTP_URI is blank"
+        self.activity.settings.PMC_FTP_URI = ""
+        test_data = self.do_activity_passes[1]
+        result = self.activity.do_activity(test_data["input_data"])
+        self.assertEqual(self.activity.ACTIVITY_PERMANENT_FAILURE, result)
+
+    @patch("provider.lax_provider.article_related")
+    @patch.object(FakeStorageContext, "list_resources")
+    @patch.object(activity_PMCDeposit, "ftp_to_endpoint")
+    @patch("activity.activity_PMCDeposit.storage_context")
     def test_do_activity_lax_failure(
         self,
         fake_storage_context,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7689

Possibly since recent refactoring of some downstream workflows, in a non-prod environment when the URI for an FTP or SFTP endpoint is blank, the workflows continued to try sending again until it finally reached time out.

Instead, if the URI is blank then permanently fail the workflow after the first attempt in `PMCDeposit` and `FTPArticle` activities.