### PR TITLE
Move bucket preprint XML download function for reuse.

### DIFF
--- a/activity/activity_ScheduleCrossrefPreprint.py
+++ b/activity/activity_ScheduleCrossrefPreprint.py
@@ -1,6 +1,6 @@
 import json
 import os
-from provider import download_helper, outbox_provider, preprint
+from provider import outbox_provider, preprint
 from provider.execution_context import get_session
 from activity.objects import Activity
 
@@ -75,19 +75,8 @@ class activity_ScheduleCrossrefPreprint(Activity):
             return self.ACTIVITY_SUCCESS
 
         # get preprint server XML from a bucket
-        real_filename = preprint.PREPRINT_XML_FILE_NAME_PATTERN.format(
-            article_id=article_id, version=version
-        )
-        bucket_name = self.settings.epp_data_bucket
-        bucket_folder = preprint.PREPRINT_XML_PATH_PATTERN.format(
-            article_id=article_id, version=version
-        )
-        article_xml_path = download_helper.download_file_from_s3(
-            self.settings,
-            real_filename,
-            bucket_name,
-            bucket_folder,
-            self.directories.get("TEMP_DIR"),
+        article_xml_path = preprint.download_original_preprint_xml(
+            self.settings, self.directories.get("TEMP_DIR"), article_id, version
         )
 
         # generate preprint XML from data sources

--- a/provider/preprint.py
+++ b/provider/preprint.py
@@ -3,7 +3,7 @@ from elifearticle.parse import build_article_from_xml
 from elifearticle.article import Article, ArticleDate, Contributor, Event, License
 from jatsgenerator import generate
 from jatsgenerator.conf import raw_config, parse_raw_config
-from provider import cleaner, utils
+from provider import cleaner, download_helper, utils
 
 
 CONFIG_SECTION = "elife_preprint"
@@ -174,3 +174,23 @@ def preprint_xml(article, settings):
     article_xml = generate.ArticleXML(article, jats_config, add_comment)
     xml_string = article_xml.output_xml(pretty=True, indent="")
     return xml_string
+
+
+def download_original_preprint_xml(settings, to_dir, article_id, version):
+    "download the preprint server version of the XML"
+    # get preprint server XML from a bucket
+    real_filename = PREPRINT_XML_FILE_NAME_PATTERN.format(
+        article_id=article_id, version=version
+    )
+    bucket_name = settings.epp_data_bucket
+    bucket_folder = PREPRINT_XML_PATH_PATTERN.format(
+        article_id=article_id, version=version
+    )
+    article_xml_path = download_helper.download_file_from_s3(
+        settings,
+        real_filename,
+        bucket_name,
+        bucket_folder,
+        to_dir,
+    )
+    return article_xml_path


### PR DESCRIPTION
Move the preprint XML download logic from `activity/activity_ScheduleCrossrefPreprint.py` to `provider.preprint.download_original_preprint_xml()`