### PR TITLE
Transform and OCR table images in peer reviews.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewTables.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewTables.py
@@ -1,0 +1,93 @@
+import os
+import json
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner
+from activity.objects import AcceptedBaseActivity
+
+
+class activity_AcceptedSubmissionPeerReviewTables(AcceptedBaseActivity):
+    "AcceptedSubmissionPeerReviewTables activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionPeerReviewTables, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionPeerReviewTables"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Transform certain peer review inline graphic image content into "
+            "table-wrap tags."
+        )
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"hrefs": None, "modify_xml": None, "rename_files": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        session = get_session(self.settings, data, data["run"])
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        self.start_cleaner_log()
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
+
+        # find S3 object for article XML and download it
+        xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
+
+        # search XML file for graphic tags
+        inline_graphic_tags = cleaner.inline_graphic_tags(xml_file_path)
+        if not inline_graphic_tags:
+            self.logger.info(
+                "%s, no inline-graphic tags in %s" % (self.name, input_filename)
+            )
+            self.end_cleaner_log(session)
+            return True
+
+        self.statuses["hrefs"] = True
+
+        xml_root = cleaner.parse_article_xml(xml_file_path)
+
+        # transform inline-graphic into table-wrap
+        for sub_article_root in xml_root.iterfind("./sub-article"):
+            sub_article_root = cleaner.transform_table(sub_article_root, input_filename)
+
+        # write the XML root to disk
+        cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
+
+        # upload the XML to the bucket
+        self.upload_xml_file_to_bucket(asset_file_name_map, expanded_folder, storage)
+
+        self.end_cleaner_log(session)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -15,6 +15,7 @@ from elifecleaner import (
     parse,
     prc,
     sub_article,
+    table,
     transform,
     video,
     video_xml,
@@ -187,6 +188,15 @@ def inline_graphic_tags(xml_file_path):
     return tags
 
 
+def table_wrap_graphic_tags(xml_file_path):
+    "find graphic tags which are inside table-wrap tags"
+    root = parse_article_xml(xml_file_path)
+    tags = []
+    for graphic_tag in root.findall(".//table-wrap/graphic"):
+        tags.append(graphic_tag)
+    return tags
+
+
 def tag_xlink_href(tag):
     "return a the xlink:href attribute"
     return tag.get("{http://www.w3.org/1999/xlink}href", None)
@@ -274,6 +284,21 @@ def transform_fig(sub_article_root, identifier):
     return fig.transform_fig(sub_article_root, identifier)
 
 
+def transform_table(sub_article_root, identifier):
+    "transform inline-graphic tags into table-wrap tags"
+    return table.transform_table(sub_article_root, identifier)
+
+
+def tsv_to_list(tsv_string):
+    "parse TSV string into lists of rows"
+    return table.tsv_to_list(tsv_string)
+
+
+def list_to_table_xml(table_rows):
+    "create a table Element tag from the table rows"
+    return table.list_to_table_xml(table_rows)
+
+
 def remove_tag_attributes(tag):
     "remove attributes from the tag"
     fig.remove_tag_attributes(tag)
@@ -322,6 +347,11 @@ def docmap_url(settings, article_id):
     return (
         docmap_url_pattern.format(article_id=article_id) if docmap_url_pattern else None
     )
+
+
+def sub_article_data(docmap_string, article):
+    # add sub-article data from the docmap and get requests to the article object
+    return sub_article.sub_article_data(docmap_string, article)
 
 
 def add_sub_article_xml(docmap_string, article_xml, terms_yaml=None):

--- a/provider/ocr.py
+++ b/provider/ocr.py
@@ -14,6 +14,38 @@ DEFAULT_OPTIONS_JSON = {
     },
 }
 
+TABLE_OPTIONS_JSON = {
+    "math_inline_delimiters": ["$", "$"],
+    "rm_spaces": True,
+    "formats": "data",
+    "data_options": {
+        "include_table_html": True,
+        "include_tsv": True,
+    },
+    "enable_tables_fallback": True,
+}
+
+
+def mathpix_table_post_request(
+    url,
+    app_id,
+    app_key,
+    file_path,
+    options_json=None,
+    verify_ssl=False,
+    logger=None,
+):
+    "POST to Mathpix API endpoint using table options"
+    return mathpix_post_request(
+        url,
+        app_id,
+        app_key,
+        file_path,
+        options_json=TABLE_OPTIONS_JSON,
+        verify_ssl=verify_ssl,
+        logger=logger,
+    )
+
 
 def mathpix_post_request(
     url,

--- a/register.py
+++ b/register.py
@@ -138,6 +138,7 @@ def start(settings):
     activity_names.append("OutputAcceptedSubmission")
     activity_names.append("AcceptedSubmissionPeerReviews")
     activity_names.append("AcceptedSubmissionPeerReviewImages")
+    activity_names.append("AcceptedSubmissionPeerReviewTables")
     activity_names.append("AcceptedSubmissionPeerReviewFigs")
     activity_names.append("AcceptedSubmissionPeerReviewOcr")
     activity_names.append("AcceptedSubmissionVersionDoi")

--- a/tests/activity/test_activity_accepted_submission_peer_review_tables.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_tables.py
@@ -1,0 +1,302 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionPeerReviewTables as activity_module
+from activity.activity_AcceptedSubmissionPeerReviewTables import (
+    activity_AcceptedSubmissionPeerReviewTables as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionPeerReviewTables(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "example with no inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "image_names": None,
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": None,
+            "expected_upload_xml_status": None,
+            "expected_activity_log_contains": [
+                (
+                    "AcceptedSubmissionPeerReviewTables, no inline-graphic tags in "
+                    "30-01-2019-RA-eLife-45644.zip"
+                )
+            ],
+        },
+        {
+            "comment": "example with no label or caption content inline-graphic",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                '<sub-article id="sa1">'
+                "<body>"
+                '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+            ),
+            "image_names": ["local.jpg"],
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml_contains": [
+                (
+                    '<sub-article id="sa1">'
+                    "<body>"
+                    '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                    "</body>"
+                    "</sub-article>"
+                ),
+            ],
+        },
+        {
+            "comment": "example with label and caption",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "sub_article_xml": (
+                '<sub-article id="sa1">'
+                "<body>"
+                "<p>First paragraph.</p>"
+                "<p><bold>Review table 1.</bold></p>"
+                "<p>Caption title. Caption paragraph.</p>"
+                '<p><inline-graphic xlink:href="local.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+                '<sub-article id="sa2">'
+                "<body>"
+                "<p>First paragraph.</p>"
+                "<p><bold>Review table 1.</bold></p>"
+                "<p>Caption title. Caption paragraph.</p>"
+                '<p><inline-graphic xlink:href="local2.jpg"/></p>'
+                "</body>"
+                "</sub-article>"
+            ),
+            "image_names": ["local.jpg", "local2.jpg"],
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_hrefs_status": True,
+            "expected_upload_xml_status": True,
+            "expected_xml_contains": [
+                (
+                    '<sub-article id="sa1">'
+                    "<body>"
+                    "<p>First paragraph.</p>"
+                    '<table-wrap id="sa1table1">'
+                    "<label>Review table 1.</label>"
+                    "<caption>"
+                    "<title>Caption title.</title>"
+                    "<p>Caption paragraph.</p>"
+                    "</caption>"
+                    '<graphic mimetype="image" mime-subtype="jpg" xlink:href="local.jpg"/>'
+                    "</table-wrap>"
+                    "</body>"
+                    "</sub-article>"
+                    '<sub-article id="sa2">'
+                    "<body>"
+                    "<p>First paragraph.</p>"
+                    '<table-wrap id="sa2table1">'
+                    "<label>Review table 1.</label>"
+                    "<caption>"
+                    "<title>Caption title.</title>"
+                    "<p>Caption paragraph.</p>"
+                    "</caption>"
+                    '<graphic mimetype="image" mime-subtype="jpg" xlink:href="local2.jpg"/>'
+                    "</table-wrap>"
+                    "</body>"
+                    "</sub-article>"
+                    "</article>"
+                ),
+            ],
+            "expected_bucket_upload_folder_contents": [
+                "30-01-2019-RA-eLife-45644.xml",
+                "local.jpg",
+                "local2.jpg",
+            ],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        # set REPAIR_XML value because test fixture is malformed XML
+        activity_module.REPAIR_XML = True
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        zip_sub_folder = test_data.get("filename").replace(".zip", "")
+        zip_xml_file = "%s.xml" % zip_sub_folder
+
+        # create a new zip file fixtur
+        file_details = []
+        if test_data.get("image_names"):
+            for image_name in test_data.get("image_names"):
+                details = {
+                    "file_path": "tests/files_source/digests/outbox/99999/digest-99999.jpg",
+                    "file_type": "figure",
+                    "upload_file_nm": image_name,
+                }
+                file_details.append(details)
+        new_zip_file_path = helpers.add_files_to_accepted_zip(
+            "tests/files_source/30-01-2019-RA-eLife-45644.zip",
+            directory.path,
+            file_details,
+        )
+
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            new_zip_file_path,
+        )
+
+        # write additional XML to the XML file
+        if test_data.get("sub_article_xml"):
+            sub_folder = test_data.get("filename").rsplit(".", 1)[0]
+            xml_path = os.path.join(
+                directory.path,
+                self.session.get_value("expanded_folder"),
+                sub_folder,
+                "%s.xml" % sub_folder,
+            )
+            with open(xml_path, "r", encoding="utf-8") as open_file:
+                xml_string = open_file.read()
+            with open(xml_path, "w", encoding="utf-8") as open_file:
+                xml_string = xml_string.replace(
+                    "</article>", "%s</article>" % test_data.get("sub_article_xml")
+                )
+                open_file.write(xml_string)
+
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            zip_sub_folder,
+            zip_xml_file,
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # assertion on XML contents
+        if test_data.get("expected_xml_contains"):
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_content = open_file.read()
+            for fragment in test_data.get("expected_xml_contains"):
+                self.assertTrue(
+                    fragment in xml_content,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        self.assertEqual(
+            self.activity.statuses.get("hrefs"),
+            test_data.get("expected_hrefs_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        self.assertEqual(
+            self.activity.statuses.get("upload_xml"),
+            test_data.get("expected_upload_xml_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on cleaner.log contents
+        if test_data.get("expected_cleaner_log_contains"):
+            log_file_path = os.path.join(
+                self.activity.get_tmp_dir(), self.activity.activity_log_file
+            )
+            with open(log_file_path, "r", encoding="utf8") as open_file:
+                log_contents = open_file.read()
+            for fragment in test_data.get("expected_cleaner_log_contains"):
+                self.assertTrue(
+                    fragment in log_contents,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on the session cleaner log content
+        if test_data.get("expected_upload_xml_status"):
+            session_log = self.session.get_value("cleaner_log")
+            self.assertIsNotNone(
+                session_log,
+                "failed in {comment}".format(comment=test_data.get("comment")),
+            )
+
+        # check output bucket folder contents
+        if "expected_bucket_upload_folder_contents" in test_data:
+            bucket_folder_path = os.path.join(
+                directory.path,
+                test_activity_data.accepted_session_example.get("expanded_folder"),
+                zip_sub_folder,
+            )
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            for bucket_file in test_data.get("expected_bucket_upload_folder_contents"):
+                self.assertTrue(
+                    bucket_file in output_bucket_list,
+                    "%s not found in bucket upload folder" % bucket_file,
+                )
+
+        # reset REPAIR_XML value
+        activity_module.REPAIR_XML = False

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -335,6 +335,58 @@ class TestInlineGraphicTags(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
+class TestTableWrapGraphicTags(unittest.TestCase):
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_table_wrap_graphic_tags(self):
+        "test finding graphic tags inside table-wrap tags"
+        directory = TempDirectory()
+        xml_file_name = "test.xml"
+
+        xml_string = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<sub-article>"
+            "<body><p>"
+            '<graphic xlink:href="https://example.org/image1.jpg" />'
+            "<table-wrap>"
+            '<graphic xlink:href="https://example.org/image2.jpg" />'
+            "</table-wrap>"
+            "</p></body>"
+            "</sub-article>"
+            "</article>"
+        )
+        expected_result_len = 1
+        expected_tag_0_string = (
+            '<graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'xlink:href="https://example.org/image2.jpg" />'
+        )
+        xml_file_path = os.path.join(directory.path, xml_file_name)
+        with open(xml_file_path, "w") as open_file:
+            open_file.write(xml_string)
+        # invoke the function
+        result = cleaner.table_wrap_graphic_tags(xml_file_path)
+        # check output
+        self.assertEqual(len(result), expected_result_len)
+        self.assertEqual(
+            ElementTree.tostring(result[0]).decode("utf8"), expected_tag_0_string
+        )
+
+    def test_table_wrap_graphic_tags_none(self):
+        "test if there are no graphic tags"
+        directory = TempDirectory()
+        xml_file_name = "test.xml"
+        xml_string = "<article />"
+        expected = []
+        xml_file_path = os.path.join(directory.path, xml_file_name)
+        with open(xml_file_path, "w") as open_file:
+            open_file.write(xml_string)
+        # invoke the function
+        result = cleaner.table_wrap_graphic_tags(xml_file_path)
+        # check output
+        self.assertEqual(result, expected)
+
+
 class TestTagXlinkHref(unittest.TestCase):
     def test_tag_xlink_href(self):
         xlink_href = "https://example.org/image1.jpg"

--- a/tests/provider/test_ocr.py
+++ b/tests/provider/test_ocr.py
@@ -5,6 +5,49 @@ from tests import settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeResponse
 
 
+class TestMathpixTablePostRequest(unittest.TestCase):
+    "tests for provider.ocr.mathpix_table_post_request()"
+
+    def setUp(self):
+        self.url = settings_mock.mathpix_endpoint
+        self.app_id = settings_mock.mathpix_app_id
+        self.app_key = settings_mock.mathpix_app_key
+        self.logger = FakeLogger()
+        self.file_path = "tests/files_source/digests/outbox/99999/digest-99999.jpg"
+        self.options_json = None
+        self.response_content_success = None
+        self.response_json_success = {"data": [{"type": "tsv", "value": ""}]}
+
+    @patch("requests.post")
+    def test_mathpix_table_post_request_201(self, mock_requests_post):
+        verify_ssl = False
+        response_status_code = 201
+        response = FakeResponse(response_status_code)
+        response.content = self.response_content_success
+        response.response_json = self.response_json_success
+        mock_requests_post.return_value = response
+
+        ocr.mathpix_table_post_request(
+            self.url,
+            self.app_id,
+            self.app_key,
+            self.file_path,
+            self.options_json,
+            verify_ssl,
+            self.logger,
+        )
+
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            "Response from Mathpix API: %s\n%s"
+            % (response_status_code, self.response_content_success),
+        )
+        self.assertEqual(
+            self.logger.loginfo[-2],
+            "Post file %s to Mathpix API: POST %s\n" % (self.file_path, self.url),
+        )
+
+
 class TestMathpixPostRequest(unittest.TestCase):
     def setUp(self):
         self.url = settings_mock.mathpix_endpoint
@@ -14,7 +57,7 @@ class TestMathpixPostRequest(unittest.TestCase):
         self.file_path = "tests/files_source/digests/outbox/99999/digest-99999.jpg"
         self.options_json = None
         self.response_content_success = None
-        self.response_json_success = {"data": [{"latex": ""}]}
+        self.response_json_success = {"data": [{"type": "latex", "value": ""}]}
 
     @patch("requests.post")
     def test_mathpix_post_request_201(self, mock_requests_post):
@@ -42,8 +85,7 @@ class TestMathpixPostRequest(unittest.TestCase):
         )
         self.assertEqual(
             self.logger.loginfo[-2],
-            "Post file %s to Mathpix API: POST %s\n"
-            % (self.file_path, self.url),
+            "Post file %s to Mathpix API: POST %s\n" % (self.file_path, self.url),
         )
 
     @patch("requests.post")

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -55,6 +55,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
                 define_workflow_step_short("AcceptedSubmissionPeerReviewFigs", data),
+                define_workflow_step_short("AcceptedSubmissionPeerReviewTables", data),
                 define_workflow_step_short("AcceptedSubmissionPeerReviewOcr", data),
                 define_workflow_step_short("AddCommentsToAcceptedSubmissionXml", data),
                 define_workflow_step_medium("OutputAcceptedSubmission", data),


### PR DESCRIPTION
In ingestion of accepted submission zip files, detect table images and convert them to `<table-wrap>` in peer review XML. Then try to OCR them into `<table>` XML.

Re issue https://github.com/elifesciences/issues/issues/8383