### PR TITLE
Fix cron to start FindNewPreprints

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -416,6 +416,7 @@ def start_workflow(settings, starter_name, workflow_id=None):
         "starter_DepositCrossrefPeerReview",
         "starter_DepositCrossrefPendingPublication",
         "starter_PubmedArticleDeposit",
+        "starter_FindNewPreprints",
     ]:
         starter_object.start(settings=settings)
 


### PR DESCRIPTION
Fix to PR https://github.com/elifesciences/elife-bot/pull/1823, the starter name needs to be added in an additional place.