### PR TITLE
Fix EJP CSV preprint_author file name matching.

### DIFF
--- a/provider/ejp.py
+++ b/provider/ejp.py
@@ -146,10 +146,11 @@ class EJP:
         # remove backslashes from regular expression fragments
         clean_fn_fragment = fn_fragment[file_type].replace("\\", "")
         # add an extra part of file name for new CSV files
-        rp_extra = ""
+        rp_extra = "eLife"
         if "Reviewed_preprint_author_details" in clean_fn_fragment:
-            rp_extra = "-rp"
-        file_name_to_match = "%s_%s_eLife%s.csv" % (
+            # note lower case l
+            rp_extra = "elife-rp"
+        file_name_to_match = "%s_%s_%s.csv" % (
             clean_fn_fragment,
             date_string,
             rp_extra,

--- a/tests/provider/test_ejp.py
+++ b/tests/provider/test_ejp.py
@@ -314,7 +314,7 @@ class TestProviderEJP(unittest.TestCase):
             "preprint_author",
             (
                 "ejp_query_tool_query_id_Production_data_04_-_"
-                "Reviewed_preprint_author_details_2019_06_10_eLife-rp.csv"
+                "Reviewed_preprint_author_details_2019_06_10_elife-rp.csv"
             ),
         ),
         (


### PR DESCRIPTION
Preprint authors CSV file has a lowercase l in `elife` in its filename, whereas others have upper case L.

Re issue https://github.com/elifesciences/issues/issues/8696