### PR TITLE
Dependency `elifecleaner` pinned to `0.49.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.48.0"
+elifecleaner = "~=0.49.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-07-24 - see update-dependencies.sh
+# file generated 2023-07-25 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.6
 async-timeout==4.0.2
@@ -20,7 +20,7 @@ docker==5.0.3
 docmaptools==0.13.0
 ejpcsvparser==0.2.0
 elifearticle==0.15.0
-elifecleaner==0.48.0
+elifecleaner==0.49.0
 elifecrossref==0.19.0
 elifepubmed==0.5.1
 elifetools==0.32.0

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -138,7 +138,7 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
                     '<date date-type="preprint" iso-8601-date="2022-11-22">'
                     "<day>22</day><month>11</month><year>2022</year>"
                     "</date>"
-                    '<self-uri content-type="preprint">https://doi.org/10.1101/2022.11.08.515698</self-uri>'
+                    '<self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2022.11.08.515698"/>'
                     "</event>"
                     "</pub-history>"
                 )


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/150/display/redirect which resulted in this pull request.