### PR TITLE
Update protobuf==3.20.2 w/ update_dependencies.sh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-09-22 - see update-dependencies.sh
+# file generated 2022-09-23 - see update-dependencies.sh
 arrow==1.2.2
 astroid==2.11.6
 attrs==21.4.0
@@ -56,7 +56,7 @@ paramiko==2.11.0
 platformdirs==2.5.2
 pluggy==1.0.0
 proto-plus==1.20.6
-protobuf==3.20.1
+protobuf==3.20.2
 psutil==5.9.1
 py==1.11.0
 pyasn1==0.4.8


### PR DESCRIPTION
Replacement for PR https://github.com/elifesciences/elife-bot/pull/1555. It turns out the `Pipfile` isn't updated anyway for `protobuf` updates, but we get the date stamp changed in the `requirements.txt`.