### PR TITLE
Add pub-history to accepted submission from docmap

### DIFF
--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -93,6 +93,7 @@ class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
         )
 
         # add log messages if an external href is not approved to download
+        xml_root = None
         if not review_date_string:
             cleaner.LOGGER.warning(
                 "%s A sent-for-review date was not added to the XML", input_filename
@@ -109,6 +110,14 @@ class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
                 )
 
                 self.statuses["xml_root"] = True
+
+        # add pub-history tag
+        history_data = cleaner.docmap_preprint_history_from_docmap(docmap_string)
+        if history_data:
+            if xml_root is None:
+                xml_root = cleaner.parse_article_xml(xml_file_path)
+            xml_root = cleaner.add_pub_history(xml_root, history_data, input_filename)
+            self.statuses["xml_root"] = True
 
         if self.statuses.get("xml_root"):
             # write the XML root to disk

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -5,6 +5,7 @@ import re
 from urllib.parse import urlparse
 from xml.etree.ElementTree import SubElement
 import requests
+from docmaptools import parse as docmap_parse
 from elifecleaner import (
     LOGGER,
     assessment_terms,
@@ -416,6 +417,15 @@ def date_struct_from_string(date_string):
 
 def add_history_date(root, date_type, date_struct, identifier):
     return prc.add_history_date(root, date_type, date_struct, identifier)
+
+
+def docmap_preprint_history_from_docmap(docmap_string):
+    d_json = docmap_parse.docmap_json(docmap_string)
+    return docmap_parse.docmap_preprint_history(d_json)
+
+
+def add_pub_history(root, history_data, identifier):
+    return prc.add_pub_history(root, history_data, identifier)
 
 
 def version_doi_from_docmap(docmap_string, input_filename):

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -128,6 +128,22 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
             )
             == 1
         )
+        # assert pub-history is present in the XML
+        self.assertTrue(
+            xml_content.count(
+                (
+                    "<pub-history>"
+                    "<event>"
+                    '<date date-type="preprint">'
+                    "<day>22</day><month>11</month><year>2022</year>"
+                    "</date>"
+                    '<self-uri content-type="preprint">https://doi.org/10.1101/2022.11.08.515698</self-uri>'
+                    "</event>"
+                    "</pub-history>"
+                )
+            )
+            == 1
+        )
 
         self.assertEqual(
             self.activity.statuses.get("docmap_string"),


### PR DESCRIPTION
In the `AcceptedSubmissionHistory` activity, also add a `<pub-history>` tag to the XML from docmap data.

Re issue https://github.com/elifesciences/issues/issues/7721