### PR TITLE
Dependency `elifecleaner` pinned to `0.68.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=2.3.0"
-elifecleaner = "~=0.67.0"
+elifecleaner = "~=0.68.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-09-18 - see update-dependencies.sh
+# file generated 2024-09-20 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -20,7 +20,7 @@ docker==7.1.0
 docmaptools==0.23.0
 ejpcsvparser==0.3.1
 elifearticle==0.19.0
-elifecleaner==0.67.0
+elifecleaner==0.68.0
 elifecrossref==0.34.0
 elifepubmed==0.7.0
 elifetools==0.40.0

--- a/tests/activity/test_activity_accepted_submission_history.py
+++ b/tests/activity/test_activity_accepted_submission_history.py
@@ -119,7 +119,7 @@ class TestAcceptedSubmissionHistory(unittest.TestCase):
         self.assertTrue(
             xml_content.count(
                 (
-                    '<date date-type="sent-for-review">'
+                    '<date date-type="sent-for-review" iso-8601-date="2022-11-28">'
                     "<day>28</day><month>11</month><year>2022</year>"
                     "</date>"
                     "</history>"


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/255/display/redirect which resulted in this pull request.