### PR TITLE
Dependency `elifecleaner` pinned to `0.58.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=1.55"
-elifecleaner = "~=0.57.0"
+elifecleaner = "~=0.58.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-10-23 - see update-dependencies.sh
+# file generated 2023-10-24 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -21,7 +21,7 @@ docker==5.0.3
 docmaptools==0.19.0
 ejpcsvparser==0.3.1
 elifearticle==0.17.0
-elifecleaner==0.57.0
+elifecleaner==0.58.0
 elifecrossref==0.23.1
 elifepubmed==0.6.0
 elifetools==0.33.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/189/display/redirect which resulted in this pull request.