### PR TITLE
Use different docmap URL and handle list returned

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -103,16 +103,18 @@ class activity_AcceptedSubmissionPeerReviews(Activity):
         preprint_doi = utils.doi_uri_to_doi(preprint_url)
         self.logger.info("%s, preprint_doi: %s" % (self.name, preprint_doi))
 
-        # generate Sciety URL
-        sciety_url = cleaner.sciety_docmap_url(self.settings, preprint_doi)
-        self.logger.info("%s, sciety_url: %s" % (self.name, sciety_url))
+        # generate docmap URL
+        docmap_url = cleaner.docmap_url(self.settings, preprint_doi)
+        self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
 
         # get docmap json
         self.logger.info(
             "%s, getting docmap_string for input_filename: %s"
             % (self.name, input_filename)
         )
-        docmap_string = cleaner.get_docmap(sciety_url)
+        docmap_string = cleaner.get_docmap_by_account_id(
+            docmap_url, self.settings.docmap_account_id
+        )
         self.statuses["docmap_string"] = True
 
         # get sub-article data from docmap

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -164,12 +164,12 @@ class activity_ValidateAcceptedSubmission(Activity):
                 # get the DOI from the URL
                 preprint_doi = utils.doi_uri_to_doi(preprint_url)
 
-                # check Sciety URL exists, if fails then fail the workflow
-                sciety_url = cleaner.sciety_docmap_url(self.settings, preprint_doi)
-                if not cleaner.url_exists(sciety_url, self.logger):
+                # check docmap URL exists, if fails then fail the workflow
+                docmap_url = cleaner.docmap_url(self.settings, preprint_doi)
+                if not cleaner.url_exists(docmap_url, self.logger):
                     log_message = (
-                        "Request for a docmap was not successful for Sciety URL %s"
-                        % sciety_url
+                        "Request for a docmap was not successful for URL %s"
+                        % docmap_url
                     )
                     self.logger.info("%s, %s" % (self.name, log_message))
                     error_email_body += "%s\n" % log_message

--- a/settings-example.py
+++ b/settings-example.py
@@ -346,7 +346,8 @@ class exp:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    sciety_docmap_url_pattern = "https://sciety.example.org/path/{doi}.docmap.json"
+    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_account_id = "https://sciety.org/groups/elife"
 
 
 class dev:
@@ -679,7 +680,8 @@ class dev:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    sciety_docmap_url_pattern = "https://sciety.example.org/path/{doi}.docmap.json"
+    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_account_id = "https://sciety.org/groups/elife"
 
 
 class live:
@@ -1017,7 +1019,8 @@ class live:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    sciety_docmap_url_pattern = "https://sciety.example.org/path/{doi}.docmap.json"
+    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_account_id = "https://sciety.org/groups/elife"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -241,4 +241,5 @@ GLENCOE_FTP_CWD = "folder"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
-sciety_docmap_url_pattern = "https://sciety.example.org/path/{doi}.docmap.json"
+docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+docmap_account_id = "https://sciety.org/groups/elife"

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -391,8 +391,7 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             self.activity.logger.loginfo[-2],
             (
                 "ValidateAcceptedSubmission, Request for a docmap was not successful for "
-                "Sciety URL https://sciety.example.org/path/%s.docmap.json"
-                % preprint_doi
+                "URL https://example.org/path/get-by-id?preprint_doi=%s" % preprint_doi
             ),
         )
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -94,4 +94,5 @@ accepted_submission_queue = "cleaning_queue"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
-sciety_docmap_url_pattern = "https://sciety.example.org/path/{doi}.docmap.json"
+docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+docmap_account_id = "https://sciety.org/groups/elife"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8045

Switching over to a different URL to get docmap data. This one will return a list structure, and the correct docmap will be found by the publisher account id value.

This feature isn't used yet but it is expected to be in a matter of weeks. It can be tested after deployment using a test zip file deposited to a bucket, which I intend to do next.