### PR TITLE
Dependency `docmaptools` pinned to `0.18.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-10-18 - see update-dependencies.sh
+# file generated 2023-10-19 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -17,7 +17,7 @@ Deprecated==1.2.14
 digestparser==0.2.0
 dill==0.3.7
 docker==5.0.3
-docmaptools==0.17.0
+docmaptools==0.18.0
 ejpcsvparser==0.3.1
 elifearticle==0.17.0
 elifecleaner==0.56.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/186/display/redirect which resulted in this pull request.