### PR TITLE
Get docmap retry and preprint XML refactoring

### DIFF
--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -31,6 +31,9 @@ class TestFindNewPreprints(unittest.TestCase):
         self.activity = activity_class(settings_mock, fake_logger, None, None, None)
         self.activity.make_activity_directories()
         self.activity_data = {}
+        # reset retry values
+        activity_module.cleaner.DOCMAP_SLEEP_SECONDS = 0.0001
+        activity_module.cleaner.DOCMAP_RETRY = 2
 
     def tearDown(self):
         TempDirectory.cleanup_all()

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -828,6 +828,69 @@ class TestGetDocmapString(unittest.TestCase):
         )
 
 
+class TestGetDocmapStringWithRetry(unittest.TestCase):
+    "tests for cleaner.get_docmap_string_with_retry()"
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        # set constants for faster testing
+        self.retry = 2
+        self.original_constants = {
+            "DOCMAP_SLEEP_SECONDS": cleaner.DOCMAP_SLEEP_SECONDS,
+            "DOCMAP_RETRY": cleaner.DOCMAP_RETRY,
+        }
+        cleaner.DOCMAP_SLEEP_SECONDS = 0.001
+        cleaner.DOCMAP_RETRY = self.retry
+
+    def tearDown(self):
+        # reset constants
+        for key, value in self.original_constants.items():
+            setattr(cleaner, key, value)
+
+    @patch.object(cleaner, "get_docmap_string")
+    def test_get_get_docmap_string_with_retry(
+        self,
+        fake_get_docmap_string,
+    ):
+        "test if an exception is raised when generating an article"
+        article_id = "84364"
+        caller_name = "ScheduleCrossrefPreprint"
+        docmap_string = "docmap"
+        fake_get_docmap_string.return_value = docmap_string
+        # invoke
+        result = cleaner.get_docmap_string_with_retry(
+            settings_mock, article_id, caller_name, self.logger
+        )
+        # check assertions
+        self.assertEqual(result, docmap_string)
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            ("%s, try number 0 to get docmap_string for article_id %s")
+            % (caller_name, article_id),
+        )
+
+    @patch.object(cleaner, "get_docmap_string")
+    def test_get_docmap_exception(
+        self,
+        fake_get_docmap_string,
+    ):
+        "test if an exception is raised when getting docmap"
+        article_id = "84364"
+        caller_name = "ScheduleCrossrefPreprint"
+        fake_get_docmap_string.side_effect = Exception("An exception")
+        # invoke
+        with self.assertRaises(RuntimeError):
+            cleaner.get_docmap_string_with_retry(
+                settings_mock, article_id, caller_name, self.logger
+            )
+        # check assertions
+        self.assertEqual(
+            self.logger.loginfo[-1],
+            ("%s, exceeded %s retries to get docmap_string for article_id %s")
+            % (caller_name, self.retry, article_id),
+        )
+
+
 class TestFilesByExtension(unittest.TestCase):
     def test_files_by_extension(self):
         "filter the list based on the file name extension"

--- a/tests/provider/test_preprint.py
+++ b/tests/provider/test_preprint.py
@@ -165,7 +165,9 @@ class TestBuildArticle(unittest.TestCase):
         fake_sub_article_data.return_value = sub_article_data_fixture()
         article_id = "84364"
         docmap_string = read_fixture("sample_docmap_for_84364.json")
-        article_xml_path = "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        article_xml_path = (
+            "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        )
         article = preprint.build_article(article_id, docmap_string, article_xml_path)
         # assertions
         self.assertEqual(article.doi, "10.7554/eLife.84364")
@@ -241,7 +243,9 @@ class TestBuildArticle(unittest.TestCase):
         article_id = "84364"
         version = 1
         docmap_string = read_fixture("sample_docmap_for_84364.json")
-        article_xml_path = "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        article_xml_path = (
+            "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        )
         article = preprint.build_article(
             article_id, docmap_string, article_xml_path, version
         )
@@ -275,7 +279,9 @@ class TestBuildArticle(unittest.TestCase):
         docmap_string = docmap_string.replace(
             b'"published": "2023-06-14T14:00:00+00:00",', b""
         )
-        article_xml_path = "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        article_xml_path = (
+            "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        )
         with self.assertRaises(preprint.PreprintArticleException) as test_exception:
             preprint.build_article(article_id, docmap_string, article_xml_path)
         self.assertEqual(
@@ -524,7 +530,9 @@ class TestPreprintXml(unittest.TestCase):
         fake_sub_article_data.return_value = sub_article_data_fixture()
         article_id = "84364"
         docmap_string = read_fixture("sample_docmap_for_84364.json")
-        article_xml_path = "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        article_xml_path = (
+            "tests/files_source/epp/automation/84364/v2/article-transformed.xml"
+        )
         article = preprint.build_article(article_id, docmap_string, article_xml_path)
         result = preprint.preprint_xml(article, settings_mock)
         # print(bytes.decode(result))

--- a/tests/provider/test_preprint.py
+++ b/tests/provider/test_preprint.py
@@ -16,7 +16,7 @@ from elifearticle.article import (
     Role,
 )
 from tests import read_fixture, settings_mock
-from tests.activity.classes_mock import FakeStorageContext
+from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 from provider import cleaner, download_helper, preprint
 
 
@@ -290,15 +290,13 @@ class TestBuildArticle(unittest.TestCase):
     def test_no_version_doi(self, fake_version_doi):
         fake_version_doi.return_value = None
         with self.assertRaises(preprint.PreprintArticleException) as test_exception:
-            result = preprint.build_article(None, None, None)
-            self.assertEqual(result, None)
+            preprint.build_article(None, None, None)
 
     @patch.object(cleaner, "version_doi_from_docmap")
     def test_incorrect_version_doi(self, fake_version_doi):
         fake_version_doi.return_value = "10.999999/unwanted.doi"
         with self.assertRaises(preprint.PreprintArticleException) as test_exception:
-            result = preprint.build_article(None, None, None)
-            self.assertEqual(result, None)
+            preprint.build_article(None, None, None)
 
 
 class TestXmlFilename(unittest.TestCase):
@@ -561,3 +559,107 @@ class TestDownloadOriginalPreprintXml(unittest.TestCase):
         )
         self.assertEqual(result.rsplit(os.sep, 1)[-1], file_name)
         self.assertTrue(file_name in os.listdir(directory.path))
+
+
+class TestBuildPreprintArticle(unittest.TestCase):
+    "tests for preprint.build_preprint_article()"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch.object(download_helper, "storage_context")
+    def test_build_preprint_article(self, fake_download_storage_context):
+        "build an Article object from biorXiv XML and docmap string data"
+        directory = TempDirectory()
+        fake_logger = FakeLogger()
+        file_name = "article-transformed.xml"
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", [file_name]
+        )
+        article_id = 93405
+        version = 1
+        docmap_string = read_fixture("sample_docmap_for_84364.json")
+        # invoke
+        result = preprint.build_preprint_article(
+            settings_mock,
+            article_id,
+            version,
+            docmap_string,
+            directory.path,
+            fake_logger,
+        )
+        # assert
+        self.assertTrue(isinstance(result, Article))
+
+    @patch.object(preprint, "download_original_preprint_xml")
+    @patch.object(download_helper, "storage_context")
+    def test_download_xml_exception(
+        self,
+        fake_download_storage_context,
+        fake_download,
+    ):
+        "test an exception raised when downloading original preprint XML"
+        directory = TempDirectory()
+        fake_logger = FakeLogger()
+        exception_message = "An exception"
+        fake_download.side_effect = preprint.PreprintArticleException(exception_message)
+        file_name = "article-transformed.xml"
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", [file_name]
+        )
+        article_id = 93405
+        version = 1
+        docmap_string = read_fixture("sample_docmap_for_84364.json")
+
+        # invoke
+        with self.assertRaises(preprint.PreprintArticleException):
+            preprint.build_preprint_article(
+                settings_mock,
+                article_id,
+                version,
+                docmap_string,
+                directory.path,
+                fake_logger,
+            )
+        # assert
+        self.assertEqual(
+            fake_logger.logexception,
+            (
+                "Exception getting preprint server XML"
+                " from the bucket for article_id %s, version %s: %s"
+            )
+            % (article_id, version, exception_message),
+        )
+
+    @patch.object(preprint, "build_article")
+    @patch.object(download_helper, "storage_context")
+    def test_build_article_exception(
+        self, fake_download_storage_context, fake_build_article
+    ):
+        "test an exception raised building the Article object"
+        directory = TempDirectory()
+        fake_logger = FakeLogger()
+        exception_message = "An exception"
+        fake_build_article.side_effect = preprint.PreprintArticleException(
+            exception_message
+        )
+        file_name = "article-transformed.xml"
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", [file_name]
+        )
+        article_id = 93405
+        version = 1
+        docmap_string = read_fixture("sample_docmap_for_84364.json")
+
+        # invoke
+        with self.assertRaises(preprint.PreprintArticleException):
+            preprint.build_preprint_article(
+                settings_mock,
+                article_id,
+                version,
+                docmap_string,
+                directory.path,
+                fake_logger,
+            )
+        # assert
+        self.assertEqual(fake_logger.logexception, exception_message)


### PR DESCRIPTION
Part of issue https://github.com/elifesciences/issues/issues/8587

A round of refactoring getting docmap data, retrying when needed, and preprint XML generation functions for easier re-use.