### PR TITLE
Set volume tag of PRC XML.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -425,6 +425,10 @@ def add_pub_history(root, history_data, identifier):
     return prc.add_pub_history(root, history_data, identifier)
 
 
+def volume_from_docmap(docmap_string, input_filename):
+    return prc.volume_from_docmap(docmap_string, input_filename)
+
+
 def version_doi_from_docmap(docmap_string, input_filename):
     return prc.version_doi_from_docmap(docmap_string, input_filename)
 


### PR DESCRIPTION
In the `TransformAcceptedSubmission` activity, if the zip file is PRC type, get the journal volume value from the docmap and set the text of the XML `<volume>` tag. It will make no changes if the calculate volume is `None`, or if the `<volume>` tag does not already exist.

Re issue https://github.com/elifesciences/issues/issues/8420