### PR TITLE
ValidateAcceptedSubmission, fail if no docmap_url

### DIFF
--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -135,19 +135,17 @@ class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
             if not preprint_url:
                 log_message = "Preprint URL was not found in the article XML"
                 self.logger.info("%s, %s" % (self.name, log_message))
-                error_email_body += "%s\n" % log_message
-            else:
-                # check docmap URL exists, if fails then fail the workflow
-                docmap_url = cleaner.docmap_url(
-                    self.settings, session.get_value("article_id")
+
+            # check docmap URL exists, if fails then fail the workflow
+            docmap_url = cleaner.docmap_url(
+                self.settings, session.get_value("article_id")
+            )
+            if not cleaner.url_exists(docmap_url, self.logger):
+                log_message = (
+                    "Request for a docmap was not successful for URL %s" % docmap_url
                 )
-                if not cleaner.url_exists(docmap_url, self.logger):
-                    log_message = (
-                        "Request for a docmap was not successful for URL %s"
-                        % docmap_url
-                    )
-                    self.logger.info("%s, %s" % (self.name, log_message))
-                    error_email_body += "%s\n" % log_message
+                self.logger.info("%s, %s" % (self.name, log_message))
+                error_email_body += "%s\n" % log_message
 
             if error_email_body:
                 body_content = error_email_body_content(

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -400,12 +400,14 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
+    @patch.object(cleaner, "url_exists")
     @patch.object(cleaner, "preprint_url")
     @patch.object(cleaner, "is_prc")
     def test_do_activity_prc_no_preprint_url(
         self,
         fake_is_prc,
         fake_preprint_url,
+        fake_url_exists,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -435,15 +437,11 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         )
         fake_is_prc.return_value = True
         fake_preprint_url.return_value = None
+        fake_url_exists.return_value = True
         fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         result = self.activity.do_activity(input_data("30-01-2019-RA-eLife-45644.zip"))
-        self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
-        # assertions for activity log
-        self.assertEqual(
-            self.activity.logger.loginfo[-2],
-            "ValidateAcceptedSubmission, Preprint URL was not found in the article XML",
-        )
+        self.assertEqual(result, True)
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")


### PR DESCRIPTION
In `ValidateAcceptedSubmission`, fail the workflow if the docmap_url URL does not exist, and do not fail the workflow if the `preprint_url` is missing.

Re issue https://github.com/elifesciences/issues/issues/8390