### PR TITLE
Set PublicationEmail for twice daily in cron.py

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -284,7 +284,7 @@ def conditional_starts(current_datetime):
     elif current_time.tm_min >= 45 and current_time.tm_min <= 59:
         # Bottom quarter of the hour
 
-        # Author emails once per day 17:45 local time
+        # Author emails at 17:45 local time
         # (used to be set to 16:45 UTC during British Summer Time for 17:45 local UK time)
         if local_current_time.tm_hour == 17:
             conditional_start_list.append(
@@ -316,6 +316,18 @@ def conditional_starts(current_datetime):
                     [
                         ("starter_name", "starter_PubRouterDeposit"),
                         ("workflow_id", "PubRouterDeposit_Cengage"),
+                        ("start_seconds", 60 * 31),
+                    ]
+                )
+            )
+
+        # Author emails at 22:45 local time
+        if local_current_time.tm_hour == 22:
+            conditional_start_list.append(
+                OrderedDict(
+                    [
+                        ("starter_name", "starter_PublicationEmail"),
+                        ("workflow_id", "PublicationEmail"),
                         ("start_seconds", 60 * 31),
                     ]
                 )

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -384,6 +384,7 @@ class TestConditionalStarts(unittest.TestCase):
             "expected_starter_names": [
                 "cron_FiveMinute",
                 "starter_DepositCrossref",
+                "starter_PublicationEmail",
                 "starter_PubRouterDeposit",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
@@ -391,6 +392,7 @@ class TestConditionalStarts(unittest.TestCase):
             "expected_workflow_ids": [
                 "cron_FiveMinute",
                 "DepositCrossref",
+                "PublicationEmail",
                 "PubRouterDeposit_GoOA",
                 "PubmedArticleDeposit",
                 "AdminEmail",


### PR DESCRIPTION
Send emails for articles which are published later in the day by running `PublicationEmail` twice instead of once per day.