### PR TITLE
More accurate log message when downloading MECA XML.

### DIFF
--- a/activity/activity_MecaXslt.py
+++ b/activity/activity_MecaXslt.py
@@ -71,11 +71,12 @@ class activity_MecaXslt(Activity):
         )
 
         # download XML from the bucket folder
+        storage_resource_origin = orig_resource + "/" + article_xml_path
         self.logger.info(
-            "%s, downloading %s to %s" % (self.name, orig_resource, xml_file_path)
+            "%s, downloading %s to %s"
+            % (self.name, storage_resource_origin, xml_file_path)
         )
         with open(xml_file_path, "wb") as open_file:
-            storage_resource_origin = orig_resource + "/" + article_xml_path
             storage.get_resource_to_file(storage_resource_origin, open_file)
         self.statuses["download"] = True
 

--- a/activity/activity_ValidateJatsDtd.py
+++ b/activity/activity_ValidateJatsDtd.py
@@ -71,11 +71,12 @@ class activity_ValidateJatsDtd(Activity):
         )
 
         # download XML from the bucket folder
+        storage_resource_origin = orig_resource + "/" + article_xml_path
         self.logger.info(
-            "%s, downloading %s to %s" % (self.name, orig_resource, xml_file_path)
+            "%s, downloading %s to %s"
+            % (self.name, storage_resource_origin, xml_file_path)
         )
         with open(xml_file_path, "wb") as open_file:
-            storage_resource_origin = orig_resource + "/" + article_xml_path
             storage.get_resource_to_file(storage_resource_origin, open_file)
         self.statuses["download"] = True
 

--- a/activity/activity_ValidatePreprintSchematron.py
+++ b/activity/activity_ValidatePreprintSchematron.py
@@ -76,11 +76,12 @@ class activity_ValidatePreprintSchematron(Activity):
         )
 
         # download XML from the bucket folder
+        storage_resource_origin = orig_resource + "/" + article_xml_path
         self.logger.info(
-            "%s, downloading %s to %s" % (self.name, orig_resource, xml_file_path)
+            "%s, downloading %s to %s"
+            % (self.name, storage_resource_origin, xml_file_path)
         )
         with open(xml_file_path, "wb") as open_file:
-            storage_resource_origin = orig_resource + "/" + article_xml_path
             storage.get_resource_to_file(storage_resource_origin, open_file)
         self.statuses["download"] = True
 


### PR DESCRIPTION
Log messages were not including the full S3 bucket path from where the XML was downloaded, fixed here.