### PR TITLE
Also compare published date in FindNewDocmaps.

### DIFF
--- a/activity/activity_FindNewDocmaps.py
+++ b/activity/activity_FindNewDocmaps.py
@@ -155,7 +155,7 @@ class activity_FindNewDocmaps(Activity):
 
         # compare previous docmap index to new docmap index
         new_meca_version_dois = docmap_provider.changed_version_doi_list(
-            docmap_index_json, prev_docmap_index_json
+            docmap_index_json, prev_docmap_index_json, self.logger
         )
         self.logger.info(
             "%s, got new_meca_version_dois: %s" % (self.name, new_meca_version_dois)

--- a/tests/activity/test_activity_find_new_docmaps.py
+++ b/tests/activity/test_activity_find_new_docmaps.py
@@ -57,10 +57,19 @@ class TestFindNewDocmaps(unittest.TestCase):
             "2024-06-27 +0000", "%Y-%m-%d %z"
         )
 
+        # remove the published dates from JSON
+        docmap_json_for_84364 = json.loads(read_fixture("sample_docmap_for_84364.json"))
+        del docmap_json_for_84364["steps"]["_:b2"]["actions"][0]["outputs"][0][
+            "published"
+        ]
+        docmap_json_for_87445 = json.loads(read_fixture("sample_docmap_for_87445.json"))
+        del docmap_json_for_87445["steps"]["_:b5"]["actions"][0]["outputs"][0][
+            "published"
+        ]
         sample_docmap_index = {
             "docmaps": [
-                json.loads(read_fixture("sample_docmap_for_84364.json")),
-                json.loads(read_fixture("sample_docmap_for_87445.json")),
+                docmap_json_for_84364,
+                docmap_json_for_87445,
             ]
         }
 


### PR DESCRIPTION
Include `published` date of the preprint when profiling a docmap, and omit previously published version DOI values from starting an `IngestMeca` workflow when `FindNewDocmaps` is run.

Re issue https://github.com/elifesciences/issues/issues/8896