### PR TITLE
Accepted email subject line change, continuumtest

### DIFF
--- a/activity/activity_EmailAcceptedSubmissionOutput.py
+++ b/activity/activity_EmailAcceptedSubmissionOutput.py
@@ -72,7 +72,7 @@ class activity_EmailAcceptedSubmissionOutput(AcceptedBaseActivity):
 
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = accepted_submission_email_subject(output_file)
+        subject = accepted_submission_email_subject(output_file, self.settings)
         sender_email = self.settings.accepted_submission_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
@@ -95,6 +95,9 @@ class activity_EmailAcceptedSubmissionOutput(AcceptedBaseActivity):
         return success
 
 
-def accepted_submission_email_subject(output_file):
+def accepted_submission_email_subject(output_file, settings=None):
     "the email subject"
-    return "eLife accepted submission: %s" % output_file
+    subject_prefix = ""
+    if utils.settings_environment(settings) == "continuumtest":
+        subject_prefix = "TEST "
+    return "%seLife accepted submission: %s" % (subject_prefix, output_file)

--- a/activity/activity_UpdateRepository.py
+++ b/activity/activity_UpdateRepository.py
@@ -2,7 +2,7 @@ from ssl import SSLError
 import tempfile
 from github import Github
 from github import GithubException
-from provider.utils import pad_msid, unicode_encode
+from provider.utils import pad_msid, settings_environment, unicode_encode
 import provider.lax_provider
 from provider.storage_provider import storage_context
 from activity.objects import Activity
@@ -10,11 +10,6 @@ from activity.objects import Activity
 """
 activity_UpdateRepository.py activity
 """
-
-
-def settings_environment(settings_object):
-    "get the environment name from the settings object class name"
-    return type(settings_object()).__name__
 
 
 class RetryException(RuntimeError):

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -197,7 +197,7 @@ class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
 
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = error_email_subject(output_file)
+        subject = error_email_subject(output_file, self.settings)
         sender_email = self.settings.accepted_submission_sender_email
         recipient_email_list = email_provider.list_email_recipients(
             self.settings.accepted_submission_validate_error_recipient_email
@@ -227,9 +227,15 @@ def download_pdf_files_from_bucket(storage, files, asset_file_name_map, to_dir, 
     )
 
 
-def error_email_subject(output_file):
+def error_email_subject(output_file, settings=None):
     "the email subject"
-    return "Error validating accepted submission file: %s" % output_file
+    subject_prefix = ""
+    if utils.settings_environment(settings) == "continuumtest":
+        subject_prefix = "TEST "
+    return "%sError validating accepted submission file: %s" % (
+        subject_prefix,
+        output_file,
+    )
 
 
 def error_email_body_content(

--- a/activity/activity_ValidateAcceptedSubmissionVideos.py
+++ b/activity/activity_ValidateAcceptedSubmissionVideos.py
@@ -176,7 +176,7 @@ class activity_ValidateAcceptedSubmissionVideos(AcceptedBaseActivity):
 
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = error_email_subject(output_file)
+        subject = error_email_subject(output_file, self.settings)
         sender_email = self.settings.accepted_submission_sender_email
         recipient_email_list = email_provider.list_email_recipients(
             self.settings.accepted_submission_validate_error_recipient_email
@@ -198,9 +198,15 @@ class activity_ValidateAcceptedSubmissionVideos(AcceptedBaseActivity):
         return success
 
 
-def error_email_subject(output_file):
+def error_email_subject(output_file, settings=None):
     "the email subject"
-    return "Error validating videos in accepted submission file: %s" % output_file
+    subject_prefix = ""
+    if utils.settings_environment(settings) == "continuumtest":
+        subject_prefix = "TEST "
+    return "%sError validating videos in accepted submission file: %s" % (
+        subject_prefix,
+        output_file,
+    )
 
 
 def error_email_body_content(

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -169,6 +169,13 @@ CONSOLE_ARGUMENT_MAP = {
 }
 
 
+def settings_environment(settings_object):
+    "get the environment name from the settings object class name"
+    if not callable(settings_object):
+        return None
+    return type(settings_object()).__name__
+
+
 def add_console_argument(parser, argument_name):
     details = CONSOLE_ARGUMENT_MAP.get(argument_name)
     if details:

--- a/tests/activity/test_activity_email_accepted_submission_output.py
+++ b/tests/activity/test_activity_email_accepted_submission_output.py
@@ -175,6 +175,29 @@ class TestEmailAcceptedSubmissionOutput(unittest.TestCase):
 class TestEmailSubject(unittest.TestCase):
     def test_accepted_submission_email_subject(self):
         "email subject line with correct output_file value"
+
+        class continuumtest:
+            "mock settings object for testing"
+            pass
+
+        output_file = "file.zip"
+        expected = "TEST eLife accepted submission: %s" % output_file
+        subject = activity_module.accepted_submission_email_subject(
+            output_file, continuumtest
+        )
+        self.assertEqual(subject, expected)
+
+    def test_no_settings_class_name(self):
+        "test if the settings is not a class"
+        output_file = "file.zip"
+        expected = "eLife accepted submission: %s" % output_file
+        subject = activity_module.accepted_submission_email_subject(
+            output_file, settings_mock
+        )
+        self.assertEqual(subject, expected)
+
+    def test_settings_none(self):
+        "test if settings is not passed as an argument"
         output_file = "file.zip"
         expected = "eLife accepted submission: %s" % output_file
         subject = activity_module.accepted_submission_email_subject(output_file)

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -499,3 +499,31 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
             line for line in log_contents.split("\n") if "ERROR elifecleaner:" in line
         ]
         self.assertEqual(len(log_errors), 1)
+
+
+class TestErrorEmailSubject(unittest.TestCase):
+    def test_error_email_subject(self):
+        "email subject line with correct output_file value"
+
+        class continuumtest:
+            "mock settings object for testing"
+            pass
+
+        output_file = "file.zip"
+        expected = "TEST Error validating accepted submission file: %s" % output_file
+        subject = activity_module.error_email_subject(output_file, continuumtest)
+        self.assertEqual(subject, expected)
+
+    def test_no_settings_class_name(self):
+        "test if the settings is not a class"
+        output_file = "file.zip"
+        expected = "Error validating accepted submission file: %s" % output_file
+        subject = activity_module.error_email_subject(output_file, settings_mock)
+        self.assertEqual(subject, expected)
+
+    def test_settings_none(self):
+        "test if settings is not passed as an argument"
+        output_file = "file.zip"
+        expected = "Error validating accepted submission file: %s" % output_file
+        subject = activity_module.error_email_subject(output_file)
+        self.assertEqual(subject, expected)

--- a/tests/activity/test_activity_validate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_validate_accepted_submission_videos.py
@@ -367,3 +367,37 @@ class TestValidateVideoData(unittest.TestCase):
         # assertions
         self.assertEqual(validation_messages, expected_validation_messages)
         self.assertEqual(self.logger.loginfo[-1], expected_validation_messages)
+
+
+class TestErrorEmailSubject(unittest.TestCase):
+    def test_error_email_subject(self):
+        "email subject line with correct output_file value"
+
+        class continuumtest:
+            "mock settings object for testing"
+            pass
+
+        output_file = "file.zip"
+        expected = (
+            "TEST Error validating videos in accepted submission file: %s" % output_file
+        )
+        subject = activity_module.error_email_subject(output_file, continuumtest)
+        self.assertEqual(subject, expected)
+
+    def test_no_settings_class_name(self):
+        "test if the settings is not a class"
+        output_file = "file.zip"
+        expected = (
+            "Error validating videos in accepted submission file: %s" % output_file
+        )
+        subject = activity_module.error_email_subject(output_file, settings_mock)
+        self.assertEqual(subject, expected)
+
+    def test_settings_none(self):
+        "test if settings is not passed as an argument"
+        output_file = "file.zip"
+        expected = (
+            "Error validating videos in accepted submission file: %s" % output_file
+        )
+        subject = activity_module.error_email_subject(output_file)
+        self.assertEqual(subject, expected)

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -149,6 +149,26 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(utils.doi_uri_to_doi(doi_url), doi)
 
 
+class TestSettingsEnvironment(unittest.TestCase):
+    "test for utils.settings_environment()"
+
+    def test_settings_environment(self):
+        "test returning settings class name"
+
+        class ci:
+            "mock settings object for testing"
+            pass
+
+        settings_object = ci
+        result = utils.settings_environment(ci)
+        self.assertEqual(result, "ci")
+
+    def test_not_callable(self):
+        "test if settings is not a class"
+        result = utils.settings_environment(None)
+        self.assertEqual(result, None)
+
+
 class TestConsoleStart(unittest.TestCase):
     def test_console_start(self):
         env = "foo"


### PR DESCRIPTION
Modify emails sent by ingest accepted submission worklfows when it runs on the `continuumtest` environment. Refactored the function which gets the environment from the settings object.

Re issue https://github.com/elifesciences/issues/issues/8406