### PR TITLE
Enable sending emails for PRC accepted submissions

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -23,7 +23,7 @@ LOG_FORMAT_STRING = (
 )
 
 # November 2022 temporary config whether to send emails for PRC article ingestions
-PRC_INGEST_SEND_EMAIL = False
+PRC_INGEST_SEND_EMAIL = True
 
 
 def article_id_from_zip_file(zip_file):

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -127,9 +127,17 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
     @patch.object(activity_module, "get_session")
-    def test_do_activity_do_not_send_prc_email(self, fake_session):
+    @patch.object(activity_module.email_provider, "smtp_send")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    def test_do_activity_do_not_send_prc_email(
+        self, fake_email_smtp_connect, fake_smtp_send, fake_session
+    ):
         "test for temporary setting to not send an email for PRC article ingestion"
-        expected_email_status = None
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_smtp_send.return_value = True
+        expected_email_status = True
         session_data = copy.copy(test_activity_data.accepted_session_example)
         session_data["prc_status"] = True
         fake_session.return_value = FakeSession(session_data)


### PR DESCRIPTION
Testing of sample PRC accepted submission files is concluded, for the most part, and real files are expected to arrive soon. Enable sending an email as part of the ingestion workflow again.

The test case is fixed to use the mock SMTP server.