### PR TITLE
Remove version doi

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -9,7 +9,7 @@ import provider.s3lib as s3lib
 from provider.article_structure import ArticleInfo
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-from provider import article_processing, email_provider, lax_provider, utils
+from provider import article_processing, downstream, email_provider, lax_provider, utils
 from provider.ftp import FTP
 from activity.objects import Activity
 
@@ -109,6 +109,9 @@ class activity_PMCDeposit(Activity):
             self.directories.get("ZIP_DIR"), self.zip_file_name
         )
 
+        rules = downstream.load_config(self.settings)
+        workflow_rules = rules.get("PMC")
+
         # repackage the archive zip into PMC zip format
         archive_zip_repackaged = article_processing.repackage_archive_zip_to_pmc_zip(
             input_zip_file_name,
@@ -116,6 +119,7 @@ class activity_PMCDeposit(Activity):
             self.directories.get("TMP_DIR"),
             self.logger,
             alter_xml=True,
+            remove_version_doi=workflow_rules.get("remove_version_doi"),
         )
 
         # check if the article is retracted

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -25,6 +25,7 @@ PMC:
   send_once_only: false
   send_article_types:
     - vor
+  remove_version_doi: true
 
 PublicationEmail:
   activity_name: PublicationEmail
@@ -58,6 +59,7 @@ Cengage:
   send_file_types:
     - xml
     - pdf
+  remove_version_doi: true
   settings_friendly_email_recipients: CENGAGE_EMAIL
   settings_ftp_uri: CENGAGE_FTP_URI
   settings_ftp_username: CENGAGE_FTP_USERNAME
@@ -145,6 +147,7 @@ HEFCE:
   send_once_only: true
   send_article_types:
     - vor
+  remove_version_doi: true
   settings_friendly_email_recipients: HEFCE_EMAIL
   settings_ftp_uri: HEFCE_FTP_URI
   settings_ftp_username: HEFCE_FTP_USERNAME
@@ -208,6 +211,7 @@ WoS:
   send_file_types:
     - xml
     - pdf
+  remove_version_doi: true
   settings_friendly_email_recipients: WOS_EMAIL
   settings_ftp_uri: WOS_FTP_URI
   settings_ftp_username: WOS_FTP_USERNAME


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7854

Remove the version DOI `<article-id>` tag from the XML file when sending to particular downstream recipients in the `FTPArticle` or `PMCDeposit` activity.