### PR TITLE
related-article tags for pub-history event PMC XML

### DIFF
--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -120,6 +120,7 @@ class activity_PMCDeposit(Activity):
             self.logger,
             alter_xml=True,
             remove_version_doi=workflow_rules.get("remove_version_doi"),
+            convert_history_events=True,
         )
 
         # check if the article is retracted


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7894

When depositing XML to PMC, add `<related-article>` tags for each preprint event in the `<pub-history>`.