### PR TITLE
Fail the workflow if imgur does not provide images, flag to toggle this.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewFigs.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewFigs.py
@@ -165,8 +165,7 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
                 )
                 self.log_statuses(input_filename)
 
-                # return self.ACTIVITY_PERMANENT_FAILURE
-                # March 1 2024 do not fail the workflow temporarily
+                # do not fail the workflow at this step
                 return True
 
         # rename the files in the expanded folder
@@ -194,8 +193,7 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
                 )
                 self.log_statuses(input_filename)
 
-                # return self.ACTIVITY_PERMANENT_FAILURE
-                # March 1 2024 do not fail the workflow temporarily
+                # do not fail the workflow at this step
                 return True
 
         # upload the XML to the bucket


### PR DESCRIPTION
Fail an accepted submission workflow if peer review images were not downloaded. However, the `FAIL_IF_NO_IMAGES_DOWNLOADED` flag can be set to `False` to temporarily not fail the worklfow and allow it to complete, during an third-party service outage.

Re issue https://github.com/elifesciences/issues/issues/8662