### PR TITLE
pytest, ignore a module to silence a warning.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths=tests
+# ignore test data module when discovering tests
+addopts = --ignore=tests/test_data.py


### PR DESCRIPTION
Follow up to PR https://github.com/elifesciences/elife-bot/pull/1572 where now there is a warning when running tests, `pytest` is finding a module during test discovery which it should not attempt to run as a test module.