### PR TITLE
Fail PubmedArticleDeposit if the URI is blank.

### DIFF
--- a/activity/activity_PubmedArticleDeposit.py
+++ b/activity/activity_PubmedArticleDeposit.py
@@ -70,6 +70,13 @@ class activity_PubmedArticleDeposit(Activity):
 
         self.make_activity_directories()
 
+        # Check the settings for suitability to send
+        if not self.settings.PUBMED_SFTP_URI:
+            self.logger.info(
+                "%s PUBMED_SFTP_URI value is blank, cannot deposit articles", self.name
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
         # Get a list of outbox file names always
         self.outbox_s3_key_names = outbox_provider.get_outbox_s3_key_names(
             self.settings, self.publish_bucket, self.outbox_folder

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -164,7 +164,7 @@ git_repo_name = "elife-article-xml-ci"
 git_repo_path = "articles/"
 github_token = "1234567890abcdef"
 
-PUBMED_SFTP_URI = ""
+PUBMED_SFTP_URI = "pubmed.localhost"
 PUBMED_SFTP_USERNAME = ""
 PUBMED_SFTP_PASSWORD = ""
 PUBMED_SFTP_CWD = ""

--- a/tests/activity/test_activity_pubmed_article_deposit.py
+++ b/tests/activity/test_activity_pubmed_article_deposit.py
@@ -310,7 +310,7 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             self.activity.sftp_files_to_endpoint("", "")
         self.assertEqual(
             self.activity.logger.logexception,
-            "Failed to connect to SFTP endpoint : SFTP connect exception",
+            "Failed to connect to SFTP endpoint pubmed.localhost: SFTP connect exception",
         )
 
     @patch.object(sftp.SFTP, "sftp_to_endpoint")
@@ -326,6 +326,25 @@ class TestPubmedArticleDeposit(unittest.TestCase):
             self.activity.logger.logexception,
             "Failed to upload files by SFTP to PubMed: SFTP transfer exception",
         )
+
+
+class TestPubmedArticleDepositNoSftpUri(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_PubmedArticleDeposit(
+            settings_mock, fake_logger, None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
+    def test_do_activity_no_sftp_uri(self):
+        "test for if endpoint URI is blank"
+        self.activity.settings.PUBMED_SFTP_URI = ""
+        # do the activity
+        result = self.activity.do_activity()
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
 
 class TestPubmedGeneratePubmedXml(unittest.TestCase):


### PR DESCRIPTION
Similar to PR https://github.com/elifesciences/elife-bot/pull/1541, also do not attempt the `PubmedArticleDeposit` activity if the settings value for the deposit URI is blank, which is how non-prod environment settings are.