### PR TITLE
Fix finding email template for article-commentary non-POA.

### DIFF
--- a/activity/activity_PublicationEmail.py
+++ b/activity/activity_PublicationEmail.py
@@ -1036,6 +1036,8 @@ def email_type_from_rules(
                     return rule_data.get("email_type")
                 if int(version) > 1 and rule_data.get("first_version") is False:
                     return rule_data.get("email_type")
+            if not is_poa and not was_ever_poa and not rule_data.get("article_status"):
+                return rule_data.get("email_type")
             if is_poa is None and was_ever_poa is None:
                 return rule_data.get("email_type")
 

--- a/tests/activity/test_activity_publication_email.py
+++ b/tests/activity/test_activity_publication_email.py
@@ -1885,6 +1885,20 @@ class TestEmailTypeFromRules(unittest.TestCase):
         result = activity_module.email_type_from_rules(rules, article_type)
         self.assertEqual(result, expected)
 
+    def test_edge_case(self):
+        "edge case where is_poa and was_ever_poa are False instead of None"
+        rules = yaml_provider.load_config(
+            settings_mock, config_type="publication_email"
+        )
+        article_type = "article-commentary"
+        is_poa = False
+        was_ever_poa = False
+        expected = "author_publication_email_Insight_to_VOR"
+        result = activity_module.email_type_from_rules(
+            rules, article_type, is_poa=is_poa, was_ever_poa=was_ever_poa
+        )
+        self.assertEqual(result, expected)
+
 
 class TestRecipientsFromRules(unittest.TestCase):
     "tests for recipients_from_rules()"


### PR DESCRIPTION
I noticed an `Insight` article where the email template type could not be found. This will fix the specific situation for now, where the rule has no `article_status` value.