### PR TITLE
Fix for when peer review images could not be downloaded.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewFigs.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewFigs.py
@@ -164,7 +164,10 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
                     input_filename, body_content
                 )
                 self.log_statuses(input_filename)
-                return self.ACTIVITY_PERMANENT_FAILURE
+
+                # return self.ACTIVITY_PERMANENT_FAILURE
+                # March 1 2024 do not fail the workflow temporarily
+                return True
 
         # rename the files in the expanded folder
         if self.statuses["modify_xml"]:
@@ -190,7 +193,10 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
                     input_filename, body_content
                 )
                 self.log_statuses(input_filename)
-                return self.ACTIVITY_PERMANENT_FAILURE
+
+                # return self.ACTIVITY_PERMANENT_FAILURE
+                # March 1 2024 do not fail the workflow temporarily
+                return True
 
         # upload the XML to the bucket
         self.upload_xml_file_to_bucket(asset_file_name_map, expanded_folder, storage)

--- a/tests/activity/test_activity_accepted_submission_peer_review_figs.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_figs.py
@@ -356,7 +356,7 @@ class TestAcceptedSubmissionPeerReviewFigs(unittest.TestCase):
                 "</sub-article>"
             ),
             "image_names": ["local.jpg"],
-            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+            "expected_result": True,
         },
     )
     def test_do_activity_copy_files_exception(
@@ -426,7 +426,7 @@ class TestAcceptedSubmissionPeerReviewFigs(unittest.TestCase):
                 "</sub-article>"
             ),
             "image_names": ["local.jpg"],
-            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+            "expected_result": True,
         },
     )
     def test_do_activity_rename_files_exception(


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8628

Due to imgur outage the peer review images are not downloaded, leading to when they are assessed as figures, their absence from the bucket folder causes the workflow to be failed. This is relaxed for now as a new method to better handle outages is underway.