### PR TITLE
Move YAML loading functions to new yaml_provider.py

### DIFF
--- a/activity/activity_FTPArticle.py
+++ b/activity/activity_FTPArticle.py
@@ -5,7 +5,7 @@ import glob
 import shutil
 import re
 from elifetools import parseJATS as parser
-from provider import article_processing, downstream, utils
+from provider import article_processing, utils, yaml_provider
 from provider.storage_provider import storage_context
 from provider.sftp import SFTP
 from provider.ftp import FTP
@@ -462,7 +462,7 @@ def collect_credentials(settings, doi_id, workflow):
 
     credentials = {}
 
-    rules = downstream.load_config(settings)
+    rules = yaml_provider.load_config(settings)
     workflow_rules = rules.get(workflow)
 
     rule_name_credentials_name_map = {
@@ -498,7 +498,7 @@ def sending_details(settings, workflow):
 
     details = {}
 
-    rules = downstream.load_config(settings)
+    rules = yaml_provider.load_config(settings)
     workflow_rules = rules.get(workflow)
 
     if workflow_rules:

--- a/activity/activity_PMCDeposit.py
+++ b/activity/activity_PMCDeposit.py
@@ -9,7 +9,13 @@ import provider.s3lib as s3lib
 from provider.article_structure import ArticleInfo
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
-from provider import article_processing, downstream, email_provider, lax_provider, utils
+from provider import (
+    article_processing,
+    email_provider,
+    lax_provider,
+    utils,
+    yaml_provider,
+)
 from provider.ftp import FTP
 from activity.objects import Activity
 
@@ -109,7 +115,7 @@ class activity_PMCDeposit(Activity):
             self.directories.get("ZIP_DIR"), self.zip_file_name
         )
 
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
         workflow_rules = rules.get("PMC")
 
         # repackage the archive zip into PMC zip format

--- a/activity/activity_PubRouterDeposit.py
+++ b/activity/activity_PubRouterDeposit.py
@@ -6,11 +6,11 @@ import provider.article as articlelib
 from provider.storage_provider import storage_context
 from provider import (
     article_processing,
-    downstream,
     email_provider,
     lax_provider,
     outbox_provider,
     utils,
+    yaml_provider,
 )
 
 from activity.objects import Activity
@@ -120,7 +120,7 @@ class activity_PubRouterDeposit(Activity):
         self.archive_bucket_s3_keys = self.get_archive_bucket_s3_keys()
 
         # workflow rules
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
         workflow_rules = rules.get(self.workflow)
 
         # Parse the XML
@@ -561,7 +561,7 @@ def get_friendly_email_recipients(settings, workflow):
     "get recipients of the friendly email from the settings via YAML rules"
     recipient_email_list = []
 
-    rules = downstream.load_config(settings)
+    rules = yaml_provider.load_config(settings)
     workflow_rules = rules.get(workflow)
     # get the name of the settings value from the rules
     settings_name = (

--- a/activity/activity_ScheduleDownstream.py
+++ b/activity/activity_ScheduleDownstream.py
@@ -1,6 +1,6 @@
 import json
 from provider.storage_provider import storage_context
-from provider import downstream, lax_provider, utils
+from provider import downstream, lax_provider, utils, yaml_provider
 from activity.objects import Activity
 
 """
@@ -60,7 +60,7 @@ class activity_ScheduleDownstream(Activity):
             article_id, version, status, self.settings
         )
 
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
 
         try:
             xml_file_name = lax_provider.get_xml_file_name(

--- a/activity/activity_SchedulePreprintDownstream.py
+++ b/activity/activity_SchedulePreprintDownstream.py
@@ -1,6 +1,6 @@
 import json
 import os
-from provider import downstream, outbox_provider, preprint
+from provider import downstream, preprint, yaml_provider
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from activity.objects import Activity
@@ -55,7 +55,7 @@ class activity_SchedulePreprintDownstream(Activity):
 
         publish_bucket_name = self.settings.poa_packaging_bucket
 
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
 
         status = "preprint"
         first_by_status = bool(int(version) == 1)

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -4,7 +4,7 @@ import os
 import re
 import botocore
 import dashboard_queue
-from provider import cleaner, downstream, outbox_provider, utils
+from provider import cleaner, downstream, outbox_provider, utils, yaml_provider
 
 """
 Amazon SWF activity base class
@@ -300,7 +300,7 @@ class Activity:
 
     def s3_bucket_folder(self, workflow_name):
         "get the S3 bucket folder from YAML file for outbox folders"
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
         downstream_workflow_map = downstream.workflow_s3_bucket_folder_map(rules)
         return outbox_provider.workflow_foldername(
             workflow_name, downstream_workflow_map

--- a/provider/article.py
+++ b/provider/article.py
@@ -3,7 +3,7 @@ import re
 import urllib
 import requests
 from elifetools import parseJATS as parser
-from provider import downstream, outbox_provider, s3lib
+from provider import downstream, outbox_provider, s3lib, yaml_provider
 from provider.lax_provider import article_highest_version
 from provider.storage_provider import storage_context
 from provider.utils import msid_from_doi, get_doi_url, pad_msid
@@ -180,7 +180,7 @@ class article:
 
         doi_ids = []
 
-        rules = downstream.load_config(self.settings)
+        rules = yaml_provider.load_config(self.settings)
         downstream_workflow_map = downstream.workflow_s3_bucket_folder_map(rules)
 
         # workflow e.g. "HEFCE"

--- a/provider/downstream.py
+++ b/provider/downstream.py
@@ -1,17 +1,5 @@
 from collections import OrderedDict
-import yaml
 from provider import outbox_provider
-
-
-def load_config(settings):
-    # load config from the YAML file specified in the settings
-    return load_yaml(settings.downstream_recipients_yaml)
-
-
-def load_yaml(file_path):
-    # load config from the file_path YAML file
-    with open(file_path, "r", encoding="utf-8") as open_file:
-        return yaml.load(open_file.read(), Loader=yaml.FullLoader)
 
 
 def workflow_s3_bucket_folder_map(rules):

--- a/provider/yaml_provider.py
+++ b/provider/yaml_provider.py
@@ -1,0 +1,12 @@
+import yaml
+
+
+def load_config(settings):
+    # load config from the YAML file specified in the settings
+    return load_yaml(settings.downstream_recipients_yaml)
+
+
+def load_yaml(file_path):
+    # load config from the file_path YAML file
+    with open(file_path, "r", encoding="utf-8") as open_file:
+        return yaml.load(open_file.read(), Loader=yaml.FullLoader)

--- a/tests/activity/test_activity_pub_router_deposit.py
+++ b/tests/activity/test_activity_pub_router_deposit.py
@@ -3,7 +3,7 @@ import datetime
 from mock import patch
 from ddt import ddt, data, unpack
 from testfixtures import TempDirectory
-from provider import downstream
+from provider import yaml_provider
 from provider.article import article
 import activity.activity_PubRouterDeposit as activity_module
 from activity.activity_PubRouterDeposit import activity_PubRouterDeposit
@@ -369,7 +369,7 @@ class TestApproveArticles(unittest.TestCase):
         test_article.display_channel = ["Research Article"]
         test_article.is_poa = True
         self.articles = [test_article]
-        self.rules = downstream.load_config(settings_mock)
+        self.rules = yaml_provider.load_config(settings_mock)
 
     @patch.object(activity_PubRouterDeposit, "get_latest_archive_zip_name")
     @patch("provider.article.article.was_ever_published")

--- a/tests/provider/test_downstream.py
+++ b/tests/provider/test_downstream.py
@@ -1,25 +1,19 @@
 import unittest
 from collections import OrderedDict
-from provider import downstream
+from provider import downstream, yaml_provider
 from tests import settings_mock
-
-
-class TestLoadConfig(unittest.TestCase):
-    def test_load_config(self):
-        rules = downstream.load_config(settings_mock)
-        self.assertTrue(isinstance(rules, dict))
 
 
 class TestFolderMap(unittest.TestCase):
     def test_workflow_s3_bucket_folder_map(self):
-        rules = downstream.load_config(settings_mock)
+        rules = yaml_provider.load_config(settings_mock)
         folder_map = downstream.workflow_s3_bucket_folder_map(rules)
         self.assertTrue(isinstance(folder_map, OrderedDict))
 
 
 class TestChooseOutboxes(unittest.TestCase):
     def setUp(self):
-        self.rules = downstream.load_config(settings_mock)
+        self.rules = yaml_provider.load_config(settings_mock)
 
     def test_empty_rules(self):
         rules = None

--- a/tests/provider/test_outbox_provider.py
+++ b/tests/provider/test_outbox_provider.py
@@ -3,7 +3,7 @@ import shutil
 import unittest
 from mock import patch
 from testfixtures import TempDirectory
-from provider import downstream, outbox_provider
+from provider import downstream, outbox_provider, yaml_provider
 from tests import settings_mock
 from tests.activity.classes_mock import FakeLogger, FakeStorageContext
 from tests.activity import helpers, test_activity_data
@@ -121,7 +121,7 @@ class TestOutboxProvider(unittest.TestCase):
 
 # get workflow map from the YAML file specified in the settings_mock test settings
 DOWNSTREAM_WORKFLOW_MAP = downstream.workflow_s3_bucket_folder_map(
-    downstream.load_config(settings_mock)
+    yaml_provider.load_config(settings_mock)
 )
 # list of workflows to test for good coverage
 DOWNSTREAM_WORKFLOWS = [

--- a/tests/provider/test_yaml_provider.py
+++ b/tests/provider/test_yaml_provider.py
@@ -1,0 +1,11 @@
+import unittest
+from provider import yaml_provider
+from tests import settings_mock
+
+
+class TestLoadConfig(unittest.TestCase):
+    "tests for provider.yaml_provider.load_config()"
+
+    def test_load_config(self):
+        rules = yaml_provider.load_config(settings_mock)
+        self.assertTrue(isinstance(rules, dict))


### PR DESCRIPTION
To load additional YAML files, move the functions which load it from the `downstream.py` provider module to a new `yaml_provider.py` module.

Re issue https://github.com/elifesciences/issues/issues/8588