### PR TITLE
Use the activity object directories value in test assertion.

### DIFF
--- a/tests/activity/test_activity_generate_preprint_xml.py
+++ b/tests/activity/test_activity_generate_preprint_xml.py
@@ -107,11 +107,11 @@ class TestGeneratePreprintXml(unittest.TestCase):
             self.activity.logger.loginfo[-1],
             (
                 "GeneratePreprintXml, copying preprint XML "
-                "%s/input_dir/elife-preprint-84364-v2.xml to "
+                "%s/elife-preprint-84364-v2.xml to "
                 "s3://origin_bucket/preprint.84364.2/"
                 "1ee54f9a-cb28-4c8e-8232-4b317cf4beda/elife-preprint-84364-v2.xml"
             )
-            % self.activity.get_tmp_dir(),
+            % self.activity.directories.get("INPUT_DIR"),
         )
 
     @patch.object(activity_module, "get_session")


### PR DESCRIPTION
Bug fix a test in PR https://github.com/elifesciences/elife-bot/pull/1884, where the temporary directory name can vary slightly, use the value from the object's `directories` property.