### PR TITLE
Generate preprint XML to bucket expanded folder and use it.

### DIFF
--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -327,7 +327,7 @@ class activity_FindNewPreprints(CleanerBaseActivity):
         workflow_data = {
             "article_id": article_id,
             "version": version,
-            "standalone": True,
+            "standalone": False,
         }
         message = {
             "workflow_name": workflow_name,

--- a/activity/activity_GeneratePreprintXml.py
+++ b/activity/activity_GeneratePreprintXml.py
@@ -1,0 +1,129 @@
+import json
+import os
+from provider import preprint, utils
+from provider.execution_context import get_session
+from provider.storage_provider import storage_context
+from activity.objects import Activity
+
+
+class activity_GeneratePreprintXml(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_GeneratePreprintXml, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "GeneratePreprintXml"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Generate preprint XML and save it to a bucket folder"
+        self.logger = logger
+        self.pretty_name = "Generate Preprint XML"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+    def do_activity(self, data=None):
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        self.make_activity_directories()
+
+        try:
+            # get data from the session
+            run = data["run"]
+            session = get_session(self.settings, data, run)
+        except:
+            self.logger.exception("Error starting %s activity" % self.pretty_name)
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        session.store_value("run", run)
+        # get and store the article data into the session
+        article_id = data.get("article_id")
+        version = data.get("version")
+        self.logger.info("%s, article_id: %s" % (self.name, article_id))
+        self.logger.info("%s, version: %s" % (self.name, version))
+        session.store_value("article_id", article_id)
+        session.store_value("version", version)
+
+        # set the S3 bucket path to hold files
+        bucket_folder_name = "preprint.%s.%s/%s" % (article_id, version, run)
+        session.store_value("expanded_folder", bucket_folder_name)
+        # bucket which holds files
+        bucket_name = (
+            self.settings.publishing_buckets_prefix + self.settings.expanded_bucket
+        )
+
+        # generate preprint XML
+        xml_file_path = None
+        # first check if required settings are available
+        if not hasattr(self.settings, "epp_data_bucket"):
+            self.logger.info(
+                "No epp_data_bucket in settings, skipping %s for article_id %s, version %s"
+                % (self.name, article_id, version)
+            )
+            return self.ACTIVITY_SUCCESS
+        if not self.settings.epp_data_bucket:
+            self.logger.info(
+                (
+                    "epp_data_bucket in settings is blank, skipping %s "
+                    "for article_id %s, version %s"
+                )
+                % (self.name, article_id, version)
+            )
+            return self.ACTIVITY_SUCCESS
+
+        storage = storage_context(self.settings)
+
+        # generate preprint XML file
+        try:
+            xml_file_path = preprint.generate_preprint_xml(
+                self.settings,
+                article_id,
+                version,
+                self.name,
+                self.directories,
+                self.logger,
+            )
+        except preprint.PreprintArticleException as exception:
+            self.logger.exception(
+                (
+                    "%s, exception raised generating preprint XML"
+                    " for article_id %s version %s: %s"
+                )
+                % (self.name, article_id, version, str(exception))
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+        except Exception as exception:
+            self.logger.exception(
+                (
+                    "%s, unhandled exception raised when generating preprint XML"
+                    " for article_id %s version %s: %s"
+                )
+                % (self.name, article_id, version, str(exception))
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # upload XML to the expanded_folder
+        filename = xml_file_path.rsplit(os.sep, 1)[-1]
+        dest_path = bucket_folder_name + "/" + filename
+        storage_resource_dest = (
+            self.settings.storage_provider + "://" + bucket_name + "/" + dest_path
+        )
+        metadata = {"ContentType": utils.content_type_from_file_name(filename)}
+        self.logger.info(
+            "%s, copying preprint XML %s to %s"
+            % (self.name, xml_file_path, storage_resource_dest)
+        )
+        storage.set_resource_from_filename(
+            storage_resource_dest, xml_file_path, metadata
+        )
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True

--- a/register.py
+++ b/register.py
@@ -156,6 +156,7 @@ def start(settings):
     activity_names.append("AcceptedSubmissionStrikingImages")
     activity_names.append("AcceptedSubmissionDocmap")
     activity_names.append("FindNewPreprints")
+    activity_names.append("GeneratePreprintXml")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/starter/starter_PostPreprintPublication.py
+++ b/starter/starter_PostPreprintPublication.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from argparse import ArgumentParser
 from starter.starter_helper import NullRequiredDataException
 from starter.objects import Starter, default_workflow_params
@@ -59,6 +60,9 @@ class starter_PostPreprintPublication(Starter):
         run=None,
         standalone=False,
     ):
+        if run is None:
+            run = str(uuid.uuid4())
+
         workflow_params = self.get_workflow_params(article_id, version, run, standalone)
 
         self.start_workflow_execution(workflow_params)
@@ -117,7 +121,7 @@ def main():
         settings=settings,
         article_id=article_id,
         version=version,
-        standalone=True,
+        standalone=False,
     )
 
 

--- a/tests/activity/test_activity_generate_preprint_xml.py
+++ b/tests/activity/test_activity_generate_preprint_xml.py
@@ -1,0 +1,340 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from ddt import ddt, data
+from provider import cleaner, preprint
+import activity.activity_GeneratePreprintXml as activity_module
+from activity.activity_GeneratePreprintXml import (
+    activity_GeneratePreprintXml as activity_object,
+)
+from tests import read_fixture
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeResponse,
+    FakeSession,
+    FakeStorageContext,
+)
+from tests.activity import settings_mock
+
+
+def input_data(article_id=None, version=None):
+    activity_data = {"run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda"}
+    if article_id is not None:
+        activity_data["article_id"] = article_id
+    if version is not None:
+        activity_data["version"] = version
+    return activity_data
+
+
+def session_data():
+    "activity starts with a blank session"
+    return {}
+
+
+@ddt
+class TestGeneratePreprintXml(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        # reduce the sleep time to speed up test runs
+        cleaner.DOCMAP_SLEEP_SECONDS = 0.001
+        cleaner.DOCMAP_RETRY = 2
+        self.activity = activity_object(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "storage_context")
+    @patch("provider.download_helper.storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap")
+    @patch("requests.get")
+    @data(
+        {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "expected_result": True,
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_get,
+        fake_get_docmap,
+        fake_session,
+        fake_download_storage_context,
+        fake_storage_context,
+    ):
+        directory = TempDirectory()
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", ["article-source.xml"]
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            resources=["elife-preprint-84364-v2.xml"], dest_folder=directory.path
+        )
+        fake_session.return_value = FakeSession(session_data())
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
+        sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
+        fake_get.return_value = FakeResponse(200, content=sample_html)
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(test_data.get("article_id"), test_data.get("version"))
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+        # assert XML is in the bucket folder
+        bucket_outbox_path = os.path.join(
+            directory.path, "preprint.84364.2/", "1ee54f9a-cb28-4c8e-8232-4b317cf4beda"
+        )
+        self.assertEqual(len(os.listdir(bucket_outbox_path)), 1)
+        self.assertEqual(
+            os.listdir(bucket_outbox_path), ["elife-preprint-84364-v2.xml"]
+        )
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "GeneratePreprintXml, copying preprint XML "
+                "%s/input_dir/elife-preprint-84364-v2.xml to "
+                "s3://origin_bucket/preprint.84364.2/"
+                "1ee54f9a-cb28-4c8e-8232-4b317cf4beda/elife-preprint-84364-v2.xml"
+            )
+            % self.activity.get_tmp_dir(),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @data(
+        {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+        },
+    )
+    def test_do_activity_session_exception(
+        self,
+        test_data,
+        fake_session,
+    ):
+        "test using standalone data input instead of session"
+        fake_session.side_effect = Exception("An exception")
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(test_data.get("article_id"), test_data.get("version"))
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(preprint, "generate_preprint_xml")
+    @data(
+        {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+        },
+    )
+    def test_preprint_article_exception(
+        self,
+        test_data,
+        fake_generate,
+        fake_session,
+    ):
+        "test PreprintArticleException exception raised generating preprint XML"
+        fake_session.return_value = FakeSession(session_data())
+        exception_message = "An exception"
+        fake_generate.side_effect = preprint.PreprintArticleException(exception_message)
+
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(test_data.get("article_id"), test_data.get("version"))
+        )
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "GeneratePreprintXml, exception raised generating preprint XML"
+                " for article_id %s version %s: %s"
+            )
+            % (
+                test_data.get("article_id"),
+                test_data.get("version"),
+                exception_message,
+            ),
+        )
+
+    @patch("provider.download_helper.storage_context")
+    @patch.object(activity_module, "get_session")
+    @patch.object(preprint, "generate_preprint_xml")
+    @data(
+        {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+        },
+    )
+    def test_unhandled_exception(
+        self,
+        test_data,
+        fake_generate,
+        fake_session,
+        fake_download_storage_context,
+    ):
+        "test Exception is raised when generating preprint XML"
+        exception_message = "An exception"
+        fake_generate.side_effect = Exception(exception_message)
+        fake_download_storage_context.return_value = FakeStorageContext(
+            "tests/files_source/epp", ["article-source.xml"]
+        )
+        fake_session.return_value = FakeSession(session_data())
+
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(test_data.get("article_id"), test_data.get("version"))
+        )
+
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "GeneratePreprintXml, unhandled exception raised"
+                " when generating preprint XML"
+                " for article_id %s version %s: %s"
+            )
+            % (
+                test_data.get("article_id"),
+                test_data.get("version"),
+                exception_message,
+            ),
+        )
+
+
+class TestSettingsValidation(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+
+        class FakeSettings:
+            publishing_buckets_prefix = ""
+            expanded_bucket = ""
+
+        # reduce the sleep time to speed up test runs
+        cleaner.DOCMAP_SLEEP_SECONDS = 0.001
+        cleaner.DOCMAP_RETRY = 2
+
+        settings_object = FakeSettings()
+        settings_object.downstream_recipients_yaml = (
+            settings_mock.downstream_recipients_yaml
+        )
+        self.activity = activity_object(settings_object, fake_logger, None, None, None)
+        self.test_data = {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+        }
+
+    def tearDown(self):
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module, "get_session")
+    def test_missing_setting(
+        self,
+        fake_session,
+    ):
+        "test epp_data_bucket is missing from settings"
+        fake_session.return_value = FakeSession(session_data())
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(self.test_data.get("article_id"), self.test_data.get("version"))
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            self.test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=self.test_data.get("comment"),
+                result=result,
+                article_id=self.test_data.get("article_id"),
+            ),
+        )
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "No epp_data_bucket in settings, skipping GeneratePreprintXml"
+                " for article_id %s, version %s"
+            )
+            % (self.test_data.get("article_id"), self.test_data.get("version")),
+        )
+
+    @patch.object(activity_module, "get_session")
+    def test_blank_bucket_setting(
+        self,
+        fake_session,
+    ):
+        "test epp_data_bucket setting is blank"
+        self.activity.settings.epp_data_bucket = ""
+        fake_session.return_value = FakeSession(session_data())
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(self.test_data.get("article_id"), self.test_data.get("version"))
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            self.test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=self.test_data.get("comment"),
+                result=result,
+                article_id=self.test_data.get("article_id"),
+            ),
+        )
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                "epp_data_bucket in settings is blank, skipping GeneratePreprintXml"
+                " for article_id %s, version %s"
+            )
+            % (self.test_data.get("article_id"), self.test_data.get("version")),
+        )

--- a/tests/activity/test_activity_schedule_crossref_preprint.py
+++ b/tests/activity/test_activity_schedule_crossref_preprint.py
@@ -32,7 +32,13 @@ def input_data(article_id=None, version=None, standalone=None):
 
 
 def session_data(article_id=None, version=None):
-    return input_data(article_id, version)
+    sess_data = input_data(article_id, version)
+    sess_data["expanded_folder"] = "preprint.%s.%s/%s" % (
+        article_id,
+        version,
+        sess_data.get("run"),
+    )
+    return sess_data
 
 
 @ddt
@@ -49,47 +55,43 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
         # clean the temporary directory
         self.activity.clean_tmp_dir()
 
+    @patch.object(activity_module, "storage_context")
     @patch("provider.outbox_provider.storage_context")
-    @patch("provider.download_helper.storage_context")
-    @patch.object(lax_provider, "article_status_version_map")
     @patch.object(activity_module, "get_session")
-    @patch.object(cleaner, "get_docmap")
-    @patch("requests.get")
     @data(
         {
-            "comment": "accepted submission zip file example",
+            "comment": "non-standalone preprint article example",
             "article_id": "84364",
             "version": 2,
+            "standalone": False,
             "expected_result": True,
         },
     )
     def test_do_activity(
         self,
         test_data,
-        fake_get,
-        fake_get_docmap,
         fake_session,
-        fake_version_map,
-        fake_download_storage_context,
         fake_outbox_storage_context,
+        fake_storage_context,
     ):
+        "non-standalone test which uses the preprint XML from the bucket expanded folder"
         directory = TempDirectory()
-        fake_download_storage_context.return_value = FakeStorageContext(
-            "tests/files_source/epp", ["article-source.xml"]
-        )
         fake_outbox_storage_context.return_value = FakeStorageContext(
             dest_folder=directory.path
+        )
+        fake_storage_context.return_value = FakeStorageContext(
+            resources=["elife-preprint-84364-v2.xml"], dest_folder=directory.path
         )
         fake_session.return_value = FakeSession(
             session_data(test_data.get("article_id"), test_data.get("version"))
         )
-        fake_version_map.return_value = {}
-        fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
-        sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
-        fake_get.return_value = FakeResponse(200, content=sample_html)
         # do the activity
         result = self.activity.do_activity(
-            input_data(test_data.get("article_id"), test_data.get("version"))
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                test_data.get("standalone"),
+            )
         )
         # check assertions
         self.assertEqual(
@@ -114,6 +116,56 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
             os.listdir(peer_review_outbox_path), ["elife-preprint-84364-v2.xml"]
         )
 
+    @patch.object(activity_module, "storage_context")
+    @patch("provider.outbox_provider.storage_context")
+    @patch.object(activity_module, "get_session")
+    @data(
+        {
+            "comment": "non-standalone preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "standalone": False,
+            "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
+        },
+    )
+    def test_no_xml_in_expanded_folder(
+        self,
+        test_data,
+        fake_session,
+        fake_outbox_storage_context,
+        fake_storage_context,
+    ):
+        "test if preprint XML was not found in the bucket expanded folder"
+        directory = TempDirectory()
+        fake_outbox_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
+        # no bucket resources
+        fake_storage_context.return_value = FakeStorageContext(
+            resources=[], dest_folder=directory.path
+        )
+        fake_session.return_value = FakeSession(
+            session_data(test_data.get("article_id"), test_data.get("version"))
+        )
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                test_data.get("standalone"),
+            )
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+
     @patch("provider.outbox_provider.storage_context")
     @patch("provider.download_helper.storage_context")
     @patch.object(lax_provider, "article_status_version_map")
@@ -121,7 +173,7 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
     @patch("requests.get")
     @data(
         {
-            "comment": "accepted submission zip file example",
+            "comment": "standalone preprint article example",
             "article_id": "84364",
             "version": 2,
             "standalone": True,
@@ -171,9 +223,10 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
     @patch.object(activity_module, "get_session")
     @data(
         {
-            "comment": "accepted submission zip file example",
+            "comment": "non-standalone preprint article example",
             "article_id": "84364",
             "version": 2,
+            "standalone": False,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
         },
     )
@@ -186,7 +239,11 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
         fake_session.side_effect = Exception("An exception")
         # do the activity
         result = self.activity.do_activity(
-            input_data(test_data.get("article_id"), test_data.get("version"))
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                test_data.get("standalone"),
+            )
         )
         # check assertions
         self.assertEqual(
@@ -203,9 +260,10 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
     @patch.object(preprint, "generate_preprint_xml")
     @data(
         {
-            "comment": "accepted submission zip file example",
+            "comment": "standalone preprint article example",
             "article_id": "84364",
             "version": 2,
+            "standalone": True,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
         },
     )
@@ -225,7 +283,11 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
 
         # do the activity
         result = self.activity.do_activity(
-            input_data(test_data.get("article_id"), test_data.get("version"))
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                test_data.get("standalone"),
+            )
         )
 
         # check assertions
@@ -265,13 +327,14 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
     @patch.object(preprint, "generate_preprint_xml")
     @data(
         {
-            "comment": "accepted submission zip file example",
+            "comment": "standalone preprint article example",
             "article_id": "84364",
             "version": 2,
+            "standalone": True,
             "expected_result": activity_object.ACTIVITY_PERMANENT_FAILURE,
         },
     )
-    def test_unhandled_exception(
+    def test_preprint_article_unhandled_exception(
         self,
         test_data,
         fake_generate,
@@ -291,7 +354,11 @@ class TestScheduleCrossrefPreprint(unittest.TestCase):
 
         # do the activity
         result = self.activity.do_activity(
-            input_data(test_data.get("article_id"), test_data.get("version"))
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                test_data.get("standalone"),
+            )
         )
 
         # check assertions
@@ -345,9 +412,10 @@ class TestSettingsValidation(unittest.TestCase):
         )
         self.activity = activity_object(settings_object, fake_logger, None, None, None)
         self.test_data = {
-            "comment": "accepted submission zip file example",
+            "comment": "standalone preprint article example",
             "article_id": "84364",
             "version": 2,
+            "standalone": True,
             "expected_result": activity_object.ACTIVITY_SUCCESS,
         }
 
@@ -368,7 +436,11 @@ class TestSettingsValidation(unittest.TestCase):
         )
         # do the activity
         result = self.activity.do_activity(
-            input_data(self.test_data.get("article_id"), self.test_data.get("version"))
+            input_data(
+                self.test_data.get("article_id"),
+                self.test_data.get("version"),
+                self.test_data.get("standalone"),
+            )
         )
         # check assertions
         self.assertEqual(
@@ -382,7 +454,10 @@ class TestSettingsValidation(unittest.TestCase):
         )
         self.assertEqual(
             self.activity.logger.loginfo[-1],
-            "No epp_data_bucket in settings, skipping ScheduleCrossrefPreprint for article_id %s, version %s"
+            (
+                "No epp_data_bucket in settings, skipping ScheduleCrossrefPreprint"
+                " for article_id %s, version %s"
+            )
             % (self.test_data.get("article_id"), self.test_data.get("version")),
         )
 
@@ -400,7 +475,11 @@ class TestSettingsValidation(unittest.TestCase):
         )
         # do the activity
         result = self.activity.do_activity(
-            input_data(self.test_data.get("article_id"), self.test_data.get("version"))
+            input_data(
+                self.test_data.get("article_id"),
+                self.test_data.get("version"),
+                self.test_data.get("standalone"),
+            )
         )
         # check assertions
         self.assertEqual(
@@ -414,6 +493,9 @@ class TestSettingsValidation(unittest.TestCase):
         )
         self.assertEqual(
             self.activity.logger.loginfo[-1],
-            "epp_data_bucket in settings is blank, skipping ScheduleCrossrefPreprint for article_id %s, version %s"
+            (
+                "epp_data_bucket in settings is blank, skipping ScheduleCrossrefPreprint"
+                " for article_id %s, version %s"
+            )
             % (self.test_data.get("article_id"), self.test_data.get("version")),
         )

--- a/tests/files_source/preprint.84364.2/1ee54f9a-cb28-4c8e-8232-4b317cf4beda/elife-preprint-84364-v2.xml
+++ b/tests/files_source/preprint.84364.2/1ee54f9a-cb28-4c8e-8232-4b317cf4beda/elife-preprint-84364-v2.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article
+ PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"
+  "JATS-archivearticle1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="preprint" dtd-version="1.1d3">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="nlm-ta">elife</journal-id>
+			<journal-id journal-id-type="publisher-id">eLife</journal-id>
+			<journal-title-group>
+				<journal-title>eLife</journal-title>
+			</journal-title-group>
+			<issn publication-format="electronic">2050-084X</issn>
+			<publisher>
+				<publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="publisher-id">84364</article-id>
+			<article-id pub-id-type="doi">10.7554/eLife.84364</article-id>
+			<article-id pub-id-type="doi" specific-use="version">10.7554/eLife.84364.2</article-id>
+			<title-group>
+				<article-title>Opto-RhoGEFs: an optimized optogenetic toolbox to reversibly control Rho GTPase activity on a global to subcellular scale, enabling precise control over vascular endothelial barrier strength</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<name>
+						<surname>Mahlandt</surname>
+						<given-names>Eike K.</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1">1</xref>
+				</contrib>
+				<aff id="aff1">
+					<institution>Swammerdam Institute for Life Sciences, Section of Molecular Cytology, van Leeuwenhoek Centre for Advanced Microscopy, University of Amsterdam, Science Park 904, 1098 XH, Amsterdam</institution>
+					, 
+					<country>The Netherlands</country>
+				</aff>
+			</contrib-group>
+			<pub-date date-type="posted_date" publication-format="electronic">
+				<day>13</day>
+				<month>02</month>
+				<year>2023</year>
+			</pub-date>
+			<volume>12</volume>
+			<elocation-id>RP84364</elocation-id>
+			<history/>
+			<pub-history>
+				<event>
+					<date date-type="preprint" iso-8601-date="2022-10-17">
+						<day>17</day>
+						<month>10</month>
+						<year>2022</year>
+					</date>
+					<self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2022.10.17.512253"/>
+				</event>
+				<event>
+					<date date-type="reviewed-preprint" iso-8601-date="2023-02-13">
+						<day>13</day>
+						<month>02</month>
+						<year>2023</year>
+					</date>
+					<self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.84364.1"/>
+				</event>
+				<event>
+					<date date-type="reviewed-preprint" iso-8601-date="2023-06-14">
+						<day>14</day>
+						<month>06</month>
+						<year>2023</year>
+					</date>
+					<self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.84364.2"/>
+				</event>
+			</pub-history>
+			<permissions>
+				<license xlink:href="http://creativecommons.org/licenses/by/4.0/">
+					<license-p>
+						<ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/"/>
+					</license-p>
+				</license>
+			</permissions>
+			<abstract>
+				<p>An abstract.</p>
+			</abstract>
+		</article-meta>
+	</front>
+	<sub-article id="sa0" article-type="editor-report">
+		<front-stub>
+			<article-id pub-id-type="doi">10.7554/eLife.84364.2.sa0</article-id>
+			<title-group>
+				<article-title>eLife assessment</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<name>
+						<surname>Eisen</surname>
+						<given-names>Michael B</given-names>
+					</name>
+					<aff>
+						<institution-wrap>
+							<institution>University of California</institution>
+							, 
+						</institution-wrap>
+						<addr-line>
+							<named-content content-type="city">Berkeley</named-content>
+						</addr-line>
+						, 
+						<country>United States</country>
+					</aff>
+				</contrib>
+			</contrib-group>
+		</front-stub>
+	</sub-article>
+	<sub-article id="sa1" article-type="referee-report">
+		<front-stub>
+			<article-id pub-id-type="doi">10.7554/eLife.84364.2.sa1</article-id>
+			<title-group>
+				<article-title>Reviewer #1 (Public Review)</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<anonymous/>
+				</contrib>
+			</contrib-group>
+		</front-stub>
+	</sub-article>
+	<sub-article id="sa2" article-type="referee-report">
+		<front-stub>
+			<article-id pub-id-type="doi">10.7554/eLife.84364.2.sa2</article-id>
+			<title-group>
+				<article-title>Reviewer #2 (Public Review)</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<anonymous/>
+				</contrib>
+			</contrib-group>
+		</front-stub>
+	</sub-article>
+	<sub-article id="sa3" article-type="referee-report">
+		<front-stub>
+			<article-id pub-id-type="doi">10.7554/eLife.84364.2.sa3</article-id>
+			<title-group>
+				<article-title>Reviewer #3 (Public Review)</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<anonymous/>
+				</contrib>
+			</contrib-group>
+		</front-stub>
+	</sub-article>
+	<sub-article id="sa4" article-type="author-comment">
+		<front-stub>
+			<article-id pub-id-type="doi">10.7554/eLife.84364.2.sa4</article-id>
+			<title-group>
+				<article-title>Author response</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<name>
+						<surname>Mahlandt</surname>
+						<given-names>Eike K.</given-names>
+					</name>
+				</contrib>
+			</contrib-group>
+		</front-stub>
+	</sub-article>
+</article>

--- a/workflow/workflow_PostPreprintPublication.py
+++ b/workflow/workflow_PostPreprintPublication.py
@@ -34,6 +34,7 @@ class workflow_PostPreprintPublication(Workflow):
             "start": {"requirements": None},
             "steps": [
                 define_workflow_step("PingWorker", data),
+                define_workflow_step("GeneratePreprintXml", data),
                 define_workflow_step("ScheduleCrossrefPreprint", data),
 
             ],


### PR DESCRIPTION
The `PostPreprintPublication` workflow will no longer run as `standalone`; as the first step, `GeneratePreprintXml` will generate preprint XML and store it into a bucket folder, then subsequent workflow steps will download the preprint XML from there.

An exception is `ScheduleCrossrefPreprint` will continue to support being run as `standalone`, so preprint data can be deposited as posted_content to Crossref by manually running a separate workflow, avoiding to send data to all the other downstream recipients that will be included (in future) in the full `PostPreprintPublication` workflow.

Re issue https://github.com/elifesciences/issues/issues/8587