### PR TITLE
Find new preprints cron

### DIFF
--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -56,6 +56,13 @@ class activity_FindNewPreprints(Activity):
         "Activity, do the work" ""
         self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
 
+        # check for required settings
+        if not self.settings.epp_data_bucket:
+            self.logger.info(
+                "epp_data_bucket in settings is blank, skipping %s." % self.name
+            )
+            return True
+
         # Create output directories
         self.make_activity_directories()
 

--- a/cron.py
+++ b/cron.py
@@ -22,7 +22,6 @@ LOGGER = log.logger("cron.log", "INFO", IDENTITY)
 
 
 def run_cron(settings):
-
     current_datetime = get_current_datetime()
     LOGGER.info("current_datetime: %s" % current_datetime)
 

--- a/cron.py
+++ b/cron.py
@@ -207,6 +207,17 @@ def conditional_starts(current_datetime):
                 )
             )
 
+        # Check for new preprints at 20 minutes past the hour
+        conditional_start_list.append(
+            OrderedDict(
+                [
+                    ("starter_name", "starter_FindNewPreprints"),
+                    ("workflow_id", "FindNewPreprints"),
+                    ("start_seconds", 60 * 31),
+                ]
+            )
+        )
+
     elif current_time.tm_min >= 30 and current_time.tm_min <= 44:
         # Jobs to start at the half past to quarter to the hour
         LOGGER.info("half past to quarter to the hour")

--- a/provider/preprint.py
+++ b/provider/preprint.py
@@ -138,12 +138,6 @@ def build_article(article_id, docmap_string, article_xml_path, version=None):
     article.contributors = preprint_article.contributors
     # references
     article.ref_list = preprint_article.ref_list
-    # preprint DOI
-    original_preprint_doi = cleaner.docmap_preprint(docmap_string)
-    if original_preprint_doi:
-        related_preprint_1 = Preprint()
-        related_preprint_1.doi = original_preprint_doi
-        article.related_articles = [related_preprint_1]
 
     # sub-article data from docmap and Sciety web content
     external_data = cleaner.sub_article_data(

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -218,9 +218,6 @@ class TestFindNewPreprints(unittest.TestCase):
 
         result = self.activity.do_activity(self.activity_data)
         self.assertEqual(result, True)
-        print(self.activity.logger.loginfo)
-        print(self.activity.logger.logexception)
-        # self.assertTrue(False)
 
     @patch("provider.preprint.build_article")
     @patch.object(cleaner, "get_docmap")
@@ -254,3 +251,25 @@ class TestFindNewPreprints(unittest.TestCase):
 
         result = self.activity.do_activity(self.activity_data)
         self.assertEqual(result, True)
+
+
+class TestMissingSettings(unittest.TestCase):
+    def setUp(self):
+        self.epp_data_bucket = settings_mock.epp_data_bucket
+
+    def tearDown(self):
+        # reset the settings_mock value
+        settings_mock.epp_data_bucket = self.epp_data_bucket
+
+    def test_missing_settings(self):
+        "test if settings is missing a required value"
+        settings_mock.epp_data_bucket = ""
+        activity_object = activity_class(settings_mock, FakeLogger(), None, None, None)
+        # do the activity
+        result = activity_object.do_activity()
+        # check assertions
+        self.assertEqual(result, True)
+        self.assertEqual(
+            activity_object.logger.loginfo[-1],
+            "epp_data_bucket in settings is blank, skipping FindNewPreprints.",
+        )

--- a/tests/provider/test_preprint.py
+++ b/tests/provider/test_preprint.py
@@ -218,7 +218,7 @@ class TestBuildArticle(unittest.TestCase):
         self.assertEqual(len(article.review_articles[0].contributors), 1)
         self.assertEqual(article.review_articles[0].contributors[0].surname, "Eisen")
 
-        self.assertEqual(len(article.related_articles), 1)
+        self.assertEqual(len(article.related_articles), 0)
 
         self.assertEqual(article.review_articles[1].article_type, "referee-report")
         self.assertEqual(article.review_articles[1].doi, "10.7554/eLife.84364.2.sa3")
@@ -519,6 +519,21 @@ class TestPreprintXml(unittest.TestCase):
         # print(bytes.decode(result))
         for fragment in expected_fragments:
             self.assertTrue(fragment in result, "%s not found in result" % fragment)
+
+    @patch.object(cleaner, "sub_article_data")
+    def test_article_preprint_xml(self, fake_sub_article_data):
+        "test building an article object then generate the article XML"
+        fake_sub_article_data.return_value = sub_article_data_fixture()
+        article_id = "84364"
+        docmap_string = read_fixture("sample_docmap_for_84364.json")
+        article_xml_path = "tests/files_source/epp/data/84364/v2/84364-v2.xml"
+        article = preprint.build_article(article_id, docmap_string, article_xml_path)
+        result = preprint.preprint_xml(article, settings_mock)
+        # print(bytes.decode(result))
+        self.assertTrue(
+            b'<self-uri content-type="preprint" '
+            b'xlink:href="https://doi.org/10.1101/2022.10.17.512253"/>' in result
+        )
 
 
 class TestDownloadOriginalPreprintXml(unittest.TestCase):

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -88,6 +88,7 @@ class TestCron(unittest.TestCase):
             "workflow_id": "PubRouterDeposit_HEFCE",
         },
         {"starter_name": "starter_PublishPOA", "workflow_id": "PublishPOA"},
+        {"starter_name": "starter_FindNewPreprints", "workflow_id": "FindNewPreprints"},
     )
     def test_start_workflow(self, test_data, fake_client, fake_start):
         fake_client.return_value = FakeSWFClient()
@@ -182,11 +183,13 @@ class TestConditionalStarts(unittest.TestCase):
                 "cron_FiveMinute",
                 "starter_DepositCrossref",
                 "cron_NewS3POA",
+                "starter_FindNewPreprints",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
                 "DepositCrossref",
                 "cron_NewS3POA",
+                "FindNewPreprints",
             ],
         },
     )
@@ -201,11 +204,13 @@ class TestConditionalStarts(unittest.TestCase):
                 "cron_FiveMinute",
                 "starter_DepositCrossref",
                 "cron_NewS3POA",
+                "starter_FindNewPreprints",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
                 "DepositCrossref",
                 "cron_NewS3POA",
+                "FindNewPreprints",
             ],
         },
     )


### PR DESCRIPTION
Run `FindNewPreprints` each hour in the `cron.py`. Some additional code tweaks to stop it running on non-`prod` environments.

Re issue https://github.com/elifesciences/issues/issues/8539