### PR TITLE
Different hasPreprint in Crossref deposit for PRC.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import json
 import time
 import glob
+from elifearticle.article import Preprint
 from activity.objects import Activity
 from provider import crossref, downstream, email_provider, outbox_provider, utils
 
@@ -232,6 +233,20 @@ class activity_DepositCrossref(Activity):
             crossref.set_article_version(article, self.settings)
             # set Contributor orcid_authenticated values to True
             crossref.contributor_orcid_authenticated(article, True)
+
+            # set the preprint to a different value for PRC articles
+            if article.publication_history:
+                event_list = [
+                    event_object
+                    for event_object in article.publication_history
+                    if event_object.event_type == "reviewed-preprint"
+                ]
+                if event_list:
+                    event_object = event_list[-1]
+                    preprint_object = Preprint()
+                    preprint_object.doi = event_object.doi
+                    article.preprint = preprint_object
+
         return article_object_map
 
     def approve_for_publishing(self):

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -86,7 +86,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_crossref_xml_contains": [
                 "<doi>10.7554/eLife.1234567890</doi>",
                 (
-                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.1101/2021.11.09.467796</rel:intra_work_relation>'
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.7554/eLife.1234567890.3</rel:intra_work_relation>'
                 ),
                 (
                     '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'


### PR DESCRIPTION
Deposit to Crossref the EPP DOI as the preprint of a PRC article, instead of using the DOI from the original preprint.

Re issue https://github.com/elifesciences/issues/issues/8336