### PR TITLE
Test for preprint BigQuery ORCID, and XML fix.

### DIFF
--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -140,6 +140,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
                 ),
                 '<anonymous contributor_role="author" sequence="first"/>',
                 '<peer_review stage="pre-publication" type="editor-report">',
+                '<ORCID authenticated="true">https://orcid.org/test-orcid</ORCID>',
                 '<peer_review stage="pre-publication" type="referee-report">',
                 '<peer_review stage="pre-publication" type="author-comment">',
                 "<doi>10.7554/eLife.84364.2.sa0</doi>",
@@ -197,7 +198,6 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         fake_email_smtp_connect.return_value = FakeSMTPServer(
             self.activity.get_tmp_dir()
         )
-        fake_get_client.return_value = True
         resources = helpers.populate_storage(
             from_dir="tests/test_data/crossref_peer_review/outbox/",
             to_dir=directory.path,
@@ -207,9 +207,14 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         fake_storage_context.return_value = FakeStorageContext(
             directory.path, resources, dest_folder=directory.path
         )
-        rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
+
+        if "elife-preprint-84364-v2.xml" in test_data["article_xml_filenames"]:
+            rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_84364])
+        else:
+            rows = FakeBigQueryRowIterator([bigquery_test_data.ARTICLE_RESULT_15747])
         client = FakeBigQueryClient(rows)
         fake_get_client.return_value = client
+
         # mock the POST to endpoint
         fake_post_request.return_value = FakeResponse(test_data.get("post_status_code"))
         fake_head_request.return_value = FakeResponse(302)

--- a/tests/bigquery_test_data.py
+++ b/tests/bigquery_test_data.py
@@ -40,3 +40,32 @@ ARTICLE_RESULT_15747 = Row(
         "Reviewers_And_Editors": 4,
     },
 )
+
+ARTICLE_RESULT_84364 = Row(
+    (
+        (
+            "84364",
+            "10.7554/eLife.84364",
+            datetime.datetime(2023, 2, 13, 11, 31, 1, tzinfo=UTC),
+            datetime.datetime(2023, 2, 10, 6, 28, 43, tzinfo=UTC),
+            [
+                {
+                    "Title": "Dr.",
+                    "Last_Name": "Eisen",
+                    "Middle_Name": "B",
+                    "Role": "Reviewing Editor",
+                    "ORCID": "test-orcid",
+                    "First_Name": "Michael",
+                    "Person_ID": "1013",
+                },
+            ],
+        )
+    ),
+    {
+        "Manuscript_ID": 0,
+        "DOI": 1,
+        "Review_Comment_UTC_Timestamp": 2,
+        "Author_Response_UTC_Timestamp": 3,
+        "Reviewers_And_Editors": 4,
+    },
+)

--- a/tests/test_data/crossref_peer_review/outbox/elife-preprint-84364-v2.xml
+++ b/tests/test_data/crossref_peer_review/outbox/elife-preprint-84364-v2.xml
@@ -64,7 +64,9 @@
             </pub-history>
             <permissions>
                 <license xlink:href="http://creativecommons.org/licenses/by/4.0/">
-                    <ali:license_ref>http://creativecommons.org/licenses/by/4.0/</ali:license_ref>
+                    <license-p>
+                        <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/"/>
+                    </license-p>
                 </license>
             </permissions>
             <abstract>


### PR DESCRIPTION
Updated a test case for preprint peer review Crossref deposit to confirm a missing ORCID value will be added from data returned by BigQuery.

Also fixed an XML fixture which had incorrect license XML.

Re issue https://github.com/elifesciences/issues/issues/8497