### PR TITLE
Save docmap JSON as a file into accepted submission zip.

### DIFF
--- a/activity/activity_AcceptedSubmissionDocmap.py
+++ b/activity/activity_AcceptedSubmissionDocmap.py
@@ -1,6 +1,7 @@
 import json
+import time
 from provider.execution_context import get_session
-from provider import cleaner
+from provider import cleaner, utils
 from activity.objects import AcceptedBaseActivity
 
 
@@ -53,6 +54,10 @@ class activity_AcceptedSubmissionDocmap(AcceptedBaseActivity):
             )
             self.statuses["docmap_string"] = True
             # save the docmap_string to the session
+            session.store_value(
+                "docmap_datetime_string",
+                time.strftime(utils.DATE_TIME_FORMAT, time.gmtime()),
+            )
             session.store_value("docmap_string", docmap_string.decode("utf-8"))
         except Exception as exception:
             self.logger.exception(

--- a/tests/activity/test_activity_accepted_submission_docmap.py
+++ b/tests/activity/test_activity_accepted_submission_docmap.py
@@ -82,6 +82,7 @@ class TestAcceptedSubmissionDocmap(unittest.TestCase):
             test_data.get("expected_docmap_string_status"),
             "failed in {comment}".format(comment=test_data.get("comment")),
         )
+        self.assertIsNotNone(self.session.get_value("docmap_datetime_string"))
 
     @patch.object(activity_module, "get_session")
     @patch.object(cleaner, "get_docmap_string_with_retry")

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -55,6 +55,7 @@ accepted_session_example = {
 
 valid_accepted_session_example = copy.copy(accepted_session_example)
 valid_accepted_session_example["docmap_string"] = '{"foo": "bar"}'
+valid_accepted_session_example["docmap_datetime_string"] = "2024-04-06T00:05:46.000Z"
 
 # ExpandArticle
 


### PR DESCRIPTION
As part of the accepted submission ingestion workflow, save the datetime the docmap was downloaded in the session, then when generating the file zip output, include the docmap data into a file inside it.

Re issue https://github.com/elifesciences/issues/issues/8552