### PR TITLE
Dependency `docmaptools` pinned to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2022-11-28 - see update-dependencies.sh
+# file generated 2022-11-29 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.12.12
 attrs==22.1.0
@@ -17,6 +17,7 @@ Deprecated==1.2.13
 digestparser==0.1.2
 dill==0.3.6
 docker==5.0.3
+docmaptools==0.3.0
 ejpcsvparser==0.2.0
 elifearticle==0.11.0
 elifecleaner==0.25.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/81/display/redirect which resulted in this pull request.