### PR TITLE
Cleaner GET requests to data hub tweaks

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -391,17 +391,6 @@ def clean_inline_graphic_tags(root):
                 parent_tag.remove(tag)
 
 
-def url_exists(url, logger):
-    "check if URL exists and is successful status code"
-    exists = False
-    response = requests.get(url, timeout=REQUESTS_TIMEOUT)
-    if 200 <= response.status_code < 400:
-        exists = True
-    elif response.status_code >= 400:
-        logger.info("Status code for %s was %s" % (url, response.status_code))
-    return exists
-
-
 def get_docmap(url, user_agent=None):
     "GET request for the docmap json"
     headers = None

--- a/tests/provider/test_cleaner.py
+++ b/tests/provider/test_cleaner.py
@@ -698,30 +698,6 @@ class TestCleanInlineGraphicTags(unittest.TestCase):
         self.assertEqual(ElementTree.tostring(root).decode("utf8"), expected)
 
 
-class TestUrlExists(unittest.TestCase):
-    def setUp(self):
-        self.logger = FakeLogger()
-        self.url = "https://example.org/"
-
-    @patch("requests.get")
-    def test_url_exists_200(self, mock_requests_get):
-        status_code = 200
-        mock_requests_get.return_value = FakeResponse(status_code)
-        result = cleaner.url_exists(self.url, self.logger)
-        self.assertEqual(result, True)
-
-    @patch("requests.get")
-    def test_url_exists_404(self, mock_requests_get):
-        status_code = 404
-        mock_requests_get.return_value = FakeResponse(status_code)
-        result = cleaner.url_exists(self.url, self.logger)
-        self.assertEqual(result, False)
-        self.assertEqual(
-            self.logger.loginfo[-1],
-            "Status code for %s was %s" % (self.url, status_code),
-        )
-
-
 class TestGetDocmap(unittest.TestCase):
     def setUp(self):
         self.logger = FakeLogger()


### PR DESCRIPTION
Add a `user-agent` to the request headers, taken from the `user_agent` settings value.

Use a connection timeout and read timeout for the request.

The old `url_exists()` function is removed, not used anymore.