### PR TITLE
Accepted docmap

### DIFF
--- a/activity/activity_AcceptedSubmissionDocmap.py
+++ b/activity/activity_AcceptedSubmissionDocmap.py
@@ -1,0 +1,68 @@
+import json
+from provider.execution_context import get_session
+from provider import cleaner
+from activity.objects import AcceptedBaseActivity
+
+
+class activity_AcceptedSubmissionDocmap(AcceptedBaseActivity):
+    "AcceptedSubmissionDocmap activity"
+
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_AcceptedSubmissionDocmap, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "AcceptedSubmissionDocmap"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 10
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 10
+        self.description = (
+            "Get a docmap string to use in the accepted submission ingestion."
+        )
+
+        # Track the success of some steps
+        self.statuses = {"docmap_string": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        session = get_session(self.settings, data, data["run"])
+
+        expanded_folder, input_filename, article_id = self.read_session(session)
+
+        # if the article is not PRC, return True
+        prc_status = session.get_value("prc_status")
+        if not prc_status:
+            self.logger.info(
+                "%s, %s prc_status session value is %s, activity returning True"
+                % (self.name, input_filename, prc_status)
+            )
+            return True
+
+        # get docmap as a string
+        try:
+            docmap_string = cleaner.get_docmap_string_with_retry(
+                self.settings, article_id, self.name, self.logger
+            )
+            self.statuses["docmap_string"] = True
+            # save the docmap_string to the session
+            session.store_value("docmap_string", docmap_string)
+        except Exception as exception:
+            self.logger.exception(
+                "%s, exception getting a docmap for article_id %s: %s"
+                % (self.name, article_id, str(exception))
+            )
+
+        self.log_statuses(input_filename)
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True

--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -67,9 +67,7 @@ class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = cleaner.get_docmap_string(
-            self.settings, article_id, input_filename, self.name, self.logger
-        )
+        docmap_string = session.get_value("docmap_string")
         self.statuses["docmap_string"] = True
 
         # get the under-review date from the docmap

--- a/activity/activity_AcceptedSubmissionPeerReviews.py
+++ b/activity/activity_AcceptedSubmissionPeerReviews.py
@@ -70,9 +70,7 @@ class activity_AcceptedSubmissionPeerReviews(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = cleaner.get_docmap_string(
-            self.settings, article_id, input_filename, self.name, self.logger
-        )
+        docmap_string = session.get_value("docmap_string")
         self.statuses["docmap_string"] = True
 
         # get sub-article data from docmap

--- a/activity/activity_AcceptedSubmissionVersionDoi.py
+++ b/activity/activity_AcceptedSubmissionVersionDoi.py
@@ -68,9 +68,7 @@ class activity_AcceptedSubmissionVersionDoi(AcceptedBaseActivity):
         xml_file_path = self.download_xml_file_from_bucket(asset_file_name_map)
 
         # get docmap as a string
-        docmap_string = cleaner.get_docmap_string(
-            self.settings, article_id, input_filename, self.name, self.logger
-        )
+        docmap_string = session.get_value("docmap_string")
         self.statuses["docmap_string"] = True
 
         # get latest version DOI from the docmap

--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -90,9 +90,7 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
         # PRC XML changes
         if session.get_value("prc_status"):
             cleaner.transform_prc(xml_file_path, input_filename)
-            docmap_string = cleaner.get_docmap_string(
-                self.settings, article_id, input_filename, self.name, self.logger
-            )
+            docmap_string = session.get_value("docmap_string")
             # set the volume tag value
             self.set_volume_tag(
                 article_id, xml_file_path, input_filename, docmap_string

--- a/activity/activity_ValidateAcceptedSubmission.py
+++ b/activity/activity_ValidateAcceptedSubmission.py
@@ -1,6 +1,5 @@
 import os
 import json
-import shutil
 import time
 from xml.etree.ElementTree import ParseError
 from provider.execution_context import get_session
@@ -148,14 +147,10 @@ class activity_ValidateAcceptedSubmission(AcceptedBaseActivity):
                 log_message = "Preprint URL was not found in the article XML"
                 self.logger.info("%s, %s" % (self.name, log_message))
 
-            # check docmap URL exists, if fails then fail the workflow
-            docmap_url = cleaner.docmap_url(
-                self.settings, session.get_value("article_id")
-            )
-            if not cleaner.url_exists(docmap_url, self.logger):
-                log_message = (
-                    "Request for a docmap was not successful for URL %s" % docmap_url
-                )
+            # check docmap string is in the session, if fails then fail the workflow
+            docmap_string = session.get_value("docmap_string")
+            if not docmap_string:
+                log_message = "docmap_string from the session was missing or blank"
                 self.logger.info("%s, %s" % (self.name, log_message))
                 error_email_body += "%s\n" % log_message
 

--- a/register.py
+++ b/register.py
@@ -154,6 +154,7 @@ def start(settings):
     activity_names.append("AcceptedSubmissionVersionDoi")
     activity_names.append("AcceptedSubmissionHistory")
     activity_names.append("AcceptedSubmissionStrikingImages")
+    activity_names.append("AcceptedSubmissionDocmap")
     activity_names.append("FindNewPreprints")
 
     for activity_name in activity_names:

--- a/tests/activity/test_activity_accepted_submission_docmap.py
+++ b/tests/activity/test_activity_accepted_submission_docmap.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+
+import copy
+import shutil
+import unittest
+from mock import patch
+from ddt import ddt, data
+from provider import cleaner
+import activity.activity_AcceptedSubmissionDocmap as activity_module
+from activity.activity_AcceptedSubmissionDocmap import (
+    activity_AcceptedSubmissionDocmap as activity_object,
+)
+from tests import read_fixture
+import tests.test_data as test_case_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+)
+from tests.activity import settings_mock, test_activity_data
+
+
+def input_data(file_name_to_change=""):
+    activity_data = test_case_data.ingest_accepted_submission_data
+    activity_data["file_name"] = file_name_to_change
+    return activity_data
+
+
+@ddt
+class TestAcceptedSubmissionDocmap(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+        # instantiate the session here so it can be wiped clean between test runs
+        self.session = FakeSession(
+            copy.copy(test_activity_data.accepted_session_example)
+        )
+        self.session.store_value("prc_status", True)
+        self.session.store_value(
+            "preprint_url", "https://doi.org/10.1101/2021.06.02.446694"
+        )
+        # reduce the sleep time to speed up test runs
+        cleaner.DOCMAP_SLEEP_SECONDS = 0.001
+        cleaner.DOCMAP_RETRY = 2
+
+    def tearDown(self):
+        # clean the temporary directory completely
+        shutil.rmtree(self.activity.get_tmp_dir())
+        # reset the session value
+        self.session.store_value("docmap_string", None)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_docmap_string_status": True,
+            "expected_xml_root_status": True,
+            "expected_upload_xml_status": True,
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_get_docmap,
+        fake_session,
+    ):
+        "test do_activity()"
+        fake_session.return_value = self.session
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_85111.json")
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        # assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        self.assertEqual(
+            self.session.get_value("docmap_string"),
+            read_fixture("sample_docmap_for_85111.json"),
+        )
+        self.assertEqual(
+            self.activity.statuses.get("docmap_string"),
+            test_data.get("expected_docmap_string_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+            "expected_docmap_string_status": None,
+        },
+    )
+    def test_docmap_exception(
+        self,
+        test_data,
+        fake_get_docmap,
+        fake_session,
+    ):
+        "test if an exception is raised when getting docmap string"
+        fake_session.return_value = self.session
+        fake_get_docmap.side_effect = Exception("An exception")
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        # assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        self.assertEqual(
+            self.activity.statuses.get("docmap_string"),
+            test_data.get("expected_docmap_string_status"),
+            "failed in {comment}".format(comment=test_data.get("comment")),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @data(
+        {
+            "comment": "accepted submission zip file example",
+            "filename": "30-01-2019-RA-eLife-45644.zip",
+            "expected_result": True,
+        },
+    )
+    def test_do_activity_not_prc_status(
+        self,
+        test_data,
+        fake_session,
+    ):
+        # reset prc_status from the session
+        self.session.store_value("prc_status", None)
+        fake_session.return_value = self.session
+        # do the activity
+        result = self.activity.do_activity(input_data(test_data.get("filename")))
+        self.assertEqual(result, test_data.get("expected_result"))

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -39,6 +39,9 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         self.session = FakeSession(
             copy.copy(test_activity_data.accepted_session_example)
         )
+        self.session.store_value(
+            "docmap_string", read_fixture("sample_docmap_for_85111.json")
+        )
         self.session.store_value("prc_status", True)
         self.session.store_value(
             "preprint_url", "https://doi.org/10.1101/2021.06.02.446694"
@@ -50,11 +53,11 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         shutil.rmtree(self.activity.get_tmp_dir())
         # reset the session value
         self.session.store_value("cleaner_log", None)
+        self.session.store_value("docmap_string", None)
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch("requests.get")
     @patch.object(activity_object, "clean_tmp_dir")
     @data(
@@ -72,7 +75,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         test_data,
         fake_clean_tmp_dir,
         fake_get,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -97,7 +99,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
             directory.path, resources, dest_folder=directory.path
         )
         fake_session.return_value = self.session
-        fake_get_docmap.return_value = read_fixture("sample_docmap_for_85111.json")
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity
@@ -178,7 +179,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch("requests.get")
     @patch.object(activity_object, "clean_tmp_dir")
     @data(
@@ -196,7 +196,6 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         test_data,
         fake_clean_tmp_dir,
         fake_get,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -221,7 +220,8 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
             directory.path, resources, dest_folder=directory.path
         )
         fake_session.return_value = self.session
-        fake_get_docmap.return_value = "{}"
+        # set a new docmap_string value
+        self.session.store_value("docmap_string", "{}")
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity

--- a/tests/activity/test_activity_accepted_submission_peer_reviews.py
+++ b/tests/activity/test_activity_accepted_submission_peer_reviews.py
@@ -38,6 +38,7 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
         # instantiate the session here so it can be wiped clean between test runs
         self.session = FakeSession(copy.copy(test_activity_data.accepted_session_example))
         self.session.store_value("prc_status", True)
+        self.session.store_value("docmap_string", read_fixture("2021.06.02.446694.docmap.json"))
         self.session.store_value(
             "preprint_url", "https://doi.org/10.1101/2021.06.02.446694"
         )
@@ -48,11 +49,11 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
         shutil.rmtree(self.activity.get_tmp_dir())
         # reset the session value
         self.session.store_value("cleaner_log", None)
+        self.session.store_value("docmap_string", None)
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch("requests.get")
     @patch.object(activity_object, "clean_tmp_dir")
     @data(
@@ -71,7 +72,6 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
         test_data,
         fake_clean_tmp_dir,
         fake_get,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -118,7 +118,6 @@ class TestAcceptedSubmissionPeerReviews(unittest.TestCase):
             directory.path, resources, dest_folder=directory.path
         )
         fake_session.return_value = self.session
-        fake_get_docmap.return_value = read_fixture("2021.06.02.446694.docmap.json")
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity

--- a/tests/activity/test_activity_accepted_submission_version_doi.py
+++ b/tests/activity/test_activity_accepted_submission_version_doi.py
@@ -39,6 +39,9 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         self.session = FakeSession(
             copy.copy(test_activity_data.accepted_session_example)
         )
+        self.session.store_value(
+            "docmap_string", read_fixture("sample_docmap_for_85111.json")
+        )
         self.session.store_value("prc_status", True)
         self.session.store_value(
             "preprint_url", "https://doi.org/10.1101/2021.06.02.446694"
@@ -50,11 +53,11 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         shutil.rmtree(self.activity.get_tmp_dir())
         # reset the session value
         self.session.store_value("cleaner_log", None)
+        self.session.store_value("docmap_string", None)
 
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch("requests.get")
     @patch.object(activity_object, "clean_tmp_dir")
     @data(
@@ -72,7 +75,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         test_data,
         fake_clean_tmp_dir,
         fake_get,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -97,7 +99,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
             directory.path, resources, dest_folder=directory.path
         )
         fake_session.return_value = self.session
-        fake_get_docmap.return_value = read_fixture("sample_docmap_for_85111.json")
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity
@@ -159,7 +160,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch("requests.get")
     @patch.object(activity_object, "clean_tmp_dir")
     @data(
@@ -177,7 +177,6 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         test_data,
         fake_clean_tmp_dir,
         fake_get,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -201,8 +200,9 @@ class TestAcceptedSubmissionVersionDoi(unittest.TestCase):
         fake_cleaner_storage_context.return_value = FakeStorageContext(
             directory.path, resources, dest_folder=directory.path
         )
+        # set the session docmap_string value
+        self.session.store_value("docmap_string", "{}")
         fake_session.return_value = self.session
-        fake_get_docmap.return_value = "{}"
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import base64
 
@@ -50,6 +51,9 @@ accepted_session_example = {
     ),
     "article_id": "45644",
 }
+
+valid_accepted_session_example = copy.copy(accepted_session_example)
+valid_accepted_session_example["docmap_string"] = '{"foo": "bar"}'
 
 # ExpandArticle
 

--- a/tests/activity/test_activity_transform_accepted_submission.py
+++ b/tests/activity/test_activity_transform_accepted_submission.py
@@ -70,7 +70,7 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
 
         # mock the session
         fake_session.return_value = FakeSession(
-            test_activity_data.accepted_session_example
+            test_activity_data.valid_accepted_session_example
         )
 
         # do the activity
@@ -195,12 +195,10 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "get_docmap")
     @patch.object(activity_module, "storage_context")
     def test_do_activity_prc_status(
         self,
         fake_storage_context,
-        fake_get_docmap,
         fake_cleaner_storage_context,
         fake_session,
     ):
@@ -234,14 +232,11 @@ class TestTransformAcceptedSubmission(unittest.TestCase):
             directory.path, resources
         )
 
+        docmap_string = read_fixture("sample_docmap_for_84364.json").decode("utf-8")
+        docmap_string = docmap_string.replace("RP84364", "RP45644")
         # mock the session
+        session_data["docmap_string"] = docmap_string
         fake_session.return_value = FakeSession(session_data)
-
-        docmap_content = json.dumps(
-            read_fixture("sample_docmap_for_84364.json").decode("utf-8")
-        )
-        docmap_content = docmap_content.replace("RP84364", "RP45644")
-        fake_get_docmap.return_value = json.loads(docmap_content)
 
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))

--- a/tests/activity/test_activity_validate_accepted_submission.py
+++ b/tests/activity/test_activity_validate_accepted_submission.py
@@ -31,7 +31,7 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_logger = FakeLogger()
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
         # instantiate the session here so it can be wiped clean between test runs
-        self.session = FakeSession(test_activity_data.accepted_session_example)
+        self.session = FakeSession(test_activity_data.valid_accepted_session_example)
 
     def tearDown(self):
         TempDirectory.cleanup_all()
@@ -285,14 +285,12 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "url_exists")
     @patch.object(cleaner, "preprint_url")
     @patch.object(cleaner, "is_prc")
     def test_do_activity_prc(
         self,
         fake_is_prc,
         fake_preprint_url,
-        fake_url_exists,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -320,7 +318,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         )
         fake_is_prc.return_value = True
         fake_preprint_url.return_value = "https://doi.org/10.1101/2021.06.02.446694"
-        fake_url_exists.return_value = True
         fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         result = self.activity.do_activity(input_data("30-01-2019-RA-eLife-45644.zip"))
@@ -330,14 +327,12 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "url_exists")
     @patch.object(cleaner, "preprint_url")
     @patch.object(cleaner, "is_prc")
     def test_do_activity_prc_sciety_failure(
         self,
         fake_is_prc,
         fake_preprint_url,
-        fake_url_exists,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -347,6 +342,8 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
 
         # set a non-None session value to test string concatenation
         self.session.store_value("cleaner_log", "")
+        # empty the docmap_string value in the session
+        self.session.store_value("docmap_string", "")
         fake_session.return_value = self.session
         zip_file_path = os.path.join(
             test_activity_data.ExpandArticle_files_source_folder,
@@ -366,7 +363,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         fake_is_prc.return_value = True
         preprint_doi = "10.1101/2021.06.02.999999"
         fake_preprint_url.return_value = "https://doi.org/%s" % preprint_doi
-        fake_url_exists.return_value = False
         fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         result = self.activity.do_activity(input_data("30-01-2019-RA-eLife-45644.zip"))
@@ -375,9 +371,7 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         self.assertEqual(
             self.activity.logger.loginfo[-2],
             (
-                "ValidateAcceptedSubmission, Request for a docmap was not successful for "
-                "URL https://example.org/path/get-by-manuscript-id?manuscript_id=%s"
-                % self.session.get_value("article_id")
+                "ValidateAcceptedSubmission, docmap_string from the session was missing or blank"
             ),
         )
 
@@ -385,14 +379,12 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
     @patch.object(activity_module, "storage_context")
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "storage_context")
-    @patch.object(cleaner, "url_exists")
     @patch.object(cleaner, "preprint_url")
     @patch.object(cleaner, "is_prc")
     def test_do_activity_prc_no_preprint_url(
         self,
         fake_is_prc,
         fake_preprint_url,
-        fake_url_exists,
         fake_cleaner_storage_context,
         fake_session,
         fake_storage_context,
@@ -420,7 +412,6 @@ class TestValidateAcceptedSubmission(unittest.TestCase):
         )
         fake_is_prc.return_value = True
         fake_preprint_url.return_value = None
-        fake_url_exists.return_value = True
         fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         result = self.activity.do_activity(input_data("30-01-2019-RA-eLife-45644.zip"))

--- a/workflow/workflow_IngestAcceptedSubmission.py
+++ b/workflow/workflow_IngestAcceptedSubmission.py
@@ -43,6 +43,7 @@ class workflow_IngestAcceptedSubmission(Workflow):
                 define_workflow_step("PingWorker", data),
                 define_workflow_step_short("ExpandAcceptedSubmission", data),
                 define_workflow_step_short("RepairAcceptedSubmission", data),
+                define_workflow_step_short("AcceptedSubmissionDocmap", data),
                 define_workflow_step_short("ValidateAcceptedSubmission", data),
                 define_workflow_step_short("ScheduleCrossrefPendingPublication", data),
                 define_workflow_step_short("ValidateAcceptedSubmissionVideos", data),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8552

First part of improvements to the accepted submission ingestion workflow and how it uses docmap data, a new activity step `AcceptedSubmissionDocmap` will attempt to download the data and store it in the session. Subsequent workflow steps read this value from the session instead of doing another `GET` from the external endpoint.