### PR TITLE
Sleep after files are deposited to Crossref.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -215,6 +215,14 @@ class activity_DepositCrossref(Activity):
 
         self.logger.info("%s statuses: %s" % (self.name, self.statuses))
 
+        # sleep if there was a deposit
+        if self.good_xml_files and data and data.get("sleep_seconds"):
+            self.logger.info(
+                "%s sleeping %s seconds after the deposit"
+                % (self.name, data.get("sleep_seconds"))
+            )
+            time.sleep(data.get("sleep_seconds"))
+
         return True
 
     def get_article_objects(self, article_xml_files, crossref_config):

--- a/activity/activity_DepositCrossrefMinimal.py
+++ b/activity/activity_DepositCrossrefMinimal.py
@@ -167,6 +167,14 @@ class activity_DepositCrossrefMinimal(Activity):
 
         self.logger.info("%s statuses: %s" % (self.name, self.statuses))
 
+        # sleep if there was a deposit
+        if self.good_xml_files and data and data.get("sleep_seconds"):
+            self.logger.info(
+                "%s sleeping %s seconds after the deposit"
+                % (self.name, data.get("sleep_seconds"))
+            )
+            time.sleep(data.get("sleep_seconds"))
+
         return True
 
     def get_article_objects(self, article_xml_files, crossref_config):

--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -195,6 +195,14 @@ class activity_DepositCrossrefPeerReview(Activity):
 
         self.logger.info("%s statuses: %s" % (self.name, self.statuses))
 
+        # sleep if there was a deposit
+        if self.good_xml_files and data and data.get("sleep_seconds"):
+            self.logger.info(
+                "%s sleeping %s seconds after the deposit"
+                % (self.name, data.get("sleep_seconds"))
+            )
+            time.sleep(data.get("sleep_seconds"))
+
         return True
 
     def get_article_objects(self, article_xml_files, crossref_config=None):

--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -240,6 +240,14 @@ class activity_DepositCrossrefPostedContent(Activity):
 
         self.logger.info("%s statuses: %s" % (self.name, self.statuses))
 
+        # sleep if there was a deposit
+        if self.good_xml_files and data and data.get("sleep_seconds"):
+            self.logger.info(
+                "%s sleeping %s seconds after the deposit"
+                % (self.name, data.get("sleep_seconds"))
+            )
+            time.sleep(data.get("sleep_seconds"))
+
         return True
 
     def get_article_objects(self, article_xml_files):

--- a/starter/starter_DepositCrossref.py
+++ b/starter/starter_DepositCrossref.py
@@ -1,9 +1,13 @@
+import json
 from starter.objects import Starter, default_workflow_params
 from provider import utils
 
 """
 Amazon SWF DepositCrossref starter
 """
+
+# seconds to sleep after a workflow activity deposits to Crossref for eventual consistency
+SLEEP_SECONDS = 30
 
 
 class starter_DepositCrossref(Starter):
@@ -17,6 +21,10 @@ class starter_DepositCrossref(Starter):
         workflow_params["workflow_id"] = self.name
         workflow_params["workflow_name"] = self.name
         workflow_params["workflow_version"] = "1"
+        info = {
+            "sleep_seconds": SLEEP_SECONDS,
+        }
+        workflow_params["input"] = json.dumps(info, default=lambda ob: None)
         return workflow_params
 
     def start(self, settings):

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -21,6 +21,7 @@ class TestDepositCrossref(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
         self.activity.make_activity_directories()
+        self.activity_data = {"sleep_seconds": 0.001}
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -174,7 +175,7 @@ class TestDepositCrossref(unittest.TestCase):
         # mock the POST to endpoint
         fake_request.return_value = FakeResponse(test_data.get("post_status_code"))
         # do the activity
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions

--- a/tests/activity/test_activity_deposit_crossref_minimal.py
+++ b/tests/activity/test_activity_deposit_crossref_minimal.py
@@ -21,6 +21,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
         self.activity.make_activity_directories()
+        self.activity_data = {"sleep_seconds": 0.001}
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -127,7 +128,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
         # mock the POST to endpoint
         fake_request.return_value = FakeResponse(test_data.get("post_status_code"))
         # do the activity
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -28,6 +28,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
             settings_mock, fake_logger, None, None, None
         )
         self.activity.make_activity_directories()
+        self.activity_data = {"sleep_seconds": 0.001}
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -213,7 +214,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))
         fake_head_request.return_value = FakeResponse(302)
         # do the activity
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions
@@ -291,7 +292,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         # raise an exception on a post
         fake_post_request.side_effect = Exception("")
         fake_head_request.return_value = FakeResponse(302)
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         self.assertTrue(result)
 
     @patch.object(bigquery, "get_client")
@@ -313,7 +314,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         client = FakeBigQueryClient(rows)
         fake_get_client.return_value = client
 
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         self.assertTrue(result)
 
     @patch.object(activity_DepositCrossrefPeerReview, "get_manuscript_object")

--- a/tests/activity/test_activity_deposit_crossref_posted_content.py
+++ b/tests/activity/test_activity_deposit_crossref_posted_content.py
@@ -22,6 +22,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         )
         self.activity.make_activity_directories()
         self.outbox_folder = "tests/test_data/crossref_posted_content/outbox/"
+        self.activity_data = {"sleep_seconds": 0.001}
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -82,7 +83,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         # mock the POST to endpoint
         fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))
         # do the activity
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         # check assertions
         self.assertEqual(result, test_data.get("expected_result"))
         # check statuses assertions
@@ -148,7 +149,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         fake_post_request.return_value = FakeResponse(200)
         fake_post_request.return_value = True
         fake_post_request.return_value = FakeResponse(200)
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         self.assertTrue(result)
 
     @patch.object(activity_module.email_provider, "smtp_connect")
@@ -174,7 +175,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         fake_post_request.side_effect = Exception("")
         fake_post_request.return_value = True
         fake_post_request.return_value = FakeResponse(200)
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         self.assertTrue(result)
 
     @patch.object(activity_module.email_provider, "smtp_connect")
@@ -191,7 +192,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
             self.outbox_folder, ["bad.xml"]
         )
 
-        result = self.activity.do_activity()
+        result = self.activity.do_activity(self.activity_data)
         self.assertTrue(result)
 
     def test_get_article_objects(self):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8409

When executing the `DepositCrossref` workflow steps, sleep for `SLEEP_SECONDS` between the workflow steps if any DOI were deposited, to avoid errors if the DOI does not exist in the Crossref database yet when links between DOIs are done.