### PR TITLE
Add user-agent, log non-200 status when GET peer review images.

### DIFF
--- a/settings-example.py
+++ b/settings-example.py
@@ -366,6 +366,9 @@ class exp:
     # Striking images bucket
     striking_images_bucket = "striking_images_bucket"
 
+    # user-agent for using in requests
+    user_agent = "user_agent/version (https://example.org)"
+
 
 class dev:
     # AWS settings
@@ -716,6 +719,9 @@ class dev:
 
     # Striking images bucket
     striking_images_bucket = "striking_images_bucket"
+
+    # user-agent for using in requests
+    user_agent = "user_agent/version (https://example.org)"
 
 
 class live:
@@ -1072,6 +1078,9 @@ class live:
 
     # Striking images bucket
     striking_images_bucket = "striking_images_bucket"
+
+    # user-agent for using in requests
+    user_agent = "user_agent/version (https://example.org)"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -258,3 +258,6 @@ epp_data_bucket = "epp_bucket"
 
 # Striking images bucket
 striking_images_bucket = "striking_images_bucket"
+
+# user-agent for using in requests
+user_agent = "user_agent/version (https://example.org)"

--- a/tests/activity/test_activity_accepted_submission_peer_review_images.py
+++ b/tests/activity/test_activity_accepted_submission_peer_review_images.py
@@ -203,10 +203,11 @@ class TestAcceptedSubmissionPeerReviewImages(unittest.TestCase):
             "expected_upload_xml_status": None,
             "expected_bucket_upload_folder_contents": [],
             "expected_activity_log_contains": [
+                "GET request returned a 404 status code for https://i.imgur.com/vc4GR10.png",
                 (
                     "AcceptedSubmissionPeerReviewImages, href https://i.imgur.com/vc4GR10.png "
                     "could not be downloaded"
-                )
+                ),
             ],
             "expected_cleaner_log_contains": [
                 (


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8628

Provide a `user-agent` in the headers of requests for peer review images from an external service.