### PR TITLE
Dependency `elifecleaner` pinned to `0.52.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.51.0"
+elifecleaner = "~=0.52.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -9,6 +9,7 @@ from docmaptools import parse as docmap_parse
 from elifecleaner import (
     LOGGER,
     assessment_terms,
+    block,
     configure_logging,
     fig,
     parse,
@@ -173,7 +174,7 @@ def preprint_url(xml_file_path):
 
 def is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier):
     "see if a p tag contains only an inline-graphic tag"
-    return fig.is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier)
+    return block.is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier)
 
 
 def inline_graphic_tags(xml_file_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-08-14 - see update-dependencies.sh
+# file generated 2023-08-22 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.6
 async-timeout==4.0.2
@@ -20,7 +20,7 @@ docker==5.0.3
 docmaptools==0.15.0
 ejpcsvparser==0.2.0
 elifearticle==0.15.0
-elifecleaner==0.51.0
+elifecleaner==0.52.0
 elifecrossref==0.19.0
 elifepubmed==0.5.1
 elifetools==0.32.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/157/display/redirect which resulted in this pull request.