### PR TITLE
Consistent behaviour in FakeStorageContext

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -157,9 +157,9 @@ class FakeStorageContext:
 
     def get_resource_as_string(self, origin):
         bucket_name, s3_key = self.s3_storage_objects(origin)
-        file_name = os.path.join(self.dir, s3_key.rsplit("/", 1)[-1])
-        if os.path.exists(file_name):
-            with open(file_name, "rb") as fsrc:
+        src = self.dir + s3_key
+        if os.path.exists(src):
+            with open(src, "rb") as fsrc:
                 return fsrc.read()
         # default used by verify glencoe tests
         return '<mock><media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="wmv" mimetype="video" xlink:href="elife-00569-media1.wmv"></media></mock>'
@@ -175,8 +175,11 @@ class FakeStorageContext:
 
     def set_resource_from_string(self, resource, data, content_type=None):
         bucket_name, s3_key = self.s3_storage_objects(resource)
-        file_name = os.path.join(self.dir, s3_key.rsplit("/", 1)[-1])
-        with open(file_name, "wb") as open_file:
+        origin_file_name = s3_key.lstrip("/")
+        destination_path = os.path.join(self.dest_folder, origin_file_name)
+        # create folders if they do not exist
+        os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+        with open(destination_path, "wb") as open_file:
             try:
                 open_file.write(data)
             except TypeError:

--- a/tests/activity/test_activity_generate_swh_metadata.py
+++ b/tests/activity/test_activity_generate_swh_metadata.py
@@ -7,6 +7,7 @@ import activity.activity_GenerateSWHMetadata as activity_module
 from activity.activity_GenerateSWHMetadata import (
     activity_GenerateSWHMetadata as activity_object,
 )
+from provider import software_heritage
 from provider.article import article
 from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import (
@@ -63,14 +64,19 @@ class TestGenerateSWHMetadata(unittest.TestCase):
         self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
 
         # look at the metadata XML file contents
-        files = os.listdir(directory.path)
+        run_dir = os.path.join(
+            directory.path,
+            software_heritage.BUCKET_FOLDER,
+            testdata.SoftwareHeritageDeposit_data_example.get("run"),
+        )
+        files = os.listdir(run_dir)
         xml_files = [
             file_name
             for file_name in files
             if file_name != ".gitkeep" and file_name.endswith(".xml")
         ]
         metadata_file = xml_files[0]
-        with open(os.path.join(directory.path, metadata_file), "rb") as open_file:
+        with open(os.path.join(run_dir, metadata_file), "rb") as open_file:
             metadata_xml = open_file.read()
             self.assertTrue(
                 b"<title>Replication Study: Transcriptional amplification in tumor cells with elevated c-Myc</title>"

--- a/tests/activity/test_activity_generate_swh_readme.py
+++ b/tests/activity/test_activity_generate_swh_readme.py
@@ -7,6 +7,7 @@ import activity.activity_GenerateSWHReadme as activity_module
 from activity.activity_GenerateSWHReadme import (
     activity_GenerateSWHReadme as activity_object,
 )
+from provider import software_heritage
 from provider.article import article
 from tests.activity import helpers, settings_mock
 from tests.activity.classes_mock import (
@@ -60,17 +61,21 @@ class TestGenerateSWHReadme(unittest.TestCase):
         return_value = self.activity.do_activity(
             testdata.SoftwareHeritageDeposit_data_example
         )
-        self.assertEqual(return_value, self.activity.ACTIVITY_SUCCESS)
 
         # look at the file contents
-        files = os.listdir(directory.path)
+        run_dir = os.path.join(
+            directory.path,
+            software_heritage.BUCKET_FOLDER,
+            testdata.SoftwareHeritageDeposit_data_example.get("run"),
+        )
+        files = os.listdir(run_dir)
         readme_files = [
             file_name
             for file_name in files
             if file_name != ".gitkeep" and file_name.startswith("README")
         ]
         readme_file = readme_files[0]
-        with open(os.path.join(directory.path, readme_file), "rb") as open_file:
+        with open(os.path.join(run_dir, readme_file), "rb") as open_file:
             readme_string = open_file.read()
             self.assertTrue(
                 b'# Executable Research Article for "Replication Study: Transcriptional '

--- a/tests/provider/test_execution_context.py
+++ b/tests/provider/test_execution_context.py
@@ -93,7 +93,7 @@ class TestS3Session(unittest.TestCase):
         session_key = "session_key"
         key = "foo"
         value = "bar"
-        fake_storage_context.return_value = FakeStorageContext(directory.path, [])
+        fake_storage_context.return_value = FakeStorageContext(directory.path, dest_folder=directory.path)
         s3_session_object = S3Session(settings_mock, None, session_key)
         s3_session_object.store_value(key, value)
         self.assertEqual(s3_session_object.get_value(key), value)


### PR DESCRIPTION
Test class `FakeStorageContext` was usually omitting the folder paths when reading and writing. Some of these were modified, but not all.

The changes in this PR will retain the folder paths when calling `set_resource_from_string()` and `get_resource_as_string()` methods, to be more consistent with what the real S3 storage context does.

Three test scenarios are updated for their assertions to use the right local file path of mock S3 objects.