### PR TITLE
Dependency `digestparser` pinned to `0.2.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ newrelic = "*"
 pyfunctional = "~=1.4"
 func-timeout = "~=4.3"
 python-docx = "~=0.8"
-digestparser = "~=0.1"
+digestparser = "~=0.2.0"
 medium = {git = "https://github.com/Medium/medium-sdk-python.git", ref = "bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6"}
 psutil = "~=5.8"
 pytz = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-02-14 - see update-dependencies.sh
+# file generated 2023-02-20 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.14.1
 attrs==22.2.0
@@ -14,7 +14,7 @@ configparser==5.3.0
 cryptography==39.0.1
 ddt==1.6.0
 Deprecated==1.2.13
-digestparser==0.1.2
+digestparser==0.2.0
 dill==0.3.6
 docker==5.0.3
 docmaptools==0.3.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/100/display/redirect which resulted in this pull request.