### PR TITLE
cleaner, remove ext-link tag from inline-graphic

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -125,6 +125,9 @@ class activity_AcceptedSubmissionPeerReviews(Activity):
         xml_root = cleaner.add_sub_article_xml(docmap_string, xml_file_path)
         self.statuses["xml_root"] = True
 
+        # remove ext-link tag if it wraps an inline-graphic tag
+        cleaner.clean_inline_graphic_tags(xml_root)
+
         # write the XML root to disk
         cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
 

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -297,6 +297,26 @@ def add_sub_article_xml(docmap_string, article_xml):
     return sub_article.add_sub_article_xml(docmap_string, article_xml)
 
 
+def clean_inline_graphic_tags(root):
+    "remove ext-link tags if they wrap an inline-graphic tag"
+    for parent_tag in root.findall(".//ext-link/inline-graphic/../.."):
+        # method is to move the child tags and text up a level, then ext-link tag can be removed
+        index_delta = 0
+        for index, tag in enumerate(parent_tag.findall("*")):
+            if tag.tag == "ext-link":
+                # move the child tags to the same place as the ext-link tag
+                child_tag = None
+                for child_tag in tag.findall("*"):
+                    parent_tag.insert(index + index_delta, child_tag)
+                    # because removing a tag alters the tag index, keep track of the index changes
+                    index_delta += 1
+                # add the tail if present
+                if child_tag is not None and tag.tail:
+                    child_tag.tail = tag.tail
+                # finish up by removing the ext-link tag
+                parent_tag.remove(tag)
+
+
 def url_exists(url, logger):
     "check if URL exists and is successful status code"
     exists = False

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -533,6 +533,76 @@ class TestDocmapUrl(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
+class TestCleanInlineGraphicTags(unittest.TestCase):
+    def test_clean_simple(self):
+        "simple test example for clean_inline_graphic_tags"
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>"
+            '<ext-link xlink:href="https://example.org/">'
+            '<inline-graphic xlink:href="https://example.org/" />'
+            "</ext-link>"
+            "</p>"
+            "</body>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>"
+            '<inline-graphic xlink:href="https://example.org/" />'
+            "</p>"
+            "</body>"
+        )
+        cleaner.clean_inline_graphic_tags(root)
+        self.assertEqual(ElementTree.tostring(root).decode("utf8"), expected)
+
+    def test_clean_multiple(self):
+        "test cleaning multiple inline-graphic tags plus a tag tail value"
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p><bold>A</bold> couple "
+            '<ext-link xlink:href="https://example.org/">'
+            '<inline-graphic xlink:href="https://example.org/1" /> and '
+            "<italic>also</italic> "
+            '<inline-graphic xlink:href="https://example.org/2" />'
+            "</ext-link> inline graphics."
+            '<ext-link xlink:href="https://example.org/another">'
+            '<inline-graphic xlink:href="https://example.org/another" />'
+            "</ext-link>"
+            "</p>"
+            "</body>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p><bold>A</bold> couple "
+            '<inline-graphic xlink:href="https://example.org/1" /> and '
+            "<italic>also</italic> "
+            '<inline-graphic xlink:href="https://example.org/2" />'
+            " inline graphics."
+            '<inline-graphic xlink:href="https://example.org/another" />'
+            "</p>"
+            "</body>"
+        )
+        cleaner.clean_inline_graphic_tags(root)
+        self.assertEqual(ElementTree.tostring(root).decode("utf8"), expected)
+
+    def test_clean_no_changes(self):
+        "test if the ext-link tag is not a parent of the inline-graphic tag"
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>"
+            '<ext-link xlink:href="https://example.org/" />'
+            '<inline-graphic xlink:href="https://example.org/" />'
+            "</p>"
+            "</body>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = xml_string
+        cleaner.clean_inline_graphic_tags(root)
+        self.assertEqual(ElementTree.tostring(root).decode("utf8"), expected)
+
+
 class TestUrlExists(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7937

Related to PR https://github.com/elifesciences/elife-bot/pull/1646

In accepted submission XML, the `<inline-graphic>` tags should not be wrapped by an `<ext-link>` tag. It can be removed when the peer review content is added as part of the `AcceptedSubmissionPeerReviews` activity.