### PR TITLE
Move get_docmap_string() to Activity class.

### DIFF
--- a/activity/objects.py
+++ b/activity/objects.py
@@ -308,6 +308,20 @@ class Activity:
             workflow_name, downstream_workflow_map
         )
 
+    def get_docmap_string(self, article_id, identifier):
+        # generate docmap URL
+        docmap_url = cleaner.docmap_url(self.settings, article_id)
+        self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
+
+        # get docmap json
+        self.logger.info(
+            "%s, getting docmap_string for identifier: %s"
+            % (self.name, identifier)
+        )
+        return cleaner.get_docmap_by_account_id(
+            docmap_url, self.settings.docmap_account_id
+        )
+
 
 class AcceptedBaseActivity(Activity):
     def __init__(self, settings, logger, client=None, token=None, activity_task=None):
@@ -516,17 +530,3 @@ class AcceptedBaseActivity(Activity):
                 "%s, deleting old S3 key %s" % (self.name, old_s3_resource)
             )
             storage.delete_resource(old_s3_resource)
-
-    def get_docmap_string(self, article_id, input_filename):
-        # generate docmap URL
-        docmap_url = cleaner.docmap_url(self.settings, article_id)
-        self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
-
-        # get docmap json
-        self.logger.info(
-            "%s, getting docmap_string for input_filename: %s"
-            % (self.name, input_filename)
-        )
-        return cleaner.get_docmap_by_account_id(
-            docmap_url, self.settings.docmap_account_id
-        )


### PR DESCRIPTION
Move the function from the `AcceptedBaseActivity` class to its base class `Activity`, which will make it possible for a non-accepted submission workflow step to use it.

Changed `input_filename` argument to `identifier` for more general purpose integration.