### PR TITLE
Peer review images for accepted submission

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewImages.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewImages.py
@@ -1,0 +1,316 @@
+import os
+import json
+import shutil
+from collections import OrderedDict
+import requests
+from provider.article_processing import file_extension
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner, utils
+from activity.objects import Activity
+
+
+REPAIR_XML = False
+
+FILE_NAME_FORMAT = "elife-%s-inf%s.%s"
+
+REQUESTS_TIMEOUT = 10
+
+
+class activity_AcceptedSubmissionPeerReviewImages(Activity):
+    "AcceptedSubmissionPeerReviewImages activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionPeerReviewImages, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionPeerReviewImages"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Download peer review images to the S3 bucket"
+            " and modify the accepted submission XML."
+        )
+
+        # Track some values
+        self.input_file = None
+        self.activity_log_file = "cleaner.log"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"hrefs": None, "external_hrefs": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        log_file_path = os.path.join(
+            self.get_tmp_dir(), self.activity_log_file
+        )  # log file for this activity only
+        cleaner_log_handers = cleaner.configure_activity_log_handlers(log_file_path)
+
+        expanded_folder = session.get_value("expanded_folder")
+        input_filename = session.get_value("input_filename")
+        article_id = session.get_value("article_id")
+
+        self.logger.info(
+            "%s, input_filename: %s, expanded_folder: %s"
+            % (self.name, input_filename, expanded_folder)
+        )
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = cleaner.bucket_asset_file_name_map(
+            self.settings, self.settings.bot_bucket, expanded_folder
+        )
+        self.logger.info(
+            "%s, asset_file_name_map: %s" % (self.name, asset_file_name_map)
+        )
+
+        # find S3 object for article XML and download it
+        xml_file_path = cleaner.download_xml_file_from_bucket(
+            self.settings,
+            asset_file_name_map,
+            self.directories.get("TEMP_DIR"),
+            self.logger,
+        )
+
+        # search XML file for graphic tags
+        inline_graphic_tags = cleaner.inline_graphic_tags(xml_file_path)
+        if not inline_graphic_tags:
+            self.logger.info(
+                "%s, no inline-graphic tags in %s" % (self.name, input_filename)
+            )
+            return True
+
+        self.statuses["hrefs"] = True
+
+        # find inline-graphic with https:// sources
+        external_hrefs = cleaner.external_hrefs(
+            cleaner.tag_xlink_hrefs(inline_graphic_tags)
+        )
+        if not external_hrefs:
+            self.logger.info(
+                "%s, no inline-graphic tags with external href values in %s"
+                % (self.name, input_filename)
+            )
+            return True
+
+        self.statuses["external_hrefs"] = True
+
+        approved_hrefs = cleaner.approved_inline_graphic_hrefs(external_hrefs)
+
+        # add log messages if an external href is not approved to download
+        if approved_hrefs and external_hrefs != approved_hrefs:
+            not_approved_hrefs = sorted(set(external_hrefs) - set(approved_hrefs))
+            for href in [href for href in external_hrefs if href in not_approved_hrefs]:
+                cleaner.LOGGER.info(
+                    "%s peer review image href was not approved for downloading", href
+                )
+
+        # download images to the local disk
+        href_to_file_name_map = download_images(
+            approved_hrefs, self.directories.get("INPUT_DIR"), self.name, self.logger
+        )
+
+        # add log messages if an external href download was not successful
+        if approved_hrefs and href_to_file_name_map.keys() != approved_hrefs:
+            not_downloaded_hrefs = sorted(
+                set(approved_hrefs) - set(href_to_file_name_map.keys())
+            )
+            for href in [
+                href for href in approved_hrefs if href in not_downloaded_hrefs
+            ]:
+                cleaner.LOGGER.info(
+                    "%s peer review image href was not downloaded successfully", href
+                )
+
+        # do not continue if no images were downloaded
+        if not href_to_file_name_map:
+            self.logger.info(
+                "%s, no images were downloaded for %s, returning True"
+                % (self.name, input_filename)
+            )
+            return True
+
+        # subfolder on disk where assets are stored
+        temp_dir_subfolder = cleaner.article_xml_asset(asset_file_name_map)[0].rsplit(
+            os.sep, 1
+        )[0]
+        self.logger.info(
+            "%s, temp_dir_subfolder for %s: %s"
+            % (self.name, input_filename, temp_dir_subfolder)
+        )
+
+        # rename the files, in the order as remembered by the OrderedDict
+        file_name_count = 1
+        image_asset_file_name_map = {}
+        file_details_list = []
+        for href, file_name in href_to_file_name_map.items():
+            new_file_name = FILE_NAME_FORMAT % (
+                utils.pad_msid(article_id),
+                file_name_count,
+                file_extension(file_name),
+            )
+            self.logger.info(
+                "%s, for %s, file name %s changed to file name %s"
+                % (self.name, input_filename, file_name, new_file_name)
+            )
+            new_file_asset = os.path.join(temp_dir_subfolder, new_file_name)
+            self.logger.info(
+                "%s, for %s, file %s new asset value %s"
+                % (self.name, input_filename, new_file_name, new_file_asset)
+            )
+            new_file_path = os.path.join(
+                self.directories.get("TEMP_DIR"), new_file_asset
+            )
+            self.logger.info(
+                "%s, for %s, moving %s to %s"
+                % (self.name, input_filename, file_name, new_file_path)
+            )
+            # move the file on disk
+            shutil.move(file_name, new_file_path)
+
+            # change the file path in the href map
+            href_to_file_name_map[href] = new_file_name
+            # add the file path to the asset map
+            image_asset_file_name_map[new_file_asset] = new_file_path
+            # add the file details for using later to add XML file tags
+            file_details = {"file_type": "figure", "upload_file_nm": new_file_name}
+            file_details_list.append(file_details)
+
+        # upload images to the bucket expanded files folder
+        for upload_key, file_name in image_asset_file_name_map.items():
+            s3_resource = (
+                self.settings.storage_provider
+                + "://"
+                + self.settings.bot_bucket
+                + "/"
+                + expanded_folder
+                + "/"
+                + upload_key
+            )
+            local_file_path = file_name
+            storage.set_resource_from_filename(s3_resource, local_file_path)
+            self.logger.info(
+                "%s, uploaded %s to S3 object: %s"
+                % (self.name, local_file_path, s3_resource)
+            )
+
+        # add to XML manifest <file> tags
+        cleaner.add_file_tags_to_xml(xml_file_path, file_details_list, input_filename)
+
+        # change inline-graphic xlink:href value
+        cleaner.change_inline_graphic_xlink_hrefs(
+            xml_file_path, href_to_file_name_map, input_filename
+        )
+
+        # upload the XML to the bucket
+        upload_key = cleaner.article_xml_asset(asset_file_name_map)[0]
+        s3_resource = (
+            self.settings.storage_provider
+            + "://"
+            + self.settings.bot_bucket
+            + "/"
+            + expanded_folder
+            + "/"
+            + upload_key
+        )
+        local_file_path = asset_file_name_map.get(upload_key)
+        storage.set_resource_from_filename(s3_resource, local_file_path)
+        self.logger.info(
+            "%s, uploaded %s to S3 object: %s"
+            % (self.name, local_file_path, s3_resource)
+        )
+        self.statuses["upload_xml"] = True
+
+        # remove the log handlers
+        for log_handler in cleaner_log_handers:
+            cleaner.log_remove_handler(log_handler)
+
+        # read the cleaner log contents
+        with open(log_file_path, "r", encoding="utf8") as open_file:
+            log_contents = open_file.read()
+
+        # add the log_contents to the session variable
+        cleaner_log = session.get_value("cleaner_log")
+        if cleaner_log is None:
+            cleaner_log = log_contents
+        else:
+            cleaner_log += log_contents
+        session.store_value("cleaner_log", cleaner_log)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def log_statuses(self, input_file):
+        "log the statuses value"
+        self.logger.info(
+            "%s for input_file %s statuses: %s"
+            % (self.name, str(input_file), self.statuses)
+        )
+
+    def clean_tmp_dir(self):
+        "custom cleaning of temp directory in order to retain some files for debugging purposes"
+        keep_dirs = []
+        for dir_name, dir_path in self.directories.items():
+            if dir_name in keep_dirs or not os.path.exists(dir_path):
+                continue
+            shutil.rmtree(dir_path)
+
+
+def download_images(href_list, to_dir, activity_name, logger):
+    href_to_file_name_map = OrderedDict()
+    for href in href_list:
+        file_name = href.rsplit("/", 1)[-1]
+        to_file = os.path.join(to_dir, file_name)
+        # todo!!! improve handling of potentially duplicate file_name values
+        if href in href_to_file_name_map.keys():
+            logger.info("%s, href %s was already downloaded" % (activity_name, href))
+            continue
+        try:
+            file_path = download_file(href, to_file)
+        except RuntimeError:
+            logger.info("%s, href %s could not be downloaded" % (activity_name, href))
+            continue
+        logger.info("%s, downloaded href %s to %s" % (activity_name, href, to_file))
+        # keep track of a map of href value to local file_name
+        href_to_file_name_map[href] = file_path
+    return href_to_file_name_map
+
+
+def download_file(from_path, to_file):
+    request = requests.get(from_path, timeout=REQUESTS_TIMEOUT)
+    if request.status_code == 200:
+        with open(to_file, "wb") as open_file:
+            open_file.write(request.content)
+        return to_file
+    raise RuntimeError(
+        "GET request returned a %s status code for %s"
+        % (request.status_code, from_path)
+    )

--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -46,6 +46,17 @@ class activity_EmailAcceptedSubmissionOutput(Activity):
             )
             return True
 
+        # March 2023 also do not send emails for any particular test files
+        if (
+            session.get_value("prc_status")
+            and input_filename in cleaner.PRC_INGEST_IGNORE_SEND_EMAIL
+        ):
+            self.logger.info(
+                "%s, %s is in the PRC_INGEST_IGNORE_SEND_EMAIL list so no email will be sent"
+                % (self.name, input_filename)
+            )
+            return True
+
         # format the email body content
         body_content = ""
         comments = cleaner.production_comments(cleaner_log)

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -28,6 +28,13 @@ LOG_FORMAT_STRING = (
 # November 2022 temporary config whether to send emails for PRC article ingestions
 PRC_INGEST_SEND_EMAIL = True
 
+# March 2023 temporary config to not send emails for particular test files
+PRC_INGEST_IGNORE_SEND_EMAIL = [
+    "02-28-2023-RA-RP-eLife-84747.zip",
+    "18-05-2021-RA-RP-eLife-70493.zip",
+    "22-04-2022-RA-RP-eLife-79713.zip",
+]
+
 REQUESTS_TIMEOUT = 10
 
 

--- a/register.py
+++ b/register.py
@@ -136,6 +136,7 @@ def start(settings):
     activity_names.append("AddCommentsToAcceptedSubmissionXml")
     activity_names.append("OutputAcceptedSubmission")
     activity_names.append("AcceptedSubmissionPeerReviews")
+    activity_names.append("AcceptedSubmissionPeerReviewImages")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_accepted_submission_peer_review_images.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_images.py
@@ -1,0 +1,325 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionPeerReviewImages as activity_module
+from activity.activity_AcceptedSubmissionPeerReviewImages import (
+    activity_AcceptedSubmissionPeerReviewImages as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeResponse,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch("requests.get")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "example with no inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "status_code": 200,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": None,
+            "expected_external_hrefs_status": None,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewImages, no inline-graphic tags in "
+                    "30-01-2019-RA-eLife-45644.zip"
+                )
+            ],
+        },
+        {
+            "comment": "example with a non-external inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                "<sub-article>"
+                '<inline-graphic xlink:href="local.jpg" />'
+                "</sub-article>"
+            ),
+            "status_code": 200,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_external_hrefs_status": None,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewImages, no inline-graphic tags with "
+                    "external href values in 30-01-2019-RA-eLife-45644.zip"
+                )
+            ],
+        },
+        {
+            "comment": "example with an external inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                "<sub-article>"
+                '<inline-graphic xlink:href="local.jpg" />'
+                '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                "</sub-article>"
+            ),
+            "status_code": 200,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_external_hrefs_status": True,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewImages, downloaded href "
+                    "https://i.imgur.com/vc4GR10.png to"
+                )
+            ],
+        },
+        {
+            "comment": "example with unapproved inline-graphic values",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                "<sub-article>"
+                '<inline-graphic xlink:href="local.jpg" />'
+                '<inline-graphic xlink:href="https://example.org/fake.jpg" />'
+                '<inline-graphic xlink:href="https://example.org/no_zip_please.zip" />'
+                '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                "</sub-article>"
+            ),
+            "status_code": 200,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_external_hrefs_status": True,
+            "expected_cleaner_log_contains": [
+                (
+                    "https://example.org/fake.jpg peer review image href "
+                    "was not approved for downloading"
+                ),
+            ],
+        },
+        {
+            "comment": "example with duplicate inline-graphic values",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                "<sub-article>"
+                '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                "</sub-article>"
+            ),
+            "status_code": 200,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_external_hrefs_status": True,
+            "expected_bucket_upload_folder_contents": [
+                "30-01-2019-RA-eLife-45644.xml",
+                "elife-45644-inf1.png",
+            ],
+            "expected_xml_contains": [
+                (
+                    '<file file-type="figure">'
+                    "<upload_file_nm>elife-45644-inf1.png</upload_file_nm>"
+                    "</file></files>"
+                ),
+                (
+                    '<inline-graphic xlink:href="elife-45644-inf1.png"/>'
+                    '<inline-graphic xlink:href="elife-45644-inf1.png"/>'
+                ),
+            ],
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewImages, href https://i.imgur.com/vc4GR10.png "
+                    "was already downloaded"
+                )
+            ],
+        },
+        {
+            "comment": "example with get request non-200 status code",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                "<sub-article>"
+                '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                "</sub-article>"
+            ),
+            "status_code": 404,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_external_hrefs_status": True,
+            "expected_bucket_upload_folder_contents": [],
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewImages, href https://i.imgur.com/vc4GR10.png "
+                    "could not be downloaded"
+                )
+            ],
+            "expected_cleaner_log_contains": [
+                (
+                    "https://i.imgur.com/vc4GR10.png peer review image href "
+                    "was not downloaded successfully"
+                ),
+            ],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_get,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+
+        # write additional XML to the XML file
+        if test_data.get("sub_article_xml"):
+            sub_folder = test_data.get("filename").rsplit(".", 1)[0]
+            xml_path = os.path.join(
+                directory.path,
+                self.session.get_value("expanded_folder"),
+                sub_folder,
+                "%s.xml" % sub_folder,
+            )
+            with open(xml_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            with open(xml_path, "w", encoding="utf-8") as open_file:
+                xml_string = xml_string.replace(
+                    "</article>", "%s</article>" % test_data.get("sub_article_xml")
+                )
+                open_file.write(xml_string)
+        dest_folder = os.path.join(directory.path, "files_dest")
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=dest_folder
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+
+        fake_response = FakeResponse(test_data.get("status_code"))
+        # an image file to test with
+        with open(
+            "tests/files_source/digests/outbox/99999/digest-99999.jpg", "rb"
+        ) as open_file:
+            fake_response.content = open_file.read()
+        fake_get.return_value = fake_response
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # assertion on XML contents
+        if test_data.get("expected_xml_contains"):
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_content = open_file.read()
+            for fragment in test_data.get("expected_xml_contains"):
+                self.assertTrue(fragment in xml_content)
+
+        self.assertEqual(
+            self.activity.statuses.get("hrefs"),
+            test_data.get("expected_hrefs_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("external_hrefs"),
+            test_data.get("expected_external_hrefs_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on cleaner.log contents
+        if test_data.get("expected_cleaner_log_contains"):
+            log_file_path = os.path.join(
+                self.activity.get_tmp_dir(), self.activity.activity_log_file
+            )
+            with open(log_file_path, "r", encoding="utf8") as open_file:
+                log_contents = open_file.read()
+            for fragment in test_data.get("expected_cleaner_log_contains"):
+                self.assertTrue(
+                    fragment in log_contents,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # check output bucket folder contents
+        if "expected_bucket_upload_folder_contents" in test_data:
+            bucket_folder_path = os.path.join(
+                dest_folder,
+                test_activity_data.accepted_session_example.get("expanded_folder"),
+                "30-01-2019-RA-eLife-45644",
+            )
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            self.assertEqual(
+                sorted(output_bucket_list),
+                sorted(test_data.get("expected_bucket_upload_folder_contents")),
+            )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -148,6 +148,29 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
         self.assertEqual(result, True)
         self.assertEqual(self.activity.email_status, expected_email_status)
 
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module.email_provider, "smtp_send")
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    def test_do_activity_do_not_send_email_for_input_file(
+        self, fake_email_smtp_connect, fake_smtp_send, fake_session
+    ):
+        "test for temporary setting not to send an email for particular input file names"
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_smtp_send.return_value = True
+        expected_email_status = None
+        session_data = copy.copy(test_activity_data.accepted_session_example)
+        session_data["prc_status"] = True
+        session_data["input_filename"] = "02-28-2023-RA-RP-eLife-84747.zip"
+        fake_session.return_value = FakeSession(session_data)
+        # do the activity
+        result = self.activity.do_activity(
+            test_case_data.ingest_accepted_submission_data
+        )
+        self.assertEqual(result, True)
+        self.assertEqual(self.activity.email_status, expected_email_status)
+
 
 class TestEmailSubject(unittest.TestCase):
     def test_accepted_submission_email_subject(self):

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -51,6 +51,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("AnnotateAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
+                define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
                 define_workflow_step_short("AddCommentsToAcceptedSubmissionXml", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7937

Adding new `AcceptedSubmissionPeerReviewImages` activity to the existing `IngestAcceptedSubmission` workflow. It will download images in peer review content matching particular domains, particular file types, rename the files, upload to the expanded files folder in the bucket, add `<file>` tags to the XML file, and modify the `<inline-graphic>` XML tag `xlink:href` values.

Also, ignore any input filename listed specifically in the `cleaner.PRC_INGEST_IGNORE_SEND_EMAIL` list when sending an email at the end of the workflow, so test files do not confuse the downstream consumers of the test file.
