### PR TITLE
Use a TempDirectory path in all tests using FakeSMTPServer()

### DIFF
--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -165,9 +165,7 @@ class TestDepositCrossref(unittest.TestCase):
     ):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # populate the bucket resources and copy them to the temp directory
         resources = helpers.populate_storage(
             from_dir="tests/test_data/crossref/outbox",
@@ -224,7 +222,7 @@ class TestDepositCrossref(unittest.TestCase):
                     )
 
         # check email files and contents
-        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files_filter = os.path.join(directory.path, "*.eml")
         email_files = glob.glob(email_files_filter)
         if "expected_email_count" in test_data:
             self.assertEqual(len(email_files), test_data.get("expected_email_count"))

--- a/tests/activity/test_activity_deposit_crossref_minimal.py
+++ b/tests/activity/test_activity_deposit_crossref_minimal.py
@@ -115,9 +115,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
     ):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # populate the bucket resources and copy them to the temp directory
         resources = helpers.populate_storage(
             from_dir="tests/test_data/crossref_minimal/outbox",
@@ -190,7 +188,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
                     )
 
         # check email files and contents
-        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files_filter = os.path.join(directory.path, "*.eml")
         email_files = glob.glob(email_files_filter)
         if "expected_email_count" in test_data:
             self.assertEqual(len(email_files), test_data.get("expected_email_count"))

--- a/tests/activity/test_activity_deposit_crossref_peer_review.py
+++ b/tests/activity/test_activity_deposit_crossref_peer_review.py
@@ -215,9 +215,7 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
         fake_check_vor.return_value = test_data.get("vor_exists")
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         resources = helpers.populate_storage(
             from_dir="tests/test_data/crossref_peer_review/outbox/",
             to_dir=directory.path,
@@ -299,9 +297,8 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         fake_check_vor,
         fake_get_client,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_check_vor.return_value = True
         fake_storage_context.return_value = FakeStorageContext(
             "tests/test_data/crossref_peer_review/outbox/",
@@ -329,9 +326,8 @@ class TestDepositCrossrefPeerReview(unittest.TestCase):
         fake_email_smtp_connect,
         fake_get_client,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_storage_context.return_value = FakeStorageContext(
             "tests/test_data/crossref_peer_review/outbox/", ["bad.xml"]
         )

--- a/tests/activity/test_activity_deposit_crossref_pending_publication.py
+++ b/tests/activity/test_activity_deposit_crossref_pending_publication.py
@@ -71,9 +71,7 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
         }
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         resources = helpers.populate_storage(
             from_dir=self.outbox_folder,
             to_dir=directory.path,
@@ -175,9 +173,8 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
         fake_doi_exists,
         fake_email_smtp_connect,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()    
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_storage_context.return_value = FakeStorageContext(
             self.outbox_folder, ["08-11-2020-FA-eLife-64719.xml"]
         )
@@ -198,9 +195,8 @@ class TestDepositCrossrefPendingPublication(unittest.TestCase):
         fake_storage_context,
         fake_email_smtp_connect,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_storage_context.return_value = FakeStorageContext(
             self.outbox_folder, ["bad.xml"]
         )

--- a/tests/activity/test_activity_deposit_crossref_posted_content.py
+++ b/tests/activity/test_activity_deposit_crossref_posted_content.py
@@ -114,9 +114,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
         fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_version_map.return_value = {}
         resources = helpers.populate_storage(
             from_dir=self.outbox_folder,
@@ -205,9 +203,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
         fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_version_map.return_value = {"vor": [1]}
         # fake_version_map.return_value = {}
         resources = helpers.populate_storage(
@@ -248,9 +244,7 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         fake_clean_tmp_dir.return_value = None
         # use the docmap with only version 1 steps in it
         fake_get_docmap.return_value = v1_84364_docmap_fixture()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_version_map.return_value = {}
         # fake_version_map.return_value = {}
         resources = helpers.populate_storage(
@@ -284,9 +278,8 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         fake_email_smtp_connect,
         fake_get_docmap,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
         fake_version_map.return_value = {}
         fake_storage_context.return_value = FakeStorageContext(
@@ -305,9 +298,8 @@ class TestDepositCrossrefPostedContent(unittest.TestCase):
         fake_storage_context,
         fake_email_smtp_connect,
     ):
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_storage_context.return_value = FakeStorageContext(
             self.outbox_folder, ["bad.xml"]
         )

--- a/tests/activity/test_activity_email_video.py
+++ b/tests/activity/test_activity_email_video.py
@@ -4,6 +4,7 @@ import shutil
 import copy
 from collections import OrderedDict
 from mock import patch
+from testfixtures import TempDirectory
 from tests.classes_mock import FakeSMTPServer
 import tests.activity.settings_mock as settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
@@ -43,6 +44,7 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
 
     @patch.object(activity_module.email_provider, "smtp_connect")
@@ -95,13 +97,12 @@ class TestEmailVideoArticlePublished(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         # mock objects
+        directory = TempDirectory()
         fake_emit.return_value = None
         fake_processing_storage_context.return_value = FakeStorageContext()
         fake_get_xml_file_name.return_value = test_data.get("xml_file")
         fake_first.return_value = test_data.get("first_vor")
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         success = self.activity.do_activity(test_data.get("input_data"))
         # check assertions

--- a/tests/activity/test_activity_find_new_preprints.py
+++ b/tests/activity/test_activity_find_new_preprints.py
@@ -95,9 +95,7 @@ class TestFindNewPreprints(unittest.TestCase):
         fake_get_docmap.return_value = read_fixture("sample_docmap_for_84364.json")
         sample_html = b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
         fake_get.return_value = FakeResponse(200, content=sample_html)
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         resources = []
         if test_data.get("bucket_filenames"):
             resources = test_data.get("bucket_filenames")

--- a/tests/activity/test_activity_ingest_digest_to_endpoint.py
+++ b/tests/activity/test_activity_ingest_digest_to_endpoint.py
@@ -5,6 +5,7 @@ import copy
 import unittest
 from collections import OrderedDict
 from mock import patch
+from testfixtures import TempDirectory
 from ddt import ddt, data
 from provider import article, article_processing, digest_provider, lax_provider, utils
 import activity.activity_IngestDigestToEndpoint as activity_module
@@ -60,6 +61,7 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         self.activity = activity_object(settings_mock, self.logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
 
@@ -269,14 +271,13 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         "situations where approve will be false"
+        directory = TempDirectory()
         fake_emit.return_value = True
         fake_first.return_value = test_data.get("first_vor")
         session_test_data = session_data(test_data)
         fake_session.return_value = FakeSession(session_test_data)
         fake_highest_version.return_value = test_data.get("lax_highest_version")
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
 
         activity_data = test_activity_data.data_example_before_publish
         # do the activity
@@ -404,12 +405,11 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         "test unable to download a digest docx file"
+        directory = TempDirectory()
         fake_emit.return_value = True
         session_test_data = session_data({})
         fake_session.return_value = FakeSession(session_test_data)
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_first.return_value = True
         fake_highest_version.return_value = 1
         named_fake_storage_context = FakeStorageContext()
@@ -444,11 +444,10 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_download_article_xml,
         fake_related_from_lax,
     ):
+        directory = TempDirectory()
         fake_emit.return_value = True
         session_test_data = session_data({})
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_session.return_value = FakeSession(session_test_data)
         fake_approve.return_value = True
         fake_download.return_value = True
@@ -484,11 +483,10 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_gather_digest_details,
         fake_digest_json,
     ):
+        directory = TempDirectory()
         fake_emit.return_value = True
         session_test_data = session_data({})
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_session.return_value = FakeSession(session_test_data)
         fake_approve.return_value = True
         fake_gather_digest_details.return_value = {}
@@ -523,11 +521,10 @@ class TestIngestDigestToEndpointDoActivity(unittest.TestCase):
         fake_generate_digest_content,
         fake_put_digest,
     ):
+        directory = TempDirectory()
         fake_emit.return_value = True
         session_test_data = session_data({})
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_session.return_value = FakeSession(session_test_data)
         fake_approve.return_value = True
         fake_gather_digest_details.return_value = {}

--- a/tests/activity/test_activity_package_poa.py
+++ b/tests/activity/test_activity_package_poa.py
@@ -221,7 +221,7 @@ class TestPackagePOA(unittest.TestCase):
         # mock things
         fake_copy_pdf_to_output_dir.return_value = None
         fake_clean_tmp_dir.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.poa.get_tmp_dir())
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         bucket_outbox_folder = os.path.join(directory.path, "outbox")
         bucket_list_file = os.path.join(
             "tests", "test_data", "ejp_bucket_list_new.json"
@@ -356,7 +356,7 @@ class TestPackagePOA(unittest.TestCase):
         fake_generate_xml.side_effect = ExpatError("An exception")
         fake_copy_pdf_to_output_dir.return_value = None
         fake_clean_tmp_dir.return_value = None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.poa.get_tmp_dir())
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         bucket_outbox_folder = os.path.join(directory.path, "outbox")
         bucket_list_file = os.path.join(
             "tests", "test_data", "ejp_bucket_list_new.json"

--- a/tests/activity/test_activity_pmc_deposit.py
+++ b/tests/activity/test_activity_pmc_deposit.py
@@ -266,12 +266,10 @@ class TestPMCDeposit(unittest.TestCase):
         fake_email_smtp_connect,
         mock_article_related,
     ):
-
+        directory = TempDirectory()
         test_data = self.do_activity_passes[1]
         fake_session.return_value = FakeSession({})
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
 
         fake_storage_context.return_value = FakeStorageContext(
             directory=self.test_data_dir

--- a/tests/activity/test_activity_post_decision_letter_jats.py
+++ b/tests/activity/test_activity_post_decision_letter_jats.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 import activity.activity_PostDecisionLetterJATS as activity_module
 from activity.activity_PostDecisionLetterJATS import (
     activity_PostDecisionLetterJATS as activity_object,
@@ -35,6 +36,7 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         self.input_data = input_data("elife-39122.zip")
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
 
@@ -49,11 +51,10 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         fake_email_smtp_connect,
         mock_session,
     ):
+        directory = TempDirectory()
         expected_result = activity_object.ACTIVITY_SUCCESS
         fake_download_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # mock the session
         fake_session = FakeSession(SESSION_DATA)
         mock_session.return_value = fake_session
@@ -78,11 +79,10 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         fake_email_smtp_connect,
         mock_session,
     ):
+        directory = TempDirectory()
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
         fake_download_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # mock the session
         fake_session = FakeSession(SESSION_DATA)
         mock_session.return_value = fake_session
@@ -114,11 +114,10 @@ class TestPostDecisionLetterJats(unittest.TestCase):
         fake_email_smtp_connect,
         mock_session,
     ):
+        directory = TempDirectory() 
         expected_result = activity_object.ACTIVITY_PERMANENT_FAILURE
         fake_download_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # mock the session
         fake_session = FakeSession(SESSION_DATA)
         mock_session.return_value = fake_session

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -62,9 +62,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         fake_sqs_client,
     ):
         directory = TempDirectory()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.pubrouterdeposit.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
         resources = helpers.populate_storage(
@@ -111,7 +109,7 @@ class TestPubRouterDeposit(unittest.TestCase):
         "test not_published logic by mocking Lax does not have version data"
         directory = TempDirectory()
         tmp_dir = self.pubrouterdeposit.get_tmp_dir()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(tmp_dir)
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         activity_data = {"data": {"workflow": "HEFCE"}}
         fake_was_ever_published.return_value = None
         resources = helpers.populate_storage(
@@ -190,9 +188,7 @@ class TestPubRouterDeposit(unittest.TestCase):
     ):
         "test for PMC runs which start a different workflow"
         directory = TempDirectory()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.pubrouterdeposit.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         activity_data = {"data": {"workflow": workflow_name}}
         resources = helpers.populate_storage(
             from_dir="tests/test_data/",
@@ -235,9 +231,7 @@ class TestPubRouterDeposit(unittest.TestCase):
     ):
         "test for the the PMC starter function returns False"
         directory = TempDirectory()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.pubrouterdeposit.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         activity_data = {"data": {"workflow": workflow_name}}
         resources = helpers.populate_storage(
             from_dir="tests/test_data/",

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -145,6 +145,7 @@ class TestPublicationEmail(unittest.TestCase):
         )
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
         helpers.delete_files_in_folder(
             test_activity_data.ExpandArticle_files_dest_folder, filter_out=[".gitkeep"]
@@ -161,14 +162,13 @@ class TestPublicationEmail(unittest.TestCase):
         fake_process_articles,
         fake_email_smtp_connect,
     ):
+        directory = TempDirectory()
         prepared_article_xml_filenames = ["elife00013.xml", "elife03385.xml"]
         approved_article_xml_filenames = ["elife00013.xml"]
         not_published_article_xml_filenames = ["elife03385.xml"]
         expected_result = True
 
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
 
         storage_path = "tests/files_source/publication_email/outbox/"
 
@@ -295,15 +295,14 @@ class TestPublicationEmail(unittest.TestCase):
         fake_email_smtp_connect,
     ):
         "test if no prepared or not published articles are produced"
+        directory = TempDirectory()
         fake_download_templates.return_value = True
         fake_storage_context.return_value = FakeStorageContext(
             "tests/files_source/publication_email/outbox/",
             resources=[],
         )
         fake_process_articles.return_value = [], [], [], None
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         result = self.activity.do_activity()
         self.assertEqual(result, True)
 
@@ -348,9 +347,7 @@ class TestSendAndClean(unittest.TestCase):
     ):
         "test sending email, cleaning the outbox, sending admin email"
         directory = TempDirectory()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         article_xml_filenames = ["elife-18753-v1.xml", "elife-15747-v2.xml"]
         # copy XML files for testing
         storage_path = os.path.join(directory.path, "publication_email", "outbox")
@@ -394,9 +391,7 @@ class TestSendAndClean(unittest.TestCase):
     ):
         "test sending email, cleaning the outbox, sending admin email"
         directory = TempDirectory()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         article_xml_filenames = ["elife-32991-v2.xml"]
         # copy XML files for testing
         storage_path = os.path.join(directory.path, "publication_email", "outbox")
@@ -1060,6 +1055,7 @@ class TestSendEmail(unittest.TestCase):
         )
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
 
     @patch.object(activity_PublicationEmail, "send_author_email")
@@ -1086,9 +1082,8 @@ class TestSendEmail(unittest.TestCase):
         self, fake_send_message, fake_email_smtp_connect, fake_get_email_body
     ):
         # self.activity.download_templates()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_get_email_body.return_value = "Body."
         fake_send_message.return_value = True
         author = {"e_mail": "author@example.org"}
@@ -1117,9 +1112,8 @@ class TestSendEmail(unittest.TestCase):
         self, fake_send_message, fake_email_smtp_connect, fake_get_email_body
     ):
         # self.activity.download_templates()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         fake_get_email_body.return_value = "Body."
         smtp_exception = smtplib.SMTPDataError(
             454, "Throttling failure: Maximum sending rate exceeded."
@@ -1555,14 +1549,14 @@ class TestSendAdminEmail(unittest.TestCase):
         )
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         self.activity.clean_tmp_dir()
 
     @patch.object(activity_module.email_provider, "smtp_connect")
     def test_send_admin_email(self, fake_email_smtp_connect):
         "test for when the email recipients is a list"
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         activity_status = True
         result = self.activity.send_admin_email(activity_status)
         self.assertEqual(result, True)

--- a/tests/activity/test_activity_publish_final_poa.py
+++ b/tests/activity/test_activity_publish_final_poa.py
@@ -263,8 +263,6 @@ class TestPublishFinalPOA(unittest.TestCase):
         fake_get_pub_date_str_from_lax,
         fake_email_smtp_connect,
     ):
-
-        fake_email_smtp_connect.return_value = FakeSMTPServer(self.poa.get_tmp_dir())
         fake_clean_tmp_dir.return_value = None
 
         fake_next_revision_number.return_value = 1
@@ -273,6 +271,7 @@ class TestPublishFinalPOA(unittest.TestCase):
 
         for test_data in self.do_activity_passes:
             directory = TempDirectory()
+            fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
             fake_storage_context.return_value = FakeStorageContext(
                 dest_folder=directory.path
             )

--- a/tests/activity/test_activity_validate_digest_input.py
+++ b/tests/activity/test_activity_validate_digest_input.py
@@ -5,6 +5,7 @@ import glob
 import email
 import unittest
 from mock import patch
+from testfixtures import TempDirectory
 from ddt import ddt, data
 import activity.activity_ValidateDigestInput as activity_module
 from activity.activity_ValidateDigestInput import (
@@ -31,6 +32,7 @@ class TestValidateDigestInput(unittest.TestCase):
         self.activity = activity_object(settings_mock, fake_logger, None, None, None)
 
     def tearDown(self):
+        TempDirectory.cleanup_all()
         # clean the temporary directory
         self.activity.clean_tmp_dir()
 
@@ -98,12 +100,11 @@ class TestValidateDigestInput(unittest.TestCase):
         fake_download_storage_context,
         fake_email_smtp_connect,
     ):
+        directory = TempDirectory()
         # copy XML files into the input directory using the storage context
         fake_storage_context.return_value = FakeStorageContext()
         fake_download_storage_context.return_value = FakeStorageContext()
-        fake_email_smtp_connect.return_value = FakeSMTPServer(
-            self.activity.get_tmp_dir()
-        )
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
         # do the activity
         result = self.activity.do_activity(input_data(test_data.get("filename")))
         filename_used = input_data(test_data.get("filename")).get("file_name")
@@ -157,7 +158,7 @@ class TestValidateDigestInput(unittest.TestCase):
                 "failed in {comment}".format(comment=test_data.get("comment")),
             )
         # check email files and contents
-        email_files_filter = os.path.join(self.activity.get_tmp_dir(), "*.eml")
+        email_files_filter = os.path.join(directory.path, "*.eml")
         email_files = glob.glob(email_files_filter)
         if "expected_email_count" in test_data:
             self.assertEqual(len(email_files), test_data.get("expected_email_count"))


### PR DESCRIPTION
Bug fix the tests where some were leaving `.eml` files from `FakeSMTPServer()` output.

Re issue https://github.com/elifesciences/issues/issues/8672