### PR TITLE
Fix logging file_name_map in article_processing.py

### DIFF
--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -65,7 +65,7 @@ def rename_files_remove_version_number(files_dir, output_dir, logger=None):
     """Rename files to not include the version number, if present"""
 
     # Get a list of all files
-    dirfiles = file_list(files_dir)
+    dirfiles = sorted(file_list(files_dir))
 
     file_name_map = stripped_file_name_map(dirfiles, logger)
 
@@ -226,7 +226,7 @@ def repackage_archive_zip_to_pmc_zip(
         "repackage_archive_zip_to_pmc_zip() verified renamed files from %s: %s"
         % (input_zip_file_path.rsplit(os.sep, 1)[-1], verified)
     )
-    logger.info("file_name_map: %s" % sorted(file_name_map))
+    logger.info("file_name_map: %s" % file_name_map)
     if renamed_list:
         logger.info("renamed: %s" % sorted(renamed_list))
     if not_renamed_list:

--- a/tests/provider/test_article_processing.py
+++ b/tests/provider/test_article_processing.py
@@ -229,10 +229,10 @@ class TestRepackageArchiveZip(unittest.TestCase):
         expected_article_xml_string = b"elife-19405.pdf"
         expected_file_name_map = OrderedDict(
             [
-                ("elife-19405-v1.pdf", "elife-19405.pdf"),
-                ("elife-19405-inf1-v1.tif", "elife-19405-inf1.tif"),
-                ("elife-19405-v1.xml", "elife-19405.xml"),
                 ("elife-19405-fig1-v1.tif", "elife-19405-fig1.tif"),
+                ("elife-19405-inf1-v1.tif", "elife-19405-inf1.tif"),
+                ("elife-19405-v1.pdf", "elife-19405.pdf"),
+                ("elife-19405-v1.xml", "elife-19405.xml"),
             ]
         )
         expected_pmc_zip_file_contents = expected_file_name_map.values()
@@ -266,7 +266,7 @@ class TestRepackageArchiveZip(unittest.TestCase):
         )
         self.assertEqual(
             logger.loginfo[2],
-            ("file_name_map: %s" % sorted(expected_file_name_map)),
+            ("file_name_map: %s" % expected_file_name_map),
         )
         self.assertEqual(
             logger.loginfo[3],


### PR DESCRIPTION
Fix code merged in PR https://github.com/elifesciences/elife-bot/pull/1552

The `OrderedDict` cannot be `sorted` and retain its structure, instead sort the list of files the `file_name_map` is generated from, which will allow for consistent comparison of log file output in the test scenario.