### PR TITLE
Use hra for id prefix in PMC XML history events.

### DIFF
--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -372,7 +372,7 @@ def convert_history_event_tags(xml_file, logger):
                         article_meta_tag, "related-article"
                     )
                     related_article_tag.set("ext-link-type", "doi")
-                    related_article_tag.set("id", "ra%s" % event_index)
+                    related_article_tag.set("id", "hra%s" % event_index)
                     related_article_tag.set("related-article-type", "preprint")
                     related_article_tag.set(
                         "{http://www.w3.org/1999/xlink}href",

--- a/tests/provider/test_article_processing.py
+++ b/tests/provider/test_article_processing.py
@@ -484,6 +484,7 @@ class TestConvertHistoryEventTags(unittest.TestCase):
         xml_string = """%s<article xmlns:xlink="http://www.w3.org/1999/xlink">
 <front>
 <article-meta>
+<related-article ext-link-type="doi" id="ra1" related-article-type="article-reference" xlink:href="10.7554/eLife.00666"/>
 %s
 </article-meta>
 </front>
@@ -494,15 +495,16 @@ class TestConvertHistoryEventTags(unittest.TestCase):
 
         # in test output the tags will not be separated by whitespace
         related_article_xml = (
-            '<related-article ext-link-type="doi" id="ra1" related-article-type="preprint" xlink:href="10.1101/2021.11.09.467796"/>'
-            '<related-article ext-link-type="doi" id="ra2" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.1"/>'
-            '<related-article ext-link-type="doi" id="ra3" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.2"/>'
-            '<related-article ext-link-type="doi" id="ra4" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.3"/>'
+            '<related-article ext-link-type="doi" id="hra1" related-article-type="preprint" xlink:href="10.1101/2021.11.09.467796"/>'
+            '<related-article ext-link-type="doi" id="hra2" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.1"/>'
+            '<related-article ext-link-type="doi" id="hra3" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.2"/>'
+            '<related-article ext-link-type="doi" id="hra4" related-article-type="preprint" xlink:href="10.7554/eLife.1234567890.3"/>'
         )
 
         expected = """%s<article xmlns:xlink="http://www.w3.org/1999/xlink">
 <front>
 <article-meta>
+<related-article ext-link-type="doi" id="ra1" related-article-type="article-reference" xlink:href="10.7554/eLife.00666"/>
 %s
 %s</article-meta>
 </front>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7894

Bug fix to PR https://github.com/elifesciences/elife-bot/pull/1637

Avoid the potential for setting duplicate `@id` attributes on the `<related-article>` tags set for PMC XML by using a more unique name, having them start with `hra`.