### PR TITLE
Refactor duplicate peer review images logic, expanded folder functions.

### DIFF
--- a/tests/activity/test_activity_object.py
+++ b/tests/activity/test_activity_object.py
@@ -484,7 +484,7 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
         # instantiate
         activity_object = AcceptedBaseActivity(settings_mock, logger, None, None, None)
         # invoke
-        result = activity_object.delete_expanded_folder_files(
+        activity_object.delete_expanded_folder_files(
             asset_file_name_map, expanded_folder, file_name_list, storage
         )
         # assertions
@@ -509,6 +509,6 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
         activity_object = AcceptedBaseActivity(settings_mock, logger, None, None, None)
         # invoke
         with self.assertRaises(Exception):
-            result = activity_object.delete_expanded_folder_files(
+            activity_object.delete_expanded_folder_files(
                 asset_file_name_map, expanded_folder, file_name_list, storage
             )


### PR DESCRIPTION
Fixes a bug if there is a duplicated peer review image when importing an accepted submission zip file. Some functions which rename or copy the files in the S3 expanded folder are refactored for better reuse. More test coverage too.

Re issue https://github.com/elifesciences/issues/issues/8572