### PR TITLE
Relate Crossref peer review the parent version_doi

### DIFF
--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -92,6 +92,9 @@ class activity_DepositCrossrefPeerReview(Activity):
             article_object_map, self.settings, self.logger
         )
 
+        # use the version_doi as the related article to each review article
+        crossref.set_version_doi_on_review_articles(generate_article_object_map)
+
         # Generate crossref XML
         self.statuses["generate"] = crossref.generate_crossref_xml_to_disk(
             generate_article_object_map,

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -220,6 +220,15 @@ def build_crossref_xml(
     return object_list
 
 
+def set_version_doi_on_review_articles(article_object_map):
+    "for peer review deposits set the related article of each review article to be the version_doi"
+    for xml_file, article in list(article_object_map.items()):
+        if article.version_doi:
+            for review_article in article.review_articles:
+                for related_article in review_article.related_articles:
+                    related_article.doi = article.version_doi
+
+
 def add_rel_program_tag(root):
     "add a rel:program tag to a Crossref deposit ElementTree root, if missing"
     if not find_rel_program_tag(root):

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -102,7 +102,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
                 "<title>Author response: eLife kitchen sink 3.0</title>",
                 (
                     '<rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">'
-                    + "10.7554/eLife.1234567890</rel:inter_work_relation>"
+                    + "10.7554/eLife.1234567890.4</rel:inter_work_relation>"
                 ),
                 '<anonymous contributor_role="author" sequence="first"/>',
                 '<peer_review stage="pre-publication" type="editor-report">',

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -270,6 +270,36 @@ class TestBuildCrossrefXml(unittest.TestCase):
         self.assertEqual(len(bad_xml_files), 1)
 
 
+class TestSetVersionDoiOnReviewArticles(unittest.TestCase):
+    def test_set_version_doi(self):
+        # prepare sample data, simulates parsing a more complicated XML file
+        xml_file_name = "article.xml"
+        doi = "10.7554/eLife.1234567890"
+        version_doi = "10.7554/eLife.1234567890.4"
+        parent_article = Article(doi)
+        parent_article.version_doi = version_doi
+        review_article_1 = Article("%s.sa0" % version_doi)
+        review_article_1.related_articles = [parent_article]
+        review_article_2 = Article("%s.sa1" % version_doi)
+        review_article_2.related_articles = [parent_article]
+        parent_article.review_articles = [review_article_1, review_article_2]
+        article_map = {xml_file_name: parent_article}
+        # invoke the function
+        crossref.set_version_doi_on_review_articles(article_map)
+        # assert the DOI of the related_article of a review article is the version_doi
+        self.assertEqual(
+            article_map[xml_file_name].review_articles[0].related_articles[0].doi,
+            version_doi,
+        )
+
+    def test_set_version_doi_empty_map(self):
+        "example if a blank map is supplied"
+        article_map = {}
+        expected = {}
+        crossref.set_version_doi_on_review_articles(article_map)
+        self.assertEqual(article_map, expected)
+
+
 class TestAddRelProgramTag(unittest.TestCase):
     def setUp(self):
         ElementTree.register_namespace("rel", "http://www.crossref.org/relations.xsd")


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7743

A follow-up to PR https://github.com/elifesciences/elife-bot/pull/1634

It's better to relate a Crossref peer review deposit to the version DOI of the article of which it is a review, instead of using the article DOI, if a version DOI is available.