### PR TITLE
Move get_docmap_string() from objects.py to cleaner.py

### DIFF
--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -67,7 +67,9 @@ class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = self.get_docmap_string(article_id, input_filename)
+        docmap_string = cleaner.get_docmap_string(
+            self.settings, article_id, input_filename, self.name, self.logger
+        )
         self.statuses["docmap_string"] = True
 
         # get the under-review date from the docmap

--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -70,7 +70,9 @@ class activity_AcceptedSubmissionPeerReviews(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = self.get_docmap_string(article_id, input_filename)
+        docmap_string = cleaner.get_docmap_string(
+            self.settings, article_id, input_filename, self.name, self.logger
+        )
         self.statuses["docmap_string"] = True
 
         # get sub-article data from docmap

--- a/activity/activity_AcceptedSubmissionVersionDoi.py
+++ b/activity/activity_AcceptedSubmissionVersionDoi.py
@@ -68,7 +68,9 @@ class activity_AcceptedSubmissionVersionDoi(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = self.get_docmap_string(article_id, input_filename)
+        docmap_string = cleaner.get_docmap_string(
+            self.settings, article_id, input_filename, self.name, self.logger
+        )
         self.statuses["docmap_string"] = True
 
         # get latest version DOI from the docmap

--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -110,8 +110,12 @@ class activity_DepositCrossrefPostedContent(Activity):
                 continue
 
             # check whether this is a less than more recent EPP version
-            docmap_string = self.get_docmap_string(
-                article.manuscript, article.manuscript
+            docmap_string = cleaner.get_docmap_string(
+                self.settings,
+                article.manuscript,
+                article.manuscript,
+                self.name,
+                self.logger,
             )
             newest_version_doi = cleaner.version_doi_from_docmap(
                 docmap_string, article.manuscript

--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -7,6 +7,7 @@ import boto3
 from activity.objects import CleanerBaseActivity
 from provider import (
     bigquery,
+    cleaner,
     email_provider,
     outbox_provider,
     preprint,
@@ -254,8 +255,12 @@ class activity_FindNewPreprints(CleanerBaseActivity):
                 detail.get("version"),
             )
             try:
-                docmap_string = self.get_docmap_string(
-                    detail.get("article_id"), identifier
+                docmap_string = cleaner.get_docmap_string(
+                    self.settings,
+                    detail.get("article_id"),
+                    identifier,
+                    self.name,
+                    self.logger,
                 )
             except Exception as exception:
                 self.logger.exception(

--- a/activity/activity_ScheduleCrossrefPreprint.py
+++ b/activity/activity_ScheduleCrossrefPreprint.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from provider import outbox_provider, preprint
+from provider import cleaner, outbox_provider, preprint
 from provider.execution_context import get_session
 from activity.objects import Activity
 
@@ -97,7 +97,9 @@ class activity_ScheduleCrossrefPreprint(Activity):
             )
             try:
                 # get docmap as a string
-                docmap_string = self.get_docmap_string(article_id, article_id)
+                docmap_string = cleaner.get_docmap_string(
+                    self.settings, article_id, article_id, self.name, self.logger
+                )
                 article = preprint.build_article(
                     article_id, docmap_string, article_xml_path, version
                 )

--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -90,7 +90,9 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
         # PRC XML changes
         if session.get_value("prc_status"):
             cleaner.transform_prc(xml_file_path, input_filename)
-            docmap_string = self.get_docmap_string(article_id, input_filename)
+            docmap_string = cleaner.get_docmap_string(
+                self.settings, article_id, input_filename, self.name, self.logger
+            )
             # set the volume tag value
             self.set_volume_tag(
                 article_id, xml_file_path, input_filename, docmap_string

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -306,19 +306,6 @@ class Activity:
             workflow_name, downstream_workflow_map
         )
 
-    def get_docmap_string(self, article_id, identifier):
-        # generate docmap URL
-        docmap_url = cleaner.docmap_url(self.settings, article_id)
-        self.logger.info("%s, docmap_url: %s" % (self.name, docmap_url))
-
-        # get docmap json
-        self.logger.info(
-            "%s, getting docmap_string for identifier: %s" % (self.name, identifier)
-        )
-        return cleaner.get_docmap_by_account_id(
-            docmap_url, self.settings.docmap_account_id
-        )
-
 
 class CleanerBaseActivity(Activity):
     "activity class to use cleaner provider logging"

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -464,6 +464,18 @@ def get_docmap_by_account_id(url, account_id):
                 return json.dumps(list_item)
 
 
+def get_docmap_string(settings, article_id, identifier, caller_name, logger):
+    "get a docmap string for the article from endpoint"
+    # generate docmap URL
+    docmap_endpoint_url = docmap_url(settings, article_id)
+    logger.info("%s, docmap_endpoint_url: %s" % (caller_name, docmap_endpoint_url))
+    # get docmap json
+    logger.info(
+        "%s, getting docmap_string for identifier: %s" % (caller_name, identifier)
+    )
+    return get_docmap_by_account_id(docmap_endpoint_url, settings.docmap_account_id)
+
+
 def review_date_from_docmap(docmap_string, input_filename):
     return prc.review_date_from_docmap(docmap_string, input_filename)
 

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -796,6 +796,38 @@ class TestGetDocmapByAccountId(unittest.TestCase):
         self.assertEqual(result, json.dumps(elife_docmap))
 
 
+class TestGetDocmapString(unittest.TestCase):
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.url = "https://example.org/"
+
+    @patch("requests.get")
+    def test_get_docmap_string(self, mock_requests_get):
+        "test for non-list JSON returned"
+        article_id = 84364
+        identifier = "elife-preprint-84364-v2.xml"
+        caller_name = "ScheduleCrossrefPreprint"
+        content = b'{"foo": "bar"}'
+        status_code = 200
+        expected = content
+        mock_requests_get.return_value = FakeResponse(status_code, content=content)
+        # invoke
+        result = cleaner.get_docmap_string(
+            settings_mock, article_id, identifier, caller_name, self.logger
+        )
+        # assert
+        self.assertEqual(result, expected)
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            "%s, getting docmap_string for identifier: %s" % (caller_name, identifier),
+        )
+        self.assertEqual(
+            self.logger.loginfo[-2],
+            "%s, docmap_endpoint_url: %spath/get-by-manuscript-id?manuscript_id=%s"
+            % (caller_name, self.url, article_id),
+        )
+
+
 class TestFilesByExtension(unittest.TestCase):
     def test_files_by_extension(self):
         "filter the list based on the file name extension"


### PR DESCRIPTION
Related to issue https://github.com/elifesciences/issues/issues/8587, in order to reuse functions related to generating preprint XML, this refactor should make the process more straightforward. 

Previously `get_docmap_string()` was a method of an activity object. Instead, it is moved to the `cleaner.py` provider library, and arguments are passed to it instead of relying on using activity object instance properties.

This makes it possible to refactor more in subsequent PRs to make the code more reusable throughout.