### PR TITLE
Dependency `PyGithub` pinned to `2.3.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -41,7 +41,7 @@ GitPython = "~=3.1"
 PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
-PyGithub = "~=1.55"
+PyGithub = "~=2.3.0"
 elifecleaner = "~=0.62.0"
 
 [dev-packages]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-08-02 - see update-dependencies.sh
+# file generated 2024-08-12 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -64,7 +64,7 @@ pyasn1==0.6.0
 pyasn1_modules==0.4.0
 pycparser==2.22
 pyfunctional==1.5.0
-PyGithub==1.59.1
+PyGithub==2.3.0
 PyJWT==2.8.0
 pylint==2.17.7
 PyNaCl==1.5.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/245/display/redirect which resulted in this pull request.