### PR TITLE
Dependency `docmaptools` pinned to `0.6.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-04-14 - see update-dependencies.sh
+# file generated 2023-04-18 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.1
 async-timeout==4.0.2
@@ -18,7 +18,7 @@ Deprecated==1.2.13
 digestparser==0.2.0
 dill==0.3.6
 docker==5.0.3
-docmaptools==0.5.0
+docmaptools==0.6.0
 ejpcsvparser==0.2.0
 elifearticle==0.14.0
 elifecleaner==0.31.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/114/display/redirect which resulted in this pull request.