### PR TITLE
Add Scilit to list of FTPArticle starter workflows

### DIFF
--- a/starter/starter_FTPArticle.py
+++ b/starter/starter_FTPArticle.py
@@ -18,6 +18,7 @@ WORKFLOW_NAMES = [
     "OVID",
     "Zendy",
     "OASwitchboard",
+    "Scilit",
 ]
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7956, the workflow name must be added in order to use the starter command.