### PR TITLE
Dependency `docmaptools` pinned to `0.21.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-04-12 - see update-dependencies.sh
+# file generated 2024-04-15 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -17,7 +17,7 @@ Deprecated==1.2.14
 digestparser==0.2.0
 dill==0.3.8
 docker==5.0.3
-docmaptools==0.20.0
+docmaptools==0.21.0
 ejpcsvparser==0.3.1
 elifearticle==0.18.0
 elifecleaner==0.61.0
@@ -25,7 +25,7 @@ elifecrossref==0.28.0
 elifepubmed==0.6.0
 elifetools==0.40.0
 exceptiongroup==1.2.0
-func-timeout==4.3.5
+func_timeout==4.3.5
 gitdb==4.0.11
 GitPython==3.1.43
 google-api-core==2.18.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/227/display/redirect which resulted in this pull request.