### PR TITLE
Temporarily don't send emails for PRC-style ingest

### DIFF
--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -38,6 +38,14 @@ class activity_EmailAcceptedSubmissionOutput(Activity):
         input_filename = session.get_value("input_filename")
         cleaner_log = session.get_value("cleaner_log")
 
+        # November 2022 temporary logic to not send email for PRC article ingest
+        if session.get_value("prc_status") and not cleaner.PRC_INGEST_SEND_EMAIL:
+            self.logger.info(
+                "%s for %s, PRC_INGEST_SEND_EMAIL is False so no email will be sent"
+                % (self.name, input_filename)
+            )
+            return True
+
         # format the email body content
         body_content = ""
         comments = cleaner.production_comments(cleaner_log)

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -19,6 +19,9 @@ LOG_FORMAT_STRING = (
     "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
 )
 
+# November 2022 temporary config whether to send emails for PRC article ingestions
+PRC_INGEST_SEND_EMAIL = False
+
 
 def article_id_from_zip_file(zip_file):
     "try to get an article id numeric string from a zip file name"

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -126,6 +126,20 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
         )
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
+    @patch.object(activity_module, "get_session")
+    def test_do_activity_do_not_send_prc_email(self, fake_session):
+        "test for temporary setting to not send an email for PRC article ingestion"
+        expected_email_status = None
+        session_data = copy.copy(test_activity_data.accepted_session_example)
+        session_data["prc_status"] = True
+        fake_session.return_value = FakeSession(session_data)
+        # do the activity
+        result = self.activity.do_activity(
+            test_case_data.ingest_accepted_submission_data
+        )
+        self.assertEqual(result, True)
+        self.assertEqual(self.activity.email_status, expected_email_status)
+
 
 class TestEmailSubject(unittest.TestCase):
     def test_accepted_submission_email_subject(self):


### PR DESCRIPTION
Described internally in issue comment https://github.com/elifesciences/issues/issues/7880#issuecomment-1322840930, for a little while this temporary setting will allow testing of some newer style accepted submission zip files without causing emails to be sent and confusing people.