### PR TITLE
cleaner provider PRC status, save to session.

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -129,7 +129,7 @@ class activity_ValidateAcceptedSubmission(Activity):
             )
             self.logger.exception(log_message)
             cleaner.LOGGER.exception(log_message)
-            files = []
+            prc_status = None
         finally:
             # reset the parsing library flag
             cleaner.parse.REPAIR_XML = original_repair_xml

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -114,6 +114,26 @@ class activity_ValidateAcceptedSubmission(Activity):
 
         self.logger.info("%s, files: %s" % (self.name, files))
 
+        # check PRC status and store in the session
+        try:
+            prc_status = cleaner.is_prc(xml_file_path, input_filename)
+            session.store_value("prc_status", prc_status)
+        except ParseError:
+            log_message = (
+                "%s, XML ParseError exception in cleaner.is_prc"
+                " parsing XML file %s for file %s"
+            ) % (
+                self.name,
+                article_processing.file_name_from_name(xml_file_path),
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            cleaner.LOGGER.exception(log_message)
+            files = []
+        finally:
+            # reset the parsing library flag
+            cleaner.parse.REPAIR_XML = original_repair_xml
+
         # download the PDF files so their pages can be counted
         download_pdf_files_from_bucket(
             storage,

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -117,7 +117,6 @@ class activity_ValidateAcceptedSubmission(Activity):
         # check PRC status and store in the session
         try:
             prc_status = cleaner.is_prc(xml_file_path, input_filename)
-            session.store_value("prc_status", prc_status)
         except ParseError:
             log_message = (
                 "%s, XML ParseError exception in cleaner.is_prc"
@@ -133,6 +132,8 @@ class activity_ValidateAcceptedSubmission(Activity):
         finally:
             # reset the parsing library flag
             cleaner.parse.REPAIR_XML = original_repair_xml
+
+        session.store_value("prc_status", prc_status)
 
         # download the PDF files so their pages can be counted
         download_pdf_files_from_bucket(

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -5,6 +5,7 @@ from elifecleaner import (
     LOGGER,
     configure_logging,
     parse,
+    prc,
     transform,
     video,
     video_xml,
@@ -106,6 +107,16 @@ def transform_ejp_zip(zip_file, tmp_dir, output_dir):
 
 def transform_ejp_files(asset_file_name_map, output_dir, identifier):
     return transform.transform_ejp_files(asset_file_name_map, output_dir, identifier)
+
+
+def is_prc(xml_file_path, zip_file_name):
+    "is this a PRC article"
+    # first can check the zip file name
+    if "-RP" in zip_file_name:
+        return True
+    # next, check the XML for the status
+    root = parse_article_xml(xml_file_path)
+    return prc.is_xml_prc(root)
 
 
 def rezip(asset_file_name_map, output_dir, zip_file_name):

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -138,6 +138,46 @@ class TestFileList(unittest.TestCase):
         )
 
 
+class TestIsPrc(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_is_prc(self):
+        "the standard test fixture is not PRC"
+        directory = TempDirectory()
+        zip_file_name = "30-01-2019-RA-eLife-45644.zip"
+        zip_file_path = os.path.join("tests", "files_source", zip_file_name)
+        xml_file_name = "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml"
+        with zipfile.ZipFile(zip_file_path, "r") as open_zip:
+            open_zip.extract(xml_file_name, directory.path)
+        xml_file_path = os.path.join(directory.path, xml_file_name)
+        result = cleaner.is_prc(xml_file_path, zip_file_name)
+        self.assertEqual(result, False)
+
+    def test_is_prc_by_zip_file(self):
+        "test a zip file name for PRC status"
+        zip_file_name = "30-01-2019-RP-RA-eLife-45644.zip"
+        xml_file_path = None
+        result = cleaner.is_prc(xml_file_path, zip_file_name)
+        self.assertEqual(result, True)
+
+    def test_is_prc_by_xml(self):
+        "test when the XML indicates it is PRC status"
+        directory = TempDirectory()
+        zip_file_name = "test.zip"
+        xml_file_name = "test.xml"
+        xml_string = (
+            "<article><front><journal-meta>"
+            '<journal-id journal-id-type="publisher-id">foo</journal-id><issn>2050-084X</issn>'
+            "</journal-meta></front></article>"
+        )
+        xml_file_path = os.path.join(directory.path, xml_file_name)
+        with open(xml_file_path, "w") as open_file:
+            open_file.write(xml_string)
+        result = cleaner.is_prc(xml_file_path, zip_file_name)
+        self.assertEqual(result, True)
+
+
 class TestFilesByExtension(unittest.TestCase):
     def test_files_by_extension(self):
         "filter the list based on the file name extension"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7880

A first part of ingesting PRC accepted submission files is to check if the input is PRC status, and as part of the workflow save the value to the session. `cleaner.is_prc()` checks for either the zip file name match or checks the XML values, which depend on the `elifecleaner` library function `is_xml_prc()`.