### PR TITLE
cleaner provider, journal-title and publisher-name

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -151,6 +151,8 @@ def transform_prc(xml_file_path, identifier):
     # next, check the XML for the status
     root = parse_article_xml(xml_file_path)
     prc.transform_journal_id_tags(root, identifier)
+    prc.transform_journal_title_tag(root, identifier)
+    prc.transform_publisher_name_tag(root, identifier)
     prc.add_prc_custom_meta_tags(root, identifier)
     prc.transform_elocation_id(root, identifier=identifier)
     write_xml_file(root, xml_file_path, identifier)

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -194,7 +194,13 @@ class TestTransformPrc(unittest.TestCase):
             "<front>"
             "<journal-meta>"
             '<journal-id journal-id-type="publisher-id">foo</journal-id>'
+            "<journal-title-group>"
+            "<journal-title>eLife Reviewed Preprints </journal-title>"
+            "</journal-title-group>"
             "<issn>2050-084X</issn>"
+            "<publisher>"
+            "<publisher-name>elife-rp Sciences Publications, Ltd</publisher-name>"
+            "</publisher>"
             "</journal-meta>"
             "<article-meta>"
             "<elocation-id>e1234567890</elocation-id>"
@@ -212,6 +218,11 @@ class TestTransformPrc(unittest.TestCase):
             xml_contents = open_file.read()
         self.assertTrue(
             '<journal-id journal-id-type="publisher-id">eLife</journal-id>'
+            in xml_contents
+        )
+        self.assertTrue("<journal-title>eLife</journal-title>" in xml_contents)
+        self.assertTrue(
+            "<publisher-name>eLife Sciences Publications, Ltd</publisher-name>"
             in xml_contents
         )
         self.assertTrue("<elocation-id>RP1234567890</elocation-id>" in xml_contents)


### PR DESCRIPTION
Function calls to replace the `<journal-title>` and `<publisher-name>` tag values in accepted submission XML if the article is PRC type.

Re issue https://github.com/elifesciences/issues/issues/8309