### PR TITLE
Dependency `elifecleaner` pinned to `0.72.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=2.3.0"
-elifecleaner = "~=0.71.0"
+elifecleaner = "~=0.72.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docker==7.1.0
 docmaptools==0.26.0
 ejpcsvparser==0.4.0
 elifearticle==0.20.0
-elifecleaner==0.71.0
+elifecleaner==0.72.0
 elifecrossref==0.34.0
 elifepubmed==0.7.0
 elifetools==0.40.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/267/display/redirect which resulted in this pull request.