### PR TITLE
Add isSameAs relation to posted_content Crossref deposit.

### DIFF
--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -156,6 +156,17 @@ class activity_DepositCrossrefPostedContent(Activity):
 
         # output CrossrefXML objects to XML files
         for article, c_xml in list(crossref_object_map.items()):
+            if article.version_doi:
+                # add rel:program tag if not present
+                crossref.add_posted_content_rel_program_tag(c_xml.root)
+                # find the rel:program tag
+                rel_program_tag = crossref.find_posted_content_rel_program_tag(
+                    c_xml.root
+                )
+                if article.version_doi:
+                    # add intra_work_relation isSameAs tag
+                    crossref.add_is_same_as_tag(rel_program_tag, article.version_doi)
+
             crossref.crossref_xml_to_disk(
                 c_xml, self.directories.get("TMP_DIR"), pretty=True
             )

--- a/provider/crossref.py
+++ b/provider/crossref.py
@@ -249,20 +249,40 @@ def set_version_doi_on_review_articles(article_object_map):
                     related_article.doi = article.version_doi
 
 
+def base_add_rel_program_tag(root, xpath):
+    "add rel:program to the xpath elemment found by in a Crossref deposit Element, if missing"
+    if not base_find_rel_program_tag(root, xpath):
+        namespaces = {"rel": "http://www.crossref.org/relations.xsd"}
+        parent_tag = root.find(xpath, namespaces)
+        if not parent_tag:
+            SubElement(parent_tag, "rel:program")
+
+
+def base_find_rel_program_tag(root, xpath):
+    "find rel:program from the xpath elemment found by in a Crossref deposit Element"
+    namespaces = {"rel": "http://www.crossref.org/relations.xsd"}
+    parent_tag = root.find(xpath, namespaces)
+    return parent_tag.find("rel:program")
+
+
 def add_rel_program_tag(root):
     "add a rel:program tag to a Crossref deposit ElementTree root, if missing"
-    if not find_rel_program_tag(root):
-        namespaces = {"rel": "http://www.crossref.org/relations.xsd"}
-        journal_article_tag = root.find("./body/journal/journal_article", namespaces)
-        if not journal_article_tag:
-            SubElement(journal_article_tag, "rel:program")
+    base_add_rel_program_tag(root, "./body/journal/journal_article")
 
 
 def find_rel_program_tag(root):
     "find the rel:program tag from Crossref deposit ElementTree root"
-    namespaces = {"rel": "http://www.crossref.org/relations.xsd"}
-    journal_article_tag = root.find("./body/journal/journal_article", namespaces)
-    return journal_article_tag.find("rel:program")
+    return base_find_rel_program_tag(root, "./body/journal/journal_article")
+
+
+def add_posted_content_rel_program_tag(root):
+    "add a rel:program tag to a posted_content Crossref deposit ElementTree root, if missing"
+    base_add_rel_program_tag(root, "./body/posted_content")
+
+
+def find_posted_content_rel_program_tag(root):
+    "find the rel:program tag from a posted_content Crossref deposit ElementTree root"
+    return base_find_rel_program_tag(root, "./body/posted_content")
 
 
 def clear_rel_program_tag(c_xml):

--- a/tests/activity/test_activity_deposit_crossref_posted_content.py
+++ b/tests/activity/test_activity_deposit_crossref_posted_content.py
@@ -66,6 +66,17 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
                 "<doi>10.7554/eLife.84364</doi>",
                 "<resource>https://elifesciences.org/reviewed-preprints/84364</resource>",
                 "</posted_content>",
+                (
+                    '<rel:intra_work_relation identifier-type="doi"'
+                    ' relationship-type="isVersionOf">'
+                    "10.7554/eLife.84364.1"
+                    "</rel:intra_work_relation>"
+                ),
+                (
+                    '<rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">'
+                    "10.7554/eLife.84364.2"
+                    "</rel:intra_work_relation>"
+                ),
             ],
             "expected_crossref_version_xml_contains": [
                 '<posted_content type="preprint">',
@@ -76,6 +87,12 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
                 "<doi>10.7554/eLife.84364.2</doi>",
                 "<resource>https://elifesciences.org/reviewed-preprints/84364v2</resource>",
                 "</posted_content>",
+                (
+                    '<rel:intra_work_relation identifier-type="doi"'
+                    ' relationship-type="isVersionOf">'
+                    "10.7554/eLife.84364.1"
+                    "</rel:intra_work_relation>"
+                ),
             ],
         }
         directory = TempDirectory()

--- a/tests/provider/test_crossref_provider.py
+++ b/tests/provider/test_crossref_provider.py
@@ -334,6 +334,40 @@ class TestAddRelProgramTag(unittest.TestCase):
         self.assertEqual(ElementTree.tostring(root).count(b"<rel:program />"), 1)
 
 
+class TestAddPostedContentRelProgramTag(unittest.TestCase):
+    def setUp(self):
+        ElementTree.register_namespace("rel", "http://www.crossref.org/relations.xsd")
+        self.xml_header = (
+            b'<doi_batch xmlns:rel="http://www.crossref.org/relations.xsd">'
+            b"<body><posted_content>"
+        )
+        self.xml_footer = b"</posted_content></body></doi_batch>"
+
+    def test_add_posted_content_rel_program_tag(self):
+        "test adding rel:program tag to posted_content tag"
+        xml_string = self.xml_header + self.xml_footer
+        root = ElementTree.fromstring(xml_string)
+        # check rel:program is in XML prior to the function invocation
+        self.assertTrue(b"<rel:program" not in ElementTree.tostring(root))
+        # invoke function
+        crossref.add_posted_content_rel_program_tag(root)
+        # assert rel:program tag is present
+        self.assertTrue(b"<rel:program />" in ElementTree.tostring(root))
+
+    def test_add_posted_content_rel_program_tag_already_present(self):
+        "test adding rel:program tag to posted_content tag if it is already there"
+        xml_string = self.xml_header + b"<rel:program/>" + self.xml_footer
+        root = ElementTree.fromstring(xml_string)
+        # check rel:program is in XML prior to the function invocation
+        self.assertTrue(b"<rel:program" in ElementTree.tostring(root))
+        # invoke function
+        crossref.add_posted_content_rel_program_tag(root)
+        # assert rel:program tag is present
+        self.assertTrue(b"<rel:program />" in ElementTree.tostring(root))
+        # assert only one tag is present
+        self.assertEqual(ElementTree.tostring(root).count(b"<rel:program />"), 1)
+
+
 class TestClearRelProgramTag(unittest.TestCase):
     def setUp(self):
         self.directory = TempDirectory()


### PR DESCRIPTION
For concept DOI deposits of preprint articles add an `isSameAs` relation to the version DOI, similar to how it is done for VOR deposits.

Re issue https://github.com/elifesciences/issues/issues/8570