### PR TITLE
Downstream yaml

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -292,14 +292,15 @@ class activity_FTPArticle(Activity):
         move the entire zip to the ftp folder if we want to send the full article pacakge
         """
 
+        # additional sending details
+        details = sending_details(self.settings, workflow)
+
         # Repackage or move the zip depending on the workflow type
-        if workflow in ["Cengage", "WoS", "CNKI", "OASwitchboard"]:
-            if workflow in ["CNKI", "OASwitchboard"]:
-                file_types = ["xml"]
-            else:
-                file_types = ["xml", "pdf"]
-            self.repackage_pmc_zip(doi_id, file_types)
+        if details.get("send_file_types"):
+            # only send the particular file types
+            self.repackage_pmc_zip(doi_id, details.get("send_file_types"))
         else:
+            # by default send all files
             self.move_pmc_zip()
 
     def repackage_pmc_zip(self, doi_id, keep_file_types):
@@ -491,5 +492,6 @@ def sending_details(settings, workflow):
         details["send_unzipped_files"] = workflow_rules.get(
             "send_unzipped_files", False
         )
+        details["send_file_types"] = workflow_rules.get("send_file_types")
 
     return details

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -52,48 +52,201 @@ class TestChooseOutboxes(unittest.TestCase):
     def setUp(self):
         self.rules = downstream.load_config(settings_mock)
 
+    def test_empty_rules(self):
+        rules = None
+        outbox_list = activity_module.choose_outboxes("vor", True, rules)
+        self.assertEqual(outbox_list, [])
+
+    def test_empty_workflow_rules(self):
+        rules = {"HEFCE": {}}
+        outbox_list = activity_module.choose_outboxes("vor", True, rules)
+        self.assertEqual(outbox_list, [])
+
     def test_choose_outboxes_poa_first(self):
         """first poa version"""
         outbox_list = activity_module.choose_outboxes("poa", True, self.rules)
-        self.assertTrue("pubmed/outbox/" in outbox_list)
-        self.assertTrue("publication_email/outbox/" in outbox_list)
-        self.assertFalse("pmc/outbox/" in outbox_list)
+        # schedule the following
+        for folder_name in [
+            "ovid",
+            "publication_email",
+            "pubmed",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
+
+        # do not schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnki",
+            "cnpiec",
+            "crossref",
+            "gooa",
+            "oaswitchboard",
+            "pmc",
+            "pub_router",
+            "wos",
+        ]:
+            self.assertFalse(
+                "%s/outbox/" % folder_name in outbox_list,
+                "unexpectedly found %s folder" % folder_name,
+            )
 
     def test_choose_outboxes_poa_not_first(self):
         """poa but not the first poa"""
         outbox_list = activity_module.choose_outboxes("poa", False, self.rules)
-        self.assertTrue("pubmed/outbox/" in outbox_list)
-        # do not send to pmc
-        self.assertFalse("pmc/outbox/" in outbox_list)
-        # do not send publication_email
-        self.assertFalse("publication_email/outbox/" in outbox_list)
+        # schedule the following
+        for folder_name in [
+            "ovid",
+            "pubmed",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
+        # do not schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnpiec",
+            "cnki",
+            "crossref",
+            "gooa",
+            "oaswitchboard",
+            "pmc",
+            "pub_router",
+            "publication_email",
+            "wos",
+        ]:
+            self.assertFalse(
+                "%s/outbox/" % folder_name in outbox_list,
+                "unexpectedly found %s folder" % folder_name,
+            )
 
     def test_choose_outboxes_vor_first(self):
         """first vor version"""
         outbox_list = activity_module.choose_outboxes("vor", True, self.rules)
-        self.assertTrue("pmc/outbox/" in outbox_list)
-        self.assertTrue("pubmed/outbox/" in outbox_list)
-        self.assertTrue("publication_email/outbox/" in outbox_list)
-        self.assertTrue("pub_router/outbox/" in outbox_list)
+        # schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnki",
+            "cnpiec",
+            "gooa",
+            "oaswitchboard",
+            "ovid",
+            "pmc",
+            "pub_router",
+            "publication_email",
+            "pubmed",
+            "wos",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
 
     def test_choose_outboxes_vor_not_first(self):
         """vor but not the first vor"""
         outbox_list = activity_module.choose_outboxes("vor", False, self.rules)
-        self.assertTrue("pmc/outbox/" in outbox_list)
-        self.assertTrue("pubmed/outbox/" in outbox_list)
-        self.assertTrue("pub_router/outbox/" in outbox_list)
-        # do not send publication_email
-        self.assertFalse("publication_email/outbox/" in outbox_list)
+        # schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnki",
+            "cnpiec",
+            "gooa",
+            "ovid",
+            "pmc",
+            "pub_router",
+            "pubmed",
+            "wos",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
+
+        # do not schedule the following
+        for folder_name in [
+            "oaswitchboard",
+            "publication_email",
+        ]:
+            self.assertFalse(
+                "%s/outbox/" % folder_name in outbox_list,
+                "unexpectedly found %s folder" % folder_name,
+            )
 
     def test_choose_outboxes_vor_silent_first(self):
         outbox_list = activity_module.choose_outboxes(
             "vor", True, self.rules, "silent-correction"
         )
-        self.assertTrue("pmc/outbox/" in outbox_list)
-        # do not send publication_email
-        self.assertFalse("publication_email/outbox/" in outbox_list)
-        # do not send to pubmed
-        self.assertFalse("pubmed/outbox/" in outbox_list)
+        # schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnki",
+            "cnpiec",
+            "gooa",
+            "ovid",
+            "pmc",
+            "pub_router",
+            "wos",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
+        # do not schedule the following
+        for folder_name in [
+            "oaswitchboard",
+            "publication_email",
+            "pubmed",
+        ]:
+            self.assertFalse(
+                "%s/outbox/" % folder_name in outbox_list,
+                "unexpectedly found %s folder" % folder_name,
+            )
+
+    def test_choose_outboxes_vor_silent_not_first(self):
+        """silent correction vor but not the first vor"""
+        outbox_list = activity_module.choose_outboxes(
+            "vor", False, self.rules, "silent-correction"
+        )
+        # schedule the following
+        for folder_name in [
+            "cengage",
+            "clockss",
+            "cnki",
+            "cnpiec",
+            "gooa",
+            "ovid",
+            "pmc",
+            "pub_router",
+            "wos",
+            "zendy",
+        ]:
+            self.assertTrue(
+                "%s/outbox/" % folder_name in outbox_list,
+                "did not find %s folder" % folder_name,
+            )
+        # do not schedule the following
+        for folder_name in [
+            "oaswitchboard",
+            "publication_email",
+            "pubmed",
+        ]:
+            self.assertFalse(
+                "%s/outbox/" % folder_name in outbox_list,
+                "unexpectedly found %s folder" % folder_name,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -33,6 +33,9 @@ Cengage:
   activity_name: FTPArticle
   s3_bucket_folder: cengage
   send_by_protocol: ftp
+  send_file_types:
+    - xml
+    - pdf
   settings_friendly_email_recipients: CENGAGE_EMAIL
   settings_ftp_uri: CENGAGE_FTP_URI
   settings_ftp_username: CENGAGE_FTP_USERNAME
@@ -53,6 +56,8 @@ CNKI:
   activity_name: FTPArticle
   s3_bucket_folder: cnki
   send_by_protocol: ftp
+  send_file_types:
+    - xml
   settings_friendly_email_recipients: CNKI_EMAIL
   settings_ftp_uri: CNKI_FTP_URI
   settings_ftp_username: CNKI_FTP_USERNAME
@@ -97,6 +102,8 @@ OASwitchboard:
   activity_name: FTPArticle
   s3_bucket_folder: oaswitchboard
   send_by_protocol: sftp
+  send_file_types:
+    - xml
   send_unzipped_files: true
   settings_friendly_email_recipients: OASWITCHBOARD_EMAIL
   settings_sftp_uri: OASWITCHBOARD_SFTP_URI
@@ -118,6 +125,9 @@ WoS:
   activity_name: FTPArticle
   s3_bucket_folder: wos
   send_by_protocol: ftp
+  send_file_types:
+    - xml
+    - pdf
   settings_friendly_email_recipients: WOS_EMAIL
   settings_ftp_uri: WOS_FTP_URI
   settings_ftp_username: WOS_FTP_USERNAME

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -18,20 +18,36 @@ DepositCrossrefPendingPublication:
 PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
 
 PublicationEmail:
   activity_name: PublicationEmail
   s3_bucket_folder: publication_email
+  schedule_downstream: true
+  schedule_first_version_only: true
+  schedule_article_types:
+    - poa
+    - vor
 
 Pubmed:
   activity_name: PubmedArticleDeposit
   s3_bucket_folder: pubmed
-
+  schedule_downstream: true
+  schedule_article_types:
+    - poa
+    - vor
 
 # FTPArticle workflows
 Cengage:
   activity_name: FTPArticle
   s3_bucket_folder: cengage
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   send_file_types:
     - xml
@@ -45,6 +61,10 @@ Cengage:
 CLOCKSS:
   activity_name: FTPArticle
   s3_bucket_folder: clockss
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   settings_friendly_email_recipients: CLOCKSS_EMAIL
   settings_ftp_uri: CLOCKSS_FTP_URI
@@ -55,6 +75,10 @@ CLOCKSS:
 CNKI:
   activity_name: FTPArticle
   s3_bucket_folder: cnki
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   send_file_types:
     - xml
@@ -67,6 +91,10 @@ CNKI:
 CNPIEC:
   activity_name: FTPArticle
   s3_bucket_folder: cnpiec
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   settings_friendly_email_recipients: CNPIEC_EMAIL
   settings_ftp_uri: CNPIEC_FTP_URI
@@ -77,6 +105,10 @@ CNPIEC:
 GoOA:
   activity_name: FTPArticle
   s3_bucket_folder: gooa
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   settings_friendly_email_recipients: GOOA_EMAIL
   settings_ftp_uri: GOOA_FTP_URI
@@ -87,6 +119,10 @@ GoOA:
 HEFCE:
   activity_name: FTPArticle
   s3_bucket_folder: pub_router
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: sftp
   settings_friendly_email_recipients: HEFCE_EMAIL
   settings_ftp_uri: HEFCE_FTP_URI
@@ -101,6 +137,10 @@ HEFCE:
 OASwitchboard:
   activity_name: FTPArticle
   s3_bucket_folder: oaswitchboard
+  schedule_downstream: true
+  schedule_first_version_only: true
+  schedule_article_types:
+    - vor
   send_by_protocol: sftp
   send_file_types:
     - xml
@@ -114,6 +154,11 @@ OASwitchboard:
 OVID:
   activity_name: FTPArticle
   s3_bucket_folder: ovid
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - poa
+    - vor
   send_by_protocol: ftp
   settings_friendly_email_recipients: OVID_EMAIL
   settings_ftp_uri: OVID_FTP_URI
@@ -124,6 +169,10 @@ OVID:
 WoS:
   activity_name: FTPArticle
   s3_bucket_folder: wos
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - vor
   send_by_protocol: ftp
   send_file_types:
     - xml
@@ -137,6 +186,11 @@ WoS:
 Zendy:
   activity_name: FTPArticle
   s3_bucket_folder: zendy
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - poa
+    - vor
   send_by_protocol: sftp
   settings_friendly_email_recipients: ZENDY_EMAIL
   settings_sftp_uri: ZENDY_SFTP_URI


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7652

Use more details from the `downstreamRecipients.yaml` configuration file to determine which articles from which workflows to schedule them for downstream delivery.

Blocked from deploying to the `prod` environment by PR https://github.com/elifesciences/elife-bot-formula/pull/96