### PR TITLE
GET instead of HEAD when checking docmap exists.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -162,7 +162,7 @@ def add_sub_article_xml(docmap_string, article_xml):
 def url_exists(url, logger):
     "check if URL exists and is successful status code"
     exists = False
-    response = requests.head(url)
+    response = requests.get(url)
     if 200 <= response.status_code < 400:
         exists = True
     elif response.status_code >= 400:

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -295,17 +295,17 @@ class TestUrlExists(unittest.TestCase):
         self.logger = FakeLogger()
         self.url = "https://example.org/"
 
-    @patch("requests.head")
-    def test_url_exists_200(self, mock_requests_head):
+    @patch("requests.get")
+    def test_url_exists_200(self, mock_requests_get):
         status_code = 200
-        mock_requests_head.return_value = FakeResponse(status_code)
+        mock_requests_get.return_value = FakeResponse(status_code)
         result = cleaner.url_exists(self.url, self.logger)
         self.assertEqual(result, True)
 
-    @patch("requests.head")
-    def test_url_exists_404(self, mock_requests_head):
+    @patch("requests.get")
+    def test_url_exists_404(self, mock_requests_get):
         status_code = 404
-        mock_requests_head.return_value = FakeResponse(status_code)
+        mock_requests_get.return_value = FakeResponse(status_code)
         result = cleaner.url_exists(self.url, self.logger)
         self.assertEqual(result, False)
         self.assertEqual(


### PR DESCRIPTION
To avoid status code 405 Method Not Allowed for `HEAD` request.