### PR TITLE
Fix potential circular import in tests, tweak email digest test.

### DIFF
--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -1,5 +1,4 @@
 import json
-import tests.activity.classes_mock
 import base64
 
 xml_content_for_xml_key = open(

--- a/tests/activity/test_activity_email_digest.py
+++ b/tests/activity/test_activity_email_digest.py
@@ -9,11 +9,10 @@ from digestparser.objects import Digest
 import activity.activity_EmailDigest as activity_module
 from activity.activity_EmailDigest import activity_EmailDigest as activity_object
 from tests.activity import helpers, settings_mock, test_activity_data
-from tests.activity.classes_mock import FakeLogger
 from tests.activity.helpers import create_digest
-import tests.test_data as test_case_data
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 from tests.classes_mock import FakeSMTPServer
-from tests.activity.classes_mock import FakeStorageContext
+import tests.test_data as test_case_data
 
 
 def input_data(file_name_to_change=""):
@@ -22,8 +21,9 @@ def input_data(file_name_to_change=""):
     return activity_data
 
 
-def list_test_dir(dir_name, ignore=(".keepme")):
+def list_test_dir(dir_name):
     "list the contents of a directory ignoring the ignore files"
+    ignore = [".keepme"]
     file_names = os.listdir(dir_name)
     return [file_name for file_name in file_names if file_name not in ignore]
 


### PR DESCRIPTION
Tests for `EmailDigest` are sometimes failing in the test pipeline with no clear reason why. There was a potential cicrular import in `tests/activity/test_activity_data.py` which may or may not help, plus the tests for `EmailDigest` is modified slightly.