### PR TITLE
AcceptedSubmissionHistory activity.

### DIFF
--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -1,0 +1,129 @@
+import os
+import json
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner
+from activity.objects import AcceptedBaseActivity
+
+
+REPAIR_XML = False
+
+
+class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
+    "AcceptedSubmissionHistory activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionHistory, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionHistory"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Add history dates to the accepted submission XML."
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"docmap_string": None, "xml_root": None, "upload_xml": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        session = get_session(self.settings, data, data["run"])
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # if the article is not PRC, return True
+        prc_status = session.get_value("prc_status")
+        if not prc_status:
+            self.logger.info(
+                "%s, %s prc_status session value is %s, activity returning True"
+                % (self.name, input_filename, prc_status)
+            )
+            return True
+
+        # configure log files for the cleaner provider
+        self.start_cleaner_log()
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
+
+        # find S3 object for article XML and download it
+        xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
+
+        # generate docmap URL
+        docmap_url = cleaner.docmap_url(self.settings, article_id)
+        self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
+
+        # get docmap json
+        self.logger.info(
+            "%s, getting docmap_string for input_filename: %s"
+            % (self.name, input_filename)
+        )
+        docmap_string = cleaner.get_docmap_by_account_id(
+            docmap_url, self.settings.docmap_account_id
+        )
+        self.statuses["docmap_string"] = True
+
+        # get the under-review date from the docmap
+        review_date_string = cleaner.review_date_from_docmap(
+            docmap_string, input_filename
+        )
+        self.logger.info(
+            "%s, %s review_date_string: %s"
+            % (self.name, input_filename, review_date_string)
+        )
+
+        # add log messages if an external href is not approved to download
+        if not review_date_string:
+            cleaner.LOGGER.warning(
+                "%s A sent-for-review date was not added to the XML", input_filename
+            )
+        else:
+            # convert the review-date to a time_struct object
+            date_struct = cleaner.date_struct_from_string(review_date_string)
+
+            # add the sent-for-review date to a history tag in the XML file
+            if date_struct:
+                xml_root = cleaner.parse_article_xml(xml_file_path)
+                cleaner.add_history_date(
+                    xml_root, "sent-for-review", date_struct, input_filename
+                )
+
+                self.statuses["xml_root"] = True
+
+        if self.statuses.get("xml_root"):
+            # write the XML root to disk
+            cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
+
+            # upload the XML to the bucket
+            self.upload_xml_file_to_bucket(
+                asset_file_name_map, expanded_folder, storage
+            )
+
+        self.end_cleaner_log(session)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -406,6 +406,18 @@ def get_docmap_by_account_id(url, account_id):
                 return json.dumps(list_item)
 
 
+def review_date_from_docmap(docmap_string, input_filename):
+    return prc.review_date_from_docmap(docmap_string, input_filename)
+
+
+def date_struct_from_string(date_string):
+    return prc.date_struct_from_string(date_string)
+
+
+def add_history_date(root, date_type, date_struct, identifier):
+    return prc.add_history_date(root, date_type, date_struct, identifier)
+
+
 def version_doi_from_docmap(docmap_string, input_filename):
     return prc.version_doi_from_docmap(docmap_string, input_filename)
 

--- a/register.py
+++ b/register.py
@@ -140,6 +140,7 @@ def start(settings):
     activity_names.append("AcceptedSubmissionPeerReviewFigs")
     activity_names.append("AcceptedSubmissionPeerReviewOcr")
     activity_names.append("AcceptedSubmissionVersionDoi")
+    activity_names.append("AcceptedSubmissionHistory")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -1,0 +1,293 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionHistory as activity_module
+from activity.activity_AcceptedSubmissionHistory import (
+    activity_AcceptedSubmissionHistory as activity_object,
+)
+from tests import read_fixture
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeResponse,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionHistory(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+        self.session.store_value("prc_status", True)
+        self.session.store_value(
+            "preprint_url", "https://doi.org/10.1101/2021.06.02.446694"
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "get_docmap")
+    @patch("requests.get")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_xml_root_status": True,
+            "expected_upload_xml_status": True,
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_get,
+        fake_get_docmap,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_85111.json")
+        sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
+        fake_get.return_value = FakeResponse(200, content=sample_html)
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        with open(xml_file_path, "r", encoding="utf-8") as open_file:
+            xml_content = open_file.read()
+        # assert found number of sub-article tags in the XML
+        self.assertTrue(
+            xml_content.count(
+                (
+                    '<date date-type="sent-for-review">'
+                    "<day>28</day><month>11</month><year>2022</year>"
+                    "</date>"
+                    "</history>"
+                )
+            )
+            == 1
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("docmap_string"),
+            test_data.get("expected_docmap_string_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("xml_root"),
+            test_data.get("expected_xml_root_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        log_file_path = os.path.join(
+            self.activity.get_tmp_dir(), self.activity.activity_log_file
+        )
+        with open(log_file_path, "r", encoding="utf8") as open_file:
+            log_contents = open_file.read()
+        self.assertTrue(
+            (
+                "elifecleaner:prc:review_date_from_docmap: "
+                "Get first under-review happened date from the docmap"
+            )
+            in log_contents
+        )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "get_docmap")
+    @patch("requests.get")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_xml_root_status": None,
+            "expected_upload_xml_status": None,
+        },
+    )
+    def test_do_activity_no_review_date(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_get,
+        fake_get_docmap,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+        fake_get_docmap.return_value = "{}"
+        sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
+        fake_get.return_value = FakeResponse(200, content=sample_html)
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        self.assertEqual(
+            self.activity.statuses.get("xml_root"),
+            test_data.get("expected_xml_root_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        log_file_path = os.path.join(
+            self.activity.get_tmp_dir(), self.activity.activity_log_file
+        )
+        with open(log_file_path, "r", encoding="utf8") as open_file:
+            log_contents = open_file.read()
+        self.assertTrue(
+            (
+                "WARNING elifecleaner:activity_AcceptedSubmissionHistory:do_activity: "
+                "%s A sent-for-review date was not added to the XML"
+            )
+            % test_data.get("filename")
+            in log_contents
+        )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+        },
+    )
+    def test_do_activity_not_prc_status(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # reset prc_status from the session
+        self.session.store_value("prc_status", None)
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        # expanded bucket files
+        zip_file_path = os.path.join(
+            test_activity_data.ExpandArticle_files_source_folder,
+            test_data.get("filename"),
+        )
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -51,6 +51,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_short("AnnotateAcceptedSubmissionVideos", data),
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
                 define_workflow_step_short("AcceptedSubmissionVersionDoi", data),
+                define_workflow_step_short("AcceptedSubmissionHistory", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
                 define_workflow_step_short("AcceptedSubmissionPeerReviewFigs", data),


### PR DESCRIPTION
Added `AcceptedSubmissionHistory` activity to the `IngestAcceptedSubmission` workflow. Adds `<history><date date-type="sent-for-review">...` to the XML with a date found in the docmap.

Re issue https://github.com/elifesciences/issues/issues/7721