### PR TITLE
Fix to preprint data in Crossref deposits.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -150,17 +150,12 @@ class activity_DepositCrossref(Activity):
                     # add intra_work_relation isSameAs tag
                     crossref.add_is_same_as_tag(rel_program_tag, article.version_doi)
 
+                # add a isVersionOf tag for reviewed preprint versions
                 for event_object in article.publication_history:
                     if event_object.event_type == "reviewed-preprint":
                         crossref.add_is_version_of_tag(
                             rel_program_tag, event_object.doi
                         )
-                    elif (
-                        event_object.event_type == "preprint"
-                        and event_object.doi != article.preprint
-                    ):
-                        # add a hasPreprint tag for the original preprint DOI
-                        crossref.add_has_preprint_tag(rel_program_tag, event_object.doi)
 
         # output CrossrefXML objects to XML files
         for article, c_xml in list(crossref_object_map.items()):
@@ -250,19 +245,6 @@ class activity_DepositCrossref(Activity):
             crossref.set_article_version(article, self.settings)
             # set Contributor orcid_authenticated values to True
             crossref.contributor_orcid_authenticated(article, True)
-
-            # set the preprint to a different value for PRC articles
-            if article.publication_history:
-                event_list = [
-                    event_object
-                    for event_object in article.publication_history
-                    if event_object.event_type == "reviewed-preprint"
-                ]
-                if event_list:
-                    event_object = event_list[-1]
-                    preprint_object = Preprint()
-                    preprint_object.doi = event_object.doi
-                    article.preprint = preprint_object
 
         return article_object_map
 

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -90,16 +90,19 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_crossref_xml_contains": [
                 "<doi>10.7554/eLife.1234567890</doi>",
                 (
-                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.7554/eLife.1234567890.3</rel:intra_work_relation>'
-                ),
-                (
                     '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="hasPreprint">10.1101/2021.11.09.467796</rel:intra_work_relation></rel:related_item>'
                 ),
                 (
-                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">10.7554/eLife.1234567890.1</rel:intra_work_relation>'
                 ),
                 (
-                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">10.7554/eLife.1234567890.1</rel:intra_work_relation>'
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">10.7554/eLife.1234567890.2</rel:intra_work_relation>'
+                ),
+                (
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isVersionOf">10.7554/eLife.1234567890.3</rel:intra_work_relation>'
+                ),
+                (
+                    '<rel:related_item><rel:intra_work_relation identifier-type="doi" relationship-type="isSameAs">10.7554/eLife.1234567890.4</rel:intra_work_relation>'
                 ),
             ],
             "expected_email_count": 1,


### PR DESCRIPTION
Some duplicate `hasPreprint` related item tags in Crossref deposits are fixed, and using `isVersionOf ` is more appropriate.

Re issue https://github.com/elifesciences/issues/issues/8665