### PR TITLE
github_provider.py to add issue comments, in ValidateJatsDtd.

### DIFF
--- a/activity/activity_ValidateJatsDtd.py
+++ b/activity/activity_ValidateJatsDtd.py
@@ -1,6 +1,6 @@
 import os
 import json
-from provider import meca
+from provider import github_provider, meca
 from provider.execution_context import get_session
 from provider.storage_provider import storage_context
 from activity.objects import Activity
@@ -139,3 +139,28 @@ class activity_ValidateJatsDtd(Activity):
             )
             self.logger.info(log_message)
             meca.log_to_session("\n%s" % log_message, session)
+            # add as a Github issue comment
+            if (
+                hasattr(self.settings, "github_token")
+                and hasattr(self.settings, "preprint_issues_repo_name")
+                and self.settings.github_token
+                and self.settings.preprint_issues_repo_name
+            ):
+                try:
+                    issue = github_provider.find_github_issue(
+                        self.settings.github_token,
+                        self.settings.preprint_issues_repo_name,
+                        version_doi,
+                    )
+                    if issue:
+                        github_provider.add_github_comment(
+                            issue, "elife-bot workflow message:\n\n%s" % log_message
+                        )
+                except Exception as exception:
+                    self.logger.exception(
+                        (
+                            "%s, exception when adding a comment to Github "
+                            "for version DOI %s file %s. Details: %s"
+                        )
+                        % (self.name, version_doi, xml_file_path, str(exception))
+                    )

--- a/settings-example.py
+++ b/settings-example.py
@@ -377,6 +377,8 @@ class exp:
 
     meca_bucket = "meca_bucket"
 
+    preprint_issues_repo_name = "preprint-issues"
+
 
 class dev:
     # AWS settings
@@ -738,6 +740,8 @@ class dev:
     meca_dtd_endpoint = "https://example.org/dtd"
 
     meca_bucket = "meca_bucket"
+
+    preprint_issues_repo_name = "preprint-issues"
 
 
 class live:
@@ -1105,6 +1109,8 @@ class live:
     meca_dtd_endpoint = "https://example.org/dtd"
 
     meca_bucket = "meca_bucket"
+
+    preprint_issues_repo_name = "preprint-issues"
 
 
 def get_settings(ENV="dev"):

--- a/tests/activity/classes_mock.py
+++ b/tests/activity/classes_mock.py
@@ -322,6 +322,9 @@ class FakeGithubRepository:
     ):
         pass
 
+    def get_issues(self, *args, **kwargs):
+        pass
+
 
 class FakeGithubContentFile:
     "mock object for github.ContentFile.ContentFile"
@@ -329,3 +332,24 @@ class FakeGithubContentFile:
     def __init__(self):
         self.decoded_content = b"<article/>"
         self.sha = "sha"
+
+
+class FakeIssueComment:
+    "mock object for github.IssueComment.IssueComment"
+
+
+class FakeGithubIssue:
+    "mock object for github.Issue.Issue"
+
+    def __init__(self, title=None, number=None):
+        self.title = title
+        self.number = number
+
+    def __repr__(self) -> str:
+        return "{class_name}({params})".format(
+            class_name=self.__class__.__name__,
+            params=", ".join(['title="%s"' % self.title, "number=%d" % self.number]),
+        )
+
+    def create_comment(self, body):
+        return FakeIssueComment()

--- a/tests/activity/settings_mock.py
+++ b/tests/activity/settings_mock.py
@@ -273,6 +273,8 @@ meca_dtd_endpoint = "https://example.org/dtd"
 
 meca_bucket = "meca_bucket"
 
+preprint_issues_repo_name = "preprint-issues"
+
 
 @mock_aws
 def aws_conn(service, service_creation_kwargs):

--- a/tests/activity/test_activity_validate_jats_dtd.py
+++ b/tests/activity/test_activity_validate_jats_dtd.py
@@ -1,16 +1,18 @@
 # coding=utf-8
 
 import unittest
+import copy
 import os
 from mock import patch
 from testfixtures import TempDirectory
-from provider import meca
+from provider import github_provider, meca
 import activity.activity_ValidateJatsDtd as activity_module
 from activity.activity_ValidateJatsDtd import (
     activity_ValidateJatsDtd as activity_class,
 )
 from tests.activity import settings_mock, test_activity_data
 from tests.activity.classes_mock import (
+    FakeGithubIssue,
     FakeLogger,
     FakeStorageContext,
     FakeSession,
@@ -138,16 +140,19 @@ class TestValidateJatsDtd(unittest.TestCase):
 
     @patch.object(activity_module, "get_session")
     @patch.object(meca, "post_xml_file")
+    @patch.object(github_provider, "find_github_issue")
     @patch.object(activity_module, "storage_context")
     def test_invalid_response(
         self,
         fake_storage_context,
+        fake_find_github_issue,
         fake_post_xml_file,
         fake_session,
     ):
         "test response content for invalid XML"
+        fake_find_github_issue.return_value = FakeGithubIssue()
         directory = TempDirectory()
-        mock_session = FakeSession(SESSION_DICT)
+        mock_session = FakeSession(copy.copy(SESSION_DICT))
         fake_session.return_value = mock_session
         destination_path = os.path.join(
             directory.path,
@@ -174,7 +179,73 @@ class TestValidateJatsDtd(unittest.TestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(
             mock_session.get_value("log_messages"),
-            ("\n%s, validation error for version DOI %s file %s/content/24301711.xml: %s")
+            (
+                "\n%s, validation error for version DOI %s file %s/content/24301711.xml: %s"
+            )
+            % (
+                self.activity.name,
+                SESSION_DICT.get("version_doi"),
+                self.activity.directories.get("INPUT_DIR"),
+                errors.decode("utf-8"),
+            ),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(meca, "post_xml_file")
+    @patch.object(github_provider, "find_github_issue")
+    @patch.object(activity_module, "storage_context")
+    def test_github_exception(
+        self,
+        fake_storage_context,
+        fake_find_github_issue,
+        fake_post_xml_file,
+        fake_session,
+    ):
+        "test if Github communication raises an error"
+        fake_find_github_issue.side_effect = Exception("An exception")
+        directory = TempDirectory()
+        mock_session = FakeSession(copy.copy(SESSION_DICT))
+        fake_session.return_value = mock_session
+        destination_path = os.path.join(
+            directory.path,
+            SESSION_DICT.get("expanded_folder"),
+            SESSION_DICT.get("article_xml_path"),
+        )
+        # create folders if they do not exist
+        os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+        xml_string = b"<root/>"
+        errors = b"[]"
+        validation_content = b'{\n  "status":"invalid",\n  "errors":%s\n}' % errors
+        with open(destination_path, "wb") as open_file:
+            open_file.write(xml_string)
+        fake_storage_context.return_value = FakeStorageContext(
+            directory=directory.path,
+            dest_folder=directory.path,
+            resources=[SESSION_DICT.get("article_xml_path")],
+        )
+        fake_post_xml_file.return_value = validation_content
+        expected_result = activity_class.ACTIVITY_SUCCESS
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # check assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "%s, exception when adding a comment to Github for version DOI %s "
+                "file %s/content/24301711.xml. Details: An exception"
+            )
+            % (
+                self.activity.name,
+                SESSION_DICT.get("version_doi"),
+                self.activity.directories.get("INPUT_DIR"),
+            ),
+        )
+        self.assertEqual(
+            mock_session.get_value("log_messages"),
+            (
+                "\n%s, validation error for version DOI %s file %s/content/24301711.xml: %s"
+            )
             % (
                 self.activity.name,
                 SESSION_DICT.get("version_doi"),

--- a/tests/provider/test_github_provider.py
+++ b/tests/provider/test_github_provider.py
@@ -1,0 +1,78 @@
+import unittest
+from mock import patch
+from provider import github_provider
+from tests import settings_mock
+from tests.activity.classes_mock import (
+    FakeGithub,
+    FakeGithubIssue,
+    FakeGithubRepository,
+)
+
+
+class TestMatchIssueTitle(unittest.TestCase):
+    "tests for match_issue_title()"
+
+    def test_match_issue_title(self):
+        "test title matching article_id MSID and version"
+        title = "MSID: 95901 Version: 1 DOI x"
+        msid = 95901
+        version = 1
+        result = github_provider.match_issue_title(title, msid, version)
+        self.assertEqual(result, True)
+
+    def test_no_match(self):
+        "test if the title does not match"
+        title = "MSID: 5 Version: b DOI x"
+        msid = 95901
+        version = 1
+        result = github_provider.match_issue_title(title, msid, version)
+        self.assertEqual(result, False)
+
+    def test_blank_title(self):
+        "test if the title is blank"
+        title = ""
+        msid = 95901
+        version = 1
+        result = github_provider.match_issue_title(title, msid, version)
+        self.assertEqual(result, False)
+
+
+class TestFindGithubIssue(unittest.TestCase):
+    "tests for find_github_issue()"
+
+    @patch.object(FakeGithubRepository, "get_issues")
+    @patch.object(github_provider, "Github")
+    def test_find_github_issue(self, fake_github, fake_get_issues):
+        "test find_github_issue matches an issue"
+
+        fake_github.return_value = FakeGithub()
+        fake_get_issues.return_value = [
+            FakeGithubIssue(
+                title="MSID: 96848 Version: 2 DOI: 10.1101/2024.01.31.xxxx96848",
+                number=1,
+            ),
+            FakeGithubIssue(
+                title="MSID: 95901 Version: 1 DOI: 10.1101/2024.01.31.xxxx95901",
+                number=2,
+            ),
+        ]
+        version_doi = "10.7554/eLife.95901.1"
+        # invoke
+        result = github_provider.find_github_issue(settings_mock.github_token, settings_mock.preprint_issues_repo_name, version_doi)
+        # assert
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result.title, "MSID: 95901 Version: 1 DOI: 10.1101/2024.01.31.xxxx95901"
+        )
+
+    @patch.object(FakeGithubRepository, "get_issues")
+    @patch.object(github_provider, "Github")
+    def test_no_issue(self, fake_github, fake_get_issues):
+        "test if no issue matches"
+        fake_github.return_value = FakeGithub()
+        fake_get_issues.return_value = []
+        version_doi = "10.7554/eLife.95901.1"
+        # invoke
+        result = github_provider.find_github_issue(settings_mock.github_token, settings_mock.preprint_issues_repo_name, version_doi)
+        # assert
+        self.assertEqual(result, None)

--- a/tests/settings_mock.py
+++ b/tests/settings_mock.py
@@ -62,6 +62,8 @@ crossref_login_passwd = ""
 # Logging
 setLevel = "INFO"
 
+github_token = "1234567890abcdef"
+
 # PDF cover
 pdf_cover_generator = "https://localhost/personalised-covers/"
 pdf_cover_landing_page = "https://localhost.org/download-your-cover/"
@@ -119,6 +121,8 @@ user_agent = "user_agent/version (https://example.org)"
 
 meca_xsl_endpoint = "https://example.org/xsl"
 meca_dtd_endpoint = "https://example.org/dtd"
+
+preprint_issues_repo_name = "preprint-issues"
 
 
 @mock_aws


### PR DESCRIPTION
Module `github_provider.py` can add comments to preprint repo Github issues, finding the right one by manuscript ID and version matching the title. If `ValidateJatsDtd` gets validation errors, the errors will be added as a Github comment.

There may be a tweak to this code after more testing.

Re issue https://github.com/elifesciences/issues/issues/8792