### PR TITLE
Dependency `elifetools` pinned to `0.36.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-11-06 - see update-dependencies.sh
+# file generated 2023-11-10 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/199/display/redirect which resulted in this pull request.