### PR TITLE
Move date functions to utils.py, change utcnow() and …

### DIFF
--- a/activity/activity_AdminEmailHistory.py
+++ b/activity/activity_AdminEmailHistory.py
@@ -1,7 +1,7 @@
 import json
 import calendar
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from activity.objects import Activity
 
 import provider.swfmeta as swfmetalib
@@ -138,9 +138,9 @@ class activity_AdminEmailHistory(Activity):
         swfmeta.connect()
 
         # convert timestamp to datetime objects
-        start_latest_date = datetime.utcfromtimestamp(current_timestamp)
-        start_oldest_date = datetime.utcfromtimestamp(
-            swfmetalib.utctimestamp(start_latest_date) - time_period
+        start_latest_date = datetime.fromtimestamp(current_timestamp, tz=timezone.utc)
+        start_oldest_date = datetime.fromtimestamp(
+            utils.utctimestamp(start_latest_date) - time_period, tz=timezone.utc
         )
 
         workflow_count = {}

--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -349,11 +349,14 @@ class activity_FindNewPreprints(CleanerBaseActivity):
     def sqs_connect(self):
         "connect to the queue service"
         if not self.sqs_client:
-            self.sqs_client = self.settings.aws_conn('sqs', {
-                'aws_access_key_id': self.settings.aws_access_key_id,
-                'aws_secret_access_key': self.settings.aws_secret_access_key,
-                'region_name': self.settings.sqs_region,
-            })
+            self.sqs_client = self.settings.aws_conn(
+                "sqs",
+                {
+                    "aws_access_key_id": self.settings.aws_access_key_id,
+                    "aws_secret_access_key": self.settings.aws_secret_access_key,
+                    "region_name": self.settings.sqs_region,
+                },
+            )
 
     def sqs_queue_url(self):
         "get the queues"

--- a/activity/activity_FindNewPreprints.py
+++ b/activity/activity_FindNewPreprints.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 import json
 import time
 import glob
@@ -69,7 +68,7 @@ class activity_FindNewPreprints(CleanerBaseActivity):
         # Create output directories
         self.make_activity_directories()
 
-        date_string = datetime.datetime.utcnow().strftime(utils.PUB_DATE_FORMAT)
+        date_string = utils.get_current_datetime().strftime(utils.PUB_DATE_FORMAT)
 
         # BigQuery
         try:

--- a/activity/objects.py
+++ b/activity/objects.py
@@ -153,7 +153,7 @@ class Activity:
                 pass
 
         # Create a new directory specifically for this activity
-        dir_name = datetime.datetime.utcnow().strftime("%Y-%m-%d.%H.%M.%S")
+        dir_name = utils.get_current_datetime().strftime("%Y-%m-%d.%H.%M.%S")
         workflowId = self.get_workflowId()
         activityId = self.get_activityId()
         try:

--- a/cron.py
+++ b/cron.py
@@ -1,6 +1,5 @@
 import calendar
 import time
-import datetime
 import importlib
 from collections import OrderedDict
 
@@ -22,7 +21,7 @@ LOGGER = log.logger("cron.log", "INFO", IDENTITY)
 
 
 def run_cron(settings):
-    current_datetime = get_current_datetime()
+    current_datetime = utils.get_current_datetime()
     LOGGER.info("current_datetime: %s" % current_datetime)
 
     for conditional_start in conditional_starts(current_datetime):
@@ -44,11 +43,6 @@ def run_cron(settings):
                 starter_name=conditional_start.get("starter_name"),
                 workflow_id=conditional_start.get("workflow_id"),
             )
-
-
-def get_current_datetime():
-    """for easier mocking in tests wrap this call"""
-    return datetime.datetime.utcnow()
 
 
 def get_local_datetime(current_datetime, timezone_object):

--- a/provider/swfmeta.py
+++ b/provider/swfmeta.py
@@ -1,15 +1,12 @@
 from datetime import datetime, timezone
 from collections import OrderedDict
+from provider import utils
+
 
 """
 SWFMeta data provider
 Functions to provide meta data from SWF so code is not duplicated
 """
-
-
-def utctimestamp(dt):
-    "get a timestamp for utc timezone from a datetime object"
-    return dt.replace(tzinfo=timezone.utc).timestamp()
 
 
 class SWFMeta:
@@ -151,15 +148,15 @@ class SWFMeta:
 
         latest_start_timestamp = None
 
-        start_latest_date = datetime.utcnow()
+        start_latest_date = utils.get_current_datetime()
 
         # Number of days to check in successive calls to SWF history
         days_list = [0.25, 1, 7, 90]
 
         for days in days_list:
-
-            start_oldest_date = datetime.utcfromtimestamp(
-                utctimestamp(start_latest_date) - int(60 * 60 * 24 * days)
+            start_oldest_date = datetime.fromtimestamp(
+                utils.utctimestamp(start_latest_date) - int(60 * 60 * 24 * days),
+                tz=timezone.utc,
             )
 
             close_status = "COMPLETED"
@@ -177,7 +174,7 @@ class SWFMeta:
             # Find the latest run
             for execution in infos.get("executionInfos"):
                 # convert the returned datetime.datetime object to a numeric timestamp
-                execution_timestamp = utctimestamp(execution["startTimestamp"])
+                execution_timestamp = utils.utctimestamp(execution["startTimestamp"])
                 if latest_start_timestamp is None:
                     latest_start_timestamp = execution_timestamp
                     continue
@@ -213,11 +210,11 @@ class SWFMeta:
 
         # Use now as the start_latest_date if not supplied
         if latest_date is None:
-            latest_date = datetime.utcnow()
+            latest_date = utils.get_current_datetime()
         # Use full 90 day history if start_oldest_date is not supplied
         if oldest_date is None:
-            oldest_date = datetime.utcfromtimestamp(
-                utctimestamp(latest_date) - (60 * 60 * 24 * 90)
+            oldest_date = datetime.fromtimestamp(
+                utils.utctimestamp(latest_date) - (60 * 60 * 24 * 90), tz=timezone.utc
             )
 
         close_status = None
@@ -273,9 +270,9 @@ class SWFMeta:
         is_open = None
 
         # use datetime() values for these
-        latest_date = datetime.utcnow()
-        oldest_date = datetime.utcfromtimestamp(
-            utctimestamp(latest_date) - (60 * 60 * 24 * 90)
+        latest_date = utils.get_current_datetime()
+        oldest_date = datetime.fromtimestamp(
+            utils.utctimestamp(latest_date) - (60 * 60 * 24 * 90), tz=timezone.utc
         )
 
         infos = self.get_open_workflow_executionInfos(

--- a/provider/swfmeta.py
+++ b/provider/swfmeta.py
@@ -17,11 +17,14 @@ class SWFMeta:
 
     def connect(self):
         # Simple connect
-        self.client = self.settings.aws_conn('swf', {
-            'aws_access_key_id': self.settings.aws_access_key_id,
-            'aws_secret_access_key': self.settings.aws_secret_access_key,
-            'region_name': self.settings.swf_region,
-        })
+        self.client = self.settings.aws_conn(
+            "swf",
+            {
+                "aws_access_key_id": self.settings.aws_access_key_id,
+                "aws_secret_access_key": self.settings.aws_secret_access_key,
+                "region_name": self.settings.swf_region,
+            },
+        )
 
     def get_closed_workflow_execution_count(
         self,

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import urllib
@@ -110,6 +111,16 @@ def set_datestamp(glue=""):
         ]
     )
     return date_stamp
+
+
+def get_current_datetime():
+    "for easier mocking in tests wrap this call"
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def utctimestamp(dt):
+    "get a timestamp for utc timezone from a datetime object"
+    return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
 
 
 def get_activity_status_text(activity_status):

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -270,7 +270,9 @@ def console_start_env_workflow_doi_id():
 
 def create_aws_connection(service, service_creation_kwargs):
     assert isinstance(service, str), "`service` must be a string"
-    assert isinstance(service_creation_kwargs, dict), "`service_creation_kwargs` must be a dictionary"
+    assert isinstance(
+        service_creation_kwargs, dict
+    ), "`service_creation_kwargs` must be a dictionary"
 
     return boto3.client(service, **service_creation_kwargs)
 
@@ -279,20 +281,27 @@ def get_aws_connection_key(service, service_creation_kwargs):
     "returns a tuple for the given `service` that can be used in a dictionary"
     kv = service_creation_kwargs
     # ('s3', 'us-east-1', '1234567890', Config{...})
-    return (service, kv.get('region_name'), kv.get('aws_access_key_id'), kv.get('config'))
+    return (
+        service,
+        kv.get("region_name"),
+        kv.get("aws_access_key_id"),
+        kv.get("config"),
+    )
 
 
 def get_aws_connection(service_conn_map, service, service_creation_kwargs):
     "centralised access to AWS service connections"
     assert isinstance(service_conn_map, dict), "`service_conn_map` must be a dictionary"
     assert isinstance(service, str), "`service` must be a string"
-    assert isinstance(service_creation_kwargs, dict), "`service_creation_kwargs` must be a dictionary"
+    assert isinstance(
+        service_creation_kwargs, dict
+    ), "`service_creation_kwargs` must be a dictionary"
 
     if service in service_conn_map:
         return service_conn_map[service]
 
     map_key = get_aws_connection_key(service, service_creation_kwargs)
-    
+
     service_conn_map[map_key] = create_aws_connection(service, service_creation_kwargs)
     return service_conn_map[map_key]
 
@@ -300,6 +309,7 @@ def get_aws_connection(service_conn_map, service, service_creation_kwargs):
 def get_settings(env):
     """for runtime importing of settings module"""
     import settings as settings_lib
+
     settings_inst = settings_lib.get_settings(env)
 
     settings_inst._aws_conn_map = {}
@@ -318,19 +328,26 @@ def content_type_from_file_name(file_name):
     else:
         return content_type
 
+
 ENVVAR_KNOWN_KEYS = {
-    'MOTO_ALLOW_NONEXISTENT_REGION',
-    'TEST_DUMMY',
+    "MOTO_ALLOW_NONEXISTENT_REGION",
+    "TEST_DUMMY",
 }
+
 
 def envvar(key, default=None):
     """returns a value for the environment variable `key`.
     raises an `AssertionError` if the requested environment variable is unknown."""
-    assert key in ENVVAR_KNOWN_KEYS, "programming error. unsupported environment key: %s" % key
+    assert key in ENVVAR_KNOWN_KEYS, (
+        "programming error. unsupported environment key: %s" % key
+    )
     return os.environ.get(key, default)
+
 
 def set_envvar(key, val):
     """set a value `val` for the environment variable `key`.
     raises an `AssertionError` if the requested environment variable is unknown."""
-    assert key in ENVVAR_KNOWN_KEYS, "programming error. unsupported environment key: %s" % key    
+    assert key in ENVVAR_KNOWN_KEYS, (
+        "programming error. unsupported environment key: %s" % key
+    )
     os.environ[key] = val

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -175,18 +175,41 @@ class TestUtils(unittest.TestCase):
         config1 = botocore.config.Config()
         config2 = botocore.config.Config(connect_timeout=50, read_timeout=70)
         cases = [
-            (('s3', {}), ('s3', None, None, None)),
-            (('s3', {'region_name': 'us-east-1'}), ('s3', 'us-east-1', None, None)),
-            (('s3', {'region_name': 'us-east-1', 'aws_access_key_id': '1234'}), ('s3', 'us-east-1', '1234', None)),
-            (('s3', {'region_name': 'us-east-1', 'aws_access_key_id': '1234', 'config': config1}),
-             ('s3', 'us-east-1', '1234', config1)),
-            (('s3', {'region_name': 'us-east-1', 'aws_access_key_id': '1234', 'config': config2}),
-             ('s3', 'us-east-1', '1234', config2)),
+            (("s3", {}), ("s3", None, None, None)),
+            (("s3", {"region_name": "us-east-1"}), ("s3", "us-east-1", None, None)),
+            (
+                ("s3", {"region_name": "us-east-1", "aws_access_key_id": "1234"}),
+                ("s3", "us-east-1", "1234", None),
+            ),
+            (
+                (
+                    "s3",
+                    {
+                        "region_name": "us-east-1",
+                        "aws_access_key_id": "1234",
+                        "config": config1,
+                    },
+                ),
+                ("s3", "us-east-1", "1234", config1),
+            ),
+            (
+                (
+                    "s3",
+                    {
+                        "region_name": "us-east-1",
+                        "aws_access_key_id": "1234",
+                        "config": config2,
+                    },
+                ),
+                ("s3", "us-east-1", "1234", config2),
+            ),
         ]
         for (service, kv), expected in cases:
             actual = utils.get_aws_connection_key(service, kv)
             self.assertEqual(actual, expected)
-            self.assertEqual({actual: 1}[actual], 1) # generated key can be used as a map key
+            self.assertEqual(
+                {actual: 1}[actual], 1
+            )  # generated key can be used as a map key
 
 
 class TestElementXmlString(unittest.TestCase):

--- a/tests/provider/test_utils.py
+++ b/tests/provider/test_utils.py
@@ -141,6 +141,9 @@ class TestUtils(unittest.TestCase):
         expected = "2021_01_01"
         self.assertEqual(utils.set_datestamp(glue), expected)
 
+    def test_get_current_datetime(self):
+        self.assertIsNotNone(utils.get_current_datetime())
+
     def test_get_doi_url(self):
         doi_url = utils.get_doi_url("10.7554/eLife.08411")
         self.assertEqual(doi_url, "https://doi.org/10.7554/eLife.08411")

--- a/tests/run/test_run_workflow_ping.py
+++ b/tests/run/test_run_workflow_ping.py
@@ -14,6 +14,7 @@ from starter.starter_Ping import starter_Ping as starter_class
 from workflow.workflow_Ping import workflow_Ping as workflow_class
 from provider import utils
 
+
 class TestRunWorkflowPing(unittest.TestCase):
     @mock_aws
     def setUp(self):

--- a/tests/run/test_run_workflow_ping.py
+++ b/tests/run/test_run_workflow_ping.py
@@ -88,10 +88,12 @@ class TestRunWorkflowPing(unittest.TestCase):
             domain=settings_mock.domain,
             startTimeFilter={
                 "oldestDate": (
-                    datetime.datetime.utcnow() - datetime.timedelta(days=365)
+                    datetime.datetime.now(datetime.timezone.utc)
+                    - datetime.timedelta(days=365)
                 ),
                 "latestDate": (
-                    datetime.datetime.utcnow() + datetime.timedelta(days=365)
+                    datetime.datetime.now(datetime.timezone.utc)
+                    + datetime.timedelta(days=365)
                 ),
             },
         )

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -3,6 +3,7 @@ import datetime
 from pytz import timezone
 from ddt import ddt, data
 from mock import patch
+from provider import utils
 import tests.settings_mock as settings_mock
 from tests.classes_mock import FakeSWFClient
 import cron
@@ -13,11 +14,8 @@ class TestCron(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_get_current_datetime(self):
-        self.assertIsNotNone(cron.get_current_datetime())
-
     @patch.object(cron, "start_workflow")
-    @patch.object(cron, "get_current_datetime")
+    @patch.object(utils, "get_current_datetime")
     @patch.object(cron, "workflow_conditional_start")
     @data(
         "1970-01-01 10:45:00",

--- a/workflow/objects.py
+++ b/workflow/objects.py
@@ -1,6 +1,7 @@
 import json
-import datetime
 import time
+from provider import utils
+
 
 """
 Amazon SWF workflow base class
@@ -289,7 +290,7 @@ class Workflow(object):
         """
         Return the current time in UTC for logging
         """
-        return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        return utils.get_current_datetime().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def activity_status(self, decision, activityType=None, activityID=None):
         """

--- a/workflow/objects.py
+++ b/workflow/objects.py
@@ -427,7 +427,6 @@ class Workflow(object):
 
     def check_for_failed_workflow_request(self, decision):
         try:
-
             # Traverse the array in reverse order
             # This is an optimisation since if there is a failure record it will
             # always be at the end of the array


### PR DESCRIPTION
…utcfromtimestamp() usage.

Re issue https://github.com/elifesciences/issues/issues/8825

Also, wanted to move the `get_current_datetime()` function out of `cron.py` to a better place for code re-use, now in `utils.py`.