### PR TITLE
Revert "Suspend automatic deposits to Crossref in cron."

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -94,15 +94,15 @@ def conditional_starts(current_datetime):
             )
         )
 
-        # conditional_start_list.append(
-        #    OrderedDict(
-        #        [
-        #            ("starter_name", "starter_DepositCrossref"),
-        #            ("workflow_id", "DepositCrossref"),
-        #            ("start_seconds", 60 * 3),
-        #        ]
-        #    )
-        # )
+        conditional_start_list.append(
+            OrderedDict(
+                [
+                    ("starter_name", "starter_DepositCrossref"),
+                    ("workflow_id", "DepositCrossref"),
+                    ("start_seconds", 60 * 3),
+                ]
+            )
+        )
 
     # Based on the minutes of the current time, run certain starters
     if current_time.tm_min >= 0 and current_time.tm_min <= 14:
@@ -149,15 +149,15 @@ def conditional_starts(current_datetime):
         # Jobs to start at quarter past the hour
         LOGGER.info("Quarter past the hour")
 
-        # conditional_start_list.append(
-        #    OrderedDict(
-        #        [
-        #            ("starter_name", "starter_DepositCrossrefPendingPublication"),
-        #            ("workflow_id", "DepositCrossrefPendingPublication"),
-        #            ("start_seconds", 60 * 31),
-        #        ]
-        #    )
-        # )
+        conditional_start_list.append(
+            OrderedDict(
+                [
+                    ("starter_name", "starter_DepositCrossrefPendingPublication"),
+                    ("workflow_id", "DepositCrossrefPendingPublication"),
+                    ("start_seconds", 60 * 31),
+                ]
+            )
+        )
 
         # Zendy deposits once per day 21:15 UTC
         if current_time.tm_hour == 21:

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -156,8 +156,8 @@ class TestConditionalStarts(unittest.TestCase):
         {
             "comment": "zero hour",
             "date_time": "1970-01-01 00:00:00 UTC",
-            "expected_starter_names": ["cron_FiveMinute"],
-            "expected_workflow_ids": ["cron_FiveMinute"],
+            "expected_starter_names": ["cron_FiveMinute", "starter_DepositCrossref"],
+            "expected_workflow_ids": ["cron_FiveMinute", "DepositCrossref"],
         }
     )
     def test_conditional_starts_00_00(self, test_data):
@@ -169,10 +169,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 00:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_FindNewDocmaps",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "FindNewDocmaps",
             ],
         }
@@ -186,11 +188,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 06:20:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "cron_NewS3POA",
                 "starter_FindNewPreprints",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "cron_NewS3POA",
                 "FindNewPreprints",
             ],
@@ -205,11 +209,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 06:25:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "cron_NewS3POA",
                 "starter_FindNewPreprints",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "cron_NewS3POA",
                 "FindNewPreprints",
             ],
@@ -224,11 +230,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 10:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PubmedArticleDeposit",
                 "AdminEmail",
             ],
@@ -243,11 +251,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-08-19 11:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "cron_NewS3POA",
                 "starter_FindNewDocmaps",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "cron_NewS3POA",
                 "FindNewDocmaps",
             ],
@@ -262,11 +272,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-10-27 12:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "cron_NewS3POA",
                 "starter_FindNewDocmaps",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "cron_NewS3POA",
                 "FindNewDocmaps",
             ],
@@ -281,10 +293,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-08-19 13:00:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PublishPOA",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PublishPOA",
             ],
         },
@@ -298,12 +312,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "2019-10-27 17:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PublicationEmail",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PublicationEmail",
                 "PubmedArticleDeposit",
                 "AdminEmail",
@@ -319,11 +335,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 20:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_FindNewDocmaps",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "FindNewDocmaps",
                 "PubRouterDeposit_PMC",
             ],
@@ -338,10 +356,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 21:15:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
+                "starter_DepositCrossrefPendingPublication",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
+                "DepositCrossrefPendingPublication",
                 "PubRouterDeposit_Zendy",
             ],
         },
@@ -355,11 +377,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 21:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_FindNewDocmaps",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "FindNewDocmaps",
                 "PubRouterDeposit_WoS",
             ],
@@ -374,6 +398,7 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 21:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PublicationEmail",
                 "starter_PubRouterDeposit",
                 "starter_PubmedArticleDeposit",
@@ -381,6 +406,7 @@ class TestConditionalStarts(unittest.TestCase):
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PublicationEmail",
                 "PubRouterDeposit_GoOA",
                 "PubmedArticleDeposit",
@@ -397,10 +423,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 22:00:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PubRouterDeposit_CLOCKSS",
             ],
         },
@@ -414,10 +442,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 22:15:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
+                "starter_DepositCrossrefPendingPublication",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
+                "DepositCrossrefPendingPublication",
                 "PubRouterDeposit_OVID",
             ],
         },
@@ -431,11 +463,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 22:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_FindNewDocmaps",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "FindNewDocmaps",
                 "PubRouterDeposit_OASwitchboard",
             ],
@@ -450,12 +484,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 22:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PubRouterDeposit",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PubRouterDeposit_Cengage",
                 "PubmedArticleDeposit",
                 "AdminEmail",
@@ -471,10 +507,12 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 23:00:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PubRouterDeposit_CNKI",
             ],
         },
@@ -488,10 +526,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 23:15:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
+                "starter_DepositCrossrefPendingPublication",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
+                "DepositCrossrefPendingPublication",
                 "PubRouterDeposit_Scilit",
             ],
         },
@@ -505,11 +547,13 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 23:30:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_FindNewDocmaps",
                 "starter_PubRouterDeposit",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "FindNewDocmaps",
                 "PubRouterDeposit_CNPIEC",
             ],
@@ -524,12 +568,14 @@ class TestConditionalStarts(unittest.TestCase):
             "date_time": "1970-01-01 23:45:00 UTC",
             "expected_starter_names": [
                 "cron_FiveMinute",
+                "starter_DepositCrossref",
                 "starter_PubRouterDeposit",
                 "starter_PubmedArticleDeposit",
                 "starter_AdminEmail",
             ],
             "expected_workflow_ids": [
                 "cron_FiveMinute",
+                "DepositCrossref",
                 "PubRouterDeposit_HEFCE",
                 "PubmedArticleDeposit",
                 "AdminEmail",


### PR DESCRIPTION
Reverts elifesciences/elife-bot#1959

For when automated Crossref deposits can be enabled again.