### PR TITLE
Cleaner provider arguments

### DIFF
--- a/activity/activity_TransformAcceptedSubmission.py
+++ b/activity/activity_TransformAcceptedSubmission.py
@@ -187,7 +187,7 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
     def set_volume_tag(self, article_id, xml_file_path, input_filename, docmap_string):
         "from the docmap calculate the volume value and set the volume XML tag text"
         # get volume from the docmap
-        volume = cleaner.volume_from_docmap(docmap_string, input_filename)
+        volume = cleaner.volume_from_docmap(docmap_string, identifier=input_filename)
         self.logger.info(
             "%s, from article %s docmap got volume value: %s",
             self.name,
@@ -212,8 +212,10 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
         self, article_id, xml_file_path, input_filename, docmap_string
     ):
         "from the docmap get the elocation-id value and set the elocation-id XML tag text"
-        # get volume from the docmap
-        elocation_id = cleaner.elocation_id_from_docmap(docmap_string, input_filename)
+        # get elocation-id from the docmap
+        elocation_id = cleaner.elocation_id_from_docmap(
+            docmap_string, identifier=input_filename
+        )
         self.logger.info(
             "%s, from article %s docmap got elocation_id value: %s",
             self.name,
@@ -221,7 +223,7 @@ class activity_TransformAcceptedSubmission(AcceptedBaseActivity):
             elocation_id,
         )
         if elocation_id:
-            # modify the volume tag text
+            # modify the elocation-id tag text
             root = cleaner.parse_article_xml(xml_file_path)
             elocation_id_tag = root.find("front/article-meta/elocation-id")
             if elocation_id_tag is not None:

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -522,12 +522,12 @@ def add_pub_history(root, history_data, identifier):
     return prc.add_pub_history(root, history_data, identifier)
 
 
-def volume_from_docmap(docmap_string, input_filename):
-    return prc.volume_from_docmap(docmap_string, input_filename)
+def volume_from_docmap(docmap_string, identifier=None):
+    return prc.volume_from_docmap(docmap_string, identifier=identifier)
 
 
-def elocation_id_from_docmap(docmap_string, input_filename):
-    return prc.elocation_id_from_docmap(docmap_string, input_filename)
+def elocation_id_from_docmap(docmap_string, identifier=None):
+    return prc.elocation_id_from_docmap(docmap_string, identifier=identifier)
 
 
 def version_doi_from_docmap(docmap_string, input_filename, published=True):

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -364,11 +364,15 @@ def sub_article_data(docmap_string, article, version_doi=None, generate_dois=Tru
     )
 
 
-def add_sub_article_xml(docmap_string, article_xml, terms_yaml=None, generate_dois=True):
+def add_sub_article_xml(
+    docmap_string, article_xml, terms_yaml=None, generate_dois=True
+):
     if terms_yaml:
         # set the path to the YAML file containing assessment terms data
         assessment_terms.ASSESSMENT_TERMS_YAML = terms_yaml
-    return sub_article.add_sub_article_xml(docmap_string, article_xml, generate_dois=generate_dois)
+    return sub_article.add_sub_article_xml(
+        docmap_string, article_xml, generate_dois=generate_dois
+    )
 
 
 def pretty_sub_article_xml(root):
@@ -548,8 +552,12 @@ def xml_rewrite_file_tags(xml_file_path, file_transformations, identifier):
     transform.xml_rewrite_file_tags(xml_file_path, file_transformations, identifier)
 
 
-def write_xml_file(root, xml_asset_path, identifier, doctype_dict=None, processing_instructions=None):
-    transform.write_xml_file(root, xml_asset_path, identifier, doctype_dict, processing_instructions)
+def write_xml_file(
+    root, xml_asset_path, identifier, doctype_dict=None, processing_instructions=None
+):
+    transform.write_xml_file(
+        root, xml_asset_path, identifier, doctype_dict, processing_instructions
+    )
 
 
 def bucket_asset_file_name_map(settings, bucket_name, expanded_folder):


### PR DESCRIPTION
In preparation for some refactoring of the `elifecleaner` library, these function calls can be made to be more forwards-compatible by specifying the `identifier` argument.

Re issue https://github.com/elifesciences/issues/issues/8586