### PR TITLE
AcceptedSubmissionPeerReviewFigs and refactoring.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewFigs.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewFigs.py
@@ -1,0 +1,121 @@
+import os
+import json
+from elifecleaner.transform import ArticleZipFile
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner
+from activity.objects import AcceptedBaseActivity
+
+
+REPAIR_XML = False
+
+
+class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
+    "AcceptedSubmissionPeerReviewFigs activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionPeerReviewFigs, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionPeerReviewFigs"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Transform certain peer review inline graphic image content into "
+            "fig tags and images."
+        )
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"hrefs": None, "modify_xml": None, "rename_files": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        session = get_session(self.settings, data, data["run"])
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        self.start_cleaner_log()
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
+
+        # find S3 object for article XML and download it
+        xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
+
+        # search XML file for graphic tags
+        inline_graphic_tags = cleaner.inline_graphic_tags(xml_file_path)
+        if not inline_graphic_tags:
+            self.logger.info(
+                "%s, no inline-graphic tags in %s" % (self.name, input_filename)
+            )
+            self.end_cleaner_log(session)
+            return True
+
+        self.statuses["hrefs"] = True
+
+        xml_root = cleaner.parse_article_xml(xml_file_path)
+
+        file_transformations = []
+        for sub_article_root in xml_root.iterfind("./sub-article"):
+            # list of old file names
+            previous_hrefs = cleaner.inline_graphic_hrefs(
+                sub_article_root, input_filename
+            )
+            cleaner.transform_fig(sub_article_root, input_filename)
+            # list of new file names
+            current_hrefs = cleaner.graphic_hrefs(sub_article_root, input_filename)
+            # add to file_transformations
+            for index, previous_href in enumerate(previous_hrefs):
+                current_href = current_hrefs[index]
+                from_file = ArticleZipFile(previous_href)
+                to_file = ArticleZipFile(current_href)
+                file_transformations.append((from_file, to_file))
+
+        # write the XML root to disk
+        cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
+
+        # rewrite the XML file with the renamed files
+        if file_transformations:
+            self.statuses["modify_xml"] = self.rewrite_file_tags(
+                xml_file_path, file_transformations, input_filename
+            )
+
+        # rename the files in the expanded folder
+        if self.statuses["modify_xml"]:
+            self.statuses["rename_files"] = self.rename_expanded_folder_files(
+                asset_file_name_map, expanded_folder, file_transformations, storage
+            )
+
+        # upload the XML to the bucket
+        self.upload_xml_file_to_bucket(asset_file_name_map, expanded_folder, storage)
+
+        self.end_cleaner_log(session)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -9,6 +9,7 @@ from elifecleaner import (
     LOGGER,
     assessment_terms,
     configure_logging,
+    fig,
     parse,
     prc,
     sub_article,
@@ -252,6 +253,21 @@ def approved_inline_graphic_hrefs(href_list):
     return filter_hrefs_by_file_extension(
         filter_hrefs_by_hostname(external_hrefs(href_list))
     )
+
+
+def inline_graphic_hrefs(sub_article_root, identifier):
+    "return a list of inline-graphic tag xlink:href values"
+    return fig.inline_graphic_hrefs(sub_article_root, identifier)
+
+
+def graphic_hrefs(sub_article_root, identifier):
+    "return a list of graphic tag xlink:href values"
+    return fig.graphic_hrefs(sub_article_root, identifier)
+
+
+def transform_fig(sub_article_root, identifier):
+    "transform inline-graphic tags into fig tags"
+    return fig.transform_fig(sub_article_root, identifier)
 
 
 def add_file_tag(parent, file_details):

--- a/register.py
+++ b/register.py
@@ -137,6 +137,7 @@ def start(settings):
     activity_names.append("OutputAcceptedSubmission")
     activity_names.append("AcceptedSubmissionPeerReviews")
     activity_names.append("AcceptedSubmissionPeerReviewImages")
+    activity_names.append("AcceptedSubmissionPeerReviewFigs")
     activity_names.append("AcceptedSubmissionVersionDoi")
 
     for activity_name in activity_names:

--- a/tests/activity/test_activity_accepted_submission_peer_review_figs.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_figs.py
@@ -1,0 +1,309 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionPeerReviewFigs as activity_module
+from activity.activity_AcceptedSubmissionPeerReviewFigs import (
+    activity_AcceptedSubmissionPeerReviewFigs as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionPeerReviewFigs(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "example with no inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "image_names": None,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": None,
+            "expected_upload_xml_status": None,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewFigs, no inline-graphic tags in "
+                    "30-01-2019-RA-eLife-45644.zip"
+                )
+            ],
+        },
+        {
+            "comment": "example with no label or caption content inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                '<sub-article id="sa1">'
+                "<body>"
+                '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+            ),
+            "image_names": ["local.jpg"],
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml_contains": [
+                (
+                    '<sub-article id="sa1">'
+                    "<body>"
+                    '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                    "</body>"
+                    "</sub-article>"
+                ),
+            ],
+        },
+        {
+            "comment": "example with label and caption",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                '<sub-article id="sa1">'
+                "<body>"
+                "<p>First paragraph.</p>"
+                "<p><bold>Review image 1.</bold></p>"
+                "<p>Caption title. Caption paragraph.</p>"
+                '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+                '<sub-article id="sa2">'
+                "<body>"
+                "<p>First paragraph.</p>"
+                "<p><bold>Review image 1.</bold></p>"
+                "<p>Caption title. Caption paragraph.</p>"
+                '<p><inline-graphic xlink:href="local2.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+            ),
+            "image_names": ["local.jpg", "local2.jpg"],
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml_contains": [
+                (
+                    '<sub-article id="sa1">'
+                    "<body>"
+                    "<p>First paragraph.</p>"
+                    '<fig id="sa1fig1">'
+                    "<label>Review image 1.</label>"
+                    "<caption>"
+                    "<title>Caption title.</title>"
+                    "<p>Caption paragraph.</p>"
+                    "</caption>"
+                    '<graphic mimetype="image" mime-subtype="jpg" xlink:href="sa1-fig1.jpg"/>'
+                    "</fig>"
+                    "</body>"
+                    "</sub-article>"
+                    '<sub-article id="sa2">'
+                    "<body>"
+                    "<p>First paragraph.</p>"
+                    '<fig id="sa2fig1">'
+                    "<label>Review image 1.</label>"
+                    "<caption>"
+                    "<title>Caption title.</title>"
+                    "<p>Caption paragraph.</p>"
+                    "</caption>"
+                    '<graphic mimetype="image" mime-subtype="jpg" xlink:href="sa2-fig1.jpg"/>'
+                    "</fig>"
+                    "</body>"
+                    "</sub-article>"
+                ),
+                (
+                    '<file file-type="figure">'
+                    "<upload_file_nm>sa1-fig1.jpg</upload_file_nm>"
+                    "</file>"
+                    '<file file-type="figure">'
+                    "<upload_file_nm>sa2-fig1.jpg</upload_file_nm>"
+                    "</file>"
+                    "</files>"
+                ),
+            ],
+            "expected_bucket_upload_folder_contents": [
+                "30-01-2019-RA-eLife-45644.xml",
+                "sa1-fig1.jpg",
+            ],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        zip_sub_folder = test_data.get("filename").replace(".zip", "")
+        zip_xml_file = "%s.xml" % zip_sub_folder
+
+        # create a new zip file fixtur
+        file_details = []
+        if test_data.get("image_names"):
+            for image_name in test_data.get("image_names"):
+                details = {
+                    "file_path": "tests/files_source/digests/outbox/99999/digest-99999.jpg",
+                    "file_type": "figure",
+                    "upload_file_nm": image_name,
+                }
+                file_details.append(details)
+        new_zip_file_path = helpers.add_files_to_accepted_zip(
+            "tests/files_source/30-01-2019-RA-eLife-45644.zip",
+            directory.path,
+            file_details,
+        )
+
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            new_zip_file_path,
+        )
+
+        # write additional XML to the XML file
+        if test_data.get("sub_article_xml"):
+            sub_folder = test_data.get("filename").rsplit(".", 1)[0]
+            xml_path = os.path.join(
+                directory.path,
+                self.session.get_value("expanded_folder"),
+                sub_folder,
+                "%s.xml" % sub_folder,
+            )
+            with open(xml_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            with open(xml_path, "w", encoding="utf-8") as open_file:
+                xml_string = xml_string.replace(
+                    "</article>", "%s</article>" % test_data.get("sub_article_xml")
+                )
+                open_file.write(xml_string)
+
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            zip_sub_folder,
+            zip_xml_file,
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # assertion on XML contents
+        if test_data.get("expected_xml_contains"):
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_content = open_file.read()
+            for fragment in test_data.get("expected_xml_contains"):
+                self.assertTrue(
+                    fragment in xml_content,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        self.assertEqual(
+            self.activity.statuses.get("hrefs"),
+            test_data.get("expected_hrefs_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on cleaner.log contents
+        if test_data.get("expected_cleaner_log_contains"):
+            log_file_path = os.path.join(
+                self.activity.get_tmp_dir(), self.activity.activity_log_file
+            )
+            with open(log_file_path, "r", encoding="utf8") as open_file:
+                log_contents = open_file.read()
+            for fragment in test_data.get("expected_cleaner_log_contains"):
+                self.assertTrue(
+                    fragment in log_contents,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on the session cleaner log content
+        if test_data.get("expected_upload_xml_status"):
+            session_log = self.session.get_value("cleaner_log")
+            self.assertIsNotNone(
+                session_log,
+                "failed in {comment}".format(comment=test_data.get("comment")),
+            )
+
+        # check output bucket folder contents
+        if "expected_bucket_upload_folder_contents" in test_data:
+            bucket_folder_path = os.path.join(
+                directory.path,
+                test_activity_data.accepted_session_example.get("expanded_folder"),
+                zip_sub_folder,
+            )
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            for bucket_file in test_data.get("expected_bucket_upload_folder_contents"):
+                self.assertTrue(
+                    bucket_file in output_bucket_list,
+                    "%s not found in bucket upload folder" % bucket_file,
+                )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -53,6 +53,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("AcceptedSubmissionVersionDoi", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
+                define_workflow_step_short("AcceptedSubmissionPeerReviewFigs", data),
                 define_workflow_step_short("AddCommentsToAcceptedSubmissionXml", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7754

Add new activity named `AcceptedSubmissionPeerReviewFigs` to the `IngestAcceptedSubmission` workflow.

Some refactoring of `RenameAcceptedSubmissionVideos` to use common methods when renaming files from old to new file names.