### PR TITLE
Dependency `elifecleaner` pinned to `0.34.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.33.0"
+elifecleaner = "~=0.34.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-05-03 - see update-dependencies.sh
+# file generated 2023-05-04 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.1
 async-timeout==4.0.2
@@ -21,7 +21,7 @@ docker==5.0.3
 docmaptools==0.7.0
 ejpcsvparser==0.2.0
 elifearticle==0.14.0
-elifecleaner==0.33.0
+elifecleaner==0.34.0
 elifecrossref==0.18.0
 elifepubmed==0.5.1
 elifetools==0.32.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/119/display/redirect which resulted in this pull request.