### PR TITLE
Set activity status in FindNewPreprints.

### DIFF
--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -130,6 +130,9 @@ class activity_FindNewPreprints(Activity):
             )
             self.statuses["upload"] = True
 
+        # determine the success of the activity
+        self.statuses["activity"] = self.statuses["generate"]
+
         # send email only if new XML files were generated
         if self.statuses["generate"]:
             self.statuses["email"] = self.send_admin_email(new_xml_filenames)

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -46,6 +46,7 @@ class TestFindNewPreprints(unittest.TestCase):
             "expected_result": True,
             "expected_generate_status": True,
             "expected_upload_status": True,
+            "expected_activity_status": True,
             "expected_email_status": True,
             "expected_file_count": 1,
             "expected_bucket_files": ["elife-preprint-87445-v2.xml"],
@@ -60,6 +61,7 @@ class TestFindNewPreprints(unittest.TestCase):
             "expected_result": True,
             "expected_generate_status": None,
             "expected_upload_status": None,
+            "expected_activity_status": None,
             "expected_email_status": None,
             "expected_file_count": 0,
             "expected_bucket_files": [],
@@ -114,8 +116,9 @@ class TestFindNewPreprints(unittest.TestCase):
         # check statuses assertions
         for status_name in [
             "generate",
-            "email",
+            "upload",
             "activity",
+            "email",
         ]:
             status_value = self.activity.statuses.get(status_name)
             expected = test_data.get("expected_" + status_name + "_status")


### PR DESCRIPTION
To get a success status in the email subject line the `activity` status must be set.

Tweak to PR https://github.com/elifesciences/elife-bot/pull/1818