### PR TITLE
Move software_heritage.metadata_xml() to utils.element_xml_string()

### DIFF
--- a/activity/activity_GenerateSWHMetadata.py
+++ b/activity/activity_GenerateSWHMetadata.py
@@ -104,7 +104,7 @@ class activity_GenerateSWHMetadata(Activity):
                     "url"
                 ] = create_origin_url
             metadata_element = software_heritage.metadata_element(metadata_object)
-            metadata_xml = software_heritage.metadata_xml(
+            metadata_xml = utils.element_xml_string(
                 metadata_element, pretty=True, indent="    "
             )
             self.logger.info("Metadata XML generated for article doi %s" % article.doi)

--- a/provider/software_heritage.py
+++ b/provider/software_heritage.py
@@ -4,8 +4,6 @@ import os
 import re
 from collections import OrderedDict
 from string import Template
-from xml.dom import minidom
-from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 import requests
 
@@ -70,17 +68,6 @@ def metadata(file_name, article):
     "generate metadata object for a deposit"
     metadata_object = MetaData(file_name, article)
     return metadata_object
-
-
-def metadata_xml(element, pretty=False, indent=""):
-    "generate string XML output from an Element object"
-    encoding = "utf-8"
-    rough_string = ElementTree.tostring(element, encoding)
-    reparsed = minidom.parseString(rough_string)
-
-    if pretty is True:
-        return reparsed.toprettyxml(indent, encoding=encoding)
-    return reparsed.toxml(encoding=encoding)
 
 
 def metadata_element(metadata_object):

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -2,6 +2,8 @@ import os
 import re
 import urllib
 import base64
+from xml.dom import minidom
+from xml.etree import ElementTree
 from argparse import ArgumentParser
 import arrow
 from mimetypes import guess_type
@@ -141,6 +143,17 @@ def version_doi_parts(version_doi):
     e.g. 10.7554/eLife.84364.2 return 10.7554/eLife.84364, 1
     """
     return version_doi.rsplit(".", 1)
+
+
+def element_xml_string(element, pretty=False, indent=""):
+    "generate string XML output from an Element object"
+    encoding = "utf-8"
+    rough_string = ElementTree.tostring(element, encoding)
+    reparsed = minidom.parseString(rough_string)
+
+    if pretty is True:
+        return reparsed.toprettyxml(indent, encoding=encoding)
+    return reparsed.toxml(encoding=encoding)
 
 
 CONSOLE_ARGUMENT_MAP = {

--- a/tests/provider/test_software_heritage.py
+++ b/tests/provider/test_software_heritage.py
@@ -57,7 +57,7 @@ class TestSoftwareHeritageProviderMetadata(unittest.TestCase):
             "url"
         ] = create_origin_url
         metadata_element = software_heritage.metadata_element(metadata_object)
-        metadata_xml = software_heritage.metadata_xml(
+        metadata_xml = utils.element_xml_string(
             metadata_element, pretty=True, indent="    "
         )
         self.assertEqual(
@@ -69,12 +69,6 @@ class TestSoftwareHeritageProviderMetadata(unittest.TestCase):
                 pretty_string(expected_xml_string),
             ),
         )
-
-    def test_metadata_xml_not_pretty(self):
-        "test for non-pretty XML output"
-        element = Element("root")
-        expected = b'<?xml version="1.0" encoding="utf-8"?><root/>'
-        self.assertEqual(software_heritage.metadata_xml(element), expected)
 
     def test_metadata_xml_contrib_collab(self):
         "test for group authors in collab tags and group member contributors"

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -3,11 +3,13 @@ import os
 import unittest
 import time
 import sys
+from xml.etree.ElementTree import Element, SubElement
 import arrow
 from mock import patch
 from ddt import ddt, data, unpack
 import provider.utils as utils
 import botocore.config
+
 
 @ddt
 class TestUtils(unittest.TestCase):
@@ -182,6 +184,34 @@ class TestUtils(unittest.TestCase):
             actual = utils.get_aws_connection_key(service, kv)
             self.assertEqual(actual, expected)
             self.assertEqual({actual: 1}[actual], 1) # generated key can be used as a map key
+
+
+class TestElementXmlString(unittest.TestCase):
+    "tests for utils.element_xml_string()"
+
+    def test_element_xml_string(self):
+        "test for pretty XML output"
+        element = Element("root")
+        p_element = SubElement(element, "p")
+        expected_xml_string = (
+            b'<?xml version="1.0" encoding="utf-8"?>\n<root>\n    <p/>\n</root>\n'
+        )
+        metadata_xml = utils.element_xml_string(element, pretty=True, indent="    ")
+        self.assertEqual(
+            metadata_xml,
+            expected_xml_string,
+            "\n\n%s\n\nis not equal to expected\n\n%s"
+            % (
+                metadata_xml,
+                expected_xml_string,
+            ),
+        )
+
+    def test_element_xml_string_not_pretty(self):
+        "test for non-pretty XML output"
+        element = Element("root")
+        expected = b'<?xml version="1.0" encoding="utf-8"?><root/>'
+        self.assertEqual(utils.element_xml_string(element), expected)
 
 
 class TestSettingsEnvironment(unittest.TestCase):


### PR DESCRIPTION
To reuse some code which generates a pretty formatting XML string, move it to the utils provider module.

Part of issue https://github.com/elifesciences/issues/issues/8592