### PR TITLE
Dependency `elifecleaner` pinned to `0.56.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.55.0"
+elifecleaner = "~=0.56.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-09-26 - see update-dependencies.sh
+# file generated 2023-09-27 - see update-dependencies.sh
 arrow==1.2.3
 astroid==2.15.6
 async-timeout==4.0.3
@@ -20,7 +20,7 @@ docker==5.0.3
 docmaptools==0.17.0
 ejpcsvparser==0.2.0
 elifearticle==0.15.0
-elifecleaner==0.55.0
+elifecleaner==0.56.0
 elifecrossref==0.19.0
 elifepubmed==0.5.1
 elifetools==0.32.0

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -452,7 +452,8 @@ class TestSetVolumeTag(unittest.TestCase):
         self.docmap_json = {
             "first-step": "_:b0",
             "steps": {
-                "_:b0": {
+                "_:b0": {"next-step": "_:b1"},
+                "_:b1": {
                     "actions": [
                         {
                             "participants": [],
@@ -464,11 +465,20 @@ class TestSetVolumeTag(unittest.TestCase):
                                     "versionIdentifier": "1",
                                     "license": "http://creativecommons.org/licenses/by/4.0/",
                                     "published": "2023-02-13T14:00:00+00:00",
+                                    "partOf": {
+                                        "type": "manuscript",
+                                        "doi": "10.7554/eLife.84364",
+                                        "identifier": "84364",
+                                        "subjectDisciplines": ["Cell Biology"],
+                                        "published": "2023-02-13T14:00:00+00:00",
+                                        "volumeIdentifier": "12",
+                                        "electronicArticleIdentifier": "RP84364",
+                                    },
                                 }
                             ],
                         }
                     ]
-                }
+                },
             },
         }
 


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/168/display/redirect which resulted in this pull request.