### PR TITLE
DepositCrossref add isVersionOf tags, bug fix tag.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -139,16 +139,21 @@ class activity_DepositCrossref(Activity):
 
         for article, c_xml in list(crossref_object_map.items()):
             # set related item tags
-            if article.version_doi:
+            if article.version_doi or article.publication_history:
                 # add rel:program tag if not present
                 crossref.add_rel_program_tag(c_xml.root)
                 # find the rel:program tag
                 rel_program_tag = crossref.find_rel_program_tag(c_xml.root)
 
-                # add intra_work_relation isSameAs tag
-                crossref.add_is_same_as_tag(rel_program_tag, article.version_doi)
+                if article.version_doi:
+                    # add intra_work_relation isSameAs tag
+                    crossref.add_is_same_as_tag(rel_program_tag, article.version_doi)
 
-            # todo!!! add rel:intra_work_relation isVersionOf tags
+                for event_object in article.publication_history:
+                    if event_object.event_type == "reviewed-preprint":
+                        crossref.add_is_version_of_tag(
+                            rel_program_tag, event_object.doi
+                        )
 
         # output CrossrefXML objects to XML files
         for article, c_xml in list(crossref_object_map.items()):

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -247,10 +247,23 @@ def clear_rel_program_tag(c_xml):
 
 def add_is_same_as_tag(rel_program_tag, doi):
     "add doi as intra_work_relation isSameAs tag to the rel:program tag"
+    related_item_tag = SubElement(rel_program_tag, "rel:related_item")
     related.set_related_item_work_relation(
-        rel_program_tag,
+        related_item_tag,
         "intra_work_relation",
         "isSameAs",
+        "doi",
+        doi,
+    )
+
+
+def add_is_version_of_tag(rel_program_tag, doi):
+    "add doi as intra_work_relation isVersionOf tag to the rel:program tag"
+    related_item_tag = SubElement(rel_program_tag, "rel:related_item")
+    related.set_related_item_work_relation(
+        related_item_tag,
+        "intra_work_relation",
+        "isVersionOf",
         "doi",
         doi,
     )

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -86,10 +86,13 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_crossref_xml_contains": [
                 "<doi>10.7554/eLife.1234567890</doi>",
                 (
-                    '<rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.1101/2021.11.09.467796</rel:intra_work_relation>'
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.1101/2021.11.09.467796</rel:intra_work_relation>'
                 ),
                 (
-                    '<rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'
+                ),
+                (
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">10.7554/eLife.1234567890.1</rel:intra_work_relation>'
                 ),
             ],
             "expected_email_count": 1,

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -341,13 +341,38 @@ class TestAddIsSameAsTag(unittest.TestCase):
         doi = "10.7554/eLife.1234567890"
         expected = (
             b'<rel:program xmlns:rel="http://www.crossref.org/relations.xsd">'
+            b"<rel:related_item>"
             b'<rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">'
             b"10.7554/eLife.1234567890"
             b"</rel:intra_work_relation>"
+            b"</rel:related_item>"
             b"</rel:program>"
         )
         # invoke function
         crossref.add_is_same_as_tag(root, doi)
+        # assert
+        self.assertEqual(ElementTree.tostring(root), expected)
+
+
+class TestAddIsVersionOfTag(unittest.TestCase):
+    def setUp(self):
+        ElementTree.register_namespace("rel", "http://www.crossref.org/relations.xsd")
+
+    def test_add_is_version_of_tag(self):
+        xml_string = b'<rel:program xmlns:rel="http://www.crossref.org/relations.xsd"/>'
+        root = ElementTree.fromstring(xml_string)
+        doi = "10.7554/eLife.1234567890"
+        expected = (
+            b'<rel:program xmlns:rel="http://www.crossref.org/relations.xsd">'
+            b"<rel:related_item>"
+            b'<rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">'
+            b"10.7554/eLife.1234567890"
+            b"</rel:intra_work_relation>"
+            b"</rel:related_item>"
+            b"</rel:program>"
+        )
+        # invoke function
+        crossref.add_is_version_of_tag(root, doi)
         # assert
         self.assertEqual(ElementTree.tostring(root), expected)
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7743

Add the `isVersionOf` tags to Crossref deposits based on the publication history of the XML file.

Bug fixed the Crossref deposits which were invalid since the last PR; each relationship needs to be wrapped in a `<rel:related_item>` tag.