### PR TITLE
Handle in FindNewPreprints if preprint XML cannot be generated,

### DIFF
--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -265,13 +265,23 @@ class activity_FindNewPreprints(CleanerBaseActivity):
                 self.bad_xml_files.append(new_xml_filename)
                 continue
 
-            # write the article object to XML file
-            xml_file_path = os.path.join(
-                self.directories.get("OUTPUT_DIR"), new_xml_filename
-            )
-            xml_string = preprint.preprint_xml(article_object, self.settings)
-            with open(xml_file_path, "wb") as open_file:
-                open_file.write(xml_string)
+            try:
+                # write the article object to XML file
+                xml_file_path = os.path.join(
+                    self.directories.get("OUTPUT_DIR"), new_xml_filename
+                )
+                xml_string = preprint.preprint_xml(article_object, self.settings)
+                with open(xml_file_path, "wb") as open_file:
+                    open_file.write(xml_string)
+            except Exception as exception:
+                self.logger.exception(
+                    "%s, failed to generate preprint XML"
+                    " from the article_object for article_id %s: %s"
+                    % (self.name, detail.get("article_id"), str(exception))
+                )
+                self.bad_xml_files.append(new_xml_filename)
+                continue
+
             self.good_xml_files.append(new_xml_filename)
 
     def send_admin_email(self, new_xml_filenames):

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -267,6 +267,42 @@ class TestFindNewPreprints(unittest.TestCase):
         result = self.activity.do_activity(self.activity_data)
         self.assertEqual(result, True)
 
+    @patch("provider.preprint.preprint_xml")
+    @patch("provider.preprint.build_article")
+    @patch.object(cleaner, "get_docmap")
+    @patch.object(bigquery, "get_client")
+    @patch.object(activity_module, "storage_context")
+    @patch("provider.download_helper.storage_context")
+    def test_preprint_xml_exception(
+        self,
+        fake_download_storage_context,
+        fake_storage_context,
+        fake_get_client,
+        fake_get_docmap,
+        fake_build_article,
+        fake_preprint_xml,
+    ):
+        "test if an exception is raised generating preprint XML"
+        directory = TempDirectory()
+        rows = FakeBigQueryRowIterator(
+            bigquery_preprint_test_data.PREPRINT_QUERY_RESULT
+        )
+        client = FakeBigQueryClient(rows)
+        fake_get_client.return_value = client
+        resources = ["elife-preprint-92362-v1.xml"]
+        fake_storage_context.return_value = FakeStorageContext(
+            directory.path, resources
+        )
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", ["article-transformed.xml"]
+        )
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_87445.json")
+        fake_build_article.return_value = True
+        fake_preprint_xml.side_effect = Exception("")
+
+        result = self.activity.do_activity(self.activity_data)
+        self.assertEqual(result, True)
+
 
 class TestMissingSettings(unittest.TestCase):
     def setUp(self):

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -273,7 +273,7 @@ class TestFindNewPreprints(unittest.TestCase):
     @patch.object(bigquery, "get_client")
     @patch.object(activity_module, "storage_context")
     @patch("provider.download_helper.storage_context")
-    def test_preprint_xml_exception(
+    def test_generate_preprint_xml_exception(
         self,
         fake_download_storage_context,
         fake_storage_context,


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8662

For an article object which raises an exception when generating XML output, handle the exception temporarily.