### PR TITLE
AcceptedSubmissionStrikingImages activity.

### DIFF
--- a/activity/activity_AcceptedSubmissionStrikingImages.py
+++ b/activity/activity_AcceptedSubmissionStrikingImages.py
@@ -1,0 +1,183 @@
+import json
+import os
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from provider import cleaner, utils
+from activity.objects import AcceptedBaseActivity
+
+
+class activity_AcceptedSubmissionStrikingImages(AcceptedBaseActivity):
+    "AcceptedSubmissionStrikingImages activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionStrikingImages, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionStrikingImages"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 30
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Rename cover art images in the zip file and upload them to a bucket"
+        )
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {
+            "images": None,
+            "modify_xml": None,
+            "rename_files": None,
+            "upload_files": None,
+        }
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        session = get_session(self.settings, data, data["run"])
+
+        self.make_activity_directories()
+
+        # configure the S3 bucket storage library
+        storage = storage_context(self.settings)
+
+        # configure log files for the cleaner provider
+        self.start_cleaner_log()
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # get list of bucket objects from expanded folder
+        asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
+
+        # find S3 object for article XML and download it
+        xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
+
+        # find cover_art images
+        cover_art_files = cleaner.cover_art_file_list(xml_file_path)
+        self.logger.info("cover_art_files: %s" % cover_art_files)
+        if not cover_art_files:
+            self.logger.info(
+                "%s, no cover_art files in %s" % (self.name, input_filename)
+            )
+            self.end_cleaner_log(session)
+            return True
+        self.statuses["images"] = True
+
+        # rename the cover_art images
+
+        xml_root = cleaner.parse_article_xml(xml_file_path)
+
+        file_transformations = cleaner.cover_art_file_transformations(
+            cover_art_files,
+            asset_file_name_map,
+            utils.pad_msid(article_id),
+            input_filename,
+        )
+        self.logger.info(
+            "%s, %s striking images file transformations for %s"
+            % (len(file_transformations), self.name, input_filename)
+        )
+        # write the XML root to disk
+        cleaner.write_xml_file(xml_root, xml_file_path, input_filename)
+
+        new_asset_file_name_map = cleaner.transform_cover_art_files(
+            xml_file_path, asset_file_name_map, file_transformations, input_filename
+        )
+        self.statuses["modify_xml"] = True
+
+        # rename the files in the expanded folder
+
+        if self.statuses["modify_xml"]:
+            self.logger.info(
+                "%s, renaming striking images files in the expanded folder for %s"
+                % (self.name, input_filename)
+            )
+            self.statuses["rename_files"] = self.rename_expanded_folder_files(
+                asset_file_name_map, expanded_folder, file_transformations, storage
+            )
+
+        # upload the XML to the bucket
+        self.upload_xml_file_to_bucket(asset_file_name_map, expanded_folder, storage)
+
+        # copy the cover_art images to the striking images bucket
+        if self.statuses["rename_files"]:
+            self.logger.info(
+                "%s, uploading files to the striking images bucket for %s"
+                % (self.name, input_filename)
+            )
+            try:
+                self.statuses["upload_files"] = self.copy_to_striking_image_bucket(
+                    new_asset_file_name_map,
+                    expanded_folder,
+                    file_transformations,
+                    article_id,
+                    storage,
+                )
+            except Exception as exception:
+                self.logger.exception(
+                    "Exception copying files to the striking images bucket, input_filename %s: %s"
+                    % (input_filename, str(exception))
+                )
+
+        self.end_cleaner_log(session)
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def copy_to_striking_image_bucket(
+        self,
+        asset_file_name_map,
+        expanded_folder,
+        file_transformations,
+        article_id,
+        storage,
+    ):
+        "rename objects in the S3 bucket expanded folder"
+        # map values without folder names to match them later
+        asset_key_map = {key.rsplit("/", 1)[-1]: key for key in asset_file_name_map}
+        old_resource_prefix = (
+            self.settings.storage_provider
+            + "://"
+            + self.settings.bot_bucket
+            + "/"
+            + expanded_folder
+        )
+        new_resource_prefix = (
+            self.settings.storage_provider
+            + "://"
+            + self.settings.striking_images_bucket
+            + "/"
+            + utils.pad_msid(article_id)
+            + "/"
+            + "vor"
+        )
+        for file_transform in file_transformations:
+            old_s3_resource = (
+                old_resource_prefix
+                + "/"
+                + asset_key_map.get(file_transform[1].xml_name)
+            )
+            new_s3_resource = new_resource_prefix + "/" + file_transform[1].xml_name
+            # copy old key to new key
+            self.logger.info(
+                "%s, copying S3 key %s to %s"
+                % (self.name, old_s3_resource, new_s3_resource)
+            )
+            storage.copy_resource(old_s3_resource, new_s3_resource)
+        return True

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -118,6 +118,29 @@ def video_file_list(xml_file_path):
     return video.video_file_list(files)
 
 
+def cover_art_file_list(xml_file_path):
+    "get a list of cover_art from the XML"
+    root = parse_article_xml(xml_file_path)
+    return transform.cover_art_file_list(root)
+
+
+def transform_cover_art_files(
+    xml_file_path, asset_file_name_map, file_transformations, identifier
+):
+    "rename cover art files"
+    return transform.transform_cover_art_files(
+        xml_file_path, asset_file_name_map, file_transformations, identifier
+    )
+
+
+def cover_art_file_transformations(
+    cover_art_files, asset_file_name_map, article_id, identifier
+):
+    return transform.cover_art_file_transformations(
+        cover_art_files, asset_file_name_map, article_id, identifier
+    )
+
+
 def glencoe_xml(xml_file_path, video_data, pretty=True, indent=""):
     return video_xml.glencoe_xml(xml_file_path, video_data, pretty, indent)
 
@@ -356,7 +379,9 @@ def docmap_url(settings, article_id):
 
 def sub_article_data(docmap_string, article, version_doi=None, generate_dois=True):
     # add sub-article data from the docmap and get requests to the article object
-    return sub_article.sub_article_data(docmap_string, article, version_doi, generate_dois)
+    return sub_article.sub_article_data(
+        docmap_string, article, version_doi, generate_dois
+    )
 
 
 def add_sub_article_xml(docmap_string, article_xml, terms_yaml=None):

--- a/register.py
+++ b/register.py
@@ -145,6 +145,7 @@ def start(settings):
     activity_names.append("AcceptedSubmissionPeerReviewOcr")
     activity_names.append("AcceptedSubmissionVersionDoi")
     activity_names.append("AcceptedSubmissionHistory")
+    activity_names.append("AcceptedSubmissionStrikingImages")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/settings-example.py
+++ b/settings-example.py
@@ -362,6 +362,9 @@ class exp:
     # EPP settings
     epp_data_bucket = "epp_bucket"
 
+    # Striking images bucket
+    striking_images_bucket = "striking_images_bucket"
+
 
 class dev:
     # AWS settings
@@ -708,6 +711,9 @@ class dev:
 
     # EPP settings
     epp_data_bucket = "epp_bucket"
+
+    # Striking images bucket
+    striking_images_bucket = "striking_images_bucket"
 
 
 class live:
@@ -1060,6 +1066,9 @@ class live:
 
     # EPP settings
     epp_data_bucket = "epp_bucket"
+
+    # Striking images bucket
+    striking_images_bucket = "striking_images_bucket"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -254,3 +254,6 @@ mathpix_app_key = "key"
 
 # EPP settings
 epp_data_bucket = "epp_bucket"
+
+# Striking images bucket
+striking_images_bucket = "striking_images_bucket"

--- a/tests/activity/test_activity_accepted_submission_striking_images.py
+++ b/tests/activity/test_activity_accepted_submission_striking_images.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+
+import copy
+import os
+import glob
+import shutil
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionStrikingImages as activity_module
+from activity.activity_AcceptedSubmissionStrikingImages import (
+    activity_AcceptedSubmissionStrikingImages as activity_object,
+)
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import helpers, settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionStrikingImages(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("cleaner_log", None)
+
+    @patch.object(activity_module, "storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "storage_context")
+    @patch.object(activity_object, "clean_tmp_dir")
+    @data(
+        {
+            "comment": "example with no cover art",
+            "filename": "28-09-2020-RA-eLife-63532.zip",
+            "expected_result": True,
+            "expected_images_status": None,
+            "expected_upload_xml_status": None,
+            "expected_rename_files_status": None,
+            "expected_upload_files_status": None,
+        },
+        {
+            "comment": "example with cover art",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_images_status": True,
+            "expected_upload_xml_status": True,
+            "expected_rename_files_status": True,
+            "expected_upload_files_status": True,
+            "expected_xml_contains": [
+                ("<upload_file_nm>45644-a_striking_image.tif</upload_file_nm>"),
+            ],
+            "expected_bucket_upload_folder_contents": [
+                "30-01-2019-RA-eLife-45644.xml",
+                "45644-a_striking_image.tif",
+            ],
+            "expected_striking_images_bucket_folder_contents": [
+                "45644-a_striking_image.tif"
+            ],
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_clean_tmp_dir,
+        fake_cleaner_storage_context,
+        fake_session,
+        fake_storage_context,
+    ):
+        directory = TempDirectory()
+        fake_clean_tmp_dir.return_value = None
+
+        zip_sub_folder = test_data.get("filename").replace(".zip", "")
+        zip_xml_file = "%s.xml" % zip_sub_folder
+        article_id = zip_sub_folder.rsplit("-", 1)[1]
+
+        zip_file_path = os.path.join("tests", "files_source", test_data.get("filename"))
+
+        resources = helpers.expanded_folder_bucket_resources(
+            directory,
+            test_activity_data.accepted_session_example.get("expanded_folder"),
+            zip_file_path,
+        )
+
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_cleaner_storage_context.return_value = FakeStorageContext(
+            directory.path, resources, dest_folder=directory.path
+        )
+        fake_session.return_value = self.session
+
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))
+
+        temp_dir_files = glob.glob(self.activity.directories.get("TEMP_DIR") + "/*/*")
+        xml_file_path = os.path.join(
+            self.activity.directories.get("TEMP_DIR"),
+            zip_sub_folder,
+            zip_xml_file,
+        )
+        self.assertTrue(xml_file_path in temp_dir_files)
+
+        # assertion on XML contents
+        if test_data.get("expected_xml_contains"):
+            with open(xml_file_path, "r", encoding="utf-8") as open_file:
+                xml_content = open_file.read()
+            for fragment in test_data.get("expected_xml_contains"):
+                self.assertTrue(
+                    fragment in xml_content,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        for status_type in ["images", "upload_xml", "rename_files", "upload_files"]:
+            self.assertEqual(
+                self.activity.statuses.get(status_type),
+                test_data.get("expected_%s_status" % status_type),
+                "status_type {status_type} failed in {comment}".format(
+                    status_type=status_type, comment=test_data.get("comment")
+                ),
+            )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on cleaner.log contents
+        if test_data.get("expected_cleaner_log_contains"):
+            log_file_path = os.path.join(
+                self.activity.get_tmp_dir(), self.activity.activity_log_file
+            )
+            with open(log_file_path, "r", encoding="utf8") as open_file:
+                log_contents = open_file.read()
+            for fragment in test_data.get("expected_cleaner_log_contains"):
+                self.assertTrue(
+                    fragment in log_contents,
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+        # assertion on the session cleaner log content
+        if test_data.get("expected_upload_xml_status"):
+            session_log = self.session.get_value("cleaner_log")
+            self.assertIsNotNone(
+                session_log,
+                "failed in {comment}".format(comment=test_data.get("comment")),
+            )
+
+        # check output bucket folder contents
+        if "expected_bucket_upload_folder_contents" in test_data:
+            bucket_folder_path = os.path.join(
+                directory.path,
+                test_activity_data.accepted_session_example.get("expanded_folder"),
+                zip_sub_folder,
+            )
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            for bucket_file in test_data.get("expected_bucket_upload_folder_contents"):
+                self.assertTrue(
+                    bucket_file in output_bucket_list,
+                    "%s not found in bucket upload folder" % bucket_file,
+                )
+
+        # check striking images bucket folder contents
+        if "expected_striking_images_bucket_folder_contents" in test_data:
+            bucket_folder_path = os.path.join(directory.path, article_id, "vor")
+            try:
+                output_bucket_list = os.listdir(bucket_folder_path)
+            except FileNotFoundError:
+                # no objects were uploaded so the folder path does not exist
+                output_bucket_list = []
+            for bucket_file in test_data.get(
+                "expected_striking_images_bucket_folder_contents"
+            ):
+                self.assertTrue(
+                    bucket_file in output_bucket_list,
+                    "%s not found in striking images bucket folder" % bucket_file,
+                )

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -52,6 +52,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step_medium("TransformAcceptedSubmission", data),
                 define_workflow_step_short("AcceptedSubmissionVersionDoi", data),
                 define_workflow_step_short("AcceptedSubmissionHistory", data),
+                define_workflow_step_short("AcceptedSubmissionStrikingImages", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviews", data),
                 define_workflow_step_medium("AcceptedSubmissionPeerReviewImages", data),
                 define_workflow_step_short("AcceptedSubmissionPeerReviewFigs", data),


### PR DESCRIPTION
Add `AcceptedSubmissionStrikingImages` to the `IngestAcceptedSubmission` workflow, which finds cover_art images in an accepted images zip file, renames them, and copies them to an S3 bucket.

Re issue https://github.com/elifesciences/issues/issues/8103