### PR TITLE
preprint.generate_preprint_xml(), and invoke it in the places.

### DIFF
--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -7,7 +7,6 @@ import boto3
 from activity.objects import CleanerBaseActivity
 from provider import (
     bigquery,
-    cleaner,
     email_provider,
     outbox_provider,
     preprint,
@@ -39,8 +38,8 @@ class activity_FindNewPreprints(CleanerBaseActivity):
 
         # Local directory settings
         self.directories = {
-            "TMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
-            "OUTPUT_DIR": os.path.join(self.get_tmp_dir(), "output_dir"),
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
         }
 
         # Bucket for published files
@@ -142,7 +141,7 @@ class activity_FindNewPreprints(CleanerBaseActivity):
             )
             to_folder = self.bucket_folder
             # copy the XML files to the bucket
-            batch_file_names = glob.glob(self.directories.get("OUTPUT_DIR") + "/*.xml")
+            batch_file_names = glob.glob(self.directories.get("INPUT_DIR") + "/*.xml")
             outbox_provider.upload_files_to_s3_folder(
                 self.settings,
                 self.publish_bucket,
@@ -226,58 +225,43 @@ class activity_FindNewPreprints(CleanerBaseActivity):
                 )
             )
 
-            # get the docmap_string for the article
-            identifier = "%s-%s-v%s" % (
-                self.name,
-                detail.get("article_id"),
-                detail.get("version"),
-            )
+            # generate preprint XML file
             try:
-                docmap_string = cleaner.get_docmap_string_with_retry(
-                    self.settings,
-                    detail.get("article_id"),
-                    self.name,
-                    self.logger,
-                )
-            except Exception as exception:
-                self.logger.exception(
-                    "%s, exception getting the docmap_string for article_id %s, %s: %s"
-                    % (self.name, detail.get("article_id"), identifier, str(exception))
-                )
-                self.bad_xml_files.append(new_xml_filename)
-                continue
-
-            # build the article object
-            try:
-                article_object = preprint.build_preprint_article(
+                xml_file_path = preprint.generate_preprint_xml(
                     self.settings,
                     detail.get("article_id"),
                     detail.get("version"),
-                    docmap_string,
-                    self.directories.get("TMP_DIR"),
+                    self.name,
+                    self.directories,
                     self.logger,
                 )
-            except Exception as exception:
+            except preprint.PreprintArticleException as exception:
                 self.logger.exception(
-                    "%s, failed to build the article_object for article_id %s: %s"
-                    % (self.name, detail.get("article_id"), str(exception))
+                    (
+                        "%s, exception raised generating preprint XML"
+                        " for article_id %s version %s: %s"
+                    )
+                    % (
+                        self.name,
+                        detail.get("article_id"),
+                        detail.get("version"),
+                        str(exception),
+                    )
                 )
                 self.bad_xml_files.append(new_xml_filename)
                 continue
-
-            try:
-                # write the article object to XML file
-                xml_file_path = os.path.join(
-                    self.directories.get("OUTPUT_DIR"), new_xml_filename
-                )
-                xml_string = preprint.preprint_xml(article_object, self.settings)
-                with open(xml_file_path, "wb") as open_file:
-                    open_file.write(xml_string)
             except Exception as exception:
                 self.logger.exception(
-                    "%s, failed to generate preprint XML"
-                    " from the article_object for article_id %s: %s"
-                    % (self.name, detail.get("article_id"), str(exception))
+                    (
+                        "%s, unhandled exception raised when generating preprint XML"
+                        " for article_id %s version %s: %s"
+                    )
+                    % (
+                        self.name,
+                        detail.get("article_id"),
+                        detail.get("version"),
+                        str(exception),
+                    )
                 )
                 self.bad_xml_files.append(new_xml_filename)
                 continue

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -32,15 +32,15 @@ class TestFindNewPreprints(unittest.TestCase):
         self.activity.make_activity_directories()
         self.activity_data = {}
         # reset retry values
-        activity_module.cleaner.DOCMAP_SLEEP_SECONDS = 0.0001
-        activity_module.cleaner.DOCMAP_RETRY = 2
+        cleaner.DOCMAP_SLEEP_SECONDS = 0.0001
+        cleaner.DOCMAP_RETRY = 2
 
     def tearDown(self):
         TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
 
     @patch("boto3.client")
-    @patch.object(cleaner, "get_docmap")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
     @patch.object(bigquery, "get_client")
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("provider.download_helper.storage_context")
@@ -148,7 +148,7 @@ class TestFindNewPreprints(unittest.TestCase):
                 ),
             )
         # Count XML files in the output directory
-        file_count = len(os.listdir(self.activity.directories.get("OUTPUT_DIR")))
+        file_count = len(os.listdir(self.activity.directories.get("INPUT_DIR")))
         self.assertEqual(
             file_count, test_data.get("expected_file_count"), test_data.get("comment")
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8587

Generate preprint XML with a single function call, and raise an exception when a step in the process fails.