### PR TITLE
dashboard_queue.py, fixes typo from 'sns_region' to 'sqs_region'

### DIFF
--- a/dashboard_queue.py
+++ b/dashboard_queue.py
@@ -8,7 +8,7 @@ def send_message(message, settings):
     sns_client = settings.aws_conn('sns', {
         'aws_access_key_id': settings.aws_access_key_id,
         'aws_secret_access_key': settings.aws_secret_access_key,
-        'region_name': settings.sns_region,
+        'region_name': settings.sqs_region,
     })
 
     payload = utils.unicode_encode(json.dumps(message))


### PR DESCRIPTION
again. this happened before