### PR TITLE
Fix peer review image file name increment logic.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewImages.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewImages.py
@@ -200,6 +200,9 @@ class activity_AcceptedSubmissionPeerReviewImages(Activity):
             file_details = {"file_type": "figure", "upload_file_nm": new_file_name}
             file_details_list.append(file_details)
 
+            # increment the file name counter
+            file_name_count += 1
+
         # upload images to the bucket expanded files folder
         for upload_key, file_name in image_asset_file_name_map.items():
             s3_resource = (

--- a/tests/activity/test_activity_accepted_submission_peer_review_images.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_images.py
@@ -94,6 +94,7 @@ class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
                 "<sub-article>"
                 '<inline-graphic xlink:href="local.jpg" />'
                 '<inline-graphic xlink:href="https://i.imgur.com/vc4GR10.png" />'
+                '<inline-graphic xlink:href="https://i.imgur.com/FFeuydR.jpg" />'
                 "</sub-article>"
             ),
             "status_code": 200,
@@ -106,6 +107,20 @@ class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
                     "AcceptedSubmissionPeerReviewImages, downloaded href "
                     "https://i.imgur.com/vc4GR10.png to"
                 )
+            ],
+            "expected_xml_contains": [
+                (
+                    '<file file-type="figure">'
+                    "<upload_file_nm>elife-45644-inf1.png</upload_file_nm>"
+                    "</file>"
+                    '<file file-type="figure">'
+                    "<upload_file_nm>elife-45644-inf2.jpg</upload_file_nm>"
+                    "</file></files>"
+                ),
+                (
+                    '<inline-graphic xlink:href="elife-45644-inf1.png"/>'
+                    '<inline-graphic xlink:href="elife-45644-inf2.jpg"/>'
+                ),
             ],
         },
         {


### PR DESCRIPTION
Bug fix PR https://github.com/elifesciences/elife-bot/pull/1646 to assign unique file names to the peer review images downloaded. Updated a test case to represent an example with multiple images.