### PR TITLE
To deposit preprint peer reviews to Crossref.

### DIFF
--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -24,6 +24,16 @@ def elifecrossref_config(settings):
     )
 
 
+def elifecrossref_preprint_config(settings):
+    "parse the preprint config values from the elifecrossref config"
+    return parse_raw_config(
+        raw_config(
+            settings.elifecrossref_preprint_config_section,
+            settings.elifecrossref_config_file,
+        )
+    )
+
+
 def parse_article_xml(article_xml_files, tmp_dir=None):
     """Given a list of article XML files, parse into objects"""
     override_tmp_dir(tmp_dir)

--- a/settings-example.py
+++ b/settings-example.py
@@ -157,6 +157,7 @@ class exp:
     # Crossref generation
     elifecrossref_config_file = "crossref.cfg"
     elifecrossref_config_section = "elife"
+    elifecrossref_preprint_config_section = "elife_preprint"
 
     # Crossref
     crossref_url = "http://test.crossref.org/servlet/deposit"
@@ -497,6 +498,7 @@ class dev:
     # Crossref generation
     elifecrossref_config_file = "crossref.cfg"
     elifecrossref_config_section = "elife"
+    elifecrossref_preprint_config_section = "elife_preprint"
 
     # Crossref
     crossref_url = "http://test.crossref.org/servlet/deposit"
@@ -834,6 +836,7 @@ class live:
     # Crossref generation
     elifecrossref_config_file = "crossref.cfg"
     elifecrossref_config_section = "elife"
+    elifecrossref_preprint_config_section = "elife_preprint"
 
     # Crossref
     crossref_url = "http://doi.crossref.org/servlet/deposit"

--- a/tests/activity/crossref.cfg
+++ b/tests/activity/crossref.cfg
@@ -50,3 +50,12 @@ access_indicators_applies_to: ["vor", "am", "tdm"]
 reference_distribution_opts: any
 text_mining_xml_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.xml
 text_mining_pdf_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf
+
+[elife_preprint]
+registrant: eLife
+depositor_name: eLife
+email_address: production@elifesciences.org
+batch_file_prefix: elife-crossref-preprint-
+doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}
+peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews#{id}
+elocation_id: true

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -93,6 +93,7 @@ no_download_extensions = "tif"
 
 elifecrossref_config_file = "tests/activity/crossref.cfg"
 elifecrossref_config_section = "elife"
+elifecrossref_preprint_config_section = "elife_preprint"
 
 jatsgenerator_config_file = "tests/activity/jatsgenerator.cfg"
 jatsgenerator_config_section = "elife"

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -113,6 +113,38 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
                 '<institution_id type="ror">https://ror.org/01an7q238</institution_id>',
             ],
         },
+        {
+            "comment": "Preprint article",
+            "article_xml_filenames": ["elife-preprint-84364-v2.xml"],
+            "post_status_code": 200,
+            "expected_result": True,
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_outbox_status": True,
+            "expected_email_status": True,
+            "expected_activity_status": True,
+            "expected_file_count": 1,
+            "expected_crossref_xml_contains": [
+                "<doi_batch_id>elife-crossref-preprint-peer_review-84364-",
+                "<ai:license_ref>http://creativecommons.org/licenses/by/4.0/</ai:license_ref>",
+                "<title>eLife assessment: Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</title>",
+                "<title>Reviewer #1 (Public Review): Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</title>",
+                "<title>Reviewer #2 (Public Review): Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</title>",
+                "<title>Reviewer #3 (Public Review): Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</title>",
+                "<title>Author response: Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</title>",
+                (
+                    '<rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">'
+                    + "10.7554/eLife.84364.2</rel:inter_work_relation>"
+                ),
+                '<anonymous contributor_role="author" sequence="first"/>',
+                '<peer_review stage="pre-publication" type="editor-report">',
+                '<peer_review stage="pre-publication" type="referee-report">',
+                '<peer_review stage="pre-publication" type="author-comment">',
+                "<doi>10.7554/eLife.84364.2.sa0</doi>",
+                "<resource>https://elifesciences.org/reviewed-preprints/84364/reviews#sa0</resource>",
+            ],
+        },
     )
     def test_do_activity(
         self,
@@ -172,7 +204,9 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
             )
         # Count crossref XML file in the tmp directory
         file_count = len(os.listdir(self.tmp_dir()))
-        self.assertEqual(file_count, test_data.get("expected_file_count"))
+        self.assertEqual(
+            file_count, test_data.get("expected_file_count"), test_data.get("comment")
+        )
 
         if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
             # Open the first crossref XML and check some of its contents

--- a/tests/test_data/crossref_peer_review/outbox/elife-preprint-84364-v2.xml
+++ b/tests/test_data/crossref_peer_review/outbox/elife-preprint-84364-v2.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article
+ PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"
+  "JATS-archivearticle1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="preprint" dtd-version="1.1d3">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="nlm-ta">elife</journal-id>
+            <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            <journal-title-group>
+                <journal-title>eLife</journal-title>
+            </journal-title-group>
+            <issn publication-format="electronic">2050-084X</issn>
+            <publisher>
+                <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">84364</article-id>
+            <article-id pub-id-type="doi">10.7554/eLife.84364</article-id>
+            <article-id pub-id-type="doi" specific-use="version">10.7554/eLife.84364.2</article-id>
+            <title-group>
+                <article-title>Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name name-style="western">
+                        <surname>Mahlandt</surname>
+                        <given-names>Eike K.</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="a1">1</xref>
+                </contrib>
+                <aff id="a1">
+                    <label>1</label>
+                    <institution>Swammerdam Institute for Life Sciences, Section of Molecular Cytology, van Leeuwenhoek Centre for Advanced Microscopy, University of Amsterdam, Science Park 904</institution>
+                    , 1098 XH, Amsterdam,
+                    <country>The Netherlands</country>
+                </aff>
+            </contrib-group>
+            <pub-date publication-format="electronic" date-type="posted_date">
+                <day>13</day>
+                <month>02</month>
+                <year>2023</year>
+            </pub-date>
+            <volume>12</volume>
+            <elocation-id>RP84364</elocation-id>
+            <pub-history>
+                <event>
+                    <date date-type="preprint" iso-8601-date="2022-10-17">
+                        <day>17</day>
+                        <month>10</month>
+                        <year>2022</year>
+                    </date>
+                    <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2022.10.17.512253"/>   
+                </event>
+                <event>
+                    <date date-type="reviewed-preprint" iso-8601-date="2023-02-12">
+                        <day>12</day>
+                        <month>02</month>
+                        <year>2023</year>
+                    </date>
+                    <self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.84364.1"/>   
+                </event>
+            </pub-history>
+            <permissions>
+                <license xlink:href="http://creativecommons.org/licenses/by/4.0/">
+                    <ali:license_ref>http://creativecommons.org/licenses/by/4.0/</ali:license_ref>
+                </license>
+            </permissions>
+            <abstract>
+                <sec id="p-2">
+                    <title >Abstract</title>
+                    <p>The inner layer of blood vessels consists of endothelial cells, which form the physical barrier between blood and tissue. This vascular barrier is tightly regulated to allow the passage of essential molecules like oxygen, carbon-dioxide, water, ions, and nutrients. The vascular endothelial barrier is defined by cell-cell contacts through adherens and tight junctions. To further investigate the signaling in the endothelium that regulates vascular barrier strength, we focused on Rho GTPases, regulators of the actin cytoskeleton and known to control junction integrity. Rho GTPase signaling is confined in space and time. To manipulate the signaling in a temporal and spatial manner we applied optogenetics. Guanine exchange factor (GEF) domains from ITSN1, TIAM1 and p63RhoGEF, activating Cdc42, Rac and Rho respectively, were integrated into the optogenetic recruitment tool iLID. This tool allows for activation at the subcellular level in a reversible and non-invasive manner and thereby to recruit a GEF to local areas at the plasma membrane, enabling the local activation of specific Rho GTPases. The membrane tag of iLID was optimized and a HaloTag was applied to gain more flexibility for multiplex imaging. The resulting Opto-RhoGEFs were tested in an endothelial cell monolayer and demonstrated precise temporal control of vascular barrier strength by a cell-cell overlap-dependent, VE-cadherin-independent, mechanism. Furthermore, Opto-RhoGEFs enabled precise optogenetic control in endothelial cells over morphological features such as cell-size, -roundness, local extension, and cell contraction. In conclusion, we have optimized and applied the optogenetic iLID GEF recruitment tool i.e. Opto-RhoGEFs, to study the role of Rho GTPases in the vascular barrier of the endothelium and found that membrane protrusions at the junction region can rapidly increase barrier integrity independent of VE-cadherin.</p>
+                </sec>
+            </abstract>
+        </article-meta>
+    </front>
+    <sub-article id="sa0" article-type="editor-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa0</article-id>
+            <title-group>
+                <article-title>eLife assessment</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Eisen</surname>
+                        <given-names>Michael B</given-names>
+                    </name>
+                    <aff>
+                        <institution-wrap>
+                            <institution>University of California</institution>
+                        </institution-wrap>
+                        <addr-line><named-content content-type="city">Berkeley</named-content></addr-line>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa1" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa1</article-id>
+            <title-group>
+                <article-title>Reviewer #1 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa2" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa2</article-id>
+            <title-group>
+                <article-title>Reviewer #2 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa3" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa3</article-id>
+            <title-group>
+                <article-title>Reviewer #3 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa4" article-type="author-comment">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa4</article-id>
+            <title-group>
+                <article-title>Author response</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name name-style="western">
+                        <surname>Mahlandt</surname>
+                        <given-names>Eike K.</given-names>
+                    </name>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+</article>


### PR DESCRIPTION
To deposit peer review materials from preprint XML, use a different configuration section from the `elifecrossref.cfg` file. In the `DepositCrossrefPeerReview` activity, separate the articles based on their `article-type` in the XML, and then the correct configuration can be loaded when generating Crossref deposit output.

Re issue https://github.com/elifesciences/issues/issues/7717