### PR TITLE
REPAIR_XML into cleaner.py, fix test fixture XML.

### DIFF
--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -6,9 +6,6 @@ from provider import cleaner
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
     "AcceptedSubmissionHistory activity"
 

--- a/activity/activity_AcceptedSubmissionPeerReviewFigs.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewFigs.py
@@ -7,9 +7,6 @@ from provider import cleaner
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
     "AcceptedSubmissionPeerReviewFigs activity"
 

--- a/activity/activity_AcceptedSubmissionPeerReviewImages.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewImages.py
@@ -10,8 +10,6 @@ from provider import cleaner, utils
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
 FILE_NAME_FORMAT = "elife-%s-inf%s.%s"
 
 REQUESTS_TIMEOUT = 10

--- a/activity/activity_AcceptedSubmissionPeerReviewOcr.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewOcr.py
@@ -8,9 +8,6 @@ from provider import article_processing, cleaner, ocr
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AcceptedSubmissionPeerReviewOcr(AcceptedBaseActivity):
     "AcceptedSubmissionPeerReviewOcr activity"
 

--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -7,9 +7,6 @@ from provider import cleaner, utils
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AcceptedSubmissionPeerReviews(AcceptedBaseActivity):
     "AcceptedSubmissionPeerReviews activity"
 

--- a/activity/activity_AcceptedSubmissionVersionDoi.py
+++ b/activity/activity_AcceptedSubmissionVersionDoi.py
@@ -7,9 +7,6 @@ from provider import cleaner, utils
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AcceptedSubmissionVersionDoi(AcceptedBaseActivity):
     "AcceptedSubmissionVersionDoi activity"
 

--- a/activity/activity_AddCommentsToAcceptedSubmissionXml.py
+++ b/activity/activity_AddCommentsToAcceptedSubmissionXml.py
@@ -8,9 +8,6 @@ from provider.storage_provider import storage_context
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_AddCommentsToAcceptedSubmissionXml(AcceptedBaseActivity):
     "AddCommentsToAcceptedSubmissionXml activity"
 
@@ -78,11 +75,6 @@ class activity_AddCommentsToAcceptedSubmissionXml(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # read the XML
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # parse XML
         try:
             root = cleaner.parse_article_xml(xml_file_path)
@@ -95,9 +87,6 @@ class activity_AddCommentsToAcceptedSubmissionXml(AcceptedBaseActivity):
             )
             self.logger.exception(log_message)
             root = None
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         if root:
             try:

--- a/activity/activity_AnnotateAcceptedSubmissionVideos.py
+++ b/activity/activity_AnnotateAcceptedSubmissionVideos.py
@@ -9,8 +9,6 @@ from provider.storage_provider import storage_context
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
 # session variable name to store the number of attempts
 SESSION_ATTEMPT_COUNTER_NAME = "video_metadata_attempt_count"
 
@@ -145,11 +143,6 @@ class activity_AnnotateAcceptedSubmissionVideos(AcceptedBaseActivity):
                 )
                 return True
 
-        # read the XML
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # parse XML
         try:
             root = cleaner.parse_article_xml(xml_file_path)
@@ -168,9 +161,6 @@ class activity_AnnotateAcceptedSubmissionVideos(AcceptedBaseActivity):
             root = None
 
             generated_video_data = []
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         if root:
             try:

--- a/activity/activity_DepositAcceptedSubmissionVideos.py
+++ b/activity/activity_DepositAcceptedSubmissionVideos.py
@@ -12,8 +12,6 @@ from provider.ftp import FTP
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
 FILE_NAME_PREFIX = "elife_videos_"
 
 # session variable name to store the number of attempts
@@ -104,11 +102,6 @@ class activity_DepositAcceptedSubmissionVideos(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # get the file list from the XML
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # get a list of video files from the XML
         try:
             video_files = cleaner.video_file_list(xml_file_path)
@@ -126,9 +119,6 @@ class activity_DepositAcceptedSubmissionVideos(AcceptedBaseActivity):
             )
             self.logger.exception(log_message)
             video_files = []
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         # download video files from the bucket folder
         if video_files:

--- a/activity/activity_RenameAcceptedSubmissionVideos.py
+++ b/activity/activity_RenameAcceptedSubmissionVideos.py
@@ -9,9 +9,6 @@ from provider import cleaner
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_RenameAcceptedSubmissionVideos(AcceptedBaseActivity):
     "RenameAcceptedSubmissionVideos activity"
 
@@ -80,11 +77,6 @@ class activity_RenameAcceptedSubmissionVideos(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # get the file list from the XML
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # get list of files from the article XML
         files = []
         try:
@@ -97,9 +89,6 @@ class activity_RenameAcceptedSubmissionVideos(AcceptedBaseActivity):
                 input_filename,
             )
             self.logger.exception(log_message)
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         # generate new file names for the videos
         generated_video_data = []

--- a/activity/activity_RepairAcceptedSubmission.py
+++ b/activity/activity_RepairAcceptedSubmission.py
@@ -8,9 +8,6 @@ from provider import article_processing, cleaner
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = True
-
-
 class activity_RepairAcceptedSubmission(AcceptedBaseActivity):
     "RepairAcceptedSubmission activity"
 
@@ -65,10 +62,6 @@ class activity_RepairAcceptedSubmission(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # parse XML
         try:
             root = cleaner.parse_article_xml(xml_file_path)
@@ -82,9 +75,6 @@ class activity_RepairAcceptedSubmission(AcceptedBaseActivity):
             )
             self.logger.exception(log_message)
             root = None
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         # write the repaired XML to disk
         if self.statuses.get("repair_xml"):

--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -8,9 +8,6 @@ from provider.storage_provider import storage_context
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
     "TransformAcceptedSubmission activity"
 
@@ -67,10 +64,6 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # download the code files so they can be modified
         try:
             download_code_files_from_bucket(
@@ -93,9 +86,6 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
             self.logger.exception(log_message)
             cleaner.LOGGER.exception(log_message)
             self.statuses["download"] = False
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         # PRC XML changes
         if session.get_value("prc_status"):

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -9,9 +9,6 @@ from provider import article_processing, cleaner, email_provider, utils
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
     "ValidateAcceptedSubmission activity"
 
@@ -65,10 +62,6 @@ class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
 
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
-
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
 
         # first check if XML can be parsed
         try:
@@ -145,9 +138,6 @@ class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
             files = []
 
         self.logger.info("%s, files: %s" % (self.name, files))
-
-        # reset the parsing library flag
-        cleaner.parse.REPAIR_XML = original_repair_xml
 
         # check whether PRC preprint data is present
         if prc_status:

--- a/activity/activity_ValidateAcceptedSubmissionVideos.py
+++ b/activity/activity_ValidateAcceptedSubmissionVideos.py
@@ -8,9 +8,6 @@ from provider import cleaner, email_provider, glencoe_check, utils
 from activity.objects import AcceptedBaseActivity
 
 
-REPAIR_XML = False
-
-
 class activity_ValidateAcceptedSubmissionVideos(AcceptedBaseActivity):
     "ValidateAcceptedSubmissionVideos activity"
 
@@ -62,10 +59,6 @@ class activity_ValidateAcceptedSubmissionVideos(AcceptedBaseActivity):
         # find S3 object for article XML and download it
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
-        # reset the REPAIR_XML constant
-        original_repair_xml = cleaner.parse.REPAIR_XML
-        cleaner.parse.REPAIR_XML = REPAIR_XML
-
         # get list of video files from the article XML
         video_files = []
         try:
@@ -81,9 +74,6 @@ class activity_ValidateAcceptedSubmissionVideos(AcceptedBaseActivity):
             )
             self.logger.exception(log_message)
             self.log_statuses(input_filename)
-        finally:
-            # reset the parsing library flag
-            cleaner.parse.REPAIR_XML = original_repair_xml
 
         ###### start validation checks
         if video_files:

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -25,6 +25,8 @@ from provider import utils
 from provider.storage_provider import storage_context
 from provider.article_processing import file_extension
 
+REPAIR_XML = False
+
 LOG_FILENAME = "elifecleaner.log"
 LOG_FORMAT_STRING = (
     "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
@@ -92,6 +94,9 @@ def article_xml_asset(asset_file_name_map):
 
 
 def parse_article_xml(xml_file_path):
+    # set the REPAIR_XML value
+    parse.REPAIR_XML = REPAIR_XML
+    # parse the XML file
     return parse.parse_article_xml(xml_file_path)
 
 

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -77,8 +77,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -177,9 +175,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
             in log_contents
         )
 
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
-
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
@@ -206,8 +201,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -260,9 +253,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
             % test_data.get("filename")
             in log_contents
         )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_accepted_submission_peer_review_figs.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_figs.py
@@ -169,8 +169,6 @@ class TestAcceptedSubmissionPeerReviewFigs(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -304,6 +302,3 @@ class TestAcceptedSubmissionPeerReviewFigs(unittest.TestCase):
                     bucket_file in output_bucket_list,
                     "%s not found in bucket upload folder" % bucket_file,
                 )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False

--- a/tests/activity/test_activity_accepted_submission_peer_review_images.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_images.py
@@ -225,8 +225,6 @@ class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -355,6 +353,3 @@ class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
                 sorted(output_bucket_list),
                 sorted(test_data.get("expected_bucket_upload_folder_contents")),
             )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False

--- a/tests/activity/test_activity_accepted_submission_peer_review_ocr.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_ocr.py
@@ -319,8 +319,6 @@ class TestAcceptedSubmissionPeerReviewOcr(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -485,9 +483,6 @@ class TestAcceptedSubmissionPeerReviewOcr(unittest.TestCase):
                     bucket_file not in output_bucket_list,
                     "%s unexpectedly found in bucket upload folder" % bucket_file,
                 )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")

--- a/tests/activity/test_activity_accepted_submission_peer_review_tables.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_tables.py
@@ -162,8 +162,6 @@ class TestAcceptedSubmissionPeerReviewTables(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -297,6 +295,3 @@ class TestAcceptedSubmissionPeerReviewTables(unittest.TestCase):
                     bucket_file in output_bucket_list,
                     "%s not found in bucket upload folder" % bucket_file,
                 )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False

--- a/tests/activity/test_activity_accepted_submission_peer_reviews.py
+++ b/tests/activity/test_activity_accepted_submission_peer_reviews.py
@@ -76,8 +76,6 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -174,9 +172,6 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
             "elifecleaner:sub_article:add_sub_article_xml: Parsing article XML into root Element"
             in log_contents
         )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_accepted_submission_version_doi.py
+++ b/tests/activity/test_activity_accepted_submission_version_doi.py
@@ -77,8 +77,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -158,9 +156,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
             in log_contents
         )
 
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
-
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
@@ -187,8 +182,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -241,9 +234,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
             % test_data.get("filename")
             in log_contents
         )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")

--- a/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
+++ b/tests/activity/test_activity_add_comments_to_accepted_submission_xml.py
@@ -103,8 +103,6 @@ class TestAddCommentsToAcceptedSubmissionXml(unittest.TestCase):
         fake_storage_context,
         fake_session,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -184,9 +182,6 @@ class TestAddCommentsToAcceptedSubmissionXml(unittest.TestCase):
                     "%s not found in xml_string" % expected_xml,
                 )
 
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
-
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
     @patch.object(cleaner, "parse_article_xml")
@@ -257,9 +252,6 @@ class TestAddXmlException(unittest.TestCase):
         fake_add_comments_to_xml,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
-
         directory = TempDirectory()
         filename = "30-01-2019-RA-eLife-45644.zip"
         article_id = "45644"
@@ -296,9 +288,6 @@ class TestAddXmlException(unittest.TestCase):
                 "AddCommentsToAcceptedSubmissionXml, exception in add_comments_to_xml"
             )
         )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
 
 class TestAddCommentsToXml(unittest.TestCase):

--- a/tests/activity/test_activity_deposit_accepted_submission_videos.py
+++ b/tests/activity/test_activity_deposit_accepted_submission_videos.py
@@ -136,8 +136,6 @@ class TestDepositAcceptedSubmissionVideos(unittest.TestCase):
         fake_storage_context,
         fake_session,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -226,9 +224,6 @@ class TestDepositAcceptedSubmissionVideos(unittest.TestCase):
                         sorted(zip_namelist),
                         sorted(test_data.get("expected_zip_file_list")),
                     )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")

--- a/tests/activity/test_activity_output_accepted_submission.py
+++ b/tests/activity/test_activity_output_accepted_submission.py
@@ -173,9 +173,6 @@ class TestOutputAcceptedSubmission(unittest.TestCase):
         fake_session,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
-
         zip_filename = "30-01-2019-RA-eLife-45644.zip"
         zip_file_path = os.path.join(
             test_activity_data.ExpandArticle_files_source_folder,

--- a/tests/activity/test_activity_rename_accepted_submission_videos.py
+++ b/tests/activity/test_activity_rename_accepted_submission_videos.py
@@ -89,8 +89,6 @@ class TestRenameAcceptedSubmissionVideos(unittest.TestCase):
         fake_storage_context,
         fake_session,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -173,9 +171,6 @@ class TestRenameAcceptedSubmissionVideos(unittest.TestCase):
                     expected_file=expected_file, comment=test_data.get("comment")
                 ),
             )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -48,9 +48,6 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
             "expected_transform_status": True,
         }
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
-
         # copy files into the input directory using the storage context
         # expanded bucket files
         zip_file_path = os.path.join(
@@ -216,8 +213,6 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
         session_data = copy.copy(test_activity_data.accepted_session_example)
         session_data["prc_status"] = True
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # copy files into the input directory using the storage context
         # expanded bucket files
@@ -350,8 +345,6 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
         fake_session,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         filename_base = "30-01-2019-RA-eLife-45644"
         zip_filename = "%s.zip" % filename_base
         xml_filename = "%s.xml" % filename_base
@@ -400,9 +393,6 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
         fake_session,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
-
         zip_filename = "30-01-2019-RA-eLife-45644.zip"
         zip_file_path = os.path.join(
             test_activity_data.ExpandArticle_files_source_folder,

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -61,8 +61,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_session,
         fake_storage_context,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -133,9 +131,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         # check session cleaner_log contains content
         self.assertTrue("elifecleaner:parse:" in self.session.get_value("cleaner_log"))
 
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
-
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
@@ -148,8 +143,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_storage_context,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -204,8 +197,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_storage_context,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -260,8 +251,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_storage_context,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         fake_session.return_value = self.session
         zip_file_path = os.path.join(
@@ -310,8 +299,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -357,8 +344,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -414,8 +399,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -455,8 +438,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_storage_context,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
@@ -514,8 +495,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         directory = TempDirectory()
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")

--- a/tests/activity/test_activity_validate_accepted_submission_videos.py
+++ b/tests/activity/test_activity_validate_accepted_submission_videos.py
@@ -101,8 +101,6 @@ class TestValidateAcceptedSubmissionVideos(unittest.TestCase):
         fake_session,
         fake_get,
     ):
-        # set REPAIR_XML value because test fixture is malformed XML
-        activity_module.REPAIR_XML = True
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
 
@@ -160,9 +158,6 @@ class TestValidateAcceptedSubmissionVideos(unittest.TestCase):
             test_data.get("expected_deposit_videos_status"),
             "failed in {comment}".format(comment=test_data.get("comment")),
         )
-
-        # reset REPAIR_XML value
-        activity_module.REPAIR_XML = False
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")


### PR DESCRIPTION
Move `REPAIR_XML` into `provider/cleaner.py` where it is defined once only, remove the other mentions of it in specific activity code and from their tests.

The XML file in the `30-01-2019-RA-eLife-45644.zip` text fixture is modified so it is now valid, by adding a missing XML namespace.

Re issue https://github.com/elifesciences/issues/issues/8452