### PR TITLE
Decode the docmap string before storing it in the session.

### DIFF
--- a/activity/activity_AcceptedSubmissionDocmap.py
+++ b/activity/activity_AcceptedSubmissionDocmap.py
@@ -53,7 +53,7 @@ class activity_AcceptedSubmissionDocmap(AcceptedBaseActivity):
             )
             self.statuses["docmap_string"] = True
             # save the docmap_string to the session
-            session.store_value("docmap_string", docmap_string)
+            session.store_value("docmap_string", docmap_string.decode("utf-8"))
         except Exception as exception:
             self.logger.exception(
                 "%s, exception getting a docmap for article_id %s: %s"

--- a/tests/activity/test_activity_accepted_submission_docmap.py
+++ b/tests/activity/test_activity_accepted_submission_docmap.py
@@ -75,7 +75,7 @@ class TestAcceptedSubmissionDocmap(unittest.TestCase):
         self.assertEqual(result, test_data.get("expected_result"))
         self.assertEqual(
             self.session.get_value("docmap_string"),
-            read_fixture("sample_docmap_for_85111.json"),
+            read_fixture("sample_docmap_for_85111.json").decode("utf-8"),
         )
         self.assertEqual(
             self.activity.statuses.get("docmap_string"),


### PR DESCRIPTION
Fix for storing the docmap string in the session.

Re issue https://github.com/elifesciences/issues/issues/8552