### PR TITLE
Dependency `elifecleaner` pinned to `0.24.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.23.0"
+elifecleaner = "~=0.24.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-11-18 - see update-dependencies.sh
+# file generated 2022-11-23 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.12.12
 attrs==22.1.0
@@ -19,7 +19,7 @@ dill==0.3.6
 docker==5.0.3
 ejpcsvparser==0.2.0
 elifearticle==0.11.0
-elifecleaner==0.23.0
+elifecleaner==0.24.0
 elifecrossref==0.18.0
 elifepubmed==0.5.0
 elifetools==0.27.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/79/display/redirect which resulted in this pull request.