### PR TITLE
Dependency `google-cloud-bigquery` pinned to `3.13.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,7 @@ digestparser = "~=0.2.0"
 medium = {git = "https://github.com/Medium/medium-sdk-python.git", ref = "bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6"}
 psutil = "~=5.8"
 pytz = "*"
-google-cloud-bigquery = "~=3.3.2"
+google-cloud-bigquery = "~=3.13.0"
 Jinja2 = "~=3.0"
 GitPython = "~=3.1"
 PyYAML = "~=5.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ gitdb==4.0.11
 GitPython==3.1.40
 google-api-core==2.12.0
 google-auth==2.23.3
-google-cloud-bigquery==3.3.6
+google-cloud-bigquery==3.13.0
 google-cloud-bigquery-storage==2.22.0
 google-cloud-core==2.3.3
 google-crc32c==1.5.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/202/display/redirect which resulted in this pull request.