### PR TITLE
Add ScheduleCrossrefMinimal activity, to workflow.

### DIFF
--- a/activity/activity_ScheduleCrossrefMinimal.py
+++ b/activity/activity_ScheduleCrossrefMinimal.py
@@ -1,0 +1,139 @@
+import json
+from provider import lax_provider, outbox_provider
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+"""
+ScheduleCrossrefMinimal.py activity
+"""
+
+
+class activity_ScheduleCrossrefMinimal(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_ScheduleCrossrefMinimal, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "ScheduleCrossrefMinimal"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Queue the article XML for depositing minimal data to Crossref."
+        )
+        self.logger = logger
+
+        # For copying to crossref outbox from here for now
+        self.crossref_outbox_folder = outbox_provider.outbox_folder(
+            self.s3_bucket_folder("DepositCrossrefMinimal")
+        )
+
+    def do_activity(self, data=None):
+
+        """
+        Do the work
+        """
+        if self.logger:
+            self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        expanded_bucket_name = (
+            self.settings.publishing_buckets_prefix + self.settings.expanded_bucket
+        )
+        outbox_bucket_name = self.settings.poa_packaging_bucket
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        version = session.get_value("version")
+        article_id = session.get_value("article_id")
+        expanded_folder_name = session.get_value("expanded_folder")
+
+        # if is a silent-correction workflow, only deposit for the most recent article version
+        run_type = session.get_value("run_type")
+        if run_type == "silent-correction":
+            highest_version = lax_provider.article_highest_version(
+                article_id, self.settings
+            )
+            if str(version) != str(highest_version):
+                self.logger.info(
+                    "ScheduleCrossrefMinimal will not deposit article %s"
+                    + " ingested by silent-correction, its version of %s does not equal the"
+                    + " highest version which is %s",
+                    (article_id, version, highest_version),
+                )
+                return True
+
+        self.emit_monitor_event(
+            self.settings,
+            article_id,
+            version,
+            run,
+            "Schedule Crossref Minimal",
+            "start",
+            "Starting scheduling of crossref minimal deposit for " + article_id,
+        )
+
+        try:
+            xml_file_name = lax_provider.get_xml_file_name(
+                self.settings, expanded_folder_name, expanded_bucket_name
+            )
+
+            xml_key_name = expanded_folder_name + "/" + xml_file_name
+
+            new_key_name = self.crossref_outbox_folder + xml_file_name
+
+            self.copy_article_xml_to_outbox(
+                dest_bucket_name=outbox_bucket_name,
+                new_key_name=new_key_name,
+                source_bucket_name=expanded_bucket_name,
+                old_key_name=xml_key_name,
+            )
+
+            self.emit_monitor_event(
+                self.settings,
+                article_id,
+                version,
+                run,
+                "Schedule Crossref Minimal",
+                "end",
+                "Finished scheduling of crossref minimal deposit "
+                + article_id
+                + " for version "
+                + version
+                + " run "
+                + str(run),
+            )
+
+        except Exception as exception:
+            self.logger.exception("Exception when scheduling crossref minimal")
+            self.emit_monitor_event(
+                self.settings,
+                article_id,
+                version,
+                run,
+                "Schedule Crossref Minimal",
+                "error",
+                "Error scheduling crossref minimal "
+                + article_id
+                + " message:"
+                + str(exception),
+            )
+            return False
+
+        return True
+
+    def copy_article_xml_to_outbox(
+        self, dest_bucket_name, new_key_name, source_bucket_name, old_key_name
+    ):
+        "copy the XML file to an S3 outbox folder, for now"
+        storage = storage_context(self.settings)
+        storage_provider = self.settings.storage_provider + "://"
+        orig_resource = storage_provider + source_bucket_name + "/" + old_key_name
+        dest_resource = storage_provider + dest_bucket_name + "/" + new_key_name
+        self.logger.info(
+            "%s Copying %s to %s " % (self.name, orig_resource, dest_resource)
+        )
+        storage.copy_resource(orig_resource, dest_resource)

--- a/register.py
+++ b/register.py
@@ -99,6 +99,7 @@ def start(settings):
     activity_names.append("PubRouterDeposit")
     activity_names.append("PMCDeposit")
     activity_names.append("ScheduleCrossref")
+    activity_names.append("ScheduleCrossrefMinimal")
     activity_names.append("ScheduleCrossrefPeerReview")
     activity_names.append("ScheduleCrossrefPendingPublication")
     activity_names.append("ScheduleDownstream")

--- a/tests/activity/test_activity_schedule_crossref_minimal.py
+++ b/tests/activity/test_activity_schedule_crossref_minimal.py
@@ -1,0 +1,69 @@
+import unittest
+import copy
+from ddt import ddt, data, unpack
+from mock import patch
+import activity.activity_ScheduleCrossrefMinimal as activity_module
+from activity.activity_ScheduleCrossrefMinimal import activity_ScheduleCrossrefMinimal
+from provider import lax_provider
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import settings_mock
+import tests.activity.test_activity_data as testdata
+
+
+@ddt
+class TestScheduleCrossrefMinimal(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_ScheduleCrossrefMinimal(
+            settings_mock, fake_logger, None, None, None
+        )
+
+    def tearDown(self):
+        pass
+
+    @patch("provider.lax_provider.get_xml_file_name")
+    @patch("activity.activity_ScheduleCrossrefMinimal.get_session")
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_ScheduleCrossrefMinimal, "emit_monitor_event")
+    @patch.object(activity_ScheduleCrossrefMinimal, "set_monitor_property")
+    @data(
+        ("elife-00353-v1.xml", True),
+        (None, False),
+    )
+    @unpack
+    def test_do_activity(
+        self,
+        xml_filename,
+        expected_result,
+        mock_set_monitor_property,
+        mock_emit_monitor_event,
+        fake_storage_context,
+        fake_session_mock,
+        fake_get_xml_file_name,
+    ):
+        mock_emit_monitor_event.return_value = True
+        mock_set_monitor_property.return_value = True
+        fake_session_mock.return_value = FakeSession(testdata.session_example)
+        fake_storage_context.return_value = FakeStorageContext()
+        fake_get_xml_file_name.return_value = None
+        if xml_filename:
+            fake_get_xml_file_name.return_value = xml_filename
+        result = self.activity.do_activity(testdata.ExpandArticle_data)
+        self.assertEqual(result, expected_result)
+
+    @patch.object(lax_provider, "article_highest_version")
+    @patch("activity.activity_ScheduleCrossrefMinimal.get_session")
+    def test_do_activity_silent_correction(
+        self, fake_session_mock, fake_highest_version
+    ):
+        expected_result = True
+        session_dict = copy.copy(testdata.session_example)
+        session_dict["run_type"] = "silent-correction"
+        fake_session_mock.return_value = FakeSession(session_dict)
+        fake_highest_version.return_value = 2
+        result = self.activity.do_activity(testdata.ExpandArticle_data)
+        self.assertEqual(result, expected_result)

--- a/workflow/workflow_ProcessArticleZip.py
+++ b/workflow/workflow_ProcessArticleZip.py
@@ -37,6 +37,7 @@ class workflow_ProcessArticleZip(Workflow):
                 define_workflow_step("PingWorker", data),
                 define_workflow_step_short("VerifyLaxResponse", data),
                 define_workflow_step("ScheduleCrossref", data),
+                define_workflow_step("ScheduleCrossrefMinimal", data),
                 define_workflow_step("ScheduleCrossrefPeerReview", data),
                 define_workflow_step("IngestDigestToEndpoint", data),
                 define_workflow_step("ReadyToPublish", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7550

The test of `DepositCrossrefMinimal` was successful, now schedule each article to be deposited when it is ingested.