### PR TITLE
Use publicationEmail.yaml rules when sending emails.

### DIFF
--- a/provider/yaml_provider.py
+++ b/provider/yaml_provider.py
@@ -1,12 +1,27 @@
 import yaml
 
 
-def load_config(settings):
+def load_config(settings, config_type="downstream_recipients"):
     # load config from the YAML file specified in the settings
-    return load_yaml(settings.downstream_recipients_yaml)
+    if config_type == "downstream_recipients":
+        return load_yaml(settings.downstream_recipients_yaml)
+    if config_type == "publication_email":
+        return load_yaml(settings.publication_email_yaml)
+    return None
 
 
 def load_yaml(file_path):
     # load config from the file_path YAML file
     with open(file_path, "r", encoding="utf-8") as open_file:
         return yaml.load(open_file.read(), Loader=yaml.FullLoader)
+
+
+def value_as_list(value):
+    "cast the value as a list"
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return None

--- a/settings-example.py
+++ b/settings-example.py
@@ -348,6 +348,8 @@ class exp:
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
 
+    publication_email_yaml = "publicationEmail.yaml"
+
     docmap_url_pattern = (
         "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
     )
@@ -701,6 +703,8 @@ class dev:
     GLENCOE_FTP_CWD = ""
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
+
+    publication_email_yaml = "publicationEmail.yaml"
 
     docmap_url_pattern = (
         "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
@@ -1060,6 +1064,8 @@ class live:
     GLENCOE_FTP_CWD = ""
 
     downstream_recipients_yaml = "downstreamRecipients.yaml"
+
+    publication_email_yaml = "publicationEmail.yaml"
 
     docmap_url_pattern = (
         "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -246,6 +246,8 @@ GLENCOE_FTP_CWD = "folder"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
+publication_email_yaml = "tests/publicationEmail.yaml"
+
 docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
 docmap_account_id = "https://sciety.org/groups/elife"
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -787,7 +787,7 @@ class TestPrepareArticles(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
     @patch.object(activity_module, "choose_email_type")
-    def test_prepare_articles(self, fake_choose_email_type):
+    def test_exception(self, fake_choose_email_type):
         "test exception"
         exception_message = "An exception"
         fake_choose_email_type.side_effect = EmailRulesException(exception_message)

--- a/tests/provider/test_yaml_provider.py
+++ b/tests/provider/test_yaml_provider.py
@@ -9,3 +9,38 @@ class TestLoadConfig(unittest.TestCase):
     def test_load_config(self):
         rules = yaml_provider.load_config(settings_mock)
         self.assertTrue(isinstance(rules, dict))
+
+    def test_load_publication_email_config(self):
+        rules = yaml_provider.load_config(
+            settings_mock, config_type="publication_email"
+        )
+        self.assertTrue(isinstance(rules, dict))
+
+    def test_unknown(self):
+        "unknown YAML file"
+        rules = yaml_provider.load_config(settings_mock, config_type="__unknown")
+        self.assertEqual(rules, None)
+
+
+class TestValueAsList(unittest.TestCase):
+    "tests for value_as_list()"
+
+    def test_list(self):
+        "test list value"
+        value = ["item"]
+        self.assertEqual(value, yaml_provider.value_as_list(value))
+
+    def test_str(self):
+        "test str value"
+        value = "item"
+        self.assertEqual([value], yaml_provider.value_as_list(value))
+
+    def test_none(self):
+        "test None value"
+        value = None
+        self.assertEqual([], yaml_provider.value_as_list(value))
+
+    def test_dict(self):
+        "test dict value"
+        value = {"key": "value"}
+        self.assertEqual(None, yaml_provider.value_as_list(value))

--- a/tests/publicationEmail.yaml
+++ b/tests/publicationEmail.yaml
@@ -1,0 +1,71 @@
+# Details about emails sent to authors after article publication
+# For some no email is sent, then evaluate the article status, type, other details
+# to determine who receives the email and which email template to use
+
+DoNotSend:
+  article_type:
+    - correction
+    - editorial
+    - retraction
+  do_not_send: true
+
+Insight:
+  article_type:
+    - article-commentary
+  recipients:
+    - authors
+    - features_publication_recipient_email
+  features_recipient_name: Features
+  email_type: author_publication_email_Insight_to_VOR
+
+Feature:
+  article_type:
+    - discussion
+  recipients:
+    - features_publication_recipient_email
+  features_recipient_name: Features
+  email_type: author_publication_email_Feature
+
+Poa:
+  article_status: poa
+  article_type:
+    - research-article
+    - review-article
+  recipients:
+    - authors
+  email_type: author_publication_email_POA
+
+VorAfterPoa:
+  article_status: vor
+  was_ever_poa: true
+  article_type:
+    - research-article
+    - review-article
+  recipients:
+    - authors
+  email_type: author_publication_email_VOR_after_POA
+
+Vor:
+  article_status: vor
+  article_type:
+    - research-article
+    - review-article
+  recipients:
+    - authors
+  email_type: author_publication_email_VOR_no_POA
+
+PreprintFirstVersion:
+  article_type:
+    - preprint
+  first_version: true
+  recipients:
+    - authors
+  email_type: author_publication_email_RP_first_version
+
+PreprintRevisedVersion:
+  article_type:
+    - preprint
+  first_version: false
+  recipients:
+    - authors
+  email_type: author_publication_email_RP_revised_version

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -100,6 +100,8 @@ accepted_submission_queue = "cleaning_queue"
 
 downstream_recipients_yaml = "tests/downstreamRecipients.yaml"
 
+publication_email_yaml = "tests/publicationEmail.yaml"
+
 docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
 docmap_account_id = "https://sciety.org/groups/elife"
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8588

In `PublicationEmail` activity, use the `publicationEmail.yaml` file rules to determine the email type and some other sending details.