### PR TITLE
Clear <rel:program> Crossref tag, do not remove it

### DIFF
--- a/activity/activity_DepositCrossrefMinimal.py
+++ b/activity/activity_DepositCrossrefMinimal.py
@@ -100,8 +100,8 @@ class activity_DepositCrossrefMinimal(Activity):
         self.statuses["generate"] = True
 
         for c_xml in crossref_object_list:
-            # remove relations program tag
-            crossref.remove_rel_program_tag(c_xml)
+            # remove child tags tags from the relations program tag
+            crossref.clear_rel_program_tag(c_xml)
 
             # also change the batch id
             c_xml.batch_id = c_xml.batch_id.replace(

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -219,13 +219,15 @@ def build_crossref_xml(
     return object_list
 
 
-def remove_rel_program_tag(c_xml):
-    "remove rel:program tag from CrossrefXML object XML root"
+def clear_rel_program_tag(c_xml):
+    "remove child tags in the rel:program tag from CrossrefXML object XML root"
     namespaces = {"rel": "http://www.crossref.org/relations.xsd"}
     journal_article_tag = c_xml.root.find("./body/journal/journal_article", namespaces)
     rel_program_tag = journal_article_tag.find("rel:program")
     if rel_program_tag:
-        journal_article_tag.remove(rel_program_tag)
+        child_tags = rel_program_tag.findall("*")
+        for sub_tag in child_tags:
+            rel_program_tag.remove(sub_tag)
 
 
 def crossref_xml_to_disk(c_xml, output_dir, pretty=False, indent=""):

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -269,14 +269,14 @@ class TestBuildCrossrefXml(unittest.TestCase):
         self.assertEqual(len(bad_xml_files), 1)
 
 
-class TestRemoveRelProgramTag(unittest.TestCase):
+class TestClearRelProgramTag(unittest.TestCase):
     def setUp(self):
         self.directory = TempDirectory()
 
     def tearDown(self):
         TempDirectory.cleanup_all()
 
-    def test_remove_rel_program_tag(self):
+    def test_clear_rel_program_tag(self):
         xml_file = "tests/test_data/crossref_minimal/outbox/elife-1234567890-v99.xml"
         articles = crossref.parse_article_xml([xml_file], self.directory.path)
         article_object_map = OrderedDict([(xml_file, articles[0])])
@@ -287,10 +287,13 @@ class TestRemoveRelProgramTag(unittest.TestCase):
         crossref_xml_object = object_list[0]
         # check rel:program is in XML prior to the function invocation
         self.assertTrue("<rel:program" in crossref_xml_object.output_xml())
+        self.assertTrue("<rel:related_item>" in crossref_xml_object.output_xml())
         # invoke function
-        crossref.remove_rel_program_tag(crossref_xml_object)
-        # assert rel:program is now gone
-        self.assertTrue("<rel:program" not in crossref_xml_object.output_xml())
+        crossref.clear_rel_program_tag(crossref_xml_object)
+        # assert rel:program tag is empty
+        self.assertTrue("<rel:program/>" in crossref_xml_object.output_xml())
+        # assert rel:program child tag is not present
+        self.assertTrue("<rel:related_item>" not in crossref_xml_object.output_xml())
 
 
 class TestCrossrefXmlToDisk(unittest.TestCase):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7550
Fix PR https://github.com/elifesciences/elife-bot/pull/1617

After testing, the Crossref deposit must include an empty `<rel:program/>` tag in order to remove previously deposited relationships; if the tag is omitted it results in an error when processed by Crossref on articles with existing relationship data.

Renamed `remove_rel_program_tag()` to `clear_rel_program_tag()` to more accurately represent its effect.