### PR TITLE
Bug fix cleaner.elocation_id_from_docmap() version_doi argument.

### DIFF
--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -533,7 +533,9 @@ def volume_from_docmap(docmap_string, version_doi=None, identifier=None):
 
 
 def elocation_id_from_docmap(docmap_string, version_doi=None, identifier=None):
-    return prc.elocation_id_from_docmap(docmap_string, version_doi=None, identifier=identifier)
+    return prc.elocation_id_from_docmap(
+        docmap_string, version_doi=version_doi, identifier=identifier
+    )
 
 
 def version_doi_from_docmap(docmap_string, input_filename, published=True):


### PR DESCRIPTION
Fix to PR https://github.com/elifesciences/elife-bot/pull/1985, `version_doi=None` to `version_doi=version_doi`