### PR TITLE
Change docmap_url_pattern to use article_id value.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -96,15 +96,8 @@ class activity_AcceptedSubmissionPeerReviews(Activity):
             self.logger,
         )
 
-        # get the preprint URL from the session
-        preprint_url = session.get_value("preprint_url")
-
-        # get the DOI from the URL
-        preprint_doi = utils.doi_uri_to_doi(preprint_url)
-        self.logger.info("%s, preprint_doi: %s" % (self.name, preprint_doi))
-
         # generate docmap URL
-        docmap_url = cleaner.docmap_url(self.settings, preprint_doi)
+        docmap_url = cleaner.docmap_url(self.settings, session.get_value("article_id"))
         self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
 
         # get docmap json

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -161,11 +161,10 @@ class activity_ValidateAcceptedSubmission(Activity):
                 self.logger.info("%s, %s" % (self.name, log_message))
                 error_email_body += "%s\n" % log_message
             else:
-                # get the DOI from the URL
-                preprint_doi = utils.doi_uri_to_doi(preprint_url)
-
                 # check docmap URL exists, if fails then fail the workflow
-                docmap_url = cleaner.docmap_url(self.settings, preprint_doi)
+                docmap_url = cleaner.docmap_url(
+                    self.settings, session.get_value("article_id")
+                )
                 if not cleaner.url_exists(docmap_url, self.logger):
                     log_message = (
                         "Request for a docmap was not successful for URL %s"

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -42,7 +42,7 @@ SCIETY_DOCMAP_URL_PATTERN = (
 )
 
 # March 2023 for testing an article which appears in Sciety docmaps but not in Data Hub docmaps
-SCIETY_TEST_PREPRINT_DOI_LIST = ["10.1101/2021.06.02.446694"]
+SCIETY_TEST_PREPRINT_DICT = {"70493": "10.1101/2021.06.02.446694"}
 
 REQUESTS_TIMEOUT = 10
 
@@ -284,14 +284,17 @@ def add_file_tags_to_xml(xml_file_path, file_detail_list, identifier):
     write_xml_file(root, xml_file_path, identifier)
 
 
-def docmap_url(settings, doi):
-    "URL of the preprint docmap at Sciety"
+def docmap_url(settings, article_id):
+    "URL of the preprint docmap endpoint"
     # temporarily use a different docmap for a test test article
-    if doi in SCIETY_TEST_PREPRINT_DOI_LIST:
-        docmap_url_pattern = SCIETY_DOCMAP_URL_PATTERN
-    else:
-        docmap_url_pattern = getattr(settings, "docmap_url_pattern", None)
-    return docmap_url_pattern.format(doi=doi) if docmap_url_pattern else None
+    if article_id in SCIETY_TEST_PREPRINT_DICT.keys():
+        return SCIETY_DOCMAP_URL_PATTERN.format(
+            doi=SCIETY_TEST_PREPRINT_DICT.get(article_id)
+        )
+    docmap_url_pattern = getattr(settings, "docmap_url_pattern", None)
+    return (
+        docmap_url_pattern.format(article_id=article_id) if docmap_url_pattern else None
+    )
 
 
 def add_sub_article_xml(docmap_string, article_xml, terms_yaml=None):

--- a/settings-example.py
+++ b/settings-example.py
@@ -346,7 +346,7 @@ class exp:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
     docmap_account_id = "https://sciety.org/groups/elife"
 
     assessment_terms_yaml = "assessment_terms.yaml"
@@ -682,7 +682,7 @@ class dev:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
     docmap_account_id = "https://sciety.org/groups/elife"
 
     assessment_terms_yaml = "assessment_terms.yaml"
@@ -1023,7 +1023,7 @@ class live:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
-    docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+    docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
     docmap_account_id = "https://sciety.org/groups/elife"
 
     assessment_terms_yaml = "assessment_terms.yaml"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -241,7 +241,7 @@ GLENCOE_FTP_CWD = "folder"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
-docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
 docmap_account_id = "https://sciety.org/groups/elife"
 
 assessment_terms_yaml = "tests/assessment_terms.yaml"

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -391,7 +391,8 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             self.activity.logger.loginfo[-2],
             (
                 "ValidateAcceptedSubmission, Request for a docmap was not successful for "
-                "URL https://example.org/path/get-by-id?preprint_doi=%s" % preprint_doi
+                "URL https://example.org/path/get-by-manuscript-id?manuscript_id=%s"
+                % self.session.get_value("article_id")
             ),
         )
 

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -518,18 +518,24 @@ class TestAddFileTagsToXml(unittest.TestCase):
 
 class TestDocmapUrl(unittest.TestCase):
     def test_docmap_url(self):
-        doi = "10.1101/2021.06.02.999999"
-        result = cleaner.docmap_url(settings_mock, doi)
-        expected = "https://example.org/path/get-by-id?preprint_doi=%s" % doi
+        article_id = "1234567890"
+        result = cleaner.docmap_url(settings_mock, article_id)
+        expected = "https://example.org/path/get-by-manuscript-id?manuscript_id=%s" % article_id
         self.assertEqual(result, expected)
 
     def test_docmap_url_no_settings(self):
         class FakeSettings:
             pass
 
-        doi = "10.1101/2021.06.02.999999"
-        result = cleaner.docmap_url(FakeSettings(), doi)
+        article_id = "1234567890"
+        result = cleaner.docmap_url(FakeSettings(), article_id)
         expected = None
+        self.assertEqual(result, expected)
+
+    def test_sciety_docmap_temporary_value(self):
+        article_id = "70493"
+        result = cleaner.docmap_url(settings_mock, article_id)
+        expected = "https://sciety.org/docmaps/v1/evaluations-by/elife/10.1101/2021.06.02.446694.docmap.json"
         self.assertEqual(result, expected)
 
 

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -94,5 +94,5 @@ accepted_submission_queue = "cleaning_queue"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
-docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
+docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
 docmap_account_id = "https://sciety.org/groups/elife"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8237

The endpoint for docmaps is changed to query by `article_id` instead of the preprint DOI.