### PR TITLE
Handle a CSV parsing exception in PublicationEmail

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -583,7 +583,13 @@ class activity_PublicationEmail(Activity):
             i = 0
             recipient_author = {}
             for value in author:
-                heading = column_headings[i]
+                try:
+                    heading = column_headings[i]
+                except IndexError:
+                    log_info = "Missing column_headings for article doi id " + str(
+                        doi_id
+                    )
+                    continue
                 recipient_author[heading] = value
                 i = i + 1
             # Special: convert the dict to an object for use in templates

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -996,6 +996,73 @@ class TestArticleAuthors(unittest.TestCase):
         self.assertEqual(all_authors, expected)
 
 
+class TestGetAuthorList(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_PublicationEmail(
+            settings_mock, fake_logger, None, None, None
+        )
+
+    def tearDown(self):
+        self.activity.clean_tmp_dir()
+
+    def test_get_author_list(self):
+        "test getting authors for a research article"
+        column_headings = [
+            "ms_no",
+            "author_seq",
+            "first_nm",
+            "last_nm",
+            "author_type_cde",
+            "dual_corr_author_ind",
+            "e_mail",
+        ]
+        authors = [
+            [
+                "3",
+                "1",
+                "Author",
+                "One",
+                "Contributing Author",
+                " ",
+                "author01@example.com",
+            ]
+        ]
+        doi_id = "3"
+        expected = [
+            {
+                "ms_no": "3",
+                "author_seq": "1",
+                "first_nm": "Author",
+                "last_nm": "One",
+                "author_type_cde": "Contributing Author",
+                "dual_corr_author_ind": " ",
+                "e_mail": "author01@example.com",
+            }
+        ]
+        author_list = self.activity.get_author_list(column_headings, authors, doi_id)
+        self.assertEqual(author_list, expected)
+
+    def test_get_author_list_exception(self):
+        "test for when column heading data is missing"
+        column_headings = []
+        authors = [
+            [
+                "3",
+                "1",
+                "Author",
+                "One",
+                "Contributing Author",
+                " ",
+                "author01@example.com",
+            ]
+        ]
+        doi_id = "3"
+        expected = [{}]
+        author_list = self.activity.get_author_list(column_headings, authors, doi_id)
+        self.assertEqual(author_list, expected)
+
+
 @ddt
 class TestChooseRecipientAuthors(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Some weird CSV file data raised an exception, which causes the `PublicationEmail` activity to not complete. Ignore the bad data rows and continue if this exception happens again.