### PR TITLE
remove end2end test from pipeline elifesciences/issues#8940

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,17 +20,6 @@ elifePipeline {
     }
 
     elifeMainlineOnly {
-        stage 'End2end tests', {
-            elifeSpectrum(
-                deploy: [
-                    stackname: 'elife-bot--end2end',
-                    revision: commit,
-                    folder: '/opt/elife-bot',
-                ],
-                marker: 'bot'
-            )
-        }
-
         stage 'Deploy on continuumtest', {
             lock('elife-bot--continuumtest') {
                 builderDeployRevision 'elife-bot--continuumtest', commit


### PR DESCRIPTION
Since end2end test is not [being run on journal ](https://github.com/elifesciences/journal/pull/1895) they are starting to fail.
We've also moved `search` to the cluster, so we are dismantling all deployments including end2end tests.
So we're removing all end2end tests pipelines