### PR TITLE
Remove folder from PMCDeposit workflow starter params.

### DIFF
--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -316,7 +316,6 @@ class activity_PubRouterDeposit(Activity):
         workflow_name = "PMCDeposit"
         workflow_data = {
             "document": zip_file_name,
-            "folder": folder,
         }
         message = {
             "workflow_name": workflow_name,


### PR DESCRIPTION
Fix to code merged in PR https://github.com/elifesciences/elife-bot/pull/1851. The starter parameter `folder` is not allowed and it raises and exception when trying to use the starter object, only `document` is accepted.