### PR TITLE
Dependency `elifecleaner` pinned to `0.26.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.25.0"
+elifecleaner = "~=0.26.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docker==5.0.3
 docmaptools==0.3.0
 ejpcsvparser==0.2.0
 elifearticle==0.11.0
-elifecleaner==0.25.0
+elifecleaner==0.26.0
 elifecrossref==0.18.0
 elifepubmed==0.5.0
 elifetools==0.28.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/83/display/redirect which resulted in this pull request.