### PR TITLE
Only use published version DOI values from the docmap.

### DIFF
--- a/activity/activity_AcceptedSubmissionVersionDoi.py
+++ b/activity/activity_AcceptedSubmissionVersionDoi.py
@@ -72,7 +72,9 @@ class activity_AcceptedSubmissionVersionDoi(AcceptedBaseActivity):
         self.statuses["docmap_string"] = True
 
         # get latest version DOI from the docmap
-        version_doi = cleaner.version_doi_from_docmap(docmap_string, input_filename)
+        version_doi = cleaner.version_doi_from_docmap(
+            docmap_string, input_filename, published=True
+        )
         self.logger.info(
             "%s, %s version_doi: %s" % (self.name, input_filename, version_doi)
         )

--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -118,7 +118,7 @@ class activity_DepositCrossrefPostedContent(Activity):
                 self.logger,
             )
             newest_version_doi = cleaner.version_doi_from_docmap(
-                docmap_string, article.manuscript
+                docmap_string, article.manuscript, published=True
             )
             if newest_version_doi != article.version_doi:
                 self.logger.info(

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -550,8 +550,10 @@ def elocation_id_from_docmap(docmap_string, input_filename):
     return prc.elocation_id_from_docmap(docmap_string, input_filename)
 
 
-def version_doi_from_docmap(docmap_string, input_filename):
-    return prc.version_doi_from_docmap(docmap_string, input_filename)
+def version_doi_from_docmap(docmap_string, input_filename, published=True):
+    return prc.version_doi_from_docmap(
+        docmap_string, input_filename, published=published
+    )
 
 
 def next_version_doi(version_doi, input_filename):

--- a/provider/preprint.py
+++ b/provider/preprint.py
@@ -41,7 +41,9 @@ def jatsgenerator_config(config_section, config_file):
 
 def build_article(article_id, docmap_string, article_xml_path, version=None):
     "collect data from docmap and preprint XML to populate an Article object"
-    newest_version_doi = cleaner.version_doi_from_docmap(docmap_string, article_id)
+    newest_version_doi = cleaner.version_doi_from_docmap(
+        docmap_string, article_id, published=True
+    )
 
     if not newest_version_doi:
         raise PreprintArticleException(


### PR DESCRIPTION
Explicitly use only `published` version DOI values from the docmap when checking as part of the Crossref posted_content deposits, and when assigning the next version DOI to an accepted submission.

Re issue https://github.com/elifesciences/issues/issues/8694