### PR TITLE
Mock Crossref clinical trials registry data in tests.

### DIFF
--- a/tests/activity/test_activity_deposit_crossref_minimal.py
+++ b/tests/activity/test_activity_deposit_crossref_minimal.py
@@ -4,6 +4,7 @@ import unittest
 from mock import patch
 from ddt import ddt, data
 from testfixtures import TempDirectory
+from elifecrossref import clinical_trials
 from provider import crossref
 import activity.activity_DepositCrossrefMinimal as activity_module
 from activity.activity_DepositCrossrefMinimal import activity_DepositCrossrefMinimal
@@ -31,6 +32,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
         "return the tmp dir name for the activity"
         return self.activity.directories.get("TMP_DIR")
 
+    @patch.object(clinical_trials, "registry_name_to_doi_map")
     @patch.object(activity_module.email_provider, "smtp_connect")
     @patch("requests.post")
     @patch("provider.outbox_provider.storage_context")
@@ -112,6 +114,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
         fake_storage_context,
         fake_request,
         fake_email_smtp_connect,
+        fake_clinical_trial_name_map,
     ):
         directory = TempDirectory()
         fake_clean_tmp_dir.return_value = None
@@ -128,6 +131,11 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
         )
         # mock the POST to endpoint
         fake_request.return_value = FakeResponse(test_data.get("post_status_code"))
+        # mock GET response data from Crossref clinical trials endpoint
+        fake_clinical_trial_name_map.return_value = {
+            "ClinicalTrials.gov": "10.18810/clinical-trials-gov",
+            "ChiCTR": "10.18810/chictr",
+        }
         # do the activity
         result = self.activity.do_activity(self.activity_data)
         # check assertions


### PR DESCRIPTION
A temporary outage of the clinical trials registry DOI resolution uncovered a bug in the tests using Crossref generation; it was doing a real `GET` request to resolve clinical trial data in the abstract of XML test fixtures. 

Here the return value of the function `registry_name_to_doi_map()` in the `elifecrossref.clinical_trials` module is mocked in those tests.