### PR TITLE
Add related-article tag directly before abstract.

### DIFF
--- a/provider/article_processing.py
+++ b/provider/article_processing.py
@@ -3,7 +3,7 @@ import shutil
 import zipfile
 import glob
 from collections import OrderedDict
-from xml.etree.ElementTree import SubElement
+from xml.etree.ElementTree import Element
 import dateutil.parser
 from elifetools import xmlio
 from provider import utils, lax_provider
@@ -368,9 +368,7 @@ def convert_history_event_tags(xml_file, logger):
                         "Adding a related-article tag for event self-uri %s"
                         % self_uri_tag.get("{http://www.w3.org/1999/xlink}href")
                     )
-                    related_article_tag = SubElement(
-                        article_meta_tag, "related-article"
-                    )
+                    related_article_tag = Element("related-article")
                     related_article_tag.set("ext-link-type", "doi")
                     related_article_tag.set("id", "hra%s" % event_index)
                     related_article_tag.set("related-article-type", "preprint")
@@ -380,7 +378,22 @@ def convert_history_event_tags(xml_file, logger):
                             self_uri_tag.get("{http://www.w3.org/1999/xlink}href")
                         ),
                     )
+                    # find the index of the abstract tag for where to insert the tag
+                    abstract_tag_index = 0
+                    for tag_index, meta_tag in enumerate(
+                        article_meta_tag.iterfind("*")
+                    ):
+                        if meta_tag.tag == "abstract":
+                            abstract_tag_index = tag_index
+                            logger.info(
+                                "Found abstract tag at index %s" % abstract_tag_index
+                            )
+                            break
+                    # insert the tag directly prior to the abstract tag
+                    article_meta_tag.insert(abstract_tag_index, related_article_tag)
+
                     event_index += 1
+
     # Start the file output
     reparsed_string = xmlio.output(
         root,

--- a/tests/provider/test_article_processing.py
+++ b/tests/provider/test_article_processing.py
@@ -486,6 +486,7 @@ class TestConvertHistoryEventTags(unittest.TestCase):
 <article-meta>
 <related-article ext-link-type="doi" id="ra1" related-article-type="article-reference" xlink:href="10.7554/eLife.00666"/>
 %s
+<abstract>An abstract.</abstract>
 </article-meta>
 </front>
 </article>""" % (
@@ -506,7 +507,8 @@ class TestConvertHistoryEventTags(unittest.TestCase):
 <article-meta>
 <related-article ext-link-type="doi" id="ra1" related-article-type="article-reference" xlink:href="10.7554/eLife.00666"/>
 %s
-%s</article-meta>
+%s<abstract>An abstract.</abstract>
+</article-meta>
 </front>
 </article>""" % (
             xml_declaration,
@@ -522,9 +524,12 @@ class TestConvertHistoryEventTags(unittest.TestCase):
         with open(test_file, "r", encoding="utf-8") as open_file:
             self.assertEqual(open_file.read(), expected)
         self.assertTrue(
-            self.logger.loginfo[-1].startswith(
+            self.logger.loginfo[1].startswith(
                 "Adding a related-article tag for event self-uri"
             ),
+        )
+        self.assertTrue(
+            self.logger.loginfo[2].startswith("Found abstract tag at index 2"),
         )
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7894
Bug fix for code merged in PR https://github.com/elifesciences/elife-bot/pull/1637

The PMC schema expects `<related-article>` tags to be in a particular place in the XML file. The tags will be added directly before the `<abstract>` tag.