### PR TITLE
Add DepositCrossrefPostedContent activity.

### DIFF
--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -1,0 +1,343 @@
+import os
+import copy
+import json
+import time
+import glob
+from collections import OrderedDict
+from activity.objects import Activity
+from provider import (
+    crossref,
+    email_provider,
+    lax_provider,
+    outbox_provider,
+    utils,
+)
+
+
+class activity_DepositCrossrefPostedContent(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_DepositCrossrefPostedContent, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "DepositCrossrefPostedContent"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 15
+        self.description = (
+            "Download article XML from S3 bucket outbox, "
+            + "generate Crossref posted_content deposit XML, and deposit with Crossref."
+        )
+
+        # Local directory settings
+        self.directories = {
+            "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Bucket for outgoing files
+        self.publish_bucket = settings.poa_packaging_bucket
+        self.outbox_folder = outbox_provider.outbox_folder(
+            self.s3_bucket_folder(self.name)
+        )
+        self.published_folder = outbox_provider.published_folder(
+            self.s3_bucket_folder(self.name)
+        )
+        self.not_published_folder = outbox_provider.not_published_folder(
+            self.s3_bucket_folder(self.name)
+        )
+
+        # Track the success of some steps
+        self.statuses = {}
+
+        # Track XML files selected for pubmed XML
+        self.good_xml_files = []
+        self.bad_xml_files = []
+        self.not_published_xml_files = []
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        # Create output directories
+        self.make_activity_directories()
+
+        # override the crossref.generate TMP_DIR first
+        crossref.override_tmp_dir(self.directories.get("TMP_DIR"))
+
+        date_stamp = utils.set_datestamp()
+
+        outbox_s3_key_names = outbox_provider.get_outbox_s3_key_names(
+            self.settings, self.publish_bucket, self.outbox_folder
+        )
+
+        # Download the S3 objects
+        self.statuses["download"] = outbox_provider.download_files_from_s3_outbox(
+            self.settings,
+            self.publish_bucket,
+            outbox_s3_key_names,
+            self.directories.get("INPUT_DIR"),
+            self.logger,
+        )
+
+        article_xml_files = glob.glob(self.directories.get("INPUT_DIR") + "/*.xml")
+
+        crossref_config = crossref.elifecrossref_preprint_config(self.settings)
+
+        article_object_map = self.get_article_objects(article_xml_files)
+
+        # prune files if a POA or VOR version already exists
+        generate_article_object_map = prune_article_object_map(
+            article_object_map, self.settings, self.logger
+        )
+
+        # files omitted from the pruning procedure, add them to not_published_xml_files
+        for file_name in article_object_map.keys():
+            if file_name not in generate_article_object_map.keys():
+                self.not_published_xml_files.append(file_name)
+
+        # build Crossref deposit objects
+        crossref_object_map = OrderedDict()
+        for xml_file, article in list(generate_article_object_map.items()):
+            crossref_object_list = crossref.build_crossref_xml(
+                {xml_file: article},
+                crossref_config,
+                self.good_xml_files,
+                self.bad_xml_files,
+                submission_type="posted_content",
+            )
+            if crossref_object_list[0]:
+                crossref_object_map[article] = crossref_object_list[0]
+
+        # duplicate and modify the article for a version_doi deposit, set a different batch_id
+        for xml_file, article in list(generate_article_object_map.items()):
+            if article.version_doi:
+                # track a separate list of good and bad files later to be collated
+                good_xml_files = []
+                bad_xml_files = []
+                article_version = copy.copy(article)
+                article_version.doi = article_version.version_doi
+                article_version.version_doi = None
+                # generate CrossrefXML
+                crossref_object_list = crossref.build_crossref_xml(
+                    {xml_file: article_version},
+                    crossref_config,
+                    good_xml_files,
+                    bad_xml_files,
+                    submission_type="posted_content",
+                )
+                # collate good and bad files
+                self.good_xml_files = list(
+                    set(self.good_xml_files).union(set(good_xml_files))
+                )
+                self.bad_xml_files = list(
+                    set(self.bad_xml_files).union(set(bad_xml_files))
+                )
+                # add the CrossrefXML
+                if crossref_object_list[0]:
+                    # change the batch_id
+                    crossref_object_list[0].batch_id = crossref_object_list[
+                        0
+                    ].batch_id.replace(
+                        "elife-crossref-preprint-posted_content-",
+                        "elife-crossref-preprint-posted_content-version-",
+                    )
+                    crossref_object_map[article_version] = crossref_object_list[0]
+
+        # generate status will be True if no unhandled exception was raised
+        self.statuses["generate"] = True
+
+        # output CrossrefXML objects to XML files
+        for article, c_xml in list(crossref_object_map.items()):
+            crossref.crossref_xml_to_disk(
+                c_xml, self.directories.get("TMP_DIR"), pretty=True
+            )
+
+        # Approve files for publishing
+        self.statuses["approve"] = self.approve_for_publishing()
+
+        http_detail_list = []
+        if self.statuses.get("approve") is True:
+            file_type = "/*.xml"
+            sub_dir = self.directories.get("TMP_DIR")
+            try:
+                # Publish files
+                (
+                    self.statuses["publish"],
+                    http_detail_list,
+                ) = self.deposit_files_to_endpoint(file_type, sub_dir)
+            except:
+                self.logger.info(
+                    "Exception publishing files to Crossref: %s"
+                    % glob.glob(sub_dir + file_type)
+                )
+                self.statuses["publish"] = False
+
+        if self.statuses.get("publish") is True:
+            # Clean up outbox
+            self.logger.info("Moving files from outbox folder to published folder")
+            to_folder = outbox_provider.get_to_folder_name(
+                self.published_folder, date_stamp
+            )
+            outbox_provider.clean_outbox(
+                self.settings,
+                self.publish_bucket,
+                self.outbox_folder,
+                to_folder,
+                self.good_xml_files,
+            )
+            # copy the Crossref deposit XML files to the batch folder
+            batch_file_names = glob.glob(self.directories.get("TMP_DIR") + "/*.xml")
+            batch_file_to_folder = to_folder + "batch/"
+            outbox_provider.upload_files_to_s3_folder(
+                self.settings,
+                self.publish_bucket,
+                batch_file_to_folder,
+                batch_file_names,
+            )
+            # move files if the DOI already exists to out of the outbox folder
+            self.logger.info(
+                "Moving files from outbox folder to the not_published folder"
+            )
+            not_published_to_folder = outbox_provider.get_to_folder_name(
+                self.not_published_folder, date_stamp
+            )
+            outbox_provider.clean_outbox(
+                self.settings,
+                self.publish_bucket,
+                self.outbox_folder,
+                not_published_to_folder,
+                self.not_published_xml_files,
+            )
+
+            self.statuses["outbox"] = True
+        else:
+            self.logger.info(
+                "Failed to publish all posted content deposits to Crossref"
+            )
+
+        # Set the activity status of this activity based on successes
+        self.statuses["activity"] = bool(
+            self.statuses.get("publish") is not False
+            and self.statuses.get("generate") is not False
+        )
+
+        # Send email
+        # Only if there were files approved for publishing
+        if self.good_xml_files:
+            self.statuses["email"] = self.send_admin_email(
+                outbox_s3_key_names, http_detail_list
+            )
+        else:
+            self.logger.info(
+                "No Crossref deposit files generated in %s. bad_xml_files: %s"
+                % (self.name, self.bad_xml_files)
+            )
+
+        self.logger.info("%s statuses: %s" % (self.name, self.statuses))
+
+        return True
+
+    def get_article_objects(self, article_xml_files):
+        """turn XML into article objects and populate their data"""
+        # parse XML files into the basic article object map to start with
+        article_object_map = crossref.article_xml_list_parse(
+            article_xml_files, self.bad_xml_files, self.directories.get("TMP_DIR")
+        )
+        return article_object_map
+
+    def approve_for_publishing(self):
+        """check if any files were generated before publishing files to the endpoint"""
+        return bool(glob.glob(self.directories.get("INPUT_DIR") + "/*.xml"))
+
+    def deposit_files_to_endpoint(self, file_type="/*.xml", sub_dir=None):
+        """Using an HTTP POST, deposit the file to the endpoint"""
+        xml_files = glob.glob(sub_dir + file_type)
+        if not xml_files:
+            return None
+        payload = crossref.crossref_data_payload(
+            self.settings.crossref_login_id, self.settings.crossref_login_passwd
+        )
+        return crossref.upload_files_to_endpoint(
+            self.settings.crossref_url, payload, xml_files
+        )
+
+    def send_admin_email(self, outbox_s3_key_names, http_detail_list):
+        """
+        After do_activity is finished, send emails to recipients
+        on the status
+        """
+        datetime_string = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
+        activity_status_text = utils.get_activity_status_text(
+            self.statuses.get("activity")
+        )
+
+        body = email_provider.get_email_body_head(
+            self.name, activity_status_text, self.statuses
+        )
+        body += email_provider.get_email_body_middle(
+            self.s3_bucket_folder(self.name),
+            outbox_s3_key_names,
+            self.good_xml_files,
+            self.bad_xml_files,
+            http_detail_list,
+            self.not_published_xml_files,
+        )
+        body += email_provider.get_admin_email_body_foot(
+            self.get_activityId(),
+            self.get_workflowId(),
+            datetime_string,
+            self.settings.domain,
+        )
+
+        subject = email_provider.get_email_subject(
+            datetime_string,
+            activity_status_text,
+            self.name,
+            self.settings.domain,
+            outbox_s3_key_names,
+        )
+        sender_email = self.settings.ses_poa_sender_email
+
+        recipient_email_list = email_provider.list_email_recipients(
+            self.settings.ses_admin_email
+        )
+
+        for email in recipient_email_list:
+            # Add the email to the email queue
+            message = email_provider.simple_message(
+                sender_email, email, subject, body, logger=self.logger
+            )
+
+            email_provider.smtp_send_messages(
+                self.settings, messages=[message], logger=self.logger
+            )
+            self.logger.info(
+                "Email sending details: admin email, email %s, to %s"
+                % ("DepositCrossrefPostedContent", email)
+            )
+
+        return True
+
+
+def prune_article_object_map(article_object_map, settings, logger):
+    "remove any articles from the map that should not be deposited as posted_content"
+    good_article_object_map = OrderedDict()
+    for file_name, article in article_object_map.items():
+        # check if there is any published POA or VOR version
+        status_version_map = lax_provider.article_status_version_map(
+            article.manuscript, settings
+        )
+        if len(status_version_map.keys()) > 0:
+            logger.info(
+                "Pruning article %s from Crossref posted content deposit,"
+                " a POA or VOR version is already published" % article.doi
+            )
+        else:
+            good_article_object_map[file_name] = article
+
+    return good_article_object_map

--- a/register.py
+++ b/register.py
@@ -93,6 +93,7 @@ def start(settings):
     activity_names.append("DepositCrossrefMinimal")
     activity_names.append("DepositCrossrefPeerReview")
     activity_names.append("DepositCrossrefPendingPublication")
+    activity_names.append("DepositCrossrefPostedContent")
     activity_names.append("PubmedArticleDeposit")
     activity_names.append("PublicationEmail")
     activity_names.append("FTPArticle")

--- a/tests/activity/test_activity_deposit_crossref_posted_content.py
+++ b/tests/activity/test_activity_deposit_crossref_posted_content.py
@@ -1,0 +1,235 @@
+import os
+import time
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from provider import crossref, lax_provider
+import activity.activity_DepositCrossrefPostedContent as activity_module
+from activity.activity_DepositCrossrefPostedContent import (
+    activity_DepositCrossrefPostedContent,
+)
+from tests.classes_mock import FakeSMTPServer
+from tests.activity.classes_mock import FakeLogger, FakeResponse, FakeStorageContext
+from tests.activity import helpers, settings_mock
+import tests.activity.test_activity_data as activity_test_data
+
+
+class TestDepositCrossrefPostedContent(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_DepositCrossrefPostedContent(
+            settings_mock, fake_logger, None, None, None
+        )
+        self.activity.make_activity_directories()
+        self.outbox_folder = "tests/test_data/crossref_posted_content/outbox/"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        self.activity.clean_tmp_dir()
+
+    def tmp_dir(self):
+        "return the tmp dir name for the activity"
+        return self.activity.directories.get("TMP_DIR")
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch.object(lax_provider, "article_status_version_map")
+    @patch("requests.post")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity(
+        self,
+        fake_storage_context,
+        fake_post_request,
+        fake_version_map,
+        fake_email_smtp_connect,
+    ):
+        test_data = {
+            "comment": "Article 84364",
+            "article_xml_filenames": ["elife-preprint-84364-v2.xml"],
+            "post_status_code": 200,
+            "expected_result": True,
+            "expected_approve_status": True,
+            "expected_generate_status": True,
+            "expected_publish_status": True,
+            "expected_outbox_status": True,
+            "expected_email_status": True,
+            "expected_activity_status": True,
+            "expected_file_count": 2,
+            "expected_crossref_xml_contains": [
+                '<posted_content type="preprint">',
+                "<posted_date>",
+                "<month>02</month>",
+                "<day>13</day>",
+                "<year>2023</year>",
+                "<doi>10.7554/eLife.84364</doi>",
+                "<resource>https://elifesciences.org/reviewed-preprints/84364</resource>",
+                "</posted_content>",
+            ],
+        }
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_version_map.return_value = {}
+        resources = helpers.populate_storage(
+            from_dir=self.outbox_folder,
+            to_dir=directory.path,
+            filenames=test_data["article_xml_filenames"],
+            sub_dir="crossref_posted_content/outbox",
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        # mock the POST to endpoint
+        fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))
+        # do the activity
+        result = self.activity.do_activity()
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        # check statuses assertions
+        for status_name in [
+            "approve",
+            "generate",
+            "publish",
+            "outbox",
+            "email",
+            "activity",
+        ]:
+            status_value = self.activity.statuses.get(status_name)
+            expected = test_data.get("expected_" + status_name + "_status")
+            self.assertEqual(
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
+        # Count crossref XML file in the tmp directory
+        file_count = len(os.listdir(self.tmp_dir()))
+        self.assertEqual(file_count, test_data.get("expected_file_count"))
+        if file_count > 0 and test_data.get("expected_crossref_xml_contains"):
+            # Open the first crossref XML and check some of its contents
+            crossref_xml_filename_path = os.path.join(
+                self.tmp_dir(), sorted(os.listdir(self.tmp_dir()))[0]
+            )
+            with open(crossref_xml_filename_path, "rb") as open_file:
+                crossref_xml = open_file.read().decode("utf8")
+                for expected in test_data.get("expected_crossref_xml_contains"):
+                    self.assertTrue(
+                        expected in crossref_xml,
+                        "{expected} not found in crossref_xml {path}".format(
+                            expected=expected, path=crossref_xml_filename_path
+                        ),
+                    )
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch.object(lax_provider, "article_status_version_map")
+    @patch("requests.post")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity_vor_exists(
+        self,
+        fake_storage_context,
+        fake_post_request,
+        fake_version_map,
+        fake_email_smtp_connect,
+    ):
+        "test for if a VOR version already exists"
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_version_map.return_value = {"vor": [1]}
+        fake_storage_context.return_value = FakeStorageContext(
+            self.outbox_folder, ["elife-preprint-84364-v2.xml"]
+        )
+
+        # raise an exception on a post
+        fake_post_request.return_value = FakeResponse(200)
+        fake_post_request.return_value = True
+        fake_post_request.return_value = FakeResponse(200)
+        result = self.activity.do_activity()
+        self.assertTrue(result)
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch.object(lax_provider, "article_status_version_map")
+    @patch("requests.post")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity_crossref_exception(
+        self,
+        fake_storage_context,
+        fake_post_request,
+        fake_version_map,
+        fake_email_smtp_connect,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_version_map.return_value = {}
+        fake_storage_context.return_value = FakeStorageContext(
+            self.outbox_folder, ["elife-preprint-84364-v2.xml"]
+        )
+
+        # raise an exception on a post
+        fake_post_request.side_effect = Exception("")
+        fake_post_request.return_value = True
+        fake_post_request.return_value = FakeResponse(200)
+        result = self.activity.do_activity()
+        self.assertTrue(result)
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    @patch("provider.outbox_provider.storage_context")
+    def test_do_activity_no_good_one_bad(
+        self,
+        fake_storage_context,
+        fake_email_smtp_connect,
+    ):
+        fake_email_smtp_connect.return_value = FakeSMTPServer(
+            self.activity.get_tmp_dir()
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            self.outbox_folder, ["bad.xml"]
+        )
+
+        result = self.activity.do_activity()
+        self.assertTrue(result)
+
+    def test_get_article_objects(self):
+        """test for parsing an XML file"""
+        xml_file_name = "%selife-preprint-84364-v2.xml" % self.outbox_folder
+        article_object_map = self.activity.get_article_objects([xml_file_name])
+        self.assertEqual(len(article_object_map), 1)
+        article_object = article_object_map.get(xml_file_name)
+        self.assertEqual(article_object.doi, "10.7554/eLife.84364")
+        self.assertEqual(
+            article_object.get_date("posted_date").date,
+            time.strptime("2023-02-13 UTC", "%Y-%m-%d %Z"),
+        )
+
+
+ARTICLE_OBJECT_MAP = crossref.article_xml_list_parse(
+    [
+        "tests/test_data/crossref_posted_content/outbox/elife-preprint-84364-v2.xml",
+    ],
+    [],
+    activity_test_data.ExpandArticle_files_dest_folder,
+)
+
+
+class TestPrune(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
+
+    def tearDown(self):
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
+
+    @patch.object(lax_provider, "article_status_version_map")
+    def test_prune_article_object_map_version_exists(self, fake_version_map):
+        fake_version_map.return_value = {"vor": [1]}
+
+        good_article_map = activity_module.prune_article_object_map(
+            ARTICLE_OBJECT_MAP, settings_mock, self.logger
+        )
+        self.assertEqual(len(good_article_map), 0)

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -19,6 +19,10 @@ DepositCrossrefPendingPublication:
   activity_name: DepositCrossrefPendingPublication
   s3_bucket_folder: crossref_pending_publication
 
+DepositCrossrefPostedContent:
+  activity_name: DepositCrossrefPostedContent
+  s3_bucket_folder: crossref_posted_content
+
 PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -128,6 +128,7 @@ DOWNSTREAM_WORKFLOWS = [
     "DepositCrossref",
     "DepositCrossrefPeerReview",
     "DepositCrossrefPendingPublication",
+    "DepositCrossrefPostedContent",
     "GoOA",
     "HEFCE",
     "OASwitchboard",

--- a/tests/test_data/crossref_posted_content/outbox/elife-preprint-84364-v2.xml
+++ b/tests/test_data/crossref_posted_content/outbox/elife-preprint-84364-v2.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.2 20190208//EN" "JATS-archivearticle1-mathml3.dtd">
+<article article-type="preprint" dtd-version="1.2" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="nlm-ta">elife</journal-id>
+            <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            <journal-title-group>
+                <journal-title>eLife</journal-title>
+            </journal-title-group>
+            <issn publication-format="electronic" pub-type="epub">2050-084X</issn>
+            <publisher>
+                <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">84364</article-id>
+            <article-id pub-id-type="doi">10.7554/eLife.84364</article-id>
+            <article-id pub-id-type="doi" specific-use="version">10.7554/eLife.84364.2</article-id>
+            <title-group>
+                <article-title>Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name name-style="western">
+                        <surname>Mahlandt</surname>
+                        <given-names>Eike K.</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="a1">1</xref>
+                </contrib>
+                <aff id="a1">
+                    <label>1</label>
+                    <institution>Swammerdam Institute for Life Sciences, Section of Molecular Cytology, van Leeuwenhoek Centre for Advanced Microscopy, University of Amsterdam, Science Park 904</institution>
+                    , 1098 XH, Amsterdam,
+                    <country>The Netherlands</country>
+                </aff>
+            </contrib-group>
+            <pub-date publication-format="electronic" date-type="posted_date">
+                <day>13</day>
+                <month>02</month>
+                <year>2023</year>
+            </pub-date>
+            <volume>12</volume>
+            <elocation-id>RP84364</elocation-id>
+            <pub-history>
+                <event>
+                    <date date-type="preprint" iso-8601-date="2022-10-17">
+                        <day>17</day>
+                        <month>10</month>
+                        <year>2022</year>
+                    </date>
+                    <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2022.10.17.512253"/>   
+                </event>
+                <event>
+                    <date date-type="reviewed-preprint" iso-8601-date="2023-02-12">
+                        <day>12</day>
+                        <month>02</month>
+                        <year>2023</year>
+                    </date>
+                    <self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.84364.1"/>   
+                </event>
+            </pub-history>
+            <permissions>
+				<license xlink:href="http://creativecommons.org/licenses/by/4.0/">
+					<license-p>
+						<ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/"/>
+					</license-p>
+				</license>
+            </permissions>
+            <abstract>
+                <sec id="p-2">
+                    <title >Abstract</title>
+                    <p>The inner layer of blood vessels consists of endothelial cells, which form the physical barrier between blood and tissue. This vascular barrier is tightly regulated to allow the passage of essential molecules like oxygen, carbon-dioxide, water, ions, and nutrients. The vascular endothelial barrier is defined by cell-cell contacts through adherens and tight junctions. To further investigate the signaling in the endothelium that regulates vascular barrier strength, we focused on Rho GTPases, regulators of the actin cytoskeleton and known to control junction integrity. Rho GTPase signaling is confined in space and time. To manipulate the signaling in a temporal and spatial manner we applied optogenetics. Guanine exchange factor (GEF) domains from ITSN1, TIAM1 and p63RhoGEF, activating Cdc42, Rac and Rho respectively, were integrated into the optogenetic recruitment tool iLID. This tool allows for activation at the subcellular level in a reversible and non-invasive manner and thereby to recruit a GEF to local areas at the plasma membrane, enabling the local activation of specific Rho GTPases. The membrane tag of iLID was optimized and a HaloTag was applied to gain more flexibility for multiplex imaging. The resulting Opto-RhoGEFs were tested in an endothelial cell monolayer and demonstrated precise temporal control of vascular barrier strength by a cell-cell overlap-dependent, VE-cadherin-independent, mechanism. Furthermore, Opto-RhoGEFs enabled precise optogenetic control in endothelial cells over morphological features such as cell-size, -roundness, local extension, and cell contraction. In conclusion, we have optimized and applied the optogenetic iLID GEF recruitment tool i.e. Opto-RhoGEFs, to study the role of Rho GTPases in the vascular barrier of the endothelium and found that membrane protrusions at the junction region can rapidly increase barrier integrity independent of VE-cadherin.</p>
+                </sec>
+            </abstract>
+        </article-meta>
+    </front>
+    <sub-article id="sa0" article-type="editor-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa0</article-id>
+            <title-group>
+                <article-title>eLife assessment</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Eisen</surname>
+                        <given-names>Michael B</given-names>
+                    </name>
+                    <aff>
+                        <institution-wrap>
+                            <institution>University of California</institution>
+                        </institution-wrap>
+                        <addr-line><named-content content-type="city">Berkeley</named-content></addr-line>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa1" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa1</article-id>
+            <title-group>
+                <article-title>Reviewer #1 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa2" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa2</article-id>
+            <title-group>
+                <article-title>Reviewer #2 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article id="sa3" article-type="referee-report">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa3</article-id>
+            <title-group>
+                <article-title>Reviewer #3 (Public Review)</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <anonymous/>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+    <sub-article article-type="author-comment" id="sa5">
+        <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.84364.2.sa4</article-id>
+            <title-group>
+                <article-title>Author response</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name name-style="western">
+                        <surname>Mahlandt</surname>
+                        <given-names>Eike K.</given-names>
+                    </name>
+                </contrib>
+            </contrib-group>
+        </front-stub>
+    </sub-article>
+</article>

--- a/workflow/workflow_DepositCrossref.py
+++ b/workflow/workflow_DepositCrossref.py
@@ -36,6 +36,7 @@ class workflow_DepositCrossref(Workflow):
             "steps": [
                 define_workflow_step("PingWorker", data),
                 define_workflow_step_medium("DepositCrossrefMinimal", data),
+                define_workflow_step_medium("DepositCrossrefPostedContent", data),
                 define_workflow_step_medium("DepositCrossref", data),
                 define_workflow_step_medium("DepositCrossrefPeerReview", data),
             ],


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7717

New activity `DepositCrossrefPostedContent` to generate `<posted_content>` deposits to Crossref, added to the existing Crossref deposit workflow.