### PR TITLE
Use yaml rules more in PubRouterDeposit

### DIFF
--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -3,6 +3,7 @@ import datetime
 from mock import patch
 from ddt import ddt, data, unpack
 from testfixtures import TempDirectory
+from provider import downstream
 from provider.article import article
 import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
@@ -356,6 +357,7 @@ class TestApproveArticles(unittest.TestCase):
         test_article.display_channel = ["Research Article"]
         test_article.is_poa = True
         self.articles = [test_article]
+        self.rules = downstream.load_config(settings_mock)
 
     @patch.object(activity_PubRouterDeposit, "get_latest_archive_zip_name")
     @patch("provider.article.article.was_ever_published")
@@ -393,7 +395,7 @@ class TestApproveArticles(unittest.TestCase):
         expected_approved_article_dois = ["10.7554/eLife.00666"]
         expected_remove_doi_list = []
         approved_articles, remove_doi_list = self.pubrouterdeposit.approve_articles(
-            self.articles, workflow_name
+            self.articles, workflow_name, self.rules.get(workflow_name)
         )
         # self.assertTrue(False)
         approved_article_dois = [article.doi for article in approved_articles]
@@ -428,7 +430,7 @@ class TestApproveArticles(unittest.TestCase):
         expected_approved_article_dois = []
         expected_remove_doi_list = ["10.7554/eLife.00666"]
         approved_articles, remove_doi_list = self.pubrouterdeposit.approve_articles(
-            self.articles, workflow_name
+            self.articles, workflow_name, self.rules.get(workflow_name)
         )
         approved_article_dois = [article.doi for article in approved_articles]
         self.assertEqual(approved_article_dois, expected_approved_article_dois)
@@ -467,7 +469,7 @@ class TestApproveArticles(unittest.TestCase):
         expected_approved_article_dois = []
         expected_remove_doi_list = ["10.7554/eLife.00666"]
         approved_articles, remove_doi_list = self.pubrouterdeposit.approve_articles(
-            self.articles, workflow_name
+            self.articles, workflow_name, self.rules.get(workflow_name)
         )
         approved_article_dois = [article.doi for article in approved_articles]
         self.assertEqual(approved_article_dois, expected_approved_article_dois)
@@ -509,7 +511,7 @@ class TestApproveArticles(unittest.TestCase):
         expected_approved_article_dois = []
         expected_remove_doi_list = ["10.7554/eLife.00666"]
         approved_articles, remove_doi_list = self.pubrouterdeposit.approve_articles(
-            self.articles, workflow_name
+            self.articles, workflow_name, self.rules.get(workflow_name)
         )
         approved_article_dois = [article.doi for article in approved_articles]
         self.assertEqual(approved_article_dois, expected_approved_article_dois)

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -22,6 +22,9 @@ PMC:
   schedule_silent_correction: true
   schedule_article_types:
     - vor
+  send_once_only: false
+  send_article_types:
+    - vor
 
 PublicationEmail:
   activity_name: PublicationEmail
@@ -49,6 +52,9 @@ Cengage:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: true
+  send_article_types:
+    - vor
   send_file_types:
     - xml
     - pdf
@@ -66,6 +72,9 @@ CLOCKSS:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: false
+  send_article_types:
+    - vor
   settings_friendly_email_recipients: CLOCKSS_EMAIL
   settings_ftp_uri: CLOCKSS_FTP_URI
   settings_ftp_username: CLOCKSS_FTP_USERNAME
@@ -80,6 +89,9 @@ CNKI:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: true
+  send_article_types:
+    - vor
   send_file_types:
     - xml
   settings_friendly_email_recipients: CNKI_EMAIL
@@ -96,6 +108,9 @@ CNPIEC:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: true
+  send_article_types:
+    - vor
   settings_friendly_email_recipients: CNPIEC_EMAIL
   settings_ftp_uri: CNPIEC_FTP_URI
   settings_ftp_username: CNPIEC_FTP_USERNAME
@@ -110,6 +125,9 @@ GoOA:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: true
+  send_article_types:
+    - vor
   settings_friendly_email_recipients: GOOA_EMAIL
   settings_ftp_uri: GOOA_FTP_URI
   settings_ftp_username: GOOA_FTP_USERNAME
@@ -124,6 +142,9 @@ HEFCE:
   schedule_article_types:
     - vor
   send_by_protocol: sftp
+  send_once_only: true
+  send_article_types:
+    - vor
   settings_friendly_email_recipients: HEFCE_EMAIL
   settings_ftp_uri: HEFCE_FTP_URI
   settings_ftp_username: HEFCE_FTP_USERNAME
@@ -142,6 +163,9 @@ OASwitchboard:
   schedule_article_types:
     - vor
   send_by_protocol: sftp
+  send_once_only: true
+  send_article_types:
+    - vor
   send_file_types:
     - xml
   send_unzipped_files: true
@@ -160,6 +184,10 @@ OVID:
     - poa
     - vor
   send_by_protocol: ftp
+  send_once_only: false
+  send_article_types:
+    - poa
+    - vor
   settings_friendly_email_recipients: OVID_EMAIL
   settings_ftp_uri: OVID_FTP_URI
   settings_ftp_username: OVID_FTP_USERNAME
@@ -174,6 +202,9 @@ WoS:
   schedule_article_types:
     - vor
   send_by_protocol: ftp
+  send_once_only: true
+  send_article_types:
+    - vor
   send_file_types:
     - xml
     - pdf
@@ -192,6 +223,10 @@ Zendy:
     - poa
     - vor
   send_by_protocol: sftp
+  send_once_only: false
+  send_article_types:
+    - poa
+    - vor
   settings_friendly_email_recipients: ZENDY_EMAIL
   settings_sftp_uri: ZENDY_SFTP_URI
   settings_sftp_username: ZENDY_SFTP_USERNAME


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7652

Use more of the `downstreamRecipients.yaml` data when deciding which files to send in the `PubRouterDeposit` activity.

Blocked by PR https://github.com/elifesciences/elife-bot-formula/pull/97