### PR TITLE
Retain version number in file names when sending downstream, example …

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -195,7 +195,9 @@ class activity_FTPArticle(Activity):
         details = sending_details(self.settings, workflow)
         if archive_zip_downloaded:
             archive_zip_repackaged = self.repackage_archive_zip_to_pmc_zip(
-                doi_id, details.get("remove_version_doi")
+                doi_id,
+                details.get("remove_version_doi"),
+                details.get("retain_version_number"),
             )
 
         if archive_zip_repackaged:
@@ -266,7 +268,12 @@ class activity_FTPArticle(Activity):
             )
         return False
 
-    def repackage_archive_zip_to_pmc_zip(self, doi_id, remove_version_doi=None):
+    def repackage_archive_zip_to_pmc_zip(
+        self,
+        doi_id,
+        remove_version_doi=None,
+        retain_version_number=False,
+    ):
         "repackage the zip file in the TMP_DIR to a PMC zip format"
         # unzip contents
         zip_input_dir = self.directories.get("TMP_DIR")
@@ -290,6 +297,7 @@ class activity_FTPArticle(Activity):
             zip_input_dir,
             self.logger,
             remove_version_doi=remove_version_doi,
+            retain_version_number=retain_version_number,
         )
 
     def move_or_repackage_pmc_zip(self, doi_id, workflow):
@@ -501,5 +509,6 @@ def sending_details(settings, workflow):
         )
         details["send_file_types"] = workflow_rules.get("send_file_types")
         details["remove_version_doi"] = workflow_rules.get("remove_version_doi")
+        details["retain_version_number"] = workflow_rules.get("retain_version_number")
 
     return details

--- a/settings-example.py
+++ b/settings-example.py
@@ -262,6 +262,13 @@ class exp:
     OASWITCHBOARD_SFTP_CWD = ""
     OASWITCHBOARD_EMAIL = ""
 
+    # Scilit SFTP settings
+    SCILIT_SFTP_URI = ""
+    SCILIT_SFTP_USERNAME = ""
+    SCILIT_SFTP_PASSWORD = ""
+    SCILIT_SFTP_CWD = ""
+    SCILIT_EMAIL = ""
+
     # Logging
     setLevel = "INFO"
 
@@ -592,6 +599,13 @@ class dev:
     OASWITCHBOARD_SFTP_CWD = ""
     OASWITCHBOARD_EMAIL = ""
 
+    # Scilit SFTP settings
+    SCILIT_SFTP_URI = ""
+    SCILIT_SFTP_USERNAME = ""
+    SCILIT_SFTP_PASSWORD = ""
+    SCILIT_SFTP_CWD = ""
+    SCILIT_EMAIL = ""
+
     # Logging
     setLevel = "INFO"
 
@@ -918,6 +932,13 @@ class live:
     OASWITCHBOARD_SFTP_PASSWORD = ""
     OASWITCHBOARD_SFTP_CWD = ""
     OASWITCHBOARD_EMAIL = ""
+
+    # Scilit SFTP settings
+    SCILIT_SFTP_URI = ""
+    SCILIT_SFTP_USERNAME = ""
+    SCILIT_SFTP_PASSWORD = ""
+    SCILIT_SFTP_CWD = ""
+    SCILIT_EMAIL = ""
 
     # Logging
     setLevel = "INFO"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -160,6 +160,12 @@ OASWITCHBOARD_SFTP_PASSWORD = ""
 OASWITCHBOARD_SFTP_CWD = ""
 OASWITCHBOARD_EMAIL = ""
 
+SCILIT_SFTP_URI = "scilit.localhost:22"
+SCILIT_SFTP_USERNAME = ""
+SCILIT_SFTP_PASSWORD = ""
+SCILIT_SFTP_CWD = ""
+SCILIT_EMAIL = ""
+
 git_repo_name = "elife-article-xml-ci"
 git_repo_path = "articles/"
 github_token = "1234567890abcdef"

--- a/tests/activity/test_activity_ftp_article.py
+++ b/tests/activity/test_activity_ftp_article.py
@@ -50,6 +50,7 @@ class TestFTPArticle(unittest.TestCase):
         ("OVID", True, "ovid.localhost", None, 1, True),
         ("Zendy", True, None, "zendy.localhost:22", 1, True),
         ("OASwitchboard", True, None, "oaswitchboard.localhost:22", 1, True),
+        ("Scilit", True, None, "scilit.localhost:22", 1, True),
         ("__unknown__", False, None, None, 0, False),
     )
     @unpack

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -236,3 +236,24 @@ Zendy:
   settings_sftp_username: ZENDY_SFTP_USERNAME
   settings_sftp_password: ZENDY_SFTP_PASSWORD
   settings_sftp_cwd: ZENDY_SFTP_CWD
+
+Scilit:
+  activity_name: FTPArticle
+  s3_bucket_folder: scilit
+  schedule_downstream: true
+  schedule_silent_correction: true
+  schedule_article_types:
+    - poa
+    - vor
+  send_by_protocol: sftp
+  send_once_only: false
+  send_article_types:
+    - poa
+    - vor
+  remove_version_doi: true
+  retain_version_number: true
+  settings_friendly_email_recipients: SCILIT_EMAIL
+  settings_sftp_uri: SCILIT_SFTP_URI
+  settings_sftp_username: SCILIT_SFTP_USERNAME
+  settings_sftp_password: SCILIT_SFTP_PASSWORD
+  settings_sftp_cwd: SCILIT_SFTP_CWD


### PR DESCRIPTION
…of Scilit in settings.

Re issue https://github.com/elifesciences/issues/issues/7956

The option to not remove the version numbers from file names when sending to a downstream recipient, which can be configured in the YAML file.