### PR TITLE
Set assessment_terms.yaml path in cleaner provider

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -122,7 +122,8 @@ class activity_AcceptedSubmissionPeerReviews(Activity):
             "%s, generating xml_root including sub-article tags for input_filename: %s"
             % (self.name, input_filename)
         )
-        xml_root = cleaner.add_sub_article_xml(docmap_string, xml_file_path)
+        terms_yaml = getattr(self.settings, "assessment_terms_yaml", None)
+        xml_root = cleaner.add_sub_article_xml(docmap_string, xml_file_path, terms_yaml)
         self.statuses["xml_root"] = True
 
         # remove ext-link tag if it wraps an inline-graphic tag

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -7,6 +7,7 @@ from xml.etree.ElementTree import SubElement
 import requests
 from elifecleaner import (
     LOGGER,
+    assessment_terms,
     configure_logging,
     parse,
     prc,
@@ -293,7 +294,10 @@ def docmap_url(settings, doi):
     return docmap_url_pattern.format(doi=doi) if docmap_url_pattern else None
 
 
-def add_sub_article_xml(docmap_string, article_xml):
+def add_sub_article_xml(docmap_string, article_xml, terms_yaml=None):
+    if terms_yaml:
+        # set the path to the YAML file containing assessment terms data
+        assessment_terms.ASSESSMENT_TERMS_YAML = terms_yaml
     return sub_article.add_sub_article_xml(docmap_string, article_xml)
 
 

--- a/settings-example.py
+++ b/settings-example.py
@@ -349,6 +349,8 @@ class exp:
     docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
     docmap_account_id = "https://sciety.org/groups/elife"
 
+    assessment_terms_yaml = "assessment_terms.yaml"
+
 
 class dev:
     # AWS settings
@@ -682,6 +684,8 @@ class dev:
 
     docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
     docmap_account_id = "https://sciety.org/groups/elife"
+
+    assessment_terms_yaml = "assessment_terms.yaml"
 
 
 class live:
@@ -1021,6 +1025,8 @@ class live:
 
     docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
     docmap_account_id = "https://sciety.org/groups/elife"
+
+    assessment_terms_yaml = "assessment_terms.yaml"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -243,3 +243,5 @@ downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
 docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
 docmap_account_id = "https://sciety.org/groups/elife"
+
+assessment_terms_yaml = "tests/assessment_terms.yaml"

--- a/tests/assessment_terms.yaml
+++ b/tests/assessment_terms.yaml
@@ -1,0 +1,68 @@
+Compelling:
+  group:
+    evidence-strength
+  terms:
+    - compelling
+
+Convincing:
+  group:
+    evidence-strength
+  terms:
+    - convincing
+    - convincingly
+
+Exceptional:
+  group:
+    evidence-strength
+  terms:
+    - exceptional
+
+Fundamental:
+  group:
+    claim-importance
+  terms:
+    - fundamental
+
+Important:
+  group:
+    claim-importance
+  terms:
+    - important
+
+Inadequate:
+  group:
+    evidence-strength
+  terms:
+    - inadequate
+    - inadequately
+
+Incomplete:
+  group:
+    evidence-strength
+  terms:
+    - incomplete
+    - incompletely
+
+Landmark:
+  group:
+    claim-importance
+  terms:
+    - landmark
+
+Solid:
+  group:
+    evidence-strength
+  terms:
+    - solid
+
+Useful:
+  group:
+    claim-importance
+  terms:
+    - useful
+
+Valuable:
+  group:
+    claim-importance
+  terms:
+    - valuable


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8176

Use the new feature in `elifecleaner==0.30.0` to highlight peer review assessment terms as part of the accepted submission ingestion workflow.