### PR TITLE
Move mock Github test classes for future re-use.

### DIFF
--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -290,3 +290,42 @@ class FakeLogger:
 
 FakeLaxProvider = MagicMock()
 FakeLaxProvider.get_xml_file_name = MagicMock(return_value="fake.xml")
+
+
+class FakeGithub:
+    "mock object for github.Github"
+
+    def get_user(self, login):
+        return FakeGithubNamedUser()
+
+
+class FakeGithubNamedUser:
+    "mock object for github.NamedUser.NamedUser"
+
+    def get_repo(self, full_name_or_id):
+        return FakeGithubRepository()
+
+
+class FakeGithubRepository:
+    "mock object for github.Repository.Repository"
+
+    def get_contents(self, path):
+        return FakeGithubContentFile()
+
+    def update_file(
+        self, path, message, content, sha, branch=None, committer=None, author=None
+    ):
+        pass
+
+    def create_file(
+        self, path, message, content, branch=None, committer=None, author=None
+    ):
+        pass
+
+
+class FakeGithubContentFile:
+    "mock object for github.ContentFile.ContentFile"
+
+    def __init__(self):
+        self.decoded_content = b"<article/>"
+        self.sha = "sha"

--- a/tests/activity/test_activity_update_repository.py
+++ b/tests/activity/test_activity_update_repository.py
@@ -4,46 +4,13 @@ from github import GithubException
 from mock import patch, MagicMock
 from activity.activity_UpdateRepository import activity_UpdateRepository, RetryException
 from tests.activity import settings_mock
-from tests.activity.classes_mock import FakeStorageContext, FakeLogger, FakeLaxProvider
-
-
-class FakeGithub:
-    "mock object for github.Github"
-
-    def get_user(self, login):
-        return FakeGithubNamedUser()
-
-
-class FakeGithubNamedUser:
-    "mock object for github.NamedUser.NamedUser"
-
-    def get_repo(self, full_name_or_id):
-        return FakeGithubRepository()
-
-
-class FakeGithubRepository:
-    "mock object for github.Repository.Repository"
-
-    def get_contents(self, path):
-        return FakeGithubContentFile()
-
-    def update_file(
-        self, path, message, content, sha, branch=None, committer=None, author=None
-    ):
-        pass
-
-    def create_file(
-        self, path, message, content, branch=None, committer=None, author=None
-    ):
-        pass
-
-
-class FakeGithubContentFile:
-    "mock object for github.ContentFile.ContentFile"
-
-    def __init__(self):
-        self.decoded_content = b"<article/>"
-        self.sha = "sha"
+from tests.activity.classes_mock import (
+    FakeStorageContext,
+    FakeGithub,
+    FakeGithubRepository,
+    FakeLogger,
+    FakeLaxProvider,
+)
 
 
 @patch("activity.activity_UpdateRepository.provider")


### PR DESCRIPTION
Move these from the tests for `UpdateRepository` to the central test module `classes_mock.py`.

Re issue https://github.com/elifesciences/issues/issues/8792