### PR TITLE
Modify email subject if error in EmailMecaOutput.

### DIFF
--- a/activity/activity_EmailMecaOutput.py
+++ b/activity/activity_EmailMecaOutput.py
@@ -59,9 +59,14 @@ class activity_EmailMecaOutput(Activity):
         "email the message to the recipients"
         success = True
 
+        # error status from keywords in body_content:
+        error = None
+        if "ValidateJatsDtd, validation error" in body_content:
+            error = True
+
         datetime_string = time.strftime(utils.DATE_TIME_FORMAT, time.gmtime())
         body = email_provider.simple_email_body(datetime_string, body_content)
-        subject = meca_email_subject(version_doi, self.settings)
+        subject = meca_email_subject(version_doi, self.settings, error)
         sender_email = self.settings.ses_poa_sender_email
 
         recipient_email_list = email_provider.list_email_recipients(
@@ -84,9 +89,12 @@ class activity_EmailMecaOutput(Activity):
         return success
 
 
-def meca_email_subject(version_doi, settings=None):
+def meca_email_subject(version_doi, settings=None, error=None):
     "the email subject"
     subject_prefix = ""
     if utils.settings_environment(settings) == "continuumtest":
         subject_prefix = "TEST "
-    return "%seLife ingest MECA: %s" % (subject_prefix, version_doi)
+    extra = ""
+    if error:
+        extra = "Error in "
+    return "%seLife ingest MECA: %s%s" % (subject_prefix, extra, version_doi)

--- a/tests/activity/test_activity_email_meca_output.py
+++ b/tests/activity/test_activity_email_meca_output.py
@@ -114,8 +114,41 @@ class TestEmailMecaOutput(unittest.TestCase):
         self.assertEqual(result, self.activity.ACTIVITY_PERMANENT_FAILURE)
 
 
+class TestSendEmail(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_class(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+        # clean the temporary directory
+        self.activity.clean_tmp_dir()
+
+    @patch.object(activity_module.email_provider, "smtp_connect")
+    def test_send_email_validate_error(
+        self,
+        fake_email_smtp_connect,
+    ):
+        "test email subject if email body contains an error"
+        directory = TempDirectory()
+        fake_email_smtp_connect.return_value = FakeSMTPServer(directory.path)
+        version_doi = "10.7554/eLife.95901.1"
+        body_content = "ValidateJatsDtd, validation error"
+        # do the activity
+        result = self.activity.send_email(version_doi, body_content)
+        self.assertEqual(result, True)
+        # check email files and contents
+        email_files_filter = os.path.join(directory.path, "*.eml")
+        email_files = glob.glob(email_files_filter)
+        with open(email_files[0], "r", encoding="utf8") as open_file:
+            first_email_content = open_file.read()
+        self.assertTrue(
+            "eLife ingest MECA: Error in 10.7554/eLife.95901.1" in first_email_content
+        )
+
+
 class TestEmailSubject(unittest.TestCase):
-    def test_mecan_email_subject(self):
+    def test_meca_email_subject(self):
         "email subject line with correct output_file value"
 
         class continuumtest:
@@ -124,6 +157,14 @@ class TestEmailSubject(unittest.TestCase):
         version_doi = "10.7554/eLife.95901.1"
         expected = "TEST eLife ingest MECA: %s" % version_doi
         subject = activity_module.meca_email_subject(version_doi, continuumtest)
+        self.assertEqual(subject, expected)
+
+    def test_meca_email_subject_error(self):
+        "email subject for an error email"
+        version_doi = "10.7554/eLife.95901.1"
+        error = True
+        expected = "eLife ingest MECA: Error in %s" % version_doi
+        subject = activity_module.meca_email_subject(version_doi, settings_mock, error)
         self.assertEqual(subject, expected)
 
     def test_no_settings_class_name(self):


### PR DESCRIPTION
Email subject to indicate if `ValidateJatsDtd` errors were included in the email body.

Re issue https://github.com/elifesciences/issues/issues/8765