### PR TITLE
Dependency `docmaptools` pinned to `0.8.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Deprecated==1.2.14
 digestparser==0.2.0
 dill==0.3.6
 docker==5.0.3
-docmaptools==0.7.0
+docmaptools==0.8.0
 ejpcsvparser==0.2.0
 elifearticle==0.14.0
 elifecleaner==0.38.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/128/display/redirect which resulted in this pull request.