### PR TITLE
Refactor worker and decider log for easier mocking

### DIFF
--- a/decider.py
+++ b/decider.py
@@ -5,7 +5,7 @@ import importlib
 from botocore.config import Config
 import boto3
 from provider import process, utils
-import log
+from log import create_log
 import workflow
 
 
@@ -16,7 +16,7 @@ def decide(settings, flag, debug=False):
     # Log
     identity = "decider_%s" % os.getpid()
     log_file = "decider.log"
-    logger = log.logger(log_file, settings.setLevel, identity)
+    logger = create_log(log_file, settings.setLevel, identity)
 
     # Simple connect
     client = boto3.client(

--- a/log.py
+++ b/log.py
@@ -27,3 +27,8 @@ def logger(logFile=None, setLevel="INFO", identity="", loggerName="elife-bot"):
 
 def identity(process_name):
     return "%s_%s" % (process_name, int(random.random() * 1000))
+
+
+def create_log(log_file, set_level, identity):
+    "create a log file"
+    return logger(log_file, set_level, identity)

--- a/worker.py
+++ b/worker.py
@@ -4,7 +4,7 @@ import importlib
 import botocore
 from botocore.config import Config
 import boto3
-import log
+from log import create_log
 from provider import process, utils
 import activity
 from activity.objects import Activity
@@ -18,7 +18,8 @@ Amazon SWF worker
 def work(settings, flag):
     # Log
     identity = "worker_%s" % os.getpid()
-    logger = log.logger("worker.log", settings.setLevel, identity)
+
+    logger = create_log("worker.log", settings.setLevel, identity)
 
     # Simple connect
     client = boto3.client(


### PR DESCRIPTION
So the log files created in `worker.py` and `decider.py` can be more easily mocked in test cases, added `create_log()` to the `log.py` library, and call it to create log files for these.