### PR TITLE
Dependency `docmaptools` pinned to `0.22.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-05-30 - see update-dependencies.sh
+# file generated 2024-06-14 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -17,7 +17,7 @@ Deprecated==1.2.14
 digestparser==0.2.0
 dill==0.3.8
 docker==7.1.0
-docmaptools==0.21.1
+docmaptools==0.22.0
 ejpcsvparser==0.3.1
 elifearticle==0.18.0
 elifecleaner==0.62.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/237/display/redirect which resulted in this pull request.