### PR TITLE
FakeStorageContext.copy_resource() change, tests.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -193,12 +193,11 @@ class FakeStorageContext:
         origin_file_name = s3_key.lstrip("/")
         destination_bucket_name, s3_key = self.get_bucket_and_key(destination)
         destination_file_name = s3_key.lstrip("/")
-        if origin_bucket_name == destination_bucket_name:
-            origin_path = os.path.join(self.dir, origin_file_name)
-            destination_path = os.path.join(self.dir, destination_file_name)
-            # create folders if they do not exist
-            os.makedirs(os.path.dirname(destination_path), exist_ok=True)
-            copy(origin_path, destination_path)
+        origin_path = os.path.join(self.dir, origin_file_name)
+        destination_path = os.path.join(self.dest_folder, destination_file_name)
+        # create folders if they do not exist
+        os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+        copy(origin_path, destination_path)
 
     def delete_resource(self, resource):
         "delete from the destination folder"

--- a/tests/activity/helpers.py
+++ b/tests/activity/helpers.py
@@ -25,8 +25,11 @@ def delete_files_in_folder(folder, filter_out=[]):
     for file_name in file_list:
         if file_name in filter_out:
             continue
-        if os.path.isfile(folder + "/" + file_name):
-            os.remove(folder + "/" + file_name)
+        path = folder + "/" + file_name
+        if os.path.isfile(path):
+            os.remove(path)
+        elif os.path.isdir(path):
+            delete_folder(path, recursively=True)
 
 
 def delete_directories_in_folder(folder):

--- a/tests/activity/test_activity_deposit_assets.py
+++ b/tests/activity/test_activity_deposit_assets.py
@@ -2,7 +2,7 @@ import unittest
 from ddt import ddt, data, unpack
 from mock import patch
 from activity.activity_DepositAssets import activity_DepositAssets
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeStorageContext, FakeSession, FakeLogger
 import tests.activity.test_activity_data as test_activity_data
 
@@ -27,6 +27,11 @@ class TestDepositAssets(unittest.TestCase):
             settings_mock, None, None, None, None
         )
         self.depositassets.logger = FakeLogger()
+
+    def tearDown(self):
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @unpack
     @data(

--- a/tests/activity/test_activity_deposit_ingest_assets.py
+++ b/tests/activity/test_activity_deposit_ingest_assets.py
@@ -1,7 +1,7 @@
 import unittest
 from mock import patch
 from activity.activity_DepositIngestAssets import activity_DepositIngestAssets
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeStorageContext, FakeSession, FakeLogger
 import tests.activity.test_activity_data as test_activity_data
 
@@ -10,6 +10,11 @@ class TestDepositIngestAssets(unittest.TestCase):
     def setUp(self):
         self.activity = activity_DepositIngestAssets(
             settings_mock, FakeLogger(), None, None, None
+        )
+
+    def tearDown(self):
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
         )
 
     @patch("activity.activity_DepositIngestAssets.get_session")

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -8,7 +8,7 @@ from ddt import ddt, data
 from digestparser.objects import Digest
 import activity.activity_EmailDigest as activity_module
 from activity.activity_EmailDigest import activity_EmailDigest as activity_object
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock, test_activity_data
 from tests.activity.classes_mock import FakeLogger
 from tests.activity.helpers import create_digest
 import tests.test_data as test_case_data
@@ -37,6 +37,9 @@ class TestEmailDigest(unittest.TestCase):
     def tearDown(self):
         # clean the temporary directory
         self.activity.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch.object(activity_module.download_helper, "storage_context")

--- a/tests/activity/test_activity_expand_article.py
+++ b/tests/activity/test_activity_expand_article.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import unittest
 from mock import mock, patch
@@ -40,7 +41,11 @@ class TestExpandArticle(unittest.TestCase):
         self.expandarticle.set_monitor_property = mock.MagicMock()
         self.expandarticle.logger = mock.MagicMock()
 
-        success = self.expandarticle.do_activity(testdata.ExpandArticle_data)
+        # reset the run of the data otherwise it rewrites the session test fixture
+        input_data = copy.copy(testdata.ExpandArticle_data)
+        input_data["run"] = "cf9c7e86-7355-4bb4-b48e-0bc284221251"
+
+        success = self.expandarticle.do_activity(input_data)
         self.assertEqual(True, success)
 
         # Check destination folder as a list

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -35,6 +35,9 @@ class TestPubRouterDeposit(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.pubrouterdeposit.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.lax_provider.article_versions")

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -20,8 +20,8 @@ from activity.activity_PublicationEmail import (
 )
 from tests import test_data
 from tests.classes_mock import FakeSMTPServer
-from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity import helpers, settings_mock, test_activity_data
 
 
 LAX_ARTICLE_VERSIONS_RESPONSE_DATA_1 = test_data.lax_article_versions_response_data[:1]
@@ -252,6 +252,9 @@ class TestPublicationEmail(unittest.TestCase):
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch.object(activity_module, "get_related_article")
     @patch("provider.article.article.download_article_xml_from_s3")

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -11,8 +11,8 @@ from ddt import ddt, data, unpack
 import activity.activity_PublishFinalPOA as activity_module
 from activity.activity_PublishFinalPOA import activity_PublishFinalPOA
 from tests.classes_mock import FakeSMTPServer
-from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity import helpers, settings_mock, test_activity_data
 
 
 class TestPublishFinalPOA(unittest.TestCase):
@@ -234,6 +234,9 @@ class TestPublishFinalPOA(unittest.TestCase):
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.poa.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     def remove_files_from_tmp_dir_subfolders(self):
         """

--- a/tests/activity/test_activity_schedule_crossref.py
+++ b/tests/activity/test_activity_schedule_crossref.py
@@ -10,7 +10,7 @@ from tests.activity.classes_mock import (
     FakeSession,
     FakeStorageContext,
 )
-from tests.activity import settings_mock
+from tests.activity import helpers, settings_mock
 import tests.activity.test_activity_data as testdata
 
 
@@ -23,7 +23,9 @@ class TestScheduleCrossref(unittest.TestCase):
         )
 
     def tearDown(self):
-        pass
+        helpers.delete_files_in_folder(
+            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch("provider.lax_provider.get_xml_file_name")
     @patch("activity.activity_ScheduleCrossref.get_session")

--- a/tests/activity/test_activity_schedule_crossref_minimal.py
+++ b/tests/activity/test_activity_schedule_crossref_minimal.py
@@ -10,7 +10,7 @@ from tests.activity.classes_mock import (
     FakeSession,
     FakeStorageContext,
 )
-from tests.activity import settings_mock
+from tests.activity import helpers, settings_mock
 import tests.activity.test_activity_data as testdata
 
 
@@ -23,7 +23,9 @@ class TestScheduleCrossrefMinimal(unittest.TestCase):
         )
 
     def tearDown(self):
-        pass
+        helpers.delete_files_in_folder(
+            testdata.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch("provider.lax_provider.get_xml_file_name")
     @patch("activity.activity_ScheduleCrossrefMinimal.get_session")

--- a/tests/activity/test_activity_schedule_crossref_peer_review.py
+++ b/tests/activity/test_activity_schedule_crossref_peer_review.py
@@ -7,7 +7,7 @@ import activity.activity_ScheduleCrossrefPeerReview as activity_module
 from activity.activity_ScheduleCrossrefPeerReview import (
     activity_ScheduleCrossrefPeerReview as activity_object,
 )
-import tests.activity.settings_mock as settings_mock
+from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeSession, FakeStorageContext
 import tests.activity.test_activity_data as activity_test_data
 
@@ -19,6 +19,9 @@ class TestScheduleCrossrefPeerReview(unittest.TestCase):
 
     def tearDown(self):
         self.activity.clean_tmp_dir()
+        helpers.delete_files_in_folder(
+            activity_test_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     @patch("provider.lax_provider.article_highest_version")
     @patch("provider.lax_provider.storage_context")

--- a/tests/activity/test_activity_schedule_downstream.py
+++ b/tests/activity/test_activity_schedule_downstream.py
@@ -1,5 +1,6 @@
 import unittest
 from mock import mock, patch
+from testfixtures import TempDirectory
 import activity.activity_ScheduleDownstream as activity_module
 from activity.activity_ScheduleDownstream import (
     activity_ScheduleDownstream as activity_object,
@@ -15,15 +16,23 @@ class TestScheduleDownstream(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
     @patch("provider.lax_provider.article_first_by_status")
     @patch.object(lax_provider, "storage_context")
     @patch.object(activity_module, "storage_context")
     def test_do_activity(
         self, fake_activity_storage_context, fake_storage_context, fake_first
     ):
+        directory = TempDirectory()
         expected_result = True
-        fake_storage_context.return_value = FakeStorageContext()
-        fake_activity_storage_context.return_value = FakeStorageContext()
+        fake_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
+        fake_activity_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
         fake_first.return_value = True
         self.activity.emit_monitor_event = mock.MagicMock()
         # do the activity
@@ -63,7 +72,7 @@ class TestChooseOutboxes(unittest.TestCase):
         self.assertEqual(outbox_list, [])
 
     def test_choose_outboxes_poa_first(self):
-        """first poa version"""
+        "first poa version"
         outbox_list = activity_module.choose_outboxes("poa", True, self.rules)
         # schedule the following
         for folder_name in [
@@ -96,7 +105,7 @@ class TestChooseOutboxes(unittest.TestCase):
             )
 
     def test_choose_outboxes_poa_not_first(self):
-        """poa but not the first poa"""
+        "poa but not the first poa"
         outbox_list = activity_module.choose_outboxes("poa", False, self.rules)
         # schedule the following
         for folder_name in [
@@ -128,7 +137,7 @@ class TestChooseOutboxes(unittest.TestCase):
             )
 
     def test_choose_outboxes_vor_first(self):
-        """first vor version"""
+        "first vor version"
         outbox_list = activity_module.choose_outboxes("vor", True, self.rules)
         # schedule the following
         for folder_name in [
@@ -152,7 +161,7 @@ class TestChooseOutboxes(unittest.TestCase):
             )
 
     def test_choose_outboxes_vor_not_first(self):
-        """vor but not the first vor"""
+        "vor but not the first vor"
         outbox_list = activity_module.choose_outboxes("vor", False, self.rules)
         # schedule the following
         for folder_name in [
@@ -216,7 +225,7 @@ class TestChooseOutboxes(unittest.TestCase):
             )
 
     def test_choose_outboxes_vor_silent_not_first(self):
-        """silent correction vor but not the first vor"""
+        "silent correction vor but not the first vor"
         outbox_list = activity_module.choose_outboxes(
             "vor", False, self.rules, "silent-correction"
         )

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -4,8 +4,9 @@ import unittest
 from mock import patch
 from testfixtures import TempDirectory
 from provider import downstream, outbox_provider
-import tests.settings_mock as settings_mock
+from tests import settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
+from tests.activity import helpers, test_activity_data
 
 
 class TestOutboxProvider(unittest.TestCase):
@@ -16,6 +17,9 @@ class TestOutboxProvider(unittest.TestCase):
 
     def tearDown(self):
         TempDirectory.cleanup_all()
+        helpers.delete_files_in_folder(
+            test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
+        )
 
     def test_get_to_folder_name(self):
         folder_name = ""
@@ -59,7 +63,7 @@ class TestOutboxProvider(unittest.TestCase):
     def test_download_files_from_s3_outbox_failure(
         self, fake_storage_context, fake_get_resource
     ):
-        """test IOError exception for coverage"""
+        "test IOError exception for coverage"
         fake_storage_context.return_value = FakeStorageContext(
             "tests/test_data/crossref/outbox/", ["elife-18753-v1.xml"]
         )


### PR DESCRIPTION
When writing new tests, the `FakeStorageContext` was not copying files between two buckets. It allows this now. Test case which used it are changed so they clear the `files_dest` folder after running, now they are copying files between "buckets".