### PR TITLE
Send Crossref deposit emails only if all were uploaded successfully.

### DIFF
--- a/activity/activity_DepositCrossref.py
+++ b/activity/activity_DepositCrossref.py
@@ -208,8 +208,8 @@ class activity_DepositCrossref(Activity):
         )
 
         # Send email
-        # Only if there were files approved for publishing
-        if self.good_xml_files:
+        # Only if there were files approved for publishing and all were sent successfully
+        if self.good_xml_files and self.statuses.get("publish") is True:
             self.statuses["email"] = self.send_admin_email(
                 outbox_s3_key_names, http_detail_list
             )

--- a/activity/activity_DepositCrossrefMinimal.py
+++ b/activity/activity_DepositCrossrefMinimal.py
@@ -159,8 +159,8 @@ class activity_DepositCrossrefMinimal(Activity):
         )
 
         # Send email
-        # Only if there were files approved for publishing
-        if self.good_xml_files:
+        # Only if there were files approved for publishing and all were sent successfully
+        if self.good_xml_files and self.statuses.get("publish") is True:
             self.statuses["email"] = self.send_admin_email(
                 outbox_s3_key_names, http_detail_list
             )

--- a/activity/activity_DepositCrossrefPeerReview.py
+++ b/activity/activity_DepositCrossrefPeerReview.py
@@ -182,8 +182,8 @@ class activity_DepositCrossrefPeerReview(Activity):
         )
 
         # Send email
-        # Only if there were files approved for publishing
-        if self.good_xml_files:
+        # Only if there were files approved for publishing and all were sent successfully
+        if self.good_xml_files and self.statuses.get("publish") is True:
             self.statuses["email"] = self.send_admin_email(
                 outbox_s3_key_names, http_detail_list
             )

--- a/activity/activity_DepositCrossrefPendingPublication.py
+++ b/activity/activity_DepositCrossrefPendingPublication.py
@@ -249,8 +249,8 @@ class activity_DepositCrossrefPendingPublication(Activity):
         )
 
         # Send email
-        # Only if there were files approved for publishing
-        if self.good_xml_files:
+        # Only if there were files approved for publishing and all were sent successfully
+        if self.good_xml_files and self.statuses.get("publish") is True:
             self.statuses["email"] = self.send_admin_email(
                 outbox_s3_key_names, http_detail_list
             )

--- a/activity/activity_DepositCrossrefPostedContent.py
+++ b/activity/activity_DepositCrossrefPostedContent.py
@@ -268,8 +268,8 @@ class activity_DepositCrossrefPostedContent(Activity):
         )
 
         # Send email
-        # Only if there were files approved for publishing
-        if self.good_xml_files:
+        # Only if there were files approved for publishing and all were sent successfully
+        if self.good_xml_files and self.statuses.get("publish") is True:
             self.statuses["email"] = self.send_admin_email(
                 outbox_s3_key_names, http_detail_list
             )

--- a/tests/activity/test_activity_deposit_crossref.py
+++ b/tests/activity/test_activity_deposit_crossref.py
@@ -155,7 +155,7 @@ class TestDepositCrossref(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": False,
             "expected_outbox_status": None,
-            "expected_email_status": True,
+            "expected_email_status": None,
             "expected_activity_status": False,
             "expected_file_count": 1,
         },

--- a/tests/activity/test_activity_deposit_crossref_minimal.py
+++ b/tests/activity/test_activity_deposit_crossref_minimal.py
@@ -102,7 +102,7 @@ class TestDepositCrossrefMinimal(unittest.TestCase):
             "expected_generate_status": True,
             "expected_publish_status": False,
             "expected_outbox_status": None,
-            "expected_email_status": True,
+            "expected_email_status": None,
             "expected_activity_status": False,
             "expected_file_count": 1,
         },


### PR DESCRIPTION
A simple change for now to not send emails when any Crossref deposits were unsuccessfully, in preparation for planned Crossref API downtime.

Re issue https://github.com/elifesciences/issues/issues/8921