### PR TITLE
Add AcceptedSubmissionPeerReviewOcr activity.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewOcr.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewOcr.py
@@ -1,0 +1,275 @@
+import os
+import json
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import article_processing, cleaner, ocr
+from activity.objects import AcceptedBaseActivity
+
+
+REPAIR_XML = False
+
+
+class activity_AcceptedSubmissionPeerReviewOcr(AcceptedBaseActivity):
+    "AcceptedSubmissionPeerReviewOcr activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionPeerReviewOcr, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionPeerReviewOcr"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Transform peer review inline graphic images into "
+            "maths equations and tables."
+        )
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"hrefs": None, "modify_xml": None, "rename_files": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        # first check if there is an endpoint in the settings specified
+        if not hasattr(self.settings, "mathpix_endpoint"):
+            self.logger.info(
+                "No mathpix_endpoint in settings, skipping %s." % self.name
+            )
+            return self.ACTIVITY_SUCCESS
+        if not self.settings.mathpix_endpoint:
+            self.logger.info(
+                "mathpix_endpoint in settings is blank, skipping %s." % self.name
+            )
+            return self.ACTIVITY_SUCCESS
+
+        session = get_session(self.settings, data, data["run"])
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        self.start_cleaner_log()
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
+
+        # find S3 object for article XML and download it
+        xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
+
+        # get list of files from the article XML
+        try:
+            files = cleaner.file_list(xml_file_path)
+        except ParseError:
+            log_message = (
+                "%s, XML ParseError exception in cleaner.file_list"
+                " parsing XML file %s for file %s"
+            ) % (
+                self.name,
+                article_processing.file_name_from_name(xml_file_path),
+                input_filename,
+            )
+            self.logger.exception(log_message)
+            cleaner.LOGGER.exception(log_message)
+            files = []
+            return True
+
+        self.logger.info("%s, files: %s" % (self.name, files))
+
+        # search XML file for graphic tags
+        if not cleaner.inline_graphic_tags(xml_file_path):
+            self.logger.info(
+                "%s, no inline-graphic tags in %s" % (self.name, input_filename)
+            )
+            self.end_cleaner_log(session)
+            return True
+
+        self.statuses["hrefs"] = True
+
+        xml_root = cleaner.parse_article_xml(xml_file_path)
+
+        # download each inline graphic image to disk
+        inline_graphic_hrefs = []
+        for inline_graphic_tag in xml_root.iterfind(".//inline-graphic"):
+            href = cleaner.tag_xlink_href(inline_graphic_tag)
+            inline_graphic_hrefs.append(href)
+
+        inline_graphic_files = [
+            file_detail
+            for file_detail in files
+            if file_detail.get("upload_file_nm") in inline_graphic_hrefs
+        ]
+
+        cleaner.download_asset_files_from_bucket(
+            storage,
+            inline_graphic_files,
+            asset_file_name_map,
+            self.directories.get("TEMP_DIR"),
+            self.logger,
+        )
+
+        # create a map of upload_file_nm to local file path
+        file_to_path_map = {}
+        for file_detail in inline_graphic_files:
+            for asset_key, asset_path in asset_file_name_map.items():
+                if file_detail.get("upload_file_nm") and asset_key.endswith(
+                    file_detail.get("upload_file_nm")
+                ):
+                    file_to_path_map[file_detail.get("upload_file_nm")] = asset_path
+
+        # request math formula from the external service
+        file_to_data_map = ocr_files(
+            file_to_path_map, self.settings, self.logger, input_filename
+        )
+
+        # a map of which files to change to math equations
+        file_to_approved_math_data_map = {
+            key: value for key, value in file_to_data_map.items() if value.get("data")
+        }
+
+        # replace inline-graphic tags with maths formulae
+        transform_inline_graphic_tags(
+            xml_root, file_to_approved_math_data_map, self.logger, input_filename
+        )
+
+        # for each inline graphic replaced, remove the file tag
+        if file_to_approved_math_data_map:
+            file_name_list = file_to_approved_math_data_map.keys()
+            self.statuses["modify_xml"] = self.remove_file_tags(
+                xml_root, file_name_list, input_filename
+            )
+
+        # write the XML root to disk
+        cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
+
+        # for each inline-graphic replaced, delete it from the expanded folder
+        if self.statuses["modify_xml"]:
+            file_name_list = file_to_approved_math_data_map.keys()
+            self.delete_expanded_folder_files(
+                asset_file_name_map, expanded_folder, file_name_list, storage
+            )
+
+        # upload the XML to the bucket
+        if self.statuses["modify_xml"]:
+            self.upload_xml_file_to_bucket(
+                asset_file_name_map, expanded_folder, storage
+            )
+
+        self.end_cleaner_log(session)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+
+def ocr_files(file_to_path_map, settings, logger, identifier):
+    "post request to an endpoint for each file and return data"
+    file_to_data_map = {}
+    for file_name, file_path in file_to_path_map.items():
+        logger.info(
+            "OCR file from %s: file_name %s, file_path %s"
+            % (identifier, file_name, file_path)
+        )
+
+        try:
+            response = ocr.mathpix_post_request(
+                url=settings.mathpix_endpoint,
+                app_id=settings.mathpix_app_id,
+                app_key=settings.mathpix_app_key,
+                file_path=file_path,
+            )
+        except Exception as exception:
+            logger.exception(
+                "Exception posting to Mathpix API endpoint, file_name %s: %s"
+                % (file_name, str(exception)),
+            )
+            continue
+
+        # get the response.json and use that
+        response_json = response.json()
+
+        # format response data
+        file_to_data_map[file_name] = response_json
+    return file_to_data_map
+
+
+def math_data_parts(math_data):
+    "from a list math_data find the different types of data"
+    mathml_data = None
+    latex_data = None
+    for math_data_row in math_data:
+        if math_data_row.get("type") == "mathml":
+            mathml_data = math_data_row
+            continue
+        if math_data_row.get("type") == "latex":
+            latex_data = math_data_row
+    return mathml_data, latex_data
+
+
+def transform_inline_graphic_tags(xml_root, file_to_math_data_map, logger, identifier):
+    "replace inline-graphic tags with maths formulae"
+    # for each inline graphic with a math formula, replace the XML tag
+    for parent_tag in xml_root.iterfind(".//inline-graphic/.."):
+        # figure out whether to use inline-formula tag or disp-formula tag
+        formula_tag_name = "inline-formula"
+        if cleaner.is_p_inline_graphic(
+            tag=parent_tag,
+            sub_article_id=None,
+            p_tag_index=None,
+            identifier=identifier,
+        ):
+            formula_tag_name = "disp-formula"
+
+        # convert each inline-graphic tag
+        for inline_graphic_tag in parent_tag.iterfind("inline-graphic"):
+            href = cleaner.tag_xlink_href(inline_graphic_tag)
+            if href in file_to_math_data_map.keys():
+                math_data = file_to_math_data_map.get(href).get("data")
+                mathml_data, latex_data = math_data_parts(math_data)
+
+                if mathml_data and mathml_data.get("value"):
+                    # first parse the mathml
+                    try:
+                        math_tag = ElementTree.fromstring(mathml_data.get("value"))
+                    except ParseError:
+                        log_message = (
+                            "transform_inline_graphic_tags XML ParseError exception"
+                            " parsing XML %s for file %s"
+                        ) % (
+                            mathml_data.get("value"),
+                            identifier,
+                        )
+                        logger.exception(log_message)
+                        continue
+
+                    # convert inline-graphic tag
+                    inline_graphic_tag.tag = formula_tag_name
+                    cleaner.remove_tag_attributes(inline_graphic_tag)
+                    # add <math> tag
+                    inline_graphic_tag.append(math_tag)
+                    # add latex if available
+                    if latex_data and latex_data.get("value"):
+                        math_tag.set("alttext", latex_data.get("value"))

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -173,6 +173,11 @@ def preprint_url(xml_file_path):
     return parse.preprint_url(root)
 
 
+def is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier):
+    "see if a p tag contains only an inline-graphic tag"
+    return fig.is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier)
+
+
 def inline_graphic_tags(xml_file_path):
     "get the inline-graphic tags from an XML file"
     root = parse_article_xml(xml_file_path)
@@ -268,6 +273,11 @@ def graphic_hrefs(sub_article_root, identifier):
 def transform_fig(sub_article_root, identifier):
     "transform inline-graphic tags into fig tags"
     return fig.transform_fig(sub_article_root, identifier)
+
+
+def remove_tag_attributes(tag):
+    "remove attributes from the tag"
+    fig.remove_tag_attributes(tag)
 
 
 def add_file_tag(parent, file_details):

--- a/provider/ocr.py
+++ b/provider/ocr.py
@@ -1,0 +1,58 @@
+import json
+import requests
+
+
+REQUESTS_TIMEOUT = 15
+
+DEFAULT_OPTIONS_JSON = {
+    "math_inline_delimiters": ["$", "$"],
+    "rm_spaces": True,
+    "formats": "text, data, html, latex_styled",
+    "data_options": {
+        "include_mathml": True,
+        "include_latex": True,
+    },
+}
+
+
+def mathpix_post_request(
+    url,
+    app_id,
+    app_key,
+    file_path,
+    options_json=None,
+    verify_ssl=False,
+    logger=None,
+):
+    "POST JSON data to Mathpix API endpoint"
+
+    if options_json is None:
+        # use the default options
+        options_json = DEFAULT_OPTIONS_JSON
+
+    headers = {"app_id": app_id, "app_key": app_key}
+    data = {"options_json": json.dumps(options_json)}
+    with open(file_path, "rb") as open_file:
+        files = ({"file": open_file},)
+        response = requests.post(
+            url,
+            files=files,
+            data=data,
+            verify=verify_ssl,
+            headers=headers,
+            timeout=REQUESTS_TIMEOUT,
+        )
+    if logger:
+        logger.info("Post file %s to Mathpix API: POST %s\n" % (file_path, url))
+        logger.info(
+            "Response from Mathpix API: %s\n%s"
+            % (response.status_code, response.content)
+        )
+    status_code = response.status_code
+    if not 300 > status_code >= 200:
+        raise Exception(
+            "Error in mathpix_post_request %s to Mathpix API: %s\n%s"
+            % (file_path, status_code, response.content)
+        )
+
+    return response

--- a/register.py
+++ b/register.py
@@ -138,6 +138,7 @@ def start(settings):
     activity_names.append("AcceptedSubmissionPeerReviews")
     activity_names.append("AcceptedSubmissionPeerReviewImages")
     activity_names.append("AcceptedSubmissionPeerReviewFigs")
+    activity_names.append("AcceptedSubmissionPeerReviewOcr")
     activity_names.append("AcceptedSubmissionVersionDoi")
 
     for activity_name in activity_names:

--- a/settings-example.py
+++ b/settings-example.py
@@ -1031,6 +1031,11 @@ class live:
 
     assessment_terms_yaml = "assessment_terms.yaml"
 
+    # Mathpix settings
+    mathpix_endpoint = "https://api.mathpix.com.example.org/v3/text"
+    mathpix_app_id = "elife-bot"
+    mathpix_app_key = "key"
+
 
 def get_settings(ENV="dev"):
     """

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -246,3 +246,8 @@ docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_i
 docmap_account_id = "https://sciety.org/groups/elife"
 
 assessment_terms_yaml = "tests/assessment_terms.yaml"
+
+# Mathpix settings
+mathpix_endpoint = "https://api.mathpix.com.example.org/v3/text"
+mathpix_app_id = "elife-bot"
+mathpix_app_key = "key"

--- a/tests/activity/test_activity_accepted_submission_peer_review_ocr.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_ocr.py
@@ -1,0 +1,682 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionPeerReviewOcr as activity_module
+from activity.activity_AcceptedSubmissionPeerReviewOcr import (
+    activity_AcceptedSubmissionPeerReviewOcr as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeResponse,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+EXAMPLE_RESPONSE_JSON = {
+    "request_id": "2023_06_20_85e56a13304ac2be4063g",
+    "version": "RSK-M115",
+    "image_width": 171,
+    "image_height": 64,
+    "is_printed": True,
+    "is_handwritten": False,
+    "auto_rotate_confidence": 0,
+    "auto_rotate_degrees": 0,
+    "confidence": 0.8816322172060609,
+    "confidence_rate": 0.8816322172060609,
+    "latex_styled": "\\tau \\frac{d \\boldsymbol{a}}{d t}=\\boldsymbol{C a}+\\boldsymbol{b}",
+    "text": "$\\tau \\frac{d \\boldsymbol{a}}{d t}=\\boldsymbol{C a}+\\boldsymbol{b}$",
+    "data": [
+        {
+            "type": "mathml",
+            "value": '<math xmlns="http://www.w3.org/1998/Math/MathML">\n  <mi>τ</mi>\n  <mfrac>\n    <mrow>\n      <mi>d</mi>\n      <mi mathvariant="bold-italic">a</mi>\n    </mrow>\n    <mrow>\n      <mi>d</mi>\n      <mi>t</mi>\n    </mrow>\n  </mfrac>\n  <mo>=</mo>\n  <mi mathvariant="bold-italic">C</mi>\n  <mi mathvariant="bold-italic">a</mi>\n  <mo>+</mo>\n  <mi mathvariant="bold-italic">b</mi>\n</math>',
+        },
+        {
+            "type": "latex",
+            "value": "\\tau \\frac{d \\boldsymbol{a}}{d t}=\\boldsymbol{C a}+\\boldsymbol{b}",
+        },
+    ],
+}
+
+
+EQUATION_DATA = EXAMPLE_RESPONSE_JSON.get("data")
+
+
+OCR_FILES_DATA = {
+    "sa1-inf1.jpg": {
+        "data": EQUATION_DATA,
+    },
+    "sa1-inf2.jpg": {
+        "data": EQUATION_DATA,
+    },
+    "sa2-inf1.jpg": {
+        "data": [],
+    },
+}
+
+
+@ddt
+class TestAcceptedSubmissionPeerReviewOcr(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(activity_module, "ocr_files")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "example with no inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "image_names": None,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": None,
+            "expected_upload_xml_status": None,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewOcr, no inline-graphic tags in "
+                    "30-01-2019-RA-eLife-45644.zip"
+                )
+            ],
+        },
+        {
+            "comment": "example with three types of inline-graphic math formula or not",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                '<sub-article id="sa1">'
+                "<body>"
+                '<p>First paragraph with an inline equation <inline-graphic xlink:href="sa1-inf1.jpg"/>.</p>'
+                "<p>Following is a display formula:</p>"
+                '<p><inline-graphic xlink:href="sa1-inf2.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+                '<sub-article id="sa2">'
+                "<body>"
+                '<p>Next can be an image containing no formula <inline-graphic xlink:href="sa2-inf1.jpg"/>.</p>'
+                "</body>"
+                "</sub-article>"
+            ),
+            "image_names": ["sa1-inf1.jpg", "sa1-inf2.jpg", "sa2-inf1.jpg"],
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml_contains": [
+                (
+                    '<sub-article id="sa1">'
+                    "<body>"
+                    "<p>First paragraph with an inline equation <inline-formula>"
+                    '<mml:math alttext="'
+                    r"\tau \frac{d \boldsymbol{a}}{d t}=\boldsymbol{C a}+\boldsymbol{b}"
+                    '">\n'
+                    "  <mml:mi>τ</mml:mi>\n"
+                    "  <mml:mfrac>\n"
+                    "    <mml:mrow>\n"
+                    "      <mml:mi>d</mml:mi>\n"
+                    '      <mml:mi mathvariant="bold-italic">a</mml:mi>\n'
+                    "    </mml:mrow>\n"
+                    "    <mml:mrow>\n"
+                    "      <mml:mi>d</mml:mi>\n"
+                    "      <mml:mi>t</mml:mi>\n"
+                    "    </mml:mrow>\n"
+                    "  </mml:mfrac>\n"
+                    "  <mml:mo>=</mml:mo>\n"
+                    '  <mml:mi mathvariant="bold-italic">C</mml:mi>\n'
+                    '  <mml:mi mathvariant="bold-italic">a</mml:mi>\n'
+                    "  <mml:mo>+</mml:mo>\n"
+                    '  <mml:mi mathvariant="bold-italic">b</mml:mi>\n'
+                    "</mml:math>"
+                    "</inline-formula>.</p>"
+                    "<p>Following is a display formula:</p>"
+                    "<p><disp-formula>"
+                    '<mml:math alttext="'
+                    r"\tau \frac{d \boldsymbol{a}}{d t}=\boldsymbol{C a}+\boldsymbol{b}"
+                    '">\n'
+                    "  <mml:mi>τ</mml:mi>\n"
+                    "  <mml:mfrac>\n"
+                    "    <mml:mrow>\n"
+                    "      <mml:mi>d</mml:mi>\n"
+                    '      <mml:mi mathvariant="bold-italic">a</mml:mi>\n'
+                    "    </mml:mrow>\n"
+                    "    <mml:mrow>\n"
+                    "      <mml:mi>d</mml:mi>\n"
+                    "      <mml:mi>t</mml:mi>\n"
+                    "    </mml:mrow>\n"
+                    "  </mml:mfrac>\n"
+                    "  <mml:mo>=</mml:mo>\n"
+                    '  <mml:mi mathvariant="bold-italic">C</mml:mi>\n'
+                    '  <mml:mi mathvariant="bold-italic">a</mml:mi>\n'
+                    "  <mml:mo>+</mml:mo>\n"
+                    '  <mml:mi mathvariant="bold-italic">b</mml:mi>\n'
+                    "</mml:math>"
+                    "</disp-formula></p>"
+                    "</body>"
+                    "</sub-article>"
+                    '<sub-article id="sa2">'
+                    "<body>"
+                    '<p>Next can be an image containing no formula <inline-graphic xlink:href="sa2-inf1.jpg"/>.</p>'
+                    "</body>"
+                    "</sub-article>"
+                ),
+                (
+                    '<file file-type="figure">'
+                    "<upload_file_nm>sa2-inf1.jpg</upload_file_nm>"
+                    "</file>"
+                    "</files>"
+                ),
+            ],
+            "expected_xml_not_contains": [
+                "<upload_file_nm>sa1-inf1.jpg</upload_file_nm>",
+                "<upload_file_nm>sa1-inf2.jpg</upload_file_nm>",
+            ],
+            "expected_bucket_upload_folder_contents": [
+                "30-01-2019-RA-eLife-45644.xml",
+                "sa2-inf1.jpg",
+            ],
+            "expected_bucket_upload_folder_not_contents": [
+                "sa1-inf1.jpg",
+                "sa1-inf2.jpg",
+            ],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_ocr_files,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        zip_sub_folder = test_data.get("filename").replace(".zip", "")
+        zip_xml_file = "%s.xml" % zip_sub_folder
+
+        # create a new zip file fixtur
+        file_details = []
+        if test_data.get("image_names"):
+            for image_name in test_data.get("image_names"):
+                details = {
+                    "file_path": "tests/files_source/digests/outbox/99999/digest-99999.jpg",
+                    "file_type": "figure",
+                    "upload_file_nm": image_name,
+                }
+                file_details.append(details)
+        new_zip_file_path = helpers.add_files_to_accepted_zip(
+            "tests/files_source/30-01-2019-RA-eLife-45644.zip",
+            directory.path,
+            file_details,
+        )
+
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            new_zip_file_path,
+        )
+
+        # write additional XML to the XML file
+        if test_data.get("sub_article_xml"):
+            sub_folder = test_data.get("filename").rsplit(".", 1)[0]
+            xml_path = os.path.join(
+                directory.path,
+                self.session.get_value("expanded_folder"),
+                sub_folder,
+                "%s.xml" % sub_folder,
+            )
+            with open(xml_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            with open(xml_path, "w", encoding="utf-8") as open_file:
+                xml_string = xml_string.replace(
+                    "</article>", "%s</article>" % test_data.get("sub_article_xml")
+                )
+                open_file.write(xml_string)
+
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+        fake_ocr_files.return_value = OCR_FILES_DATA
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            zip_sub_folder,
+            zip_xml_file,
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # assertion on XML contents
+        if test_data.get("expected_xml_contains") or test_data.get(
+            "expected_xml_not_contains"
+        ):
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_content = open_file.read()
+            for fragment in test_data.get("expected_xml_contains", []):
+                self.assertTrue(
+                    fragment in xml_content,
+                    "failed in {comment}, fragment: {fragment}".format(
+                        comment=test_data.get("comment"), fragment=fragment
+                    ),
+                )
+            for fragment in test_data.get("expected_xml_not_contains", []):
+                self.assertTrue(
+                    fragment not in xml_content,
+                    "failed in {comment}, fragment: {fragment}".format(
+                        comment=test_data.get("comment"), fragment=fragment
+                    ),
+                )
+
+        self.assertEqual(
+            self.activity.statuses.get("hrefs"),
+            test_data.get("expected_hrefs_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on cleaner.log contents
+        if test_data.get("expected_cleaner_log_contains"):
+            log_file_path = os.path.join(
+                self.activity.get_tmp_dir(), self.activity.activity_log_file
+            )
+            with open(log_file_path, "r", encoding="utf8") as open_file:
+                log_contents = open_file.read()
+            for fragment in test_data.get("expected_cleaner_log_contains"):
+                self.assertTrue(
+                    fragment in log_contents,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on the session cleaner log content
+        if test_data.get("expected_upload_xml_status"):
+            session_log = self.session.get_value("cleaner_log")
+            self.assertIsNotNone(
+                session_log,
+                "failed in {comment}".format(comment=test_data.get("comment")),
+            )
+
+        # check output bucket folder contents
+        if (
+            "expected_bucket_upload_folder_contents" in test_data
+            or "expected_bucket_upload_folder_not_contents" in test_data
+        ):
+            bucket_folder_path = os.path.join(
+                directory.path,
+                test_activity_data.accepted_session_example.get("expanded_folder"),
+                zip_sub_folder,
+            )
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            for bucket_file in test_data.get(
+                "expected_bucket_upload_folder_contents", []
+            ):
+                self.assertTrue(
+                    bucket_file in output_bucket_list,
+                    "%s not found in bucket upload folder" % bucket_file,
+                )
+            for bucket_file in test_data.get(
+                "expected_bucket_upload_folder_not_contents", []
+            ):
+                self.assertTrue(
+                    bucket_file not in output_bucket_list,
+                    "%s unexpectedly found in bucket upload folder" % bucket_file,
+                )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "file_list")
+    def test_do_activity_exception_parseerror(
+        self,
+        fake_file_list,
+        fake_cleaner_storage_context,
+        fake_session,
+    ):
+        "test if there is an XML ParseError when getting a file list"
+        directory = TempDirectory()
+        zip_file_base = "28-09-2020-RA-eLife-63532"
+        zip_file = "%s.zip" % zip_file_base
+        session_dict = copy.copy(test_activity_data.accepted_session_example)
+        session_dict["input_filename"] = zip_file
+        fake_session.return_value = FakeSession(session_dict)
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            zip_file,
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+
+        # write additional XML to the XML file
+        sub_article_xml = (
+            "<sub-article>"
+            "<body>"
+            '<p><inline-graphic xlink:href="sa1-inf1.jpg"/>.</p>'
+            "</body>"
+            "</sub-article>"
+        )
+        xml_path = os.path.join(
+            directory.path,
+            session_dict.get("expanded_folder"),
+            zip_file_base,
+            "%s.xml" % zip_file_base,
+        )
+        with open(xml_path, "r", encoding="utf-8") as open_file:
+            xml_string = open_file.read()
+        with open(xml_path, "w", encoding="utf-8") as open_file:
+            xml_string = xml_string.replace(
+                "</article>", "%s</article>" % sub_article_xml
+            )
+            open_file.write(xml_string)
+
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_file_list.side_effect = ParseError()
+        # do the activity
+        result = self.activity.do_activity(input_data(zip_file))
+        self.assertEqual(result, True)
+        expected_logexception = (
+            "AcceptedSubmissionPeerReviewOcr, XML ParseError exception "
+            "in cleaner.file_list parsing XML file %s.xml for file %s"
+        ) % (zip_file_base, zip_file)
+        self.assertEqual(self.activity.logger.logexception, expected_logexception)
+
+    def test_do_activity_settings_no_endpoint(self):
+        self.activity.settings = {}
+        # do the activity
+        result = self.activity.do_activity(input_data())
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            "No mathpix_endpoint in settings, skipping AcceptedSubmissionPeerReviewOcr.",
+        )
+
+    def test_do_activity_settings_blank_endpoint(self):
+        self.activity.settings.mathpix_endpoint = ""
+        # do the activity
+        result = self.activity.do_activity(input_data())
+
+        # check assertions
+        self.assertEqual(result, self.activity.ACTIVITY_SUCCESS)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            "mathpix_endpoint in settings is blank, skipping AcceptedSubmissionPeerReviewOcr.",
+        )
+
+
+class TestOcrFiles(unittest.TestCase):
+    "test ocr_files()"
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.file_name = "sa1-inf1.jpg"
+        self.file_path = "tests/files_source/digests/outbox/99999/digest-99999.jpg"
+        self.file_to_path_map = {self.file_name: self.file_path}
+        self.identifier = "test.zip"
+
+    @patch("requests.post")
+    def test_ocr_files(self, fake_request):
+        "test a request to the ocr endpoint but mocking the requests.post"
+        response_json = {}
+        response_status = 200
+        response = FakeResponse(response_status)
+        response.response_json = response_json
+        fake_request.return_value = response
+        expected_result = {self.file_name: response_json}
+        # invoke
+        result = activity_module.ocr_files(
+            self.file_to_path_map, settings_mock, self.logger, self.identifier
+        )
+        # assert
+        self.assertDictEqual(result, expected_result)
+
+    @patch("requests.post")
+    def test_failure_status_code(self, fake_request):
+        "test exception catching of a non-success status code response"
+        response_json = {}
+        response_status = 500
+        response = FakeResponse(response_status)
+        response.response_json = response_json
+        fake_request.return_value = response
+        expected_result = {}
+        excepted_log_message = (
+            "Exception posting to Mathpix API endpoint, file_name %s: "
+            "Error in mathpix_post_request %s to Mathpix API: %s\nNone"
+            % (self.file_name, self.file_path, response_status)
+        )
+        # invoke
+        result = activity_module.ocr_files(
+            self.file_to_path_map, settings_mock, self.logger, self.identifier
+        )
+        # assert
+        self.assertDictEqual(result, expected_result)
+        # test for logging
+        self.assertEqual(self.logger.logexception, excepted_log_message)
+
+
+class TestMathDataParts(unittest.TestCase):
+    "test math_data_parts()"
+
+    def test_math_data_parts(self):
+        "test expected input"
+        math_data = EQUATION_DATA
+        mathml_data, latex_data = activity_module.math_data_parts(math_data)
+        self.assertTrue(isinstance(mathml_data, dict))
+        self.assertTrue(isinstance(latex_data, dict))
+        self.assertEqual(list(mathml_data.keys()), ["type", "value"])
+        self.assertEqual(list(latex_data.keys()), ["type", "value"])
+
+    def test_empty_list(self):
+        "test when data is an empty list"
+        math_data = []
+        mathml_data, latex_data = activity_module.math_data_parts(math_data)
+        self.assertEqual(mathml_data, None)
+        self.assertEqual(latex_data, None)
+
+
+class TestTransformInlineGraphicTags(unittest.TestCase):
+    "test transform_inline_graphic_tags()"
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.identifier = "test.zip"
+
+    def test_inline_formula(self):
+        "test transforming one inline-graphic tag into inline-formula"
+        xml_string = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p>Test inline formula <inline-graphic xlink:href="sa1-inf1.jpg"/>.</p>'
+            "</sub-article>"
+        )
+        xml_root = ElementTree.fromstring(xml_string)
+        file_to_math_data_map = {
+            "sa1-inf1.jpg": {
+                "data": [
+                    {
+                        "type": "mathml",
+                        "value": (
+                            '<math xmlns="http://www.w3.org/1998/Math/MathML">'
+                            "<mi>τ</mi>"
+                            "</math>"
+                        ),
+                    }
+                ]
+            }
+        }
+        expected = (
+            b'<sub-article xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            b"<p>Test inline formula "
+            b"<inline-formula><mml:math><mml:mi>&#964;</mml:mi></mml:math></inline-formula>"
+            b".</p>"
+            b"</sub-article>"
+        )
+        activity_module.transform_inline_graphic_tags(
+            xml_root, file_to_math_data_map, self.logger, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(xml_root), expected)
+
+    def test_disp_formula(self):
+        "test transforming one inline-graphic tag into disp-formula"
+        xml_string = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p><inline-graphic xlink:href="sa1-inf1.jpg"/></p>'
+            "</sub-article>"
+        )
+        xml_root = ElementTree.fromstring(xml_string)
+        file_to_math_data_map = {
+            "sa1-inf1.jpg": {
+                "data": [
+                    {
+                        "type": "mathml",
+                        "value": (
+                            '<math xmlns="http://www.w3.org/1998/Math/MathML">'
+                            "<mi>τ</mi></math>"
+                        ),
+                    }
+                ]
+            }
+        }
+        expected = (
+            b'<sub-article xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            b"<p><disp-formula><mml:math><mml:mi>&#964;</mml:mi></mml:math></disp-formula>"
+            b"</p></sub-article>"
+        )
+        activity_module.transform_inline_graphic_tags(
+            xml_root, file_to_math_data_map, self.logger, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(xml_root), expected)
+
+    def test_multiple_inline_formula(self):
+        "test transforming one inline-graphic tag into disp-formula"
+        xml_string = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p>First formula <inline-graphic xlink:href="sa1-inf1.jpg"/>, '
+            'second formula <inline-graphic xlink:href="sa1-inf1.jpg"/>.</p>'
+            "</sub-article>"
+        )
+        xml_root = ElementTree.fromstring(xml_string)
+        file_to_math_data_map = {
+            "sa1-inf1.jpg": {
+                "data": [
+                    {
+                        "type": "mathml",
+                        "value": (
+                            '<math xmlns="http://www.w3.org/1998/Math/MathML">'
+                            "<mi>τ</mi></math>"
+                        ),
+                    }
+                ]
+            }
+        }
+        expected = (
+            b'<sub-article xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            b"<p>First formula "
+            b"<inline-formula><mml:math><mml:mi>&#964;</mml:mi></mml:math></inline-formula>, "
+            b"second formula "
+            b"<inline-formula><mml:math><mml:mi>&#964;</mml:mi></mml:math></inline-formula>."
+            b"</p></sub-article>"
+        )
+        activity_module.transform_inline_graphic_tags(
+            xml_root, file_to_math_data_map, self.logger, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(xml_root), expected)
+
+    def test_xml_exception(self):
+        "test exception raised when parsing mathml"
+        xml_string = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p><inline-graphic xlink:href="sa1-inf1.jpg" /></p>'
+            "</sub-article>"
+        )
+        xml_root = ElementTree.fromstring(xml_string)
+        file_to_math_data_map = {
+            "sa1-inf1.jpg": {
+                "data": [
+                    {
+                        "type": "mathml",
+                        "value": ("<malformed>"),
+                    }
+                ]
+            }
+        }
+        expected = bytes(xml_string, encoding="utf-8")
+        activity_module.transform_inline_graphic_tags(
+            xml_root, file_to_math_data_map, self.logger, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(xml_root), expected)
+
+    def test_empty_inputs(self):
+        "test minimal XML and minimal inputs"
+        xml_string = "<sub-article/>"
+        xml_root = ElementTree.fromstring(xml_string)
+        file_to_math_data_map = {}
+        expected = b"<sub-article />"
+        activity_module.transform_inline_graphic_tags(
+            xml_root, file_to_math_data_map, self.logger, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(xml_root), expected)

--- a/tests/provider/test_ocr.py
+++ b/tests/provider/test_ocr.py
@@ -1,0 +1,64 @@
+import unittest
+from mock import patch
+from provider import ocr
+from tests import settings_mock
+from tests.activity.classes_mock import FakeLogger, FakeResponse
+
+
+class TestMathpixPostRequest(unittest.TestCase):
+    def setUp(self):
+        self.url = settings_mock.mathpix_endpoint
+        self.app_id = settings_mock.mathpix_app_id
+        self.app_key = settings_mock.mathpix_app_key
+        self.logger = FakeLogger()
+        self.file_path = "tests/files_source/digests/outbox/99999/digest-99999.jpg"
+        self.options_json = None
+        self.response_content_success = None
+        self.response_json_success = {"data": [{"latex": ""}]}
+
+    @patch("requests.post")
+    def test_mathpix_post_request_201(self, mock_requests_post):
+        verify_ssl = False
+        response_status_code = 201
+        response = FakeResponse(response_status_code)
+        response.content = self.response_content_success
+        response.response_json = self.response_json_success
+        mock_requests_post.return_value = response
+
+        ocr.mathpix_post_request(
+            self.url,
+            self.app_id,
+            self.app_key,
+            self.file_path,
+            self.options_json,
+            verify_ssl,
+            self.logger,
+        )
+
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            "Response from Mathpix API: %s\n%s"
+            % (response_status_code, self.response_content_success),
+        )
+        self.assertEqual(
+            self.logger.loginfo[-2],
+            "Post file %s to Mathpix API: POST %s\n"
+            % (self.file_path, self.url),
+        )
+
+    @patch("requests.post")
+    def test_mathpix_post_request_400(self, mock_requests_post):
+        verify_ssl = False
+        response = FakeResponse(400)
+        mock_requests_post.return_value = response
+        self.assertRaises(
+            Exception,
+            ocr.mathpix_post_request,
+            self.url,
+            self.app_id,
+            self.app_key,
+            self.file_path,
+            self.options_json,
+            verify_ssl,
+            self.logger,
+        )

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -96,3 +96,8 @@ downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
 docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
 docmap_account_id = "https://sciety.org/groups/elife"
+
+# Mathpix settings
+mathpix_endpoint = "https://api.mathpix.com.example.org/v3/text"
+mathpix_app_id = "elife-bot"
+mathpix_app_key = "key"

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -54,6 +54,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
                 define_workflow_step_short("AcceptedSubmissionPeerReviewFigs", data),
+                define_workflow_step_short("AcceptedSubmissionPeerReviewOcr", data),
                 define_workflow_step_short("AddCommentsToAcceptedSubmissionXml", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),
                 define_workflow_step_short("EmailAcceptedSubmissionOutput", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7873

New activity `AcceptedSubmissionPeerReviewOcr` added to the `IngestAcceptedSubmission` workflow, and new provider library `ocr.py`. It will use an external service endpoint to convert inline graphics to `<math>`.