### PR TITLE
Dependency `docmaptools` pinned to `0.14.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-08-02 - see update-dependencies.sh
+# file generated 2023-08-09 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.6
 async-timeout==4.0.2
@@ -17,7 +17,7 @@ Deprecated==1.2.14
 digestparser==0.2.0
 dill==0.3.7
 docker==5.0.3
-docmaptools==0.13.0
+docmaptools==0.14.0
 ejpcsvparser==0.2.0
 elifearticle==0.15.0
 elifecleaner==0.50.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/154/display/redirect which resulted in this pull request.