### PR TITLE
Dependency `elifecleaner` pinned to `0.71.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=2.3.0"
-elifecleaner = "~=0.70.0"
+elifecleaner = "~=0.71.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/activity/activity_AcceptedSubmissionHistory.py
+++ b/activity/activity_AcceptedSubmissionHistory.py
@@ -72,7 +72,7 @@ class activity_AcceptedSubmissionHistory(AcceptedBaseActivity):
 
         # get the under-review date from the docmap
         review_date_string = cleaner.review_date_from_docmap(
-            docmap_string, input_filename
+            docmap_string, identifier=input_filename
         )
         self.logger.info(
             "%s, %s review_date_string: %s"

--- a/provider/cleaner.py
+++ b/provider/cleaner.py
@@ -15,6 +15,7 @@ from elifecleaner import (
     fig,
     parse,
     prc,
+    pub_history,
     sub_article,
     table,
     transform,
@@ -500,8 +501,8 @@ def get_docmap_string_with_retry(settings, article_id, caller_name, logger):
     return docmap_string
 
 
-def review_date_from_docmap(docmap_string, input_filename):
-    return prc.review_date_from_docmap(docmap_string, input_filename)
+def review_date_from_docmap(docmap_string, identifier=None):
+    return prc.review_date_from_docmap(docmap_string, identifier=identifier)
 
 
 def date_struct_from_string(date_string):
@@ -522,8 +523,10 @@ def docmap_preprint_history_from_docmap(docmap_string):
     return docmap_parse.docmap_preprint_history(d_json)
 
 
-def add_pub_history(root, history_data, identifier):
-    return prc.add_pub_history(root, history_data, identifier)
+def add_pub_history(root, history_data, docmap_string=None, identifier=None):
+    return pub_history.add_pub_history(
+        root, history_data, docmap_string=docmap_string, identifier=identifier
+    )
 
 
 def volume_from_docmap(docmap_string, version_doi=None, identifier=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-10-09 - see update-dependencies.sh
+# file generated 2024-10-22 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==4.0.3
@@ -20,7 +20,7 @@ docker==7.1.0
 docmaptools==0.26.0
 ejpcsvparser==0.4.0
 elifearticle==0.20.0
-elifecleaner==0.70.0
+elifecleaner==0.71.0
 elifecrossref==0.34.0
 elifepubmed==0.7.0
 elifetools==0.40.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/264/display/redirect which resulted in this pull request.