### PR TITLE
Remove PRC_INGEST_SEND_EMAIL hook.

### DIFF
--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -36,14 +36,6 @@ class activity_EmailAcceptedSubmissionOutput(AcceptedBaseActivity):
 
         expanded_folder, input_filename, article_id = self.read_session(session)
 
-        # November 2022 temporary logic to not send email for PRC article ingest
-        if session.get_value("prc_status") and not cleaner.PRC_INGEST_SEND_EMAIL:
-            self.logger.info(
-                "%s for %s, PRC_INGEST_SEND_EMAIL is False so no email will be sent"
-                % (self.name, input_filename)
-            )
-            return True
-
         # March 2023 also do not send emails for any particular test files
         if (
             session.get_value("prc_status")

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -28,9 +28,6 @@ LOG_FORMAT_STRING = (
     "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
 )
 
-# November 2022 temporary config whether to send emails for PRC article ingestions
-PRC_INGEST_SEND_EMAIL = True
-
 # March 2023 temporary config to not send emails for particular test files
 PRC_INGEST_IGNORE_SEND_EMAIL = [
     "02-28-2023-RA-RP-eLife-84747.zip",


### PR DESCRIPTION
The constant `PRC_INGEST_SEND_EMAIL` and logic it enabled is no longer required, emails are sent as part of each workflow, except in a testing situation.