### PR TITLE
Use Sciety docmap for one test file temporarily.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -35,6 +35,14 @@ PRC_INGEST_IGNORE_SEND_EMAIL = [
     "22-04-2022-RA-RP-eLife-79713.zip",
 ]
 
+# March 2023 for testing an article which appears in Sciety docmaps but not in Data Hub docmaps
+SCIETY_DOCMAP_URL_PATTERN = (
+    "https://sciety.org/docmaps/v1/evaluations-by/elife/{doi}.docmap.json"
+)
+
+# March 2023 for testing an article which appears in Sciety docmaps but not in Data Hub docmaps
+SCIETY_TEST_PREPRINT_DOI_LIST = ["10.1101/2021.06.02.446694"]
+
 REQUESTS_TIMEOUT = 10
 
 
@@ -277,7 +285,11 @@ def add_file_tags_to_xml(xml_file_path, file_detail_list, identifier):
 
 def docmap_url(settings, doi):
     "URL of the preprint docmap at Sciety"
-    docmap_url_pattern = getattr(settings, "docmap_url_pattern", None)
+    # temporarily use a different docmap for a test test article
+    if doi in SCIETY_TEST_PREPRINT_DOI_LIST:
+        docmap_url_pattern = SCIETY_DOCMAP_URL_PATTERN
+    else:
+        docmap_url_pattern = getattr(settings, "docmap_url_pattern", None)
     return docmap_url_pattern.format(doi=doi) if docmap_url_pattern else None
 
 

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -379,7 +379,7 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             directory.path, resources
         )
         fake_is_prc.return_value = True
-        preprint_doi = "10.1101/2021.06.02.446694"
+        preprint_doi = "10.1101/2021.06.02.999999"
         fake_preprint_url.return_value = "https://doi.org/%s" % preprint_doi
         fake_url_exists.return_value = False
         fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -518,7 +518,7 @@ class TestAddFileTagsToXml(unittest.TestCase):
 
 class TestDocmapUrl(unittest.TestCase):
     def test_docmap_url(self):
-        doi = "10.1101/2021.06.02.446694"
+        doi = "10.1101/2021.06.02.999999"
         result = cleaner.docmap_url(settings_mock, doi)
         expected = "https://example.org/path/get-by-id?preprint_doi=%s" % doi
         self.assertEqual(result, expected)
@@ -527,7 +527,7 @@ class TestDocmapUrl(unittest.TestCase):
         class FakeSettings:
             pass
 
-        doi = "10.1101/2021.06.02.446694"
+        doi = "10.1101/2021.06.02.999999"
         result = cleaner.docmap_url(FakeSettings(), doi)
         expected = None
         self.assertEqual(result, expected)


### PR DESCRIPTION
A test file using preprint DOI `10.1101/2021.06.02.446694` will not appear in the real docmaps because it is a test value, however it does appear in the Sciety docmaps. I want to test something on this test file so substitute the docmap URL when this test preprint DOI is used.

This PR can be reverted later, or the hook and values can be removed from `provider/cleaner.py` in a new PR.