### PR TITLE
Non-blank SWF settings_mock values

### DIFF
--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -1,6 +1,6 @@
 swf_region = ""
-domain = ""
-default_task_list = ""
+domain = "test_domain"
+default_task_list = "test_task_list"
 
 storage_provider = "s3"
 expanded_bucket = "origin_bucket"
@@ -10,8 +10,8 @@ production_bucket = "production_bucket"
 
 s3_session_bucket = "origin_bucket"
 
-aws_access_key_id = ""
-aws_secret_access_key = ""
+aws_access_key_id = "test_key_id"
+aws_secret_access_key = "test_access_key"
 
 lax_response_queue = "lax_response_queue"
 

--- a/tests/starter/test_starter_ftp_article.py
+++ b/tests/starter/test_starter_ftp_article.py
@@ -16,8 +16,8 @@ class TestStarterFTPArticle(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "FTPArticle_HEFCE_666"),
                 ("workflow_name", "FTPArticle"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_helper.py
+++ b/tests/starter/test_starter_helper.py
@@ -24,7 +24,6 @@ class TestStarterHelper(unittest.TestCase):
         {"execution_data": test_data.data_published_website, "execution": "website"},
     )
     def test_set_workflow_information_lax(self, execution_data, execution):
-
         (
             workflow_id,
             workflow_name,

--- a/tests/starter/test_starter_lens_article_publish.py
+++ b/tests/starter/test_starter_lens_article_publish.py
@@ -16,8 +16,8 @@ class TestStarterLensArticlePublish(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "LensArticlePublish_666"),
                 ("workflow_name", "LensArticlePublish"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_objects.py
+++ b/tests/starter/test_starter_objects.py
@@ -111,8 +111,8 @@ class TestDefaultWorkflowParams(unittest.TestCase):
     def test_default_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", None),
                 ("workflow_name", None),
                 ("workflow_version", None),

--- a/tests/starter/test_starter_post_perfect_publication.py
+++ b/tests/starter/test_starter_post_perfect_publication.py
@@ -17,8 +17,8 @@ class TestStarterPostPerfectPublication(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "PostPerfectPublication_353.1.lax"),
                 ("workflow_name", "PostPerfectPublication"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_process_article_zip.py
+++ b/tests/starter/test_starter_process_article_zip.py
@@ -17,8 +17,8 @@ class TestStarterProcessArticleZip(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "ProcessArticleZip_353.1"),
                 ("workflow_name", "ProcessArticleZip"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_pub_router_deposit.py
+++ b/tests/starter/test_starter_pub_router_deposit.py
@@ -16,8 +16,8 @@ class TestStarterPubRouterDeposit(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "PubRouterDeposit_HEFCE"),
                 ("workflow_name", "PubRouterDeposit"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_silent_corrections_ingest.py
+++ b/tests/starter/test_starter_silent_corrections_ingest.py
@@ -20,8 +20,8 @@ class TestStarterSilentCorrectionsIngest(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "SilentCorrectionsIngest_elife-00353-vor-r1.zip"),
                 ("workflow_name", "SilentCorrectionsIngest"),
                 ("workflow_version", "1"),

--- a/tests/starter/test_starter_silent_corrections_process.py
+++ b/tests/starter/test_starter_silent_corrections_process.py
@@ -17,8 +17,8 @@ class TestStarterSilentCorrectionsProcess(unittest.TestCase):
     def test_get_workflow_params(self):
         expected = OrderedDict(
             [
-                ("domain", ""),
-                ("task_list", ""),
+                ("domain", "test_domain"),
+                ("task_list", "test_task_list"),
                 ("workflow_id", "SilentCorrectionsProcess_353.1"),
                 ("workflow_name", "SilentCorrectionsProcess"),
                 ("workflow_version", "1"),


### PR DESCRIPTION
Part of issue https://github.com/elifesciences/issues/issues/7446 in prepation for testing with `moto`. To use mock SWF functions the credentials and other setting must be non-blank values.