### PR TITLE
Crossref version DOI deposit and isSameAs tag.

### DIFF
--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -72,6 +72,38 @@ class TestDepositCrossref(unittest.TestCase):
             ],
         },
         {
+            "comment": "Article 1234567890",
+            "article_xml_filenames": ["elife-1234567890-v99.xml"],
+            "post_status_code": 200,
+            "expected_result": True,
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_outbox_status": True,
+            "expected_email_status": True,
+            "expected_activity_status": True,
+            "expected_file_count": 2,
+            "expected_crossref_xml_contains": [
+                "<doi>10.7554/eLife.1234567890</doi>",
+                (
+                    '<rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.1101/2021.11.09.467796</rel:intra_work_relation>'
+                ),
+                (
+                    '<rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'
+                ),
+            ],
+            "expected_email_count": 1,
+            "expected_email_subject": "DepositCrossref Success! files: 1,",
+            "expected_email_from": "From: sender@example.org",
+            "expected_email_body_contains": [
+                r"DepositCrossref status:\n\nSuccess!\n\nactivity_status: True",
+                r"Published files generated crossref XML: \nelife-1234567890-v99.xml",
+                "elife-crossref-1234567890-",
+                "elife-crossref-version-1234567890-",
+                "HTTP status: 200",
+            ],
+        },
+        {
             "comment": "Multiple files to deposit",
             "article_xml_filenames": [
                 "elife-18753-v1.xml",
@@ -169,7 +201,7 @@ class TestDepositCrossref(unittest.TestCase):
         if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
             # Open the first crossref XML and check some of its contents
             crossref_xml_filename_path = os.path.join(
-                self.tmp_dir(), os.listdir(self.tmp_dir())[0]
+                self.tmp_dir(), sorted(os.listdir(self.tmp_dir()))[0]
             )
             with open(crossref_xml_filename_path, "rb") as open_file:
                 crossref_xml = open_file.read().decode("utf8")

--- a/tests/test_data/crossref/outbox/elife-1234567890-v99.xml
+++ b/tests/test_data/crossref/outbox/elife-1234567890-v99.xml
@@ -1,0 +1,2761 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.2 20190208//EN" "JATS-archivearticle1-mathml3.dtd">
+<!-- Use JATS 1.2 -->
+<!-- All XML would be on one line (with the exception of code snippets with new lines). 
+     Only pretty-printed here for readability -->
+<article article-type="research-article" dtd-version="1.2" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="nlm-ta">elife</journal-id>
+            <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            <journal-title-group>
+                <journal-title>eLife</journal-title>
+            </journal-title-group>
+            <issn publication-format="electronic" pub-type="epub">2050-084X</issn>
+            <publisher>
+                <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">1234567890</article-id>
+            <!-- Concept DOI -->
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890</article-id>
+            <!-- Specific version DOI -->
+            <article-id pub-id-type="doi" specific-use="version">10.7554/eLife.1234567890.4</article-id>
+            <article-categories>
+                <subj-group subj-group-type="display-channel">
+                    <subject>Research Article</subject>
+                </subj-group>
+                <subj-group subj-group-type="heading">
+                    <subject>Biochemistry and Chemical Biology</subject>
+                </subj-group>
+                <subj-group subj-group-type="heading">
+                    <subject>Chromosomes and Gene Expression</subject>
+                </subj-group>
+            </article-categories>
+            <title-group>
+                <article-title>eLife kitchen sink 3.0</article-title>
+            </title-group>
+            <contrib-group>
+                <!-- Remove id attribute from authors -->
+                <contrib contrib-type="author" equal-contrib="yes" corresp="yes">
+                    <name>
+                        <surname>Atherden</surname>
+                        <given-names>Frederick Peter</given-names>
+                        <suffix>III</suffix>
+                    </name>
+                    <contrib-id authenticated="true"
+                        contrib-id-type="orcid">https://orcid.org/0000-0002-6048-1470</contrib-id>
+                    <email>f.atherden@elifesciences.org</email>
+                    <xref ref-type="aff" rid="aff1">1</xref>
+                    <xref ref-type="fn" rid="equal-contrib1">†</xref>
+                    <xref ref-type="fn" rid="fn1">‡</xref>
+                    <!-- Without content, these do not show up well in PMC. Do we want to add indicators for these as well? -->
+                    <xref ref-type="fn" rid="con1"/>
+                    <xref ref-type="fn" rid="conf1"/>
+                </contrib>
+                <contrib contrib-type="author" equal-contrib="yes" corresp="yes">
+                    <name>
+                        <surname>Harrison</surname>
+                        <given-names>Melissa</given-names>
+                    </name>
+                    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0002-4932-938X</contrib-id>
+                    <email>...@elifesciences.org</email>
+                    <xref ref-type="aff" rid="aff1">1</xref>
+                    <xref ref-type="fn" rid="equal-contrib1">†</xref>
+                    <xref ref-type="fn" rid="fn1">‡</xref>
+                    <xref ref-type="fn" rid="con2"/>
+                    <xref ref-type="fn" rid="conf2"/>
+                </contrib>
+                <contrib contrib-type="author" corresp="yes">
+                    <collab>Example Group author
+                        <contrib-group content-type="group-members">
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>Gilbert</surname>
+                                    <given-names>James</given-names>
+                                </name>
+                                <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-1002-4932-938X</contrib-id>
+                                <aff>
+                                    <institution>eLife</institution>
+                                    <addr-line>
+                                        <named-content content-type="city">Cambridge</named-content>
+                                    </addr-line>
+                                    <country>United Kingdom</country>
+                                </aff>
+                            </contrib>
+                        </contrib-group>
+                    </collab>
+                    <!-- group author roles added at the top level -->
+                    <xref ref-type="fn" rid="con3"/>
+                    <xref ref-type="fn" rid="conf2"/>
+                    <email>...@elifesciences.org</email>
+                </contrib>
+                <contrib contrib-type="author" equal-contrib="yes" deceased="yes">
+                    <name>
+                        <surname>Claus</surname>
+                        <given-names>Santa</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="aff1">1</xref>
+                    <xref ref-type="fn" rid="equal-contrib2">§</xref>
+                    <xref ref-type="fn" rid="con4"/>
+                    <xref ref-type="fn" rid="conf2"/>
+                    <xref ref-type="fn" rid="fn2"/>
+                </contrib>
+                <contrib contrib-type="author" equal-contrib="yes">
+                    <name>
+                        <surname>West</surname>
+                        <given-names>Cornel</given-names>
+                        <suffix>Jnr</suffix>
+                    </name>
+                    <xref ref-type="aff" rid="aff2">2</xref>
+                    <xref ref-type="fn" rid="equal-contrib2">§</xref>
+                    <xref ref-type="fn" rid="con5"/>
+                    <xref ref-type="fn" rid="conf2"/>
+                </contrib>
+                <on-behalf-of>on behalf of whoever finds this interesting</on-behalf-of>
+                <aff id="aff1">
+                    <label>1</label>
+                    <institution>The department of production, eLife Sciences</institution>
+                    <addr-line><named-content content-type="city">Cambridge</named-content></addr-line>
+                    <country>United Kingdom</country>
+                </aff>
+                <aff id="aff2">
+                    <label>2</label>
+                    <!-- ROR id included institution-id 
+                        Not all instutitions may have one so its presence is optional 
+                    -->
+                    <institution-wrap>
+                        <institution-id institution-id-type="ror">https://ror.org/046rm7j60</institution-id>
+                        <institution>JATS4R</institution>
+                    </institution-wrap>
+                    <addr-line><named-content content-type="city">Bethesda</named-content></addr-line>
+                    <country country="US">United States</country>
+                </aff>
+            </contrib-group>
+            <contrib-group content-type="section">
+                <contrib contrib-type="senior_editor">
+                    <name>
+                        <surname>Eisen</surname>
+                        <given-names>Mike</given-names>
+                    </name>
+                    <role>Senior Editor</role>
+                    <aff>
+                        <institution-wrap>
+                            <institution-id institution-id-type="ror">https://ror.org/01an7q238</institution-id>
+                            <institution>University of California, Berkeley</institution>
+                        </institution-wrap>
+                        <addr-line><named-content content-type="city">Berkeley</named-content></addr-line>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+                <contrib contrib-type="editor">
+                    <name>
+                        <surname>Helaine</surname>
+                        <given-names>Sophie</given-names>
+                    </name>
+                    <role>Reviewing Editor</role>
+                    <aff>
+                        <institution>Imperial College London</institution>
+                        <country country="GB">United Kingdom</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+            <author-notes>
+                <!-- Footnote labels follow this sequence:
+                        †, ‡, §, ¶, ††, ‡‡, §§, ¶¶ etc. -->
+                <fn fn-type="con" id="equal-contrib1"><label>†</label><p>These authors contributed equally to this work</p></fn>
+                <fn fn-type="con" id="equal-contrib2"><label>§</label><p>These authors also contributed equally to this work</p></fn>
+                <!-- General use footnotes used for vanity notes etc. -->
+                <fn fn-type="other" id="fn1"><label>‡</label><p>Author order was decided on a coin toss.</p></fn>
+                <fn fn-type="fn" id="fn2"><label>&#035;</label><p>Deceased (not really!!)</p>
+                </fn>
+            </author-notes>
+            <pub-date publication-format="electronic" date-type="publication">
+                <day>22</day>
+                <month>10</month>
+                <year>2000</year>
+            </pub-date>
+            <!-- volume needs to match the RP. This will mean it should be based on the pub date of the first reviewed preprint version -->
+            <volume>12</volume>
+            <!-- elocation-id is in the format RP{article number} for PRC content
+                                           and e{article number} for non-PRC content -->
+            <elocation-id>RP1234567890</elocation-id>
+            <history>
+                <date date-type="sent-for-review" iso-8601-date="2023-03-20">
+                    <day>20</day>
+                    <month>03</month>
+                    <year>2023</year>
+                </date>           
+            </history>
+            <pub-history>
+                <event>
+                    <event-desc>This manuscript was published as a preprint.</event-desc>
+                    <date date-type="preprint" iso-8601-date="2023-02-15">
+                        <day>15</day>
+                        <month>02</month>
+                        <year>2023</year>
+                    </date>    
+                    <!-- Should this be content-type="preprint" or content-type="pre-print"? Examples and text in JATS4R conflict
+                            https://jats4r.org/article-publication-and-history-dates/ -->
+                    <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2021.11.09.467796"/>   
+                </event>
+                <event>
+                    <!-- We are using a new date-type and content-type here, 'reviewed-preprint', as the output of the PRC process is distinct from a normal preprint. There will be discussions necessary
+                    with groups like JATS4R to determine a recommendation to standardise the catpure of the PRC outputs once the process has been finalised and uptake becomes more widespread. -->
+                    <event-desc>This manuscript was published as a reviewed preprint.</event-desc>
+                    <date date-type="reviewed-preprint" iso-8601-date="2023-04-15">
+                        <day>15</day>
+                        <month>04</month>
+                        <year>2023</year>
+                    </date>
+                    <self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.1234567890.1"/>   
+                </event>
+                <!-- This one can occurr numerous times -->
+                <event>
+                    <event-desc>The reviewed preprint was revised.</event-desc>
+                    <date date-type="reviewed-preprint" iso-8601-date="2023-09-10">
+                        <day>10</day>
+                        <month>09</month>
+                        <year>2023</year>
+                    </date>
+                    <self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.1234567890.2"/>   
+                </event>
+                <event>
+                    <event-desc>The reviewed preprint was revised.</event-desc>
+                    <date date-type="reviewed-preprint" iso-8601-date="2023-11-10">
+                        <day>10</day>
+                        <month>11</month>
+                        <year>2023</year>
+                    </date>
+                    <self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.1234567890.3"/>   
+                </event>
+            </pub-history>
+            <permissions>
+                <copyright-statement>© 2023, Atherden et al</copyright-statement>
+                <copyright-year>2023</copyright-year>
+                <copyright-holder>Atherden et al</copyright-holder>
+                <ali:free_to_read/>
+                <license xlink:href="http://creativecommons.org/licenses/by/4.0/">
+                    <ali:license_ref>http://creativecommons.org/licenses/by/4.0/</ali:license_ref>
+                    <license-p>This article is distributed under the terms of the <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License</ext-link>, which permits unrestricted use and redistribution provided that the original author and source are credited.</license-p>
+                </license>
+            </permissions>
+            <self-uri content-type="pdf" xlink:href="elife-1234567890.pdf"/>
+            <!-- self-uri for (optional) figures pdf too -->
+            <self-uri content-type="pdf" xlink:href="elife-1234567890-figures.pdf"/>
+            <related-article ext-link-type="doi" id="ra1" related-article-type="article-reference" xlink:href="10.7554/eLife.16381"/>
+            <related-article ext-link-type="doi" id="ra2" related-article-type="article-reference" xlink:href="10.7554/eLife.43788"/>
+            <abstract>
+                <!-- Example is a structured abstract; unstructured abstracts consist of a single paragraph of text -->
+                <sec id="abs1">
+                    <title>Background:</title>
+                    <p>Since 2015, the World <italic>Health</italic> Organisation (WHO) <sup>a</sup><sub>b</sub>... <inline-formula>
+                            <mml:math id="infm1">
+                                <mml:mi>P</mml:mi>
+                                <mml:mi>P</mml:mi>
+                                <mml:mi>V</mml:mi>
+                                <mml:mi/>
+                                <mml:mo>=</mml:mo>
+                                <mml:mi/>
+                                <mml:mfrac>
+                                    <mml:mrow>
+                                        <mml:mi>T</mml:mi>
+                                        <mml:mi>P</mml:mi>
+                                    </mml:mrow>
+                                    <mml:mrow>
+                                        <mml:mi>T</mml:mi>
+                                        <mml:mi>P</mml:mi>
+                                        <mml:mi/>
+                                        <mml:mo>+</mml:mo>
+                                        <mml:mi/>
+                                        <mml:mi>F</mml:mi>
+                                        <mml:mi>P</mml:mi>
+                                    </mml:mrow>
+                                </mml:mfrac>
+                            </mml:math>
+                        </inline-formula></p>
+                </sec>
+                <sec id="abs2">
+                    <title>Methods:</title>
+                    <p>We <bold>conducted</bold> a stepped-wedge ...</p>
+                </sec>
+                <sec id="abs3">
+                    <title>Results:</title>
+                    <p>A total <ext-link ext-link-type="uri" xlink:href="https://elifesciences.org/">sample</ext-link> of 3019 participants ...</p>
+                </sec>
+                <sec id="abs4">
+                    <title>Conclusions:</title>
+                    <p>Our findings do not provide evidence ...</p>
+                </sec>
+                <sec id="abs5">
+                    <title>Funding:</title>
+                    <p>Funded by the Dutch Postcode Lottery in the Netherlands ...</p>
+                </sec>
+                <sec id="abs6">
+                    <title>Clinical trial number:</title>
+                    <p><related-object document-id="NCT02909218" 
+                            document-id-type="clinical-trial-number" 
+                            id="RO1" 
+                            source-id="ClinicalTrials.gov" 
+                            source-id-type="registry-name" 
+                            source-type="clinical-trials-registry" xlink:href="https://clinicaltrials.gov/show/NCT02909218"
+                            >NCT02909218</related-object> and 
+                        <related-object document-id="ChiCTR-IOR-14005319" 
+                            document-id-type="clinical-trial-number" 
+                            id="RO2" 
+                            source-id="ChiCTR" 
+                            source-id-type="registry-name" 
+                            source-type="clinical-trials-registry"
+                            xlink:href="http://www.chictr.org.cn/showprojen.aspx?proj=9639">ChiCTR-IOR-14005319</related-object>.</p>
+                </sec>
+            </abstract>
+            <abstract abstract-type="plain-language-summary">
+                <title>eLife digest</title>
+                <p>This is a digest.</p>
+                <p>It will consist of multiple paragraphs.</p>
+                <p>No links, citations etc. will appear here.</p>
+            </abstract>
+            <kwd-group kwd-group-type="author-keywords">
+                <kwd>flight</kwd>
+                <kwd>swimming</kwd>
+                <kwd>locomotion</kwd>
+                <kwd>muscle efficiency</kwd>
+                <kwd>strouhal number</kwd>
+                <kwd>wing</kwd>
+            </kwd-group>
+            <kwd-group kwd-group-type="research-organism">
+                <title>Research organism</title>
+                <kwd>Human</kwd>
+                <kwd>Mouse</kwd>
+            </kwd-group>
+            <kwd-group kwd-group-type="osf-badges" vocab-identifier="https://www.cos.io/initiatives/badges">
+                <!-- Controlled vocabulary for badge values: Open Data, Open Materials, Prereigstered -->
+                <title>Badges</title>
+                <kwd>Open Data</kwd>
+                <kwd>Open Materials</kwd>
+                <kwd>Prereigstered</kwd>
+            </kwd-group>
+            <!-- Funding is no longer linked to from the authors (using xref), since this information is not displayed in the pop-up on the website anyway
+                 If a funding source is not in the open funder registry then there is no institution-id
+                 If the funder is in the open funder registry then there is an institution-id -->
+            <funding-group>
+                <award-group id="fund1">
+                    <funding-source>
+                        <institution-wrap>
+                            <!-- vocab and vocab-identifier attribute added. institution-id-type changed to doi -->
+                            <institution-id institution-id-type="doi" vocab="open-funder-registry" vocab-identifier="10.13039/open-funder-registry">10.13039/100000002</institution-id>
+                            <institution>National Institutes of Health</institution>
+                        </institution-wrap>
+                    </funding-source>
+                    <award-id>DA037327</award-id>
+                    <!-- No longer any need to identify which authors were benefited by which funding -->
+                    <principal-award-recipient><name><surname>Todo</surname><given-names>Todo</given-names></name></principal-award-recipient>
+                </award-group>
+                <award-group id="fund2">
+                    <funding-source>
+                        <institution-wrap>
+                            <institution>eLife Sciences</institution>
+                        </institution-wrap>
+                    </funding-source>
+                    <award-id>00000000001</award-id>
+                    <principal-award-recipient><name><surname>Todo</surname><given-names>Todo</given-names></name></principal-award-recipient>
+                </award-group>
+                <funding-statement>The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication.</funding-statement>
+            </funding-group>
+            <custom-meta-group>
+                <custom-meta specific-use="meta-only">
+                    <meta-name>Author impact statement</meta-name>
+                    <meta-value>This is an impact statement <italic>i</italic><sup>a</sup><sub>b</sub>.</meta-value>
+                </custom-meta>
+                <!-- Add flag for publishing route/model that the article followed - currently this will be PRC if this flag exists; this flag won't exist for non-PRC content. Could be expanded later -->
+                <custom-meta specific-use="meta-only">
+                    <meta-name>publishing-route</meta-name>
+                    <meta-value>prc</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </article-meta>
+    </front>
+    <body>
+        <sec id="s1" sec-type="intro">
+            <title>Introduction</title>
+            <p>Lorem <bold>ipsum</bold> <italic>dolor</italic> <sup>sit</sup> <sub>amet</sub>, <sc>consectetur</sc> <monospace>adipiscing</monospace> elit. <underline>In</underline> maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc. Mauris quis iaculis diam (see Appendix 1) Etiam nec blandit ipsum, venenatis ornare libero. Aliquam sed tincidunt nisi. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nam vehicula varius placerat. Maecenas sed dictum eros, eu consequat eros (<xref ref-type="bibr" rid="bib1">Cantaut-Belarif et al., 2020</xref>) nulla a sodales tellus (see Results). Nunc id eros quis neque vehicula accumsan. Fusce a dolor non ligula euismod semper. Aoin tempor dolor nec sapien ornare, sed volutpat libero cursus. Duis at tempus lacus. Vestibulum dapibus sem sit amet sapien pulvinar, nec vestibulum est pulvinar (<xref ref-type="bibr" rid="bib2">Feyerabend, 2010</xref>; <xref ref-type="fig" rid="fig1">Figure 1</xref>; <xref ref-type="fig" rid="fig1s1">Figure 1&#x2014;figure supplement 1</xref>; <xref ref-type="video" rid="fig1video1">Figure 2&#x2014;video 1</xref>).</p>
+            <fig-group>
+                <fig id="fig1" position="float">
+                    <label>Figure 1.</label>
+                    <caption>
+                        <title>Figure title (<xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref>; <xref ref-type="bibr" rid="bib18">Himmelstein et al., 2016</xref>).</title>
+                        <p>(<bold>A, B</bold>) Dependence of CME on Hip1R. (<bold>A</bold>) Simulation varying number of Hip1R. (<bold>B</bold>) Hip1R knockdown inhibits CME (transferrin uptake) in HeLa cells... (<bold>C, D</bold>) Capping actin filaments inhibits CME. (<bold>C</bold>) Simulation. (<bold>D</bold>) Slower assembly and disassembly of endogenous dynamin2-GFP at sites of endocytosis in SK-MEL-2 cells treated with different concentrations of Cytochalasin D. (<bold>E, F</bold>) Endocytic actin filaments bend at sites of mammalian endocytosis, tested by cryo-electron tomography of intact mammalian cells. (<bold>G, H</bold>) Mammalian CME is sensitive to Arp2/3 complex activity, revealed by treating SK-MEL-2 cells expressing endogenous clathrin and dynamin2 fluorescent tags with the Arp2/3 complex inhibitor CK-666 (<xref ref-type="bibr" rid="bib2">Feyerabend, 2010</xref>; <xref ref-type="supplementary-material" rid="fig1sdata1">Figure 1&#x2014;source data 1</xref>; <xref ref-type="supplementary-material" rid="fig1sdata2">Figure 1&#x2014;source data 2</xref>; <xref ref-type="supplementary-material" rid="fig1scode1">Figure 1&#x2014;source code 1</xref>).</p>
+                        <p>We use the following model (<xref ref-type="disp-formula" rid="equ1">Equation 1</xref>) to represent the dynamics of a population of cells in which the transcription factors NANOG and GATA6 mutually repress each other through extracellular growth factor signaling:
+                            <disp-formula id="equ1">
+                                <label>(1)</label>
+                                    <mml:math id="m1">
+                                        <mml:mstyle displaystyle="true" scriptlevel="0">
+                                            <mml:mrow>
+                                                <mml:mi>d</mml:mi>
+                                                <mml:mtext> </mml:mtext>
+                                                <mml:mo>=</mml:mo>
+                                                <mml:mtext> </mml:mtext>
+                                                <mml:msqrt>
+                                                    <mml:msup>
+                                                        <mml:mrow>
+                                                            <mml:mo>(</mml:mo>
+                                                            <mml:mfrac>
+                                                                <mml:mrow>
+                                                                    <mml:mi>P</mml:mi>
+                                                                    <mml:mi>r</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>d</mml:mi>
+                                                                    <mml:mi>i</mml:mi>
+                                                                    <mml:mi>c</mml:mi>
+                                                                    <mml:mi>t</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>d</mml:mi>
+                                                                    <mml:mtext> </mml:mtext>
+                                                                    <mml:mi>c</mml:mi>
+                                                                    <mml:mi>o</mml:mi>
+                                                                    <mml:mi>u</mml:mi>
+                                                                    <mml:mi>n</mml:mi>
+                                                                    <mml:msub>
+                                                                        <mml:mi>t</mml:mi>
+                                                                        <mml:mrow>
+                                                                            <mml:mi mathvariant="bold-italic">i</mml:mi>
+                                                                            <mml:mtext> </mml:mtext>
+                                                                        </mml:mrow>
+                                                                    </mml:msub>
+                                                                    <mml:mo>−</mml:mo>
+                                                                    <mml:mtext> </mml:mtext>
+                                                                    <mml:mi>O</mml:mi>
+                                                                    <mml:mi>b</mml:mi>
+                                                                    <mml:mi>s</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>r</mml:mi>
+                                                                    <mml:mi>v</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>d</mml:mi>
+                                                                    <mml:mtext> </mml:mtext>
+                                                                    <mml:mi>c</mml:mi>
+                                                                    <mml:mi>o</mml:mi>
+                                                                    <mml:mi>u</mml:mi>
+                                                                    <mml:mi>n</mml:mi>
+                                                                    <mml:msub>
+                                                                        <mml:mi>t</mml:mi>
+                                                                        <mml:mrow>
+                                                                            <mml:mi>i</mml:mi>
+                                                                        </mml:mrow>
+                                                                    </mml:msub>
+                                                                </mml:mrow>
+                                                                <mml:mrow>
+                                                                    <mml:mi>O</mml:mi>
+                                                                    <mml:mi>b</mml:mi>
+                                                                    <mml:mi>s</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>r</mml:mi>
+                                                                    <mml:mi>v</mml:mi>
+                                                                    <mml:mi>e</mml:mi>
+                                                                    <mml:mi>d</mml:mi>
+                                                                    <mml:mtext> </mml:mtext>
+                                                                    <mml:mi>c</mml:mi>
+                                                                    <mml:mi>o</mml:mi>
+                                                                    <mml:mi>u</mml:mi>
+                                                                    <mml:mi>n</mml:mi>
+                                                                    <mml:msub>
+                                                                        <mml:mi>t</mml:mi>
+                                                                        <mml:mrow>
+                                                                            <mml:mi>i</mml:mi>
+                                                                        </mml:mrow>
+                                                                    </mml:msub>
+                                                                </mml:mrow>
+                                                            </mml:mfrac>
+                                                            <mml:mo>)</mml:mo>
+                                                        </mml:mrow>
+                                                        <mml:mrow>
+                                                            <mml:mn>2</mml:mn>
+                                                        </mml:mrow>
+                                                    </mml:msup>
+                                                </mml:msqrt>
+                                            </mml:mrow>
+                                        </mml:mstyle>
+                                    </mml:math>
+                                </disp-formula></p>
+                        <!-- Pending a suspected change in JATS 1.X or 2.0 supplementary-material could be captured as a child of fig, or could be captured in the addition files section in <back> and linked to with an <xref> which is a direct child of the object, rather than inside a p in the caption. For now kept as is, because this is not permitted in JATS. -->
+                        <p><supplementary-material id="fig1sdata1">
+                            <label>Figure 1&#x2014;source data 1.</label>
+                            <caption>
+                                <title>Source data title.</title>
+                                <p>Source data caption.</p>
+                            </caption>
+                            <media mime-subtype="docx" mimetype="application" xlink:href="elife-1234567890-fig1-data1.docx"/>
+                        </supplementary-material></p>
+                        <p>
+                            <supplementary-material id="fig1sdata2">
+                                <label>Figure 1&#x2014;source data 2.</label>
+                                <caption>
+                                    <title>Source data title (<xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref>).</title>
+                                    <p>Source data caption.</p>
+                                </caption>
+                                <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-fig1-data2.zip"/>
+                            </supplementary-material></p>
+                        <p>
+                            <supplementary-material id="fig1scode1">
+                                <label>Figure 1&#x2014;source code 1.</label>
+                                <caption>
+                                    <title>Source code title.</title>
+                                    <p>Source code caption <xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref>.</p>
+                                </caption>
+                                <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-fig1-code1.zip"/>
+                            </supplementary-material></p>
+                    </caption>
+                        <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-fig1.tif"/><permissions>
+                        <copyright-statement>© 2004, American Society for Cell Biology, All Rights Reserved</copyright-statement>
+                        <copyright-year>2004</copyright-year>
+                        <copyright-holder>American Society for Cell Biology</copyright-holder>
+                        <license>
+                            <license-p>Panel B is reproduced from <xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref> with permission. It is not covered by the CC-BY 4.0 licence and further reproduction of this panel would need permission from the copyright holder.</license-p>
+                        </license>
+                    </permissions>
+                    <permissions>
+                        <copyright-statement>© 2014, copyright holder</copyright-statement>
+                        <copyright-year>2014</copyright-year>
+                        <copyright-holder>copyright holder</copyright-holder>
+                        <license>
+                            <ali:license_ref>https://creativecommons.org/licenses/by-nc-nd/4.0/</ali:license_ref>
+                            <license-p>Panel D is reproduced from <xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref> published under a <ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution License (CC BY-NC-ND 4.0)</ext-link></license-p>
+                        </license>
+                    </permissions>
+                </fig>
+                <fig id="fig1s1" specific-use="child-fig" position="float">
+                    <label>Figure 1&#x2014;figure supplement 1.</label>
+                    <caption>
+                        <title>Figure supplement title.</title>
+                        <p>(<bold>A, B</bold>) Dependence of CME on Hip1R. (<bold>A</bold>) Simulation varying number of Hip1R. (<bold>B</bold>) Hip1R knockdown inhibits CME (transferrin uptake) in HeLa cells... (<bold>C, D</bold>) Capping actin filaments inhibits CME. (<bold>C</bold>) Simulation. (<bold>D</bold>) Slower assembly and disassembly of endogenous dynamin2-GFP at sites of endocytosis in SK-MEL-2 cells treated with different concentrations of Cytochalasin D. (<bold>E, F</bold>) Endocytic actin filaments bend at sites of mammalian endocytosis, tested by cryo-electron tomography of intact mammalian cells. (<bold>G, H</bold>) Mammalian CME is sensitive to Arp2/3 complex activity, revealed by treating SK-MEL-2 cells expressing endogenous clathrin and dynamin2 fluorescent tags with the Arp2/3 complex inhibitor CK-666 (<xref ref-type="supplementary-material" rid="fig1s1sdata1">Figure 1&#x2014;figure supplement 1&#x2014;source data 1</xref>; <xref ref-type="supplementary-material" rid="fig1s1sdata2">Figure 1&#x2014;figure supplement 1&#x2014;source data 2</xref>; <xref ref-type="supplementary-material" rid="fig1s1scode1">Figure 1&#x2014;figure supplement 1&#x2014;source code 1</xref>).</p>
+                        <p><supplementary-material id="fig1s1sdata1">
+                            <label>Figure 1&#x2014;figure supplement 1&#x2014;source data 1.</label>
+                            <caption>
+                                <title>Source data title.</title>
+                                <p>Source data caption.</p>
+                            </caption>
+                            <media mime-subtype="docx" mimetype="application" xlink:href="elife-1234567890-fig1-figsupp1-data1.docx"/>
+                        </supplementary-material></p>
+                        <p>
+                            <supplementary-material id="fig1s1sdata2">
+                                <label>Figure 1&#x2014;figure supplement 1&#x2014;source data 2.</label>
+                                <caption>
+                                    <title>Source data title.</title>
+                                    <p>Source data caption.</p>
+                                </caption>
+                                <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-fig1-figsupp1-data2.zip"/>
+                            </supplementary-material></p>
+                        <p>
+                            <supplementary-material id="fig1s1scode1">
+                                <label>Figure 1&#x2014;figure supplement 1&#x2014;source code 1.</label>
+                                <caption>
+                                    <title>Source code title.</title>
+                                    <p>Source code caption.</p>
+                                </caption>
+                                <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-fig1-figsupp1-code1.zip"/>
+                            </supplementary-material></p>
+                    </caption>
+                    <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-fig1-figsupp1.tif"/>
+                    <permissions>
+                        <copyright-statement>© 2004, American Society for Cell Biology, All Rights Reserved</copyright-statement>
+                        <copyright-year>2004</copyright-year>
+                        <copyright-holder>American Society for Cell Biology</copyright-holder>
+                        <license>
+                            <license-p>Panel B is reproduced from <xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref> with permission. It is not covered by the CC-BY 4.0 licence and further reproduction of this panel would need permission from the copyright holder.</license-p>
+                        </license>
+                    </permissions>
+                    <permissions>
+                        <copyright-statement>© 2014, copyright holder</copyright-statement>
+                        <copyright-year>2014</copyright-year>
+                        <copyright-holder>copyright holder</copyright-holder>
+                        <license>
+                            <ali:license_ref>https://creativecommons.org/licenses/by-nc-nd/4.0/</ali:license_ref>
+                            <license-p>Panel D is reproduced from <xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref> published under a <ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution License (CC BY-NC-ND 4.0)</ext-link></license-p>
+                        </license>
+                    </permissions>
+                </fig>
+                <media id="fig1video1" mime-subtype="mp4" mimetype="video" xlink:href="elife-1234567890-fig1-video1.mp4">
+                    <label>Figure 1&#x2014;video 1.</label>
+                    <caption>
+                        <title>TIRF force reconstitution assay of wild-type vinculin ABD.</title>
+                        <p>First 100 s of representative ... Scale bar, 20 µm.</p>
+                    </caption>
+                    <permissions>
+                        <copyright-statement>© 2004, American Society for Cell Biology, All Rights Reserved</copyright-statement>
+                        <copyright-year>2004</copyright-year>
+                        <copyright-holder>American Society for Cell Biology</copyright-holder>
+                        <license>
+                            <license-p>video is reproduced from  with permission. It is not covered by the CC-BY 4.0 licence and further reproduction of this panel would need permission from the copyright holder.</license-p>
+                        </license>
+                    </permissions>
+                </media>
+            </fig-group>
+            <sec id="s1-1">
+                <title>Section level 2</title>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc (<xref ref-type="fig" rid="C1">Chemical structure 1</xref>; <xref ref-type="fig" rid="S1">Scheme 1</xref>).</p>
+                <fig id="C1" position="anchor">
+                    <label>Chemical structure 1.</label>
+                    <caption>
+                        <title>Synthesis of N-(5-methylthiazol-2-yl)−3-oxobutanamide (3).</title>
+                        <p>To a solution of 5-methylthiazol-2-amine (1) (0.5 g; 4.39 mmol) in xylene (10 ml) was added 2, 2-dimethyl-4H-1, 3-dioxin-4-one (2) (685 mg; 4.83 mmol). <xref ref-type="bibr" rid="bib3">Galkin et al., 2010a</xref>. The mixture was stirred for 12 hr at 135°C, then cooled to room temperature. The solution was filtered and washed with petroleum ether, after filtration, the solid was used directly without purification (3) (0.73 g; 3.69 mmol, 84%). <sup>1</sup>H NMR (400 MHz, DMSO-<italic>d</italic><sub>6</sub>) δ 11.95 (s, 1H), 7.13 (s, 1H), 3.66 (s, 2H), 2.34 (s, 3H), 2.19 (s, 3H); <sup>13</sup>C NMR (101 MHz, DMSO-<italic>d</italic><sub>6</sub>) δ 202.68, 165.26, 156.30, 135.18, 126.70, 51.22, 30.70, 11.53; HRMS (<italic>m/z</italic>): [M+H]<sup>+</sup> calculated for C<sub>8</sub>H<sub>11</sub>N<sub>2</sub>O<sub>2</sub>S, 199.0530; found, 199.0548.</p>
+                    </caption>
+                    <!-- Filename change - see https://github.com/elifesciences/issues/issues/6256 -->
+                    <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-C1-fig1.tif"/>
+                </fig>
+                <fig id="S1" position="anchor">
+                    <label>Scheme 1.</label>
+                    <caption>
+                        <title>General procedure A.</title>
+                    </caption>
+                    <!-- Filename change - see https://github.com/elifesciences/issues/issues/6256 -->
+                    <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-scheme1-fig1.tif"/>
+                    <attrib>Image credit - Ms. Claus.</attrib>
+                </fig>
+                <sec id="s1-1-1">
+                    <title>Section level 3</title>
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit in <xref ref-type="video" rid="video1">Video 1</xref>. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc.</p>
+                    <media id="video1" mime-subtype="mp4" mimetype="video" xlink:href="elife-1234567890-video1.mp4">
+                        <label>Video 1.</label>
+                        <caption>
+                            <title>TIRF force reconstitution assay of wild-type vinculin ABD.</title>
+                            <p>First 100 s of representative ... Scale bar, 20 µm.</p>
+                        </caption>
+                    </media>
+                </sec>
+            </sec>
+        </sec>
+        <sec id="s2" sec-type="results">
+            <title>Results</title>
+            <p>... (<xref ref-type="bibr" rid="bib3">Galkin et al., 2010a</xref>; <xref ref-type="bibr" rid="bib4">Galkin et al., 2010b</xref>) ... <xref ref-type="bibr" rid="bib2">Feyerabend, 2010</xref>.</p>
+            <sec id="s2-1">
+                <title>Section level 2</title>
+                <p><xref ref-type="bibr" rid="bib5">Hao et al., 2020</xref>; <xref ref-type="bibr" rid="bib16">Zok, 2020</xref>; <xref ref-type="bibr" rid="bib17">Zurray, 2019</xref> lorem ipsum dolor sit amet, consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc.</p>
+            </sec>
+            <sec id="s2-2">
+                <title>Section level 2</title>
+                <p>Lorem ipsum <xref ref-type="bibr" rid="bib6">Harmon, 2019</xref> dolor sit amet, consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc.</p>
+                <sec id="s2-2-1">
+                    <title>Section level 3</title>
+                    <p>Lorem ipsum dolor sit amet, <xref ref-type="bibr" rid="bib8">Kok et al., 2015</xref> consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc.</p>
+                    <sec id="s2-2-1-1">
+                        <title>Section level 4</title>
+                        <p>Lorem ipsum dolor sit <xref ref-type="bibr" rid="bib7">Hogarth et al., 2012</xref> amet, consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc.</p>
+                        <!-- Up to 5 sections permitted: 
+                                h1 = article title
+                                h2-6 = body sections -->
+                        <sec id="s2-2-1-1-1">
+                            <title>Section level 5</title>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In maximus, turpis ut molestie bibendum, arcu dolor facilisis erat, eu rhoncus libero magna ac nunc <xref ref-type="table" rid="table1">Table 1</xref>.</p>
+                            <table-wrap id="table1" position="float">
+                                <label>Table 1.</label>
+                                <caption>
+                                    <title>This is the title.</title>
+                                    <p>This is the caption: A table containing interesting formating that is large enough to require landscape orientation in the PDF.</p>
+                                    <p>
+                                        <!-- Pending change in JATS 1.X-2.0, could be captured as a child of <table-wrap> instead -->
+                                        <supplementary-material id="table1sdata1">
+                                            <label>Table 1&#x2014;source data 1.</label>
+                                            <caption><title>Representative curves of steady-state kinetic analyses for each IGF1R protein characterized.</title>
+                                                <p>Each data point was performed in duplicate and is shown separately.</p>
+                                            </caption>
+                                            <media mimetype="application" mime-subtype="xlsx" xlink:href="elife-1234567890-table1-data1.xlsx"/>
+                                        </supplementary-material>
+                                    </p>
+                                </caption>
+                                <table frame="hsides" rules="groups">
+                                    <thead>
+                                        <tr>
+                                            <th colspan="3" rowspan="2"> </th>
+                                            <th align="center" colspan="8">GLV<italic>s</italic> (percent IS plant<sup>-1</sup>)</th>
+                                            <th align="center" colspan="17">TPS10 products (percent IS plant<sup>-1</sup>)</th>
+                                            <th align="center" colspan="10">Non-target volatiles (percent IS plant<sup>-1</sup>)</th>
+                                        </tr>
+                                        <tr>
+                                            <th align="center" colspan="8">(<italic>Z</italic>)-Hexen-3-ol</th>
+                                            <th align="center" colspan="10">TAB</th><th align="center" colspan="7">TBF</th>
+                                            <th align="center" colspan="6">α-Duprezianene</th>
+                                            <th align="center" colspan="4">Germacrene A</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td><bold>Genotype</bold></td>
+                                            <td><bold>Day n</bold></td>
+                                            <td><bold>Night n</bold></td>
+                                            <td colspan="3"><bold>Day</bold></td>
+                                            <td colspan="5"><bold>Night</bold></td>
+                                            <td colspan="4"><bold>Day</bold></td>
+                                            <td colspan="6"><bold>Night</bold></td>
+                                            <td colspan="4"><bold>Day</bold></td>
+                                            <td colspan="3"><bold>Night</bold></td>
+                                            <td colspan="3"><bold>Day</bold></td>
+                                            <td colspan="3"><bold>Night</bold></td>
+                                            <td colspan="3"><bold>Day</bold></td>
+                                            <td><bold>Night</bold></td>
+                                        </tr>
+                                        <tr>
+                                            <td><bold>WT</bold><sup>*</sup></td>
+                                            <td>8</td><td>8 (<xref ref-type="bibr" rid="bib9">Onoda, 2015</xref>)</td>
+                                            <td>0.99%</td>
+                                            <td>±</td>
+                                            <td>0.99%</td>
+                                            <!-- The following cell has background shading.
+                                                 The value fo @style has been updated. 
+                                                 Hex values are now used:
+                                                    - Blue: #90caf9
+                                                    - Green: #C5E1A5
+                                                    - Orange: #FFB74D
+                                                    - Yellow: #FFF176
+                                                    - Purple: #9E86C9
+                                                    - Red: #E57373
+                                                    - Pink: #F48FB1
+                                                    - Grey: #E6E6E6
+                                                 Including it in this way means that the colours are rendered on PMC.
+                                            -->
+                                            <td style="background-color: #90caf9;">7.96%</td>
+                                            <td>±</td>
+                                            <td>4.25%</td>
+                                            <!-- Coloured text is styled using styled-content instead of named-content.
+                                                 Hex values are used:
+                                                    - Blue: #366BFB
+                                                    - Purple: #9C27B0 
+                                                    - Red: #D50000
+                                                 This means that the text is rendered on PMC with that colour.
+                                                 Note that background-colour is not allowed for styled-content as it is not 
+                                                    permitted for text, only table cells.
+                                            -->
+                                            <td rowspan="2" valign="middle"><styled-content style="color: #366BFB;">}</styled-content></td>
+                                            <td rowspan="2" valign="middle"><bold><styled-content style="color: #9C27B0;">a</styled-content></bold></td>
+                                            <td>0.37%</td>
+                                            <td>±</td>
+                                            <td>0.29%</td>
+                                            <td><styled-content style="color: #D50000;">b</styled-content></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td> </td>
+                                            <td rowspan="3" valign="middle">}</td>
+                                            <td rowspan="2" valign="bottom"><bold>a</bold><sub><bold>TPS</bold></sub></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td><bold>a</bold></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td>2.13%</td>
+                                            <td>±</td>
+                                            <td>0.85%</td>
+                                            <td>0.96%</td>
+                                            <td>±</td>
+                                            <td>0.42%</td>
+                                            <td>1.68%</td>
+                                            <td>±</td>
+                                            <td>0.98%</td>
+                                            <td>&#x2014;</td>
+                                        </tr>
+                                        <tr>
+                                            <td><bold><italic>TPS10</italic></bold></td>
+                                            <td><monospace>0.17/0.21 (0.16/0.19)</monospace></td>
+                                            <td><italic>7</italic>7</td>
+                                            <td>2.37%</td>
+                                            <td>±</td>
+                                            <td>1.55%</td>
+                                            <td>2.84%</td>
+                                            <td>±</td>
+                                            <td>0.63%</td>
+                                            <td>18.97%</td>
+                                            <td>±</td>
+                                            <td>6.03%</td>
+                                            <td><bold>b</bold></td>
+                                            <td>0.94% (<xref ref-type="bibr" rid="bib10">Paciência, 2019</xref>)</td>
+                                            <td>±</td>
+                                            <td>0.53%</td>
+                                            <td rowspan="3" valign="middle">}</td>
+                                            <td>9.34%<xref ref-type="fn" rid="table1-fn2"><sup>†</sup></xref></td>
+                                            <td>±</td>
+                                            <td>3.44%</td>
+                                            <td><bold>b</bold></td>
+                                            <td>0.20%</td>
+                                            <td>±</td>
+                                            <td>0.20%</td>
+                                            <td>9.47%</td>
+                                            <td>±</td>
+                                            <td>5.26%</td>
+                                            <td>0.94%</td>
+                                            <td>±</td>
+                                            <td>0.26%</td>
+                                            <td>2.78%</td>
+                                            <td>±</td>
+                                            <td>1.52%</td>
+                                            <td>&#x2014;</td>
+                                        </tr>
+                                        <tr>
+                                            <td><bold><italic>lox2/3</italic></bold></td>
+                                            <td>7</td>
+                                            <td>8</td>
+                                            <td>0.13%</td>
+                                            <td>±</td>
+                                            <td>0.13%</td>
+                                            <td>1.06%</td>
+                                            <td>±</td>
+                                            <td>0.64%</td>
+                                            <td rowspan="2" valign="middle">}</td>
+                                            <td rowspan="2" valign="middle"><bold>b</bold><sub><bold>lox</bold></sub></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td><bold>a</bold></td>
+                                            <td>0.15%</td>
+                                            <td>±</td>
+                                            <td>0.15%</td>
+                                            <td rowspan="2"><bold>b</bold><sub><bold>TPS</bold></sub></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td><bold>a</bold></td>
+                                            <td colspan="3">&#x2014;</td>
+                                            <td>2.75%</td>
+                                            <td>±</td>
+                                            <td>1.12%</td>
+                                            <td>0.60%</td>
+                                            <td>±</td>
+                                            <td>0.19%</td>
+                                            <td>1.68%</td>
+                                            <td>±</td>
+                                            <td>1.49%</td>
+                                            <td>&#x2014;</td>
+                                        </tr>
+                                        <tr>
+                                            <td><bold><italic>lox2/3</italic>x<italic>TPS10</italic></bold></td>
+                                            <td>7</td>
+                                            <td>7</td>
+                                            <td>0.07%</td>
+                                            <td>±</td>
+                                            <td>0.07%</td>
+                                            <td>1.24%</td>
+                                            <td>±</td>
+                                            <td>0.84%</td>
+                                            <td>7.39%</td>
+                                            <td>±</td>
+                                            <td>2.56%</td>
+                                            <td><bold>b</bold></td>
+                                            <td>2.08%</td>
+                                            <td>±</td>
+                                            <td>0.84%</td>
+                                            <td> </td>
+                                            <td>4.47%</td>
+                                            <td>±</td>
+                                            <td>1.70%</td>
+                                            <td><bold>b</bold></td>
+                                            <td>0.40%</td>
+                                            <td>±</td>
+                                            <td>0.40%</td>
+                                            <td>3.02%</td>
+                                            <td>±</td>
+                                            <td>1.42%</td>
+                                            <td>0.73%</td>
+                                            <td>±</td>
+                                            <td>0.31%</td>
+                                            <td>0.66%</td>
+                                            <td>±</td>
+                                            <td>0.37%</td>
+                                            <td>&#x2014;</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table-wrap-foot>
+                                    <fn>
+                                        <p>Footnotes not linked to content within the table text are usually to define abbreviations. For example:</p>
+                                        <p>WT, wild type.</p>
+                                    </fn>
+                                    <!-- Any footnotes linked to must have an id and label -->
+                                    <fn id="table1-fn1"><label><sup>*</sup></label>
+                                        <p>Footnotes can be used to highlight properties of data reported in a table such as statistical significance. They are separate from the table caption and appear afterwards. They are hyperlinked to allow easy navigation. Footnotes in tables use the same standard set of symbols used for authors footnotes (<xref ref-type="bibr" rid="bib10">Paciência, 2019</xref>).</p>
+                                    </fn>
+                                    <fn id="table1-fn2"><label><sup>†</sup></label><p>Atoms: Cα, N, C, O.</p></fn>
+                                </table-wrap-foot>
+                            </table-wrap>
+                        </sec>
+                    </sec>
+                </sec>
+            </sec>
+        </sec>
+        <sec sec-type="discussion" id="s3">
+            <title>Discussion</title>
+            <p>... <styled-content style="color: #366BFB;">Here is another example of coloured text</styled-content>.</p>
+            <p>The function of the Discussion is to interpret your results in light of what was already known about the subject of the investigation, and to explain our new understanding of the problem after taking your results into consideration (<xref ref-type="bibr" rid="bib11">R Development Core Team, 2017</xref>; <xref ref-type="bibr" rid="bib1">Cantaut-Belarif et al., 2020</xref>; <xref ref-type="bibr" rid="bib4">Galkin et al., 2010b</xref>; <xref ref-type="box" rid="box1">Box 1</xref>). The Discussion will always connect to the Introduction by way of the question(s) or hypotheses you posed and the literature you cited, but it does not simply repeat or rearrange the Introduction (<xref ref-type="supplementary-material" rid="supp1">Supplementary file 1</xref>). Instead, it tells how your study has moved us forward from the place you left us at the end of the Introduction as in <xref ref-type="bibr" rid="bib11">R Development Core Team, 2017</xref>; <xref ref-type="fig" rid="box1fig1">Box 1&#x2014;figure 1</xref>.</p>
+            <!-- Add @position for PDF in case we want any boxes that can float -->
+            <boxed-text id="box1" position="anchor">
+                <label>Box 1.</label>
+                <caption>
+                    <!-- title instead of caption/p -->
+                    <title>What can you do now? (<xref ref-type="bibr" rid="bib15">World Health Organization, 2015</xref>)</title>
+                </caption>
+                <fig id="box1fig1" position="anchor">
+                    <label>Box 1&#x2014;figure 1.</label>
+                    <caption>
+                        <title>This is a title.</title>
+                        <p>This is a caption (<xref ref-type="bibr" rid="bib12">Richter, 2013</xref>).</p>
+                        <p>This is a second paragraph in a caption.</p>
+                    </caption>
+                    <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-box1-fig1.tif"/>
+                </fig>
+                <p>...</p>
+                <list list-type="order">
+                    <list-item>
+                        <p>'Contamination'</p>
+                        <list list-type="roman-lower">
+                            <list-item>
+                                <p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>
+                            </list-item>
+                            <list-item>
+                                <p><italic>C. elegans</italic></p>
+                            </list-item>
+                        </list>
+                    </list-item>
+                </list>
+                <p>... <disp-formula id="equ100000000">
+                    <mml:math id="m2">
+                        <mml:mi>P</mml:mi>
+                        <mml:mi>P</mml:mi>
+                        <mml:mi>V</mml:mi>
+                        <mml:mi/>
+                        <mml:mo>=</mml:mo>
+                        <mml:mi/>
+                        <mml:mfrac>
+                            <mml:mrow>
+                                <mml:mi>T</mml:mi>
+                                <mml:mi>P</mml:mi>
+                                    </mml:mrow>
+                            <mml:mrow>
+                                <mml:mi>T</mml:mi>
+                                <mml:mi>P</mml:mi>
+                                <mml:mi/>
+                                <mml:mo>+</mml:mo>
+                                <mml:mi/>
+                                <mml:mi>F</mml:mi>
+                                <mml:mi>P</mml:mi>
+                                    </mml:mrow>
+                                </mml:mfrac>
+                            </mml:math>
+                    </disp-formula>where each term above describes the rate of events that change the epidemic state: Births (<inline-formula>
+                        <mml:math id="infm2">
+                            <mml:mi>B</mml:mi>
+                        </mml:math>
+                    </inline-formula>), loss of maternally derived protection after MAB vaccination (<xref ref-type="bibr" rid="bib13">Spangler, 2014</xref>).</p>
+                <p>...</p>
+                <list list-type="simple">
+                            <list-item>
+                                <p>'Contamination'</p>
+                                <list id="box1list4" list-type="roman-upper">
+                                    <list-item>
+                                        <p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>
+                                    </list-item>
+                                    <list-item>
+                                        <p><italic>C. elegans</italic> (<xref ref-type="bibr" rid="bib13">Spangler, 2014</xref>)</p>
+                                    </list-item>
+                                </list>
+                            </list-item>
+                        </list>
+                <p>...</p>
+            </boxed-text>
+        </sec>
+        <sec sec-type="materials|methods" id="s4">
+            <title>Materials and methods</title>
+            <sec id="s4-1">
+                <title>Code example</title>
+                <p>Here is some code:
+                    <!-- add language and executable attributes -->
+                    <code xml:space="preserve"
+                    language="bash"
+                    executable="no">for i in `ls | grep accepted_hits.bam`; do 
+echo ${i} 
+module load anaconda</code>
+                </p>
+            </sec>
+            <sec id="s4-2">
+                <title>Formula</title>
+                <p>... <disp-formula id="equ2">
+                    <label>(2)</label>
+                        <mml:math id="m3">
+                            <mml:msubsup>
+                                <mml:mrow>
+                                    <mml:mi>K</mml:mi>
+                                </mml:mrow>
+                                <mml:mrow>
+                                    <mml:mi>d</mml:mi>
+                                </mml:mrow>
+                                <mml:mrow>
+                                    <mml:mi mathvariant="normal">I</mml:mi>
+                                    <mml:mi mathvariant="normal">g</mml:mi>
+                                    <mml:mi mathvariant="normal">a</mml:mi>
+                                    <mml:mi mathvariant="normal">A</mml:mi>
+                                    <mml:mo>-</mml:mo>
+                                    <mml:mi mathvariant="normal">R</mml:mi>
+                                    <mml:mi mathvariant="normal">c</mml:mi>
+                                    <mml:mi mathvariant="normal">s</mml:mi>
+                                    <mml:mi mathvariant="normal">F</mml:mi>
+                                </mml:mrow>
+                            </mml:msubsup>
+                            <mml:mi mathvariant="normal"/>
+                            <mml:mo>=</mml:mo>
+                            <mml:mi mathvariant="normal"/>
+                            <mml:mfrac>
+                                <mml:mrow>
+                                    <mml:mfenced close="]" open="[" separators="|">
+                                        <mml:mrow>
+                                            <mml:mi mathvariant="normal">I</mml:mi>
+                                            <mml:mi mathvariant="normal">g</mml:mi>
+                                            <mml:mi mathvariant="normal">a</mml:mi>
+                                            <mml:mi mathvariant="normal">A</mml:mi>
+                                        </mml:mrow>
+                                    </mml:mfenced>
+                                    <mml:mo>[</mml:mo>
+                                    <mml:mi mathvariant="normal">R</mml:mi>
+                                    <mml:mi mathvariant="normal">c</mml:mi>
+                                    <mml:mi mathvariant="normal">s</mml:mi>
+                                    <mml:mi mathvariant="normal">F</mml:mi>
+                                    <mml:mo>]</mml:mo>
+                                </mml:mrow>
+                                <mml:mrow>
+                                    <mml:mo>[</mml:mo>
+                                    <mml:mi mathvariant="normal">I</mml:mi>
+                                    <mml:mi mathvariant="normal">g</mml:mi>
+                                    <mml:mi mathvariant="normal">a</mml:mi>
+                                    <mml:mi mathvariant="normal">A</mml:mi>
+                                    <mml:mo>-</mml:mo>
+                                    <mml:mi mathvariant="normal">R</mml:mi>
+                                    <mml:mi mathvariant="normal">c</mml:mi>
+                                    <mml:mi mathvariant="normal">s</mml:mi>
+                                    <mml:mi mathvariant="normal">F</mml:mi>
+                                    <mml:mo>]</mml:mo>
+                                </mml:mrow>
+                            </mml:mfrac>
+                        </mml:math>   
+                </disp-formula></p>
+                <p>... <inline-formula>
+                        <mml:math id="infm3">
+                            <mml:mstyle displaystyle="true" scriptlevel="0">
+                                <mml:mrow>
+                                    <mml:mrow>
+                                        <mml:mo>[</mml:mo>
+                                        <mml:mi>A</mml:mi>
+                                        <mml:mo>]</mml:mo>
+                                    </mml:mrow>
+                                    <mml:mo>∼</mml:mo>
+                                    <mml:msqrt>
+                                        <mml:mfrac>
+                                            <mml:msup>
+                                                <mml:mi>F</mml:mi>
+                                                <mml:mrow>
+                                                    <mml:mi>A</mml:mi>
+                                                    <mml:mi>A</mml:mi>
+                                                </mml:mrow>
+                                            </mml:msup>
+                                            <mml:mrow>
+                                                <mml:msub>
+                                                    <mml:mi>k</mml:mi>
+                                                    <mml:mrow>
+                                                        <mml:mi>m</mml:mi>
+                                                        <mml:mi>D</mml:mi>
+                                                        <mml:mi>H</mml:mi>
+                                                        <mml:mi>F</mml:mi>
+                                                        <mml:mi>R</mml:mi>
+                                                    </mml:mrow>
+                                                </mml:msub>
+                                                <mml:msubsup>
+                                                    <mml:mi>k</mml:mi>
+                                                    <mml:mrow>
+                                                        <mml:mi>f</mml:mi>
+                                                    </mml:mrow>
+                                                    <mml:mrow>
+                                                        <mml:mi>A</mml:mi>
+                                                        <mml:mi>A</mml:mi>
+                                                    </mml:mrow>
+                                                </mml:msubsup>
+                                            </mml:mrow>
+                                        </mml:mfrac>
+                                    </mml:msqrt>
+                                </mml:mrow>
+                            </mml:mstyle>
+                        </mml:math>
+                </inline-formula> ... 
+                    <inline-formula>
+                            <mml:math id="infm4">
+                                <mml:mrow>
+                                    <mml:mi>ν</mml:mi>
+                                    <mml:mo>≪</mml:mo>
+                                    <mml:mi>X</mml:mi>
+                                </mml:mrow>
+                            </mml:math>
+                </inline-formula> ... 
+                    <inline-formula>
+                            <mml:math id="infm5">
+                                <mml:mrow>
+                                    <mml:mi>ν</mml:mi>
+                                    <mml:mo>≪</mml:mo>
+                                    <mml:mi>G</mml:mi>
+                                </mml:mrow>
+                            </mml:math>
+                </inline-formula> ...</p>
+            </sec>
+            <sec id="s4-3">
+                <title>Gene sequences</title>
+                <p>... <named-content content-type="sequence"><bold>C</bold>TAGTCTCGAGATCTCCATGTTTACTTATACAGCTCATCCATGCC</named-content> ...</p>
+                <list id="list1" list-type="order">
+                    <list-item>
+                        <p><named-content content-type="sequence"><underline>C</underline>TAGTCTCGAGATCTCCATGTTTACTTATACAGCTCATCCATGCC</named-content></p>
+                    </list-item>
+                    <list-item>
+                        <p><named-content content-type="sequence"><italic>C</italic>TAGTCTCGAGATCTCCATGTTTACTTA<styled-content style="color: #9C27B0;">CGAGATCTCCATGTTTACTTATA</styled-content>GCC</named-content></p>
+                    </list-item>
+                </list>
+                <p>Adding this paragraph here would split this list.</p>
+                <list id="list2" list-type="order">
+                    <list-item>
+                        <p><named-content content-type="sequence"><sup>C</sup><sub>T</sub>TAGTCT<styled-content style="color: #D50000;">CGAGATCTCCATGTTTACTTATA</styled-content>CAGCTCATCCATGCC</named-content></p>
+                    </list-item>
+                    <list-item>
+                        <p><named-content content-type="sequence">CTAGTCTCGAGATCTCCATGTTTACTTATACAGCTCATCCATGCC</named-content></p>
+                    </list-item>
+                </list>
+            </sec>
+        </sec>
+    </body>
+    <back>
+        <ack id="ack">
+            <title>Acknowledgements</title>
+            <p>The authors extend their sincere appreciation to ...</p>
+        </ack>
+        <sec id="s5" sec-type="additional-information">
+            <title>Additional information</title>
+            <fn-group content-type="competing-interest">
+                <title>Competing interests</title>
+                <fn fn-type="COI-statement" id="conf1"><p>is a member of some group, and has shares in some company. No other competing interests to declare</p></fn>
+                <fn fn-type="COI-statement" id="conf2"><p>No competing interests declared</p></fn>
+            </fn-group>
+            <fn-group content-type="author-contribution">
+                <title>Author contributions</title>
+                <fn fn-type="con" id="con1"><p>Conceptualization, Data curation, Formal analysis, Validation, Investigation, Visualization, Methodology, Writing - original draft</p></fn>
+                <fn fn-type="con" id="con2"><p>Conceptualization, Resources, Supervision, Funding acquisition, Validation, Writing &#x2013; review and editing</p></fn>
+                <fn fn-type="con" id="con3"><p>Resources, Methodology, Group atuhor contributions may break-down contribution per author in some cases</p></fn>
+                <fn fn-type="con" id="con4"><p>Resources, Supervision, Writing &#x2013; review and editing, Free text contribution</p></fn>
+                <fn fn-type="con" id="con5"><p>Resources, Supervision, Writing &#x2013; review and editing, Free text contribution</p></fn>
+            </fn-group>
+            <fn-group content-type="ethics-information">
+                <title>Ethics</title>
+                <fn fn-type="other">
+                    <p>Human subjects: If Research Ethics Committee and Institutional Review Board approval was required for this article the details would be listed here.</p>
+                </fn>
+                <fn fn-type="other"><p>Animal subjects: If there were animal subjects involved in the study the approval number for the research along with protocol approval would be listed here.</p></fn>
+                <fn fn-type="other">
+                    <p>If this article was part of a clinical trial and the article didn't have a structured abstract, the Clinical trial registry and ID would be listed here, for example:</p>
+                    <p>Clinical trial Registry: EudraCT.</p>
+                    <p>Registration ID: EudraCT2004-000446-20.</p>
+                </fn>
+            </fn-group>
+        </sec>
+        <sec id="s6" sec-type="supplementary-material">
+            <title>Additional files</title>         
+            <supplementary-material id="supp1">   
+                <label>Supplementary file 1.</label>
+                <caption>
+                    <title>This is the title of the supplementary file 1 (<xref ref-type="bibr" rid="bib14">Srinivasan, 2019</xref>).</title>
+                    <p>A file containing underlying data.</p>
+                </caption>
+                <media mimetype="application" mime-subtype="csv" xlink:href="elife-1234567890-supp1.csv"/>
+            </supplementary-material>
+            <supplementary-material id="audio1">
+                <label>Audio file 1.</label>
+                <caption>
+                    <title>This is a title for an audio file.</title>
+                </caption>
+                <media mime-subtype="x-wav" mimetype="audio" xlink:href="elife-1234567890-audio1.wav"/></supplementary-material>
+            <supplementary-material id="sdata1">   
+                <label>Source data 1.</label>
+                <caption>
+                    <title>This is the title of the source data that is not attached to a specific figure, but to the article as a whole.</title>
+                </caption>
+                <media mimetype="application" mime-subtype="xlsx" xlink:href="elife-1234567890-data1.xlsx"/>
+            </supplementary-material>
+            <supplementary-material id="scode1">   
+                <label>Source code 1.</label>
+                <caption>
+                    <title>This is the title of the source code that is not attached to a specific figure, but to the article as a whole.</title>
+                </caption>
+                <media mimetype="application" mime-subtype="zip" xlink:href="elife-1234567890-code1.zip"/>
+            </supplementary-material>
+            <supplementary-material id="repstand1">
+                <label>Reporting standard 1.</label>
+                <caption>
+                    <title>CONSORT checklist.</title>
+                </caption>
+                <media mimetype="application" mime-subtype="pdf" xlink:href="elife-1234567890-repstand1.pdf"/>
+            </supplementary-material>
+            <!-- The MDAR checklist replaces the Transparent reporting form used previously -->
+            <supplementary-material id="mdar">
+                <label>MDAR checklist</label>
+                <media mimetype="application" mime-subtype="pdf" xlink:href="elife-1234567890-mdarchecklist1.pdf"/>
+            </supplementary-material>
+        </sec>
+        <sec id="s7" sec-type="data-availability">
+            <title>Data availability</title>
+            <!-- data references are included in the ref list and can be cited, as in the main text -->
+            <p>Sequencing data have been deposited in GEO under accession code GSE143275 (<xref ref-type="bibr" rid="bib5">Hao et al., 2020</xref>). We also used some data from Dryad (<xref ref-type="bibr" rid="bib8">Kok et al., 2015</xref>). All other data generated or analysed during this study are included in the manuscript and supporting files. MATLAB scripts used to generate Figures 1-3 are available at <ext-link ext-link-type="uri" xlink:href="https://github.com/wyartlab/Cantaut-Belarif-et-al.-2020">GitHub</ext-link> (copy archived at <xref ref-type="bibr" rid="bib1">Cantaut-Belarif et al., 2020</xref>).</p>
+        </sec>
+        <ref-list>
+            <title>References</title>
+            <ref id="bib1">
+              <element-citation publication-type="software">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Cantaut-Belarif</surname>
+                    <given-names>Y</given-names>
+                  </name>
+                  <name>
+                    <surname>Orts Del'Immagine</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Penru</surname>
+                    <given-names>M</given-names>
+                  </name>
+                  <name>
+                    <surname>Pézeron</surname>
+                    <given-names>G</given-names>
+                  </name>
+                  <name>
+                    <surname>Wyart</surname>
+                    <given-names>C</given-names>
+                  </name>
+                  <name>
+                    <surname>Bardet</surname>
+                    <given-names>P-L</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2020">2020</year>
+                <data-title>MATLAB scripts for Adrenergic activation modulates the signal from the Reissner fiber to cerebrospinal fluid-contacting neurons during development</data-title>
+                <source>Software Heritage</source>
+                  <ext-link ext-link-type="uri" xlink:href="https://archive.softwareheritage.org/swh:1:dir:1f91fb94fed0c4a03fc9056163b442f9f9b9abd1;origin=https://github.com/wyartlab/Cantaut-Belarif-et-al.-2020;visit=swh:1:snp:2e499081fea02d16adea6449c5637a879ce0c7da;anchor=swh:1:rev:3396034de4726cb8c895a6e43bbc3d774b726fcb">https://archive.softwareheritage.org/swh:1:dir:1f91fb94fed0c4a03fc9056163b442f9f9b9abd1;origin=https://github.com/wyartlab/Cantaut-Belarif-et-al.-2020;visit=swh:1:snp:2e499081fea02d16adea6449c5637a879ce0c7da;anchor=swh:1:rev:3396034de4726cb8c895a6e43bbc3d774b726fcb</ext-link>
+              </element-citation>
+            </ref>
+            <ref id="bib2">
+              <element-citation publication-type="book">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Feyerabend</surname>
+                    <given-names>PK</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2010">2010</year>
+                <source>Against Method</source>
+                <edition>4th Edition</edition>
+                <publisher-loc>London</publisher-loc>
+                <publisher-name>Verso</publisher-name>
+                <pub-id pub-id-type="isbn">978-1844674428</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib3">
+              <element-citation publication-type="journal">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Galkin</surname>
+                    <given-names>VE</given-names>
+                  </name>
+                  <name>
+                    <surname>Orlova</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Salmazo</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Djinovic-Carugo</surname>
+                    <given-names>K</given-names>
+                  </name>
+                  <name>
+                    <surname>Egelman</surname>
+                    <given-names>EH</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2010">2010a</year>
+                <article-title>Opening of tandem calponin homology domains regulates their affinity for F-actin</article-title>
+                <source>Nature Structural &amp; Molecular Biology</source>
+                <volume>17</volume>
+                <fpage>614</fpage>
+                <lpage>616</lpage>
+                <pub-id pub-id-type="doi">10.1038/nsmb.1789</pub-id>
+                <pub-id pub-id-type="pmid">20383143</pub-id>
+              </element-citation>
+            </ref>
+            <!-- Note that this comes first even through the author list would suggest otherwise 
+                as it has been given 'b' in the year because it is cited second -->
+            <ref id="bib4">
+              <element-citation publication-type="journal">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Galkin</surname>
+                    <given-names>VE</given-names>
+                  </name>
+                  <name>
+                    <surname>Schröder</surname>
+                    <given-names>GF</given-names>
+                  </name>
+                  <name>
+                    <surname>Orlova</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Egelman</surname>
+                    <given-names>EH</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2010">2010b</year>
+                <article-title>Structural polymorphism in F-actin</article-title>
+                <source>Nature Structural &amp; Molecular Biology</source>
+                <volume>17</volume>
+                <fpage>1318</fpage>
+                <lpage>1323</lpage>
+                <pub-id pub-id-type="doi">10.1038/nsmb.1930</pub-id>
+                <pub-id pub-id-type="pmid">20935633</pub-id>
+              </element-citation>
+            </ref>
+            <!-- dataset refs moved from DAS to ref-list. id attribute removed from the element-citation 
+            specific-use="generated" for any datasets generated for this work -->
+            <ref id="bib5">
+              <element-citation publication-type="data" specific-use="generated">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Hao</surname>
+                    <given-names>Q</given-names>
+                  </name>
+                  <name>
+                    <surname>Prasanth</surname>
+                    <given-names>KV</given-names>
+                  </name>
+                  <name>
+                    <surname>Sun</surname>
+                    <given-names>Q</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2020">2020</year>
+                <data-title>poly A+ RNA sequencing of cell cycle-synchronized RNA from U2OS cells</data-title>
+                <source>NCBI Gene Expression Omnibus</source>
+                <pub-id pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE143275">GSE143275</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib6">
+              <element-citation publication-type="web">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Harmon</surname>
+                    <given-names>A</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2019">2019</year>
+                <article-title>James Watson had a chance to salvage his reputation on race. He made things worse</article-title>
+                <source>The New York Times</source>
+                <ext-link ext-link-type="uri" xlink:href="https://www.nytimes.com/2019/01/01/science/watson-dna-genetics-race.html">https://www.nytimes.com/2019/01/01/science/watson-dna-genetics-race.html</ext-link>
+                <date-in-citation iso-8601-date="2019-01-01">January 1, 2019</date-in-citation>
+              </element-citation>
+            </ref>
+            <ref id="bib7">
+              <element-citation publication-type="book">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Hogarth</surname>
+                    <given-names>KM</given-names>
+                  </name>
+                  <name>
+                    <surname>Jaroszz</surname>
+                    <given-names>J</given-names>
+                  </name>
+                  <name>
+                    <surname>Butler</surname>
+                    <given-names>P</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2012">2012</year>
+                <chapter-title>The skull and brain</chapter-title>
+                <person-group person-group-type="editor">
+                  <name>
+                    <surname>Butler</surname>
+                    <given-names>P</given-names>
+                  </name>
+                  <name>
+                    <surname>Mitchell</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Healy</surname>
+                    <given-names>JC</given-names>
+                  </name>
+                </person-group>
+                <source>Applied Radiological Anatomy</source>
+                <edition>2nd Edition</edition>
+                <publisher-loc>Cambridge</publisher-loc>
+                <publisher-name>Cambridge University Press</publisher-name>
+                <fpage>1</fpage>
+                <lpage>32</lpage>
+                <pub-id pub-id-type="doi">10.1017/CBO9780511977930.001</pub-id>
+                <pub-id pub-id-type="isbn">9780511977930</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib8">
+              <!-- specific-use="analyzed" for any datasets used but not generated for this work -->
+              <element-citation publication-type="data" specific-use="analyzed">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Kok</surname>
+                    <given-names>K</given-names>
+                  </name>
+                  <name>
+                    <surname>Ay</surname>
+                    <given-names>A</given-names>
+                  </name>
+                  <name>
+                    <surname>Li</surname>
+                    <given-names>L</given-names>
+                  </name>
+                </person-group>
+                <data-title>Genome-wide errant targeting by Hairy</data-title>
+                <source>Dryad Digital Repository</source>
+                  <year iso-8601-date="2015">2015</year>
+                <pub-id pub-id-type="doi">10.5061/dryad.cv323</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib9">
+              <element-citation publication-type="patent">
+                <person-group person-group-type="inventor">
+                  <name>
+                    <surname>Onoda</surname>
+                    <given-names>T</given-names>
+                  </name>
+                        ...
+                              </person-group>
+                <year iso-8601-date="2015">2015</year>
+                <article-title>Imidazopyridine Derivative</article-title>
+                <source>World Intellectual Property Organization</source>
+                <patent country="Japan">2015087996</patent>
+                <ext-link ext-link-type="uri" xlink:href="https://patents.google.com/patent/WO2015087996A1/en">https://patents.google.com/patent/WO2015087996A1/en</ext-link>
+              </element-citation>
+            </ref>
+            <ref id="bib10">
+              <element-citation publication-type="journal">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Paciência</surname>
+                    <given-names>F</given-names>
+                  </name>
+                        ...
+                              </person-group>
+                <year iso-8601-date="2019">2019</year>
+                <article-title>Mating avoidance in female olive baboons (<italic>Papio anubis</italic>) infected by Treponema pallidum</article-title>
+                <source>Science Advances</source>
+                <comment>In press</comment>
+              </element-citation>
+            </ref>
+            <ref id="bib11">
+                <element-citation publication-type="software">
+                    <person-group person-group-type="author">
+                        <collab>R Development Core Team</collab>
+                    </person-group>
+                    <year iso-8601-date="2017">2017</year>
+                    <data-title>R: a language and environment for statistical computing</data-title>
+                    <version designator="3.3.2">3.3.2</version>
+                    <publisher-loc>Vienna, Austria</publisher-loc>
+                    <publisher-name>R Foundation for Statistical Computing</publisher-name>
+                    <ext-link ext-link-type="uri" xlink:href="http://www.r-project.org/">http://www.r-project.org/</ext-link>
+                </element-citation>
+            </ref>
+            <ref id="bib12">
+              <element-citation publication-type="thesis">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Richter</surname>
+                    <given-names>DJ</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2013">2013</year>
+                <article-title>The Gene Content of Diverse Choanoflagellates Illuminates Animal Origins</article-title>
+                <publisher-name>University of California, Berkeley</publisher-name>
+                <ext-link ext-link-type="uri" xlink:href="https://escholarship.org/uc/item/7xc2p94p">https://escholarship.org/uc/item/7xc2p94p</ext-link>
+              </element-citation>
+            </ref>
+            <ref id="bib13">
+              <element-citation publication-type="confproc">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Spangler</surname>
+                    <given-names>S</given-names>
+                  </name>
+                </person-group>
+                <year iso-8601-date="2014">2014</year>
+                <article-title>Automated hypothesis generation based on mining scientific literature</article-title>
+                <conf-name>Proceedings of the 20th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining</conf-name>
+                <fpage>1877</fpage>
+                <lpage>1886</lpage>
+                <pub-id pub-id-type="doi">10.1145/2623330.2623667</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib14">
+              <element-citation publication-type="journal">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Srinivasan</surname>
+                    <given-names>S</given-names>
+                  </name>
+                  ...
+                </person-group>
+                <year iso-8601-date="2019">2019</year>
+                <article-title>A multiphase theory for spreadingmicrobial swarms and films</article-title>
+                <source>eLife</source>
+                <volume>8</volume>
+                <elocation-id>e42697</elocation-id>
+                <pub-id pub-id-type="doi">10.7554/eLife.42697</pub-id>
+                <pub-id pub-id-type="pmid">31038122</pub-id>
+              </element-citation>
+            </ref>
+            <ref id="bib15">
+              <element-citation publication-type="report">
+                <person-group person-group-type="author">
+                  <collab>World Health Organization</collab>
+                </person-group>
+                <year iso-8601-date="2015">2015</year>
+                <source>World Malaria Report 2015</source>
+                <publisher-loc>Geneva</publisher-loc>
+                <publisher-name>World Health Organization</publisher-name>
+                <ext-link ext-link-type="uri" xlink:href="http://www.who.int/malaria/publications/world-malaria-report-2015/en/">http://www.who.int/malaria/publications/world-malaria-report-2015/en/</ext-link>
+              </element-citation>
+            </ref>
+            <ref id="bib16">
+                <!-- General data repositories can be cited using <ext-link> -->
+                <element-citation publication-type="data" specific-use="analyzed">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Zok</surname>
+                            <given-names>K</given-names>
+                        </name>
+                    </person-group>
+                    <data-title>EpiCoV</data-title>
+                    <source>GSAID's EpiFlu</source>
+                    <year iso-8601-date="2020">2020</year>
+                    <ext-link ext-link-type="uri" xlink:href="https://www.gisaid.org/">https://www.gisaid.org/</ext-link>
+                </element-citation>
+            </ref>
+            <ref id="bib17">
+                <element-citation publication-type="preprint">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Zurray</surname>
+                            <given-names>D</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2019">2019</year>
+                    <article-title>Gender and international diversity improves equity in peer review</article-title>
+                    <source>bioRxiv</source>
+                    <pub-id pub-id-type="doi">10.1101/400515</pub-id>
+                </element-citation>
+            </ref>
+            <ref id="bib18">
+                <element-citation publication-type="software">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Himmelstein</surname>
+                            <given-names>D</given-names>
+                        </name>
+                        <name>
+                            <surname>Bastian</surname>
+                            <given-names>F</given-names>
+                        </name>
+                        <name>
+                            <surname>Baranzini</surname>
+                            <given-names>S</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2016">2016</year>
+                    <data-title>Dhimmel/Bgee V1.0: Anatomy-Specific Gene Expression In Humans From Bgee</data-title>
+                    <source>Zenodo</source>
+                    <pub-id pub-id-type="doi">10.5281/zenodo.47157</pub-id>
+                </element-citation>
+            </ref>
+        </ref-list>
+        <app-group>
+            <app id="appendix-1">
+                <title>Appendix 1</title>
+                <!-- <boxed-text> removed from appendices -->
+                <!-- Key resources table may be present in an appendix or at the start of the materials and methods. -->
+                <table-wrap id="app1keyresource" position="anchor">
+                    <label>Appendix 1—key resources table</label>
+                    <table frame="hsides" rules="groups">
+                        <thead>
+                            <tr>
+                                <th>Reagent type <break/>(species) or resource</th>
+                                <th>Designation</th>
+                                <th>Source or reference</th>
+                                <th>Identifiers</th>
+                                <th>Additional <break/>information</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>gene (<italic>Drosophila melanogaster</italic>)</td>
+                                <td>nito</td>
+                                <td>NA</td>
+                                <td>FLYB:FBgn0027548</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>gene (<italic>D. melanogaster</italic>)</td>
+                                <td>Sxl</td>
+                                <td>NA</td>
+                                <td>FLYB:FBgn0264270</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>MTD-Gal4</td>
+                                <td>Bloomington Drosophila Stock Center</td>
+                                <!-- https://identifiers.org/RRID/RRID: used for RRIDs instead of https://scicrunch.org/resolver/ -->
+                                <td>BDSC:31777; FLYB:FBtp0001612; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:BDSC_31777">BDSC_31777</ext-link></td>
+                                <td>FlyBase symbol: P{GAL4-nos.NGT}</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>ap-Gal4</td>
+                                <td>Bloomington Drosophila Stock Center</td>
+                                <td>BDSC:3041; FLYB:FBti0002785; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:BDSC_3041">BDSC_3041</ext-link></td>
+                                <td>FlyBase symbol: P{GawB}ap[md544]</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>nub-Gal4</td>
+                                <td>PMID:20798049</td>
+                                <td>FLYB:FBti0016825</td>
+                                <td>FlyBase symbol: P{GawB}nubbin-AC-62</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>dome-Gal4</td>
+                                <td>PMID:12403714</td>
+                                <td>FLYB:FBti0022298</td>
+                                <td>FlyBase symbol: P{GawB}dome[PG14]</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>UAS-2xEYFP</td>
+                                <td>PMID:12324968</td>
+                                <td>FLYB:FBtp0016537</td>
+                                <td>FlyBase symbol: P{UAS-2xEYFP}</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>nito[HP25329]</td>
+                                <td>Bloomington Drosophila Stock Center</td>
+                                <td>BDSC:22092; FLYB:FBal0238892; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:BDSC_22092">BDSC_22092</ext-link></td>
+                                <td>Genotype: w[1118]; P{w[+mC]=EPg}nito[HP25329]/CyO</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>nito[1]</td>
+                                <td>this paper</td>
+                                <td>&#x00A0;</td>
+                                <td>Progenitor = nito[HP25329]; imprecise excision; lethal</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>nito shRNA (HMJ02081)</td>
+                                <td>Bloomington Drosophila Stock Center</td>
+                                <td>TRiP:HMJ02081; BDSC:56852; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:BDSC_56852">BDSC_56852</ext-link></td>
+                                <td>FlyBase symbol: P{TRiP.HMJ02081}attP40</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>nito dsRNA (VDRC 20942)</td>
+                                <td>Vienna Drosophila RNAi Center</td>
+                                <td>VDRC:20942</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>FRT[G13]</td>
+                                <td>Bloomington Drosophila Stock Center</td>
+                                <td>BDSC:1956; FLYB:FBti0001247</td>
+                                <td>FlyBase symbol: P{FRT(whs)}G13</td>
+                            </tr>
+                            <tr>
+                                <td>genetic reagent (<italic>D. melanogaster</italic>)</td>
+                                <td>"y w hsflp; ubiGFP FRT[G13]"</td>
+                                <td>PMID:18160348</td>
+                                <td>&#x00A0;</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>cell line (<italic>D. melanogaster</italic>)</td>
+                                <td>S2</td>
+                                <td>other</td>
+                                <td>FLYB:FBtc0000181; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:CVCL_Z992">CVCL_Z992</ext-link></td>
+                                <td>Cell line maintained in N. Perrimon lab; FlyBase symbol: S2-DRSC.</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-Nito</td>
+                                <td>this paper</td>
+                                <td>&#x00A0;</td>
+                                <td>Rabbit polyclonal; against aa 479-500; used YZ3137 (1:500)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-alpha-Spectrin (mouse monoclonal)</td>
+                                <td>Developmental Studies Hybridoma Bank</td>
+                                <td>DSHB:3A9; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_528473">AB_528473</ext-link></td>
+                                <td>(1:10)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-Vasa (rabbit polyclonal)</td>
+                                <td>Santa Cruz Biotechnology</td>
+                                <td>Santa Cruz:sc-30210; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_793874">AB_793874</ext-link></td>
+                                <td>(1:250)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-Sxl (mouse monoclonal)</td>
+                                <td>Developmental Studies Hybridoma Bank</td>
+                                <td>DSHB:M18; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_528464">AB_528464</ext-link></td>
+                                <td>(1:10)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-GFP (rabbit polyclonal)</td>
+                                <td>Molecular Probes</td>
+                                <td>Molecular Probes:A-6455; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_221570">AB_221570</ext-link></td>
+                                <td>(1:1000)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-GFP (mouse monoclonal)</td>
+                                <td>Molecular Probes</td>
+                                <td>Molecular Probes:A-11120; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_221568">AB_221568</ext-link></td>
+                                <td>(1:200)</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>anti-HA (rat monoclonal)</td>
+                                <td>Roche</td>
+                                <td>Roche:3F10; RRID:<ext-link ext-link-type="uri" xlink:href="https://identifiers.org/RRID/RRID:AB_2314622">AB_2314622</ext-link></td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>antibody</td>
+                                <td>Alexa 488- or 555- secondaries</td>
+                                <td>Molecular Probes</td>
+                                <td>&#x00A0;</td>
+                                <td>(1:1000)</td>
+                            </tr>
+                            <tr>
+                                <td>other</td>
+                                <td>DAPI stain</td>
+                                <td>Molecular Probes</td>
+                                <td>&#x00A0;</td>
+                                <td>(1:1000)</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>pAGW (Gateway vector)</td>
+                                <td>Drosophila Genomics Resource Center</td>
+                                <td>DGRC:1071</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>pAHW (Gateway vector)</td>
+                                <td>Drosophila Genomics Resource Center</td>
+                                <td>DGRC:1095 (<xref ref-type="bibr" rid="bib11">R Development Core Team, 2017</xref>)</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>GH11110 (cDNA)</td>
+                                <td>Drosophila Genomics Resource Center</td>
+                                <td>DGRC:5666</td>
+                                <td>&#x00A0;</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>GFP-Nito (plasmid)</td>
+                                <td>this paper</td>
+                                <td>&#x00A0;</td>
+                                <td>Progenitors: GH11110 (cDNA); Gateway vector pAGW</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>HA-Sxl (plasmid)</td>
+                                <td>PMID:16207758</td>
+                                <td>&#x00A0;</td>
+                                <td>Progentiors: PCR, UAS-Sxl flies; Gateway vector pAHW</td>
+                            </tr>
+                            <tr>
+                                <td>recombinant DNA reagent</td>
+                                <td>GFP-Sxl (plasmid)</td>
+                                <td>PMID:16207758</td>
+                                <td>&#x00A0;</td>
+                                <td>Progentiors: PCR, UAS-Sxl flies; Gateway vector pAGW</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </table-wrap>
+            </app>
+            <app id="appendix-2">
+                <title>Appendix 2</title>
+                <sec id="app2s1">
+                    <title>Negotiation</title>
+                    <p>... <xref ref-type="fig" rid="app2fig1">Appendix 2&#x2014;figure 1</xref> ...</p>
+                    <fig id="app2fig1" position="float">
+                        <label>Appendix 2&#x2014;figure 1.</label>
+                        <caption>
+                            <title>Figure added to demonstrate that not only paragaphs but other forms of content may be included as a child of the boxed-text.</title>
+                            <p>If there is a caption to accompany the title it would display here (<xref ref-type="bibr" rid="bib5">Hao et al., 2020</xref>).</p>
+                        </caption>
+                        <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-app2-fig1.tif"/>
+                    </fig>
+                    <fig id="app2scheme1" position="float">
+                        <label>Appendix 2&#x2014;scheme 1.</label>
+                        <caption>
+                            <title>Scheme title.</title>
+                        </caption>
+                        <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-app2-scheme1-fig1.tif"/>
+                    </fig>
+                    <fig id="app2C1" position="float">
+                        <label>Appendix 2&#x2014;chemical structure 1.</label>
+                        <caption>
+                            <title>Chemical structure title.</title>
+                        </caption>
+                        <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-app2-chem1-fig1.tif"/>
+                    </fig>
+                    <sec id="app2s2">
+                        <title>Appendix heading level 1</title>
+                        <p>... <xref ref-type="disp-formula" rid="equ696">Equation 1</xref> <disp-formula id="equ696">
+                            <label>(1)</label>
+                            <!-- math id includes app id prefix -->
+                                <mml:math id="m696">
+                                    <mml:mrow>
+                                        <mml:mi>ϕ</mml:mi>
+                                        <mml:mo>=</mml:mo>
+                                        <mml:msup>
+                                            <mml:mi>e</mml:mi>
+                                            <mml:mrow>
+                                                <mml:mo>−</mml:mo>
+                                                <mml:mfrac>
+                                                    <mml:mrow>
+                                                        <mml:mi>z</mml:mi>
+                                                        <mml:mi>F</mml:mi>
+                                                        <mml:mi>V</mml:mi>
+                                                    </mml:mrow>
+                                                    <mml:mrow>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:mi>R</mml:mi>
+                                                        <mml:mi>T</mml:mi>
+                                                    </mml:mrow>
+                                                </mml:mfrac>
+                                            </mml:mrow>
+                                        </mml:msup>
+                                    </mml:mrow>
+                                </mml:math>
+                        </disp-formula></p>
+                        <sec id="app2s2-1">
+                            <title>Appendix heading level 2</title>
+                            <p>...</p>
+                            <sec id="app2s3">
+                                <title>Appendix heading level 3</title>
+                                <!-- Only 3 nested secs allowed in appendices due to h6 limit in HTML
+                                    h1 = article title
+                                    h2 = appendix title
+                                    h3-6 = appendix sections
+                                -->
+                                <p>...<xref ref-type="bibr" rid="bib5">Hao et al., 2020</xref>... <xref ref-type="bibr" rid="bib5">Hao et al., 2020</xref>...</p>
+                            </sec>
+                        </sec>
+                    </sec>
+                </sec>
+            </app>
+            <app id="appendix-3">
+                <title>Appendix 3</title>
+                <p>...</p>
+                <sec id="s9">
+                    <title>Section title</title>
+                    <p>... <xref ref-type="fig" rid="app3fig1">Appendix 3&#x2014;figure 1</xref> (<xref ref-type="supplementary-material" rid="app3fig1sdata1">Appendix 3&#x2014;figure 1&#x2014;source data 1</xref>; <xref ref-type="supplementary-material" rid="app3fig1sdata2">Appendix 3&#x2014;figure 1&#x2014;source data 2</xref>; <xref ref-type="supplementary-material" rid="app3fig1scode1">Appendix 3&#x2014;figure 1&#x2014;source code 1</xref>).</p>
+                    <fig-group>
+                        <fig id="app3fig1" position="float">
+                            <label>Appendix 3&#x2014;figure 1.</label>
+                            <caption>
+                                <title>Figure title.</title>
+                                <p>(<bold>A, B</bold>) Dependence of CME on Hip1R. (<bold>A</bold>) Simulation varying number of Hip1R. (<bold>B</bold>) Hip1R knockdown inhibits CME (transferrin uptake) in HeLa cells. (<bold>C, D</bold>) Capping actin filaments inhibits CME. (<bold>C</bold>) Simulation. (<bold>D</bold>) Slower assembly and disassembly of endogenous dynamin2-GFP at sites of endocytosis in SK-MEL-2 cells treated with different concentrations of Cytochalasin D. (<bold>E, F</bold>) Endocytic actin filaments bend at sites of mammalian endocytosis, tested by cryo-electron tomography of intact mammalian cells. (<bold>G, H</bold>) Mammalian CME is sensitive to Arp2/3 complex activity, revealed by treating SK-MEL-2 cells expressing endogenous clathrin and dynamin2 fluorescent tags with the Arp2/3 complex inhibitor CK-666 (<xref ref-type="fig" rid="app3fig1s1">Appendix 3&#x2014;figure 1&#x2014;figure supplement 1</xref>).</p>
+                                <p><supplementary-material id="app3fig1sdata1">
+                                    <label>Appendix 3&#x2014;figure 1&#x2014;source data 1.</label>
+                                    <caption>
+                                        <title>Source data title.</title>
+                                        <p>Source data caption.</p>
+                                    </caption>
+                                    <media mime-subtype="docx" mimetype="application" xlink:href="elife-1234567890-app3-fig1-data1.docx"/>
+                                </supplementary-material></p>
+                                <p>
+                                    <supplementary-material id="app3fig1sdata2">
+                                        <label>Appendix 3&#x2014;figure 1&#x2014;source data 2.</label>
+                                        <caption>
+                                            <title>Source data title.</title>
+                                            <p>Source data caption.</p>
+                                        </caption>
+                                        <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-app3-fig1-data2.zip"/>
+                                    </supplementary-material></p>
+                                <p>
+                                    <supplementary-material id="app3fig1scode1">
+                                        <label>Appendix 3&#x2014;figure 1&#x2014;source code 1.</label>
+                                        <caption>
+                                            <title>Source code title.</title>
+                                            <p>Source code caption.</p>
+                                        </caption>
+                                        <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-app3-fig1-code1.zip"/>
+                                    </supplementary-material></p>
+                            </caption>
+                            <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-app3-fig1.tif"/>
+                            <permissions>
+                                <copyright-statement>© 2004, American Society for Cell Biology, All Rights Reserved</copyright-statement>
+                                <copyright-year>2004</copyright-year>
+                                <copyright-holder>American Society for Cell Biology</copyright-holder>
+                                <license>
+                                    <license-p>Panel B is reproduced from  with permission. It is not covered by the CC-BY 4.0 licence and further reproduction of this panel would need permission from the copyright holder.</license-p>
+                                </license>
+                            </permissions>
+                            <permissions>
+                                <copyright-statement>© 2014, copyright holder</copyright-statement>
+                                <copyright-year>2014</copyright-year>
+                                <copyright-holder>copyright holder</copyright-holder>
+                                <license>
+                                    <ali:license_ref>https://creativecommons.org/licenses/by-nc-nd/4.0/</ali:license_ref>
+                                    <license-p>Panel D is reproduced from ... published under a <ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution License (CC BY-NC-ND 4.0)</ext-link></license-p>
+                                </license>
+                            </permissions>
+                        </fig>
+                        <fig id="app3fig1s1" specific-use="child-fig" position="float">
+                            <label>Appendix 3&#x2014;figure 1&#x2014;figure supplement 1.</label>
+                            <caption>
+                                <title>Figure supplement title.</title>
+                                <p>(<bold>A, B</bold>) Dependence of CME on Hip1R. (<bold>A</bold>) Simulation varying number of Hip1R. (<bold>B</bold>) Hip1R knockdown inhibits CME (transferrin uptake) in HeLa cells. (<bold>C, D</bold>) Capping actin filaments inhibits CME. (<bold>C</bold>) Simulation. (<bold>D</bold>) Slower assembly and disassembly of endogenous dynamin2-GFP at sites of endocytosis in SK-MEL-2 cells treated with different concentrations of Cytochalasin D. (<bold>E, F</bold>) Endocytic actin filaments bend at sites of mammalian endocytosis, tested by cryo-electron tomography of intact mammalian cells. (<bold>G, H</bold>) Mammalian CME is sensitive to Arp2/3 complex activity, revealed by treating SK-MEL-2 cells expressing endogenous clathrin and dynamin2 fluorescent tags with the Arp2/3 complex inhibitor CK-666.</p>
+                                <p><supplementary-material id="app3fig1s1sdata1">
+                                    <label>Appendix 3&#x2014;figure 1&#x2014;figure supplement 1&#x2014;source data 1.</label>
+                                    <caption>
+                                        <title>Source data title.</title>
+                                        <p>Source data caption.</p>
+                                    </caption>
+                                    <media mime-subtype="docx" mimetype="application" xlink:href="elife-1234567890-app3-fig1-figsupp1-data1.docx"/>
+                                </supplementary-material></p>
+                                <p>
+                                    <supplementary-material id="app3fig1s1sdata2">
+                                        <label>Appendix 3&#x2014;figure 1&#x2014;figure supplement 1&#x2014;source data 2.</label>
+                                        <caption>
+                                            <title>Source data title.</title>
+                                            <p>Source data caption.</p>
+                                        </caption>
+                                        <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-app3-fig1-figsup1-data2.zip"/>
+                                    </supplementary-material></p>
+                                <p>
+                                    <supplementary-material id="app3fig1s1scode1">
+                                        <label>Appendix 3&#x2014;figure 1&#x2014;figure supplement 1&#x2014;source code 1.</label>
+                                        <caption>
+                                            <title>Source code title.</title>
+                                            <p>Source code caption.</p>
+                                        </caption>
+                                        <media mime-subtype="zip" mimetype="application" xlink:href="elife-1234567890-app3-fig1-figsup1-code1.zip"/>
+                                    </supplementary-material></p>
+                            </caption>
+                            <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-1234567890-app3-fig1-figsupp1.tif"/>
+                            <permissions>
+                                <copyright-statement>© 2004, American Society for Cell Biology, All Rights Reserved</copyright-statement>
+                                <copyright-year>2004</copyright-year>
+                                <copyright-holder>American Society for Cell Biology</copyright-holder>
+                                <license>
+                                    <license-p>Panel B is reproduced from  with permission. It is not covered by the CC-BY 4.0 licence and further reproduction of this panel would need permission from the copyright holder.</license-p>
+                                </license>
+                            </permissions>
+                            <permissions>
+                                <copyright-statement>© 2014, copyright holder</copyright-statement>
+                                <copyright-year>2014</copyright-year>
+                                <copyright-holder>copyright holder</copyright-holder>
+                                <license>
+                                    <ali:license_ref>https://creativecommons.org/licenses/by-nc-nd/4.0/</ali:license_ref>
+                                    <license-p>Panel D is reproduced from ... published under a <ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution License (CC BY-NC-ND 4.0)</ext-link></license-p>
+                                </license>
+                            </permissions>
+                        </fig>
+                        <media id="app3fig1video1" mime-subtype="mp4" mimetype="video" xlink:href="elife-1234567890-app3-fig1-video1.mp4">
+                            <label>Appendix 3&#x2014;figure 1&#x2014;video 1.</label>
+                            <caption>
+                                <title>TIRF force reconstitution assay of wild-type vinculin ABD.</title>
+                                <p>First 100 s of representative ... Scale bar, 20 µm.</p>
+                            </caption>
+                        </media>
+                    </fig-group>
+                </sec>
+            </app>
+        </app-group>
+    </back>
+    <sub-article id="sa0" article-type="editor-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa0</article-id>
+            <title-group>
+                <!-- 'Editor's evaluation' changed to 'eLife assessment' -->
+                <article-title>eLife assessment</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Helaine</surname>
+                        <given-names>Sophie</given-names>
+                    </name>
+                    <!-- role element added with appropriate specific-use attribute value -->
+                    <role specific-use="editor">Reviewing Editor</role>
+                    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0000-0404-001X</contrib-id>
+                    <aff>
+                        <!-- ROR ids also permitted here -->
+                        <institution-wrap>
+                            <institution-id institution-id-type="ror">https://ror.org/041kmwe10</institution-id>
+                            <institution>Imperial College London</institution>
+                        </institution-wrap>
+                        <country country="GB">United Kingdom</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+            <!-- Working on assumption that Sciety related-object is not required in PRC content -->
+            <kwd-group kwd-group-type="claim-importance">
+                <!-- Controlled vocabulary of importance values: Landmark; Fundamental; Important; Noteworthy; Useful; Flawed -->
+                <!-- Multiple terms may be selected -->
+                <kwd>Noteworthy</kwd>
+                <kwd>Flawed</kwd>
+            </kwd-group>
+            <kwd-group kwd-group-type="evidence-strength">
+                <!-- Controlled vocabulary of strength values: Tour-de-force; Compelling; Convincing; Solid; Incomplete; Inadequate -->
+                <!-- Multiple terms may be selected -->
+                <kwd>Compelling</kwd>
+                <kwd>Incomplete</kwd>
+            </kwd-group>
+        </front-stub>
+        <body>
+            <!-- The summary text will include hyperlinked words identical or similar to those used in the controlled vocabulary -->
+            <p>This is an eLife assessment, which is a summary of the peer reviews provided by the BRE. It will only contain one or more paragraphs, no figures, tables or videos. It might say something like, "with respect to blah blah, this study is <bold>noteworthy</bold> backed up by data that is <bold>compelling</bold>, however the model design for blah is <bold>flawed</bold> and the evidence <bold>incomplete</bold>.</p>
+        </body>
+    </sub-article>
+    <!-- article-type changed from decision-letter to referee-report -->
+    <sub-article id="sa1" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa1</article-id>
+            <title-group>
+                <article-title>Reviewer #1 (public review)</article-title>
+            </title-group>
+            <contrib-group>
+                <!-- contrib-type changed to author, only one reviewer per reviwer report -->
+                <contrib contrib-type="author">
+                    <name><surname>Taylor</surname><given-names>J Paul</given-names></name>
+                    <!-- role element added with appropriate specific-use attribute value -->
+                    <role specific-use="referee">Reviewer</role>
+                    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0070-0001-0404-000X</contrib-id>
+                    <aff>
+                        <institution>St Jude Children's Research Hospital</institution>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+            <custom-meta-group>
+                <!-- custom-meta to indicate that this review was transferred from elsewhere -->
+                <custom-meta>
+                    <meta-name>transferred-from</meta-name>
+                    <meta-value>Review Commons</meta-value>
+                </custom-meta>
+                <!-- custom-meta to indicate peer review type -->
+                <custom-meta>
+                    <meta-name>PeerReviewType</meta-name>
+                    <meta-value>visible</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </front-stub>
+        <body>
+            <p>This paper combines two complementary approaches, translating ribosome affinity purification (TRAP) and ribosome profiling, to provide the first quantitative insight into the impact of PrP<sup>Sc</sup> on cell type-specific translation. Surprisingly few translational changes were detected in neurons. In contrast, substantial alterations to translation were evident in astrocytes and microglia prior to manifestation of prion disease features, suggesting that aberrant translation in these cell types may be a primary driver of neurodegeneration.</p>
+            <p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
+            <p>You need to make sure the XML structure you create works on the display of the PMC platform and also that there is enough information contained within the tagging to generate a typeset PDF from the XML with no additional information provided. See <xref ref-type="fig" rid="sa1fig1">Review image 1.</xref>, <xref ref-type="table" rid="sa1table1">Review table 1</xref> and <xref ref-type="video" rid="sa1video1">Review video 1</xref>.</p>
+            <fig id="sa1fig1" position="float">
+                <label>Review image 1.</label>
+                <caption>
+                    <p>Single figure: The header of an eLife article example on the HTML page.</p>
+                </caption>
+                <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-sa1-fig1.tif"/>
+            </fig>
+            <table-wrap id="sa1table1" position="float">
+                <label>Review table 1.</label>
+                <caption>
+                    <p>Review table.</p>
+                </caption>
+                <table frame="hsides" rules="groups">
+                    <thead>
+                        <tr>
+                            <th>Sample</th>
+                            <th>Same</th>
+                            <th>Difference more than 10%</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>DKO1.cell.1</td>
+                            <td>77.00%</td>
+                            <td>6.90%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.2</td>
+                            <td>78.80%</td>
+                            <td>7.20%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.3</td>
+                            <td>79.10%</td>
+                            <td>6.70%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.1</td>
+                            <td>78.90%</td>
+                            <td>6.50%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.2</td>
+                            <td>80.00%</td>
+                            <td>5.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.3</td>
+                            <td>86.80%</td>
+                            <td>2.30%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.1</td>
+                            <td>77.30%</td>
+                            <td>7.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.2</td>
+                            <td>79.70%</td>
+                            <td>6.70%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </table-wrap>
+            <media mimetype="video" mime-subtype="mp4" id="sa1video1" xlink:href="elife-1234567890-sa1-video1.mp4">
+                <label>Review video 1.</label>
+                <caption>
+                    <title>Caption and/or a title is required.</title>
+                </caption>
+            </media>
+            <p>Adding some MathML to the sub-article.<inline-formula>
+                <mml:math id="sa1m1">
+                    <mml:mstyle displaystyle="true" scriptlevel="0">
+                        <mml:mrow>
+                            <mml:msup>
+                                <mml:mi>F</mml:mi>
+                                <mml:mrow>
+                                    <mml:mi>A</mml:mi>
+                                    <mml:mi>B</mml:mi>
+                                </mml:mrow>
+                            </mml:msup>
+                            <mml:mo>∼</mml:mo>
+                            <mml:mfrac>
+                                <mml:msubsup>
+                                    <mml:mi>k</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>f</mml:mi>
+                                    </mml:mrow>
+                                    <mml:mrow>
+                                        <mml:mi>A</mml:mi>
+                                        <mml:mi>B</mml:mi>
+                                    </mml:mrow>
+                                </mml:msubsup>
+                                <mml:msqrt>
+                                    <mml:msubsup>
+                                        <mml:mi>k</mml:mi>
+                                        <mml:mrow>
+                                            <mml:mi>f</mml:mi>
+                                        </mml:mrow>
+                                        <mml:mrow>
+                                            <mml:mi>A</mml:mi>
+                                            <mml:mi>A</mml:mi>
+                                        </mml:mrow>
+                                    </mml:msubsup>
+                                    <mml:msubsup>
+                                        <mml:mi>k</mml:mi>
+                                        <mml:mrow>
+                                            <mml:mi>f</mml:mi>
+                                        </mml:mrow>
+                                        <mml:mrow>
+                                            <mml:mi>B</mml:mi>
+                                            <mml:mi>B</mml:mi>
+                                        </mml:mrow>
+                                    </mml:msubsup>
+                                </mml:msqrt>
+                            </mml:mfrac>
+                            <mml:msqrt>
+                                <mml:msup>
+                                    <mml:mi>F</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>A</mml:mi>
+                                        <mml:mi>A</mml:mi>
+                                    </mml:mrow>
+                                </mml:msup>
+                                <mml:msup>
+                                    <mml:mi>F</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>B</mml:mi>
+                                        <mml:mi>B</mml:mi>
+                                    </mml:mrow>
+                                </mml:msup>
+                            </mml:msqrt>
+                        </mml:mrow>
+                    </mml:mstyle>
+                </mml:math>
+            </inline-formula>
+            </p>
+            <p>May also contain a formula as a block
+                <disp-formula id="sa1equ1">
+                    <label>(1)</label>
+                        <mml:math id="sa1m2">
+                            <mml:mstyle displaystyle="true" scriptlevel="0">
+                                <mml:mrow>
+                                    <mml:mi>d</mml:mi>
+                                    <mml:mtext> </mml:mtext>
+                                    <mml:mo>=</mml:mo>
+                                    <mml:mtext> </mml:mtext>
+                                    <mml:msqrt>
+                                        <mml:msup>
+                                            <mml:mrow>
+                                                <mml:mo>(</mml:mo>
+                                                <mml:mfrac>
+                                                    <mml:mrow>
+                                                        <mml:mi>P</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mi>i</mml:mi>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>t</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi mathvariant="bold-italic">i</mml:mi>
+                                                                <mml:mtext> </mml:mtext>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                        <mml:mo>−</mml:mo>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>O</mml:mi>
+                                                        <mml:mi>b</mml:mi>
+                                                        <mml:mi>s</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>v</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi>i</mml:mi>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                    </mml:mrow>
+                                                    <mml:mrow>
+                                                        <mml:mi>O</mml:mi>
+                                                        <mml:mi>b</mml:mi>
+                                                        <mml:mi>s</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>v</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi>i</mml:mi>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                    </mml:mrow>
+                                                </mml:mfrac>
+                                                <mml:mo>)</mml:mo>
+                                            </mml:mrow>
+                                            <mml:mrow>
+                                                <mml:mn>2</mml:mn>
+                                            </mml:mrow>
+                                        </mml:msup>
+                                    </mml:msqrt>
+                                </mml:mrow>
+                            </mml:mstyle>
+                        </mml:math>
+                </disp-formula>
+            </p>
+            <list id="sa1list1" list-type="order">
+                <list-item>
+                    <p>'Contamination'</p>
+                    <list id="sa1list2" list-type="roman-lower">
+                        <list-item>
+                            <p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>
+                        </list-item>
+                        <list-item>
+                            <p><italic>C. elegans</italic></p>
+                        </list-item>
+                    </list>
+                </list-item>
+            </list>
+        </body>
+    </sub-article>
+    <sub-article id="sa2" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa2</article-id>
+            <title-group>
+                <article-title>Reviewer #2 (public review)</article-title>
+            </title-group>
+            <contrib-group>
+                <!-- Anonymous reviewer -->
+                <contrib contrib-type="author">
+                    <anonymous/>
+                    <role specific-use="referee">Reviewer</role>
+                </contrib>
+            </contrib-group>
+            <custom-meta-group>
+                <!-- custom-meta to indicate that this review was transferred from elsewhere -->
+                <custom-meta>
+                    <meta-name>transferred-from</meta-name>
+                    <meta-value>Review Commons</meta-value>
+                </custom-meta>
+                <!-- custom-meta to indicate peer review type -->
+                <custom-meta>
+                    <meta-name>PeerReviewType</meta-name>
+                    <meta-value>visible</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </front-stub>
+        <body>
+            <p>Each reviewer's report is included as a separate sub-article. This will usually mean three reviews, though more or fewer are permitted. Reviews may be published anonymously.</p>
+            <p>Review assets are ordered sequentially across all the separate reviews, so the second image will be called <xref ref-type="fig" rid="sa2fig1">Review image 2</xref> regardless of which reviews it appears in.</p>
+            <fig id="sa2fig1" position="float">
+                <label>Review image 2.</label>
+                <caption>
+                    <p>Another review illustrative image.</p>
+                </caption>
+                <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-sa2-fig1.tif"/>
+            </fig>
+        </body>
+    </sub-article>
+    <sub-article id="sa3" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa3</article-id>
+            <title-group>
+                <article-title>Reviewer #3 (public review)</article-title>
+            </title-group>
+            <contrib-group>
+                <!-- Anonymous reviewer -->
+                <contrib contrib-type="author">
+                    <anonymous/>
+                    <role specific-use="referee">Reviewer</role>
+                </contrib>
+            </contrib-group>
+            <custom-meta-group>
+                <!-- custom-meta to indicate that this review was transferred from elsewhere -->
+                <custom-meta>
+                    <meta-name>transferred-from</meta-name>
+                    <meta-value>Review Commons</meta-value>
+                </custom-meta>
+                <!-- custom-meta to indicate peer review type -->
+                <custom-meta>
+                    <meta-name>PeerReviewType</meta-name>
+                    <meta-value>visible</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </front-stub>
+        <body>
+            <p>Each reviewer's report is included as a separate sub-article. This will usually mean three reviews, though more or fewer are permitted. Reviews may be published anonymously.</p>
+        </body>
+    </sub-article>
+    <sub-article id="sa4" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa4</article-id>
+            <title-group>
+                <article-title>Recommendations for authors</article-title>
+            </title-group>
+            <contrib-group>
+                <!-- Reviewing editor -->
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Helaine</surname>
+                        <given-names>Sophie</given-names>
+                    </name>
+                    <!-- role element added with appropriate specific-use attribute value -->
+                    <role specific-use="editor">Reviewing Editor</role>
+                    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0000-0404-001X</contrib-id>
+                    <aff>
+                        <!-- ROR ids also permitted here -->
+                        <institution-wrap>
+                            <institution-id institution-id-type="ror">https://ror.org/041kmwe10</institution-id>
+                            <institution>Imperial College London</institution>
+                        </institution-wrap>
+                        <country country="GB">United Kingdom</country>
+                    </aff>
+                </contrib>
+                <!-- Reviewer -->
+                <contrib contrib-type="author">
+                    <name><surname>Taylor</surname><given-names>J Paul</given-names></name>
+                    <!-- role element added with appropriate specific-use attribute value -->
+                    <role specific-use="referee">Reviewer</role>
+                    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0070-0001-0404-000X</contrib-id>
+                    <aff>
+                        <institution>St Jude Children's Research Hospital</institution>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+                <!-- Anonymous reviewer -->
+                <contrib contrib-type="author">
+                    <anonymous/>
+                    <role specific-use="referee">Reviewer</role>
+                </contrib>
+                <!-- Anonymous reviewer -->
+                <contrib contrib-type="author">
+                    <anonymous/>
+                    <role specific-use="referee">Reviewer</role>
+                </contrib>
+            </contrib-group>
+            <custom-meta-group>               
+                <!-- custom-meta to indicate peer review type -->
+                <custom-meta>
+                    <meta-name>PeerReviewType</meta-name>
+                    <meta-value>visible</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </front-stub>
+        <body>
+            <p>Recommendations for edits to the initial preprint, based on the reviewers' comments.</p>
+        </body>
+    </sub-article>
+    <!-- article-type changed from reply to author-comment -->
+    <sub-article article-type="author-comment" id="sa5">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa5</article-id>
+            <title-group>
+                <article-title>Author response</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Atherden</surname>
+                        <given-names>Frederick Peter</given-names>
+                        <suffix>III</suffix>
+                    </name>
+                    <role specific-use="author">Author</role>
+                </contrib>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Harrison</surname>
+                        <given-names>Melissa</given-names>
+                    </name>
+                    <role specific-use="author">Author</role>
+                </contrib>
+                <contrib contrib-type="author">
+                    <collab>Example Group author
+                        <contrib-group content-type="group-members">
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>Gilbert</surname>
+                                    <given-names>James</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                    </collab>
+                    <role specific-use="author">Author</role>
+                </contrib>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Claus</surname>
+                        <given-names>Santa</given-names>
+                    </name>
+                    <role specific-use="author">Author</role>
+                </contrib>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>West</surname>
+                        <given-names>Cornel</given-names>
+                        <suffix>Jnr</suffix>
+                    </name>
+                    <role specific-use="author">Author</role>
+                </contrib>
+                <on-behalf-of>on behalf of whoever finds this interesting</on-behalf-of>
+            </contrib-group>
+        </front-stub>
+        <body>
+            <p>We thank the reviewers for the positive assessment of our work and their insightful remarks. Please find below a point-by-point response to each comment.</p>
+            <disp-quote content-type="editor-comment">
+                <p>Reviewer #1 (Evidence, reproducibility and clarity):</p>
+                <p>Scheckel et al. report a large dataset on cell type-specific translational profiling of PrD-associated molecular alterations in a mouse model thorough RiboTRAP and ribosome profiling approaches. They report a more severe alteration in the translatome specifically in astrocyte and microglia as compared to neuronal populations. This highlights that changes in these two cell classes might have a predominant role in the pathology of PrD.</p>
+                <p>Data and the methods are presented such that they can be reproduced. The data analysis section of the manuscript could be further elaborated. In particular, it could be clarified which/how comparisons with existing dataset have been performed. Statistical analysis description is sometimes missing (e.g. Figure 6E, not clear what the stars on top of the bars stands for, which test was performed and the significance). Moreover, the section of the Materials and methods regarding the western blots presented in Figure 6 appear to be missing.</p></disp-quote>
+            <p>Figure 6E shows the output (log2 fold change) of DESeq2. Genes with a Benjamini-Hochberg adjusted p value &lt; 0.05 (also derived from DESeq2) are marked with an asterisk. We have added this information to the legend, as well as methods regarding western blots.</p>
+            <disp-quote content-type="editor-comment">
+                <p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
+                <p>You need to make sure the XML structure you create works on the display of the PMC platform and also that there is enough information contained within the tagging to generate a typeset PDF from the XML with no additional information provided.</p>
+            </disp-quote>
+            <p>In response to this comment, we validated the XML against the DTD (JATS 1) each time we made an update. We also regularly used the PMC validator to check our decisions against display on the PMC site, see <xref ref-type="fig" rid="sa5fig1">Author response image 1.</xref>, <xref ref-type="video" rid="sa5video1">Author response video 1</xref> and <xref ref-type="table" rid="sa5table1">Author response table 1</xref>.</p>
+            <fig id="sa5fig1" position="float">
+                <label>Author response image 1.</label>
+                <caption>
+                    <p>Single figure: The header of an eLife article example on the HTML page.</p>
+                </caption>
+                <graphic mimetype="image" mime-subtype="tiff" xlink:href="elife-1234567890-sa5-fig1.tif"/>
+            </fig>
+            <table-wrap id="sa5table1" position="float">
+                <label>Author response table 1.</label>
+                <caption>
+                    <p>Author response table</p>
+                </caption>
+                <table frame="hsides" rules="groups">
+                    <thead>
+                        <tr>
+                            <th>Sample</th>
+                            <th>Same</th>
+                            <th>Difference more than 10%</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>DKO1.cell.1</td>
+                            <td>77.00%</td>
+                            <td>6.90%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.2</td>
+                            <td>78.80%</td>
+                            <td>7.20%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.3</td>
+                            <td>79.10%</td>
+                            <td>6.70%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.1</td>
+                            <td>78.90%</td>
+                            <td>6.50%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.2</td>
+                            <td>80.00%</td>
+                            <td>5.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.3</td>
+                            <td>86.80%</td>
+                            <td>2.30%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.1</td>
+                            <td>77.30%</td>
+                            <td>7.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.2</td>
+                            <td>79.70%</td>
+                            <td>6.70%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </table-wrap>
+            <media mimetype="video" mime-subtype="mp4" id="sa5video1" xlink:href="elife-1234567890-sa5-video1.mp4">
+                <label>Author response video 1.</label>
+                <caption>
+                    <title>Caption and/or a title is required for all author response assets.</title>
+                </caption>
+            </media>
+            <p>However, some decisions required some communication with PMC to discuss whether any of our updates could be accomodated by them - during this review we aimed to reduce the complexity of the XML structure and remove all  formatting and bioler plate text required for a PDF display format. We also produced buisness rules {Insert table} order to produce rules for the production systems and the website to follow. These buisness rules also informed the basis for a set of Schematron rules for our references.</p>
+            <p>Adding some MathML to the sub-article.<inline-formula>
+                <mml:math id="sa5m1">
+                    <mml:mstyle displaystyle="true" scriptlevel="0">
+                        <mml:mrow>
+                            <mml:msup>
+                                <mml:mi>F</mml:mi>
+                                <mml:mrow>
+                                    <mml:mi>A</mml:mi>
+                                    <mml:mi>B</mml:mi>
+                                </mml:mrow>
+                            </mml:msup>
+                            <mml:mo>∼</mml:mo>
+                            <mml:mfrac>
+                                <mml:msubsup>
+                                    <mml:mi>k</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>f</mml:mi>
+                                    </mml:mrow>
+                                    <mml:mrow>
+                                        <mml:mi>A</mml:mi>
+                                        <mml:mi>B</mml:mi>
+                                    </mml:mrow>
+                                </mml:msubsup>
+                                <mml:msqrt>
+                                    <mml:msubsup>
+                                        <mml:mi>k</mml:mi>
+                                        <mml:mrow>
+                                            <mml:mi>f</mml:mi>
+                                        </mml:mrow>
+                                        <mml:mrow>
+                                            <mml:mi>A</mml:mi>
+                                            <mml:mi>A</mml:mi>
+                                        </mml:mrow>
+                                    </mml:msubsup>
+                                    <mml:msubsup>
+                                        <mml:mi>k</mml:mi>
+                                        <mml:mrow>
+                                            <mml:mi>f</mml:mi>
+                                        </mml:mrow>
+                                        <mml:mrow>
+                                            <mml:mi>B</mml:mi>
+                                            <mml:mi>B</mml:mi>
+                                        </mml:mrow>
+                                    </mml:msubsup>
+                                </mml:msqrt>
+                            </mml:mfrac>
+                            <mml:msqrt>
+                                <mml:msup>
+                                    <mml:mi>F</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>A</mml:mi>
+                                        <mml:mi>A</mml:mi>
+                                    </mml:mrow>
+                                </mml:msup>
+                                <mml:msup>
+                                    <mml:mi>F</mml:mi>
+                                    <mml:mrow>
+                                        <mml:mi>B</mml:mi>
+                                        <mml:mi>B</mml:mi>
+                                    </mml:mrow>
+                                </mml:msup>
+                            </mml:msqrt>
+                        </mml:mrow>
+                    </mml:mstyle>
+                </mml:math>
+            </inline-formula>
+            </p>
+            <p>May also contain a formula as a block
+                <disp-formula id="sa5equ1">
+                    <label>(1)</label>
+                        <mml:math id="sa5m2">
+                            <mml:mstyle displaystyle="true" scriptlevel="0">
+                                <mml:mrow>
+                                    <mml:mi>d</mml:mi>
+                                    <mml:mtext> </mml:mtext>
+                                    <mml:mo>=</mml:mo>
+                                    <mml:mtext> </mml:mtext>
+                                    <mml:msqrt>
+                                        <mml:msup>
+                                            <mml:mrow>
+                                                <mml:mo>(</mml:mo>
+                                                <mml:mfrac>
+                                                    <mml:mrow>
+                                                        <mml:mi>P</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mi>i</mml:mi>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>t</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi mathvariant="bold-italic">i</mml:mi>
+                                                                <mml:mtext> </mml:mtext>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                        <mml:mo>−</mml:mo>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>O</mml:mi>
+                                                        <mml:mi>b</mml:mi>
+                                                        <mml:mi>s</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>v</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi>i</mml:mi>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                    </mml:mrow>
+                                                    <mml:mrow>
+                                                        <mml:mi>O</mml:mi>
+                                                        <mml:mi>b</mml:mi>
+                                                        <mml:mi>s</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>r</mml:mi>
+                                                        <mml:mi>v</mml:mi>
+                                                        <mml:mi>e</mml:mi>
+                                                        <mml:mi>d</mml:mi>
+                                                        <mml:mtext> </mml:mtext>
+                                                        <mml:mi>c</mml:mi>
+                                                        <mml:mi>o</mml:mi>
+                                                        <mml:mi>u</mml:mi>
+                                                        <mml:mi>n</mml:mi>
+                                                        <mml:msub>
+                                                            <mml:mi>t</mml:mi>
+                                                            <mml:mrow>
+                                                                <mml:mi>i</mml:mi>
+                                                            </mml:mrow>
+                                                        </mml:msub>
+                                                    </mml:mrow>
+                                                </mml:mfrac>
+                                                <mml:mo>)</mml:mo>
+                                            </mml:mrow>
+                                            <mml:mrow>
+                                                <mml:mn>2</mml:mn>
+                                            </mml:mrow>
+                                        </mml:msup>
+                                    </mml:msqrt>
+                                </mml:mrow>
+                            </mml:mstyle>
+                        </mml:math>
+                </disp-formula>
+            </p>
+            <list id="sa5list1" list-type="roman-upper">
+                <list-item>
+                    <p>'Contamination'</p>
+                    <list id="sa5list2" list-type="order">
+                        <list-item>
+                            <p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>
+                        </list-item>
+                        <list-item>
+                            <p><italic>C. elegans</italic> is ...</p>
+                        </list-item>
+                    </list>
+                </list-item>
+            </list>
+        </body>
+    </sub-article>
+</article>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7743

Refactored the `DepositCrossref` activity to generate output in a multi-step process. It allows additional related item tags to be added to the `CrossrefXML` object before the file output is written to disk. Some refactoring of the `provider/crossref.py` module too as well.

`DepositCrossref` will also produce two deposit files if the article has a `version_doi`, one deposit for the version DOI and one deposit for the concept DOI.

A remaining todo is to add `isVersionOf` related tags, which can be introduced in a subsequent PR.