### PR TITLE
Add peer_review module, use in AcceptedSubmissionPeerReviewImages.

### DIFF
--- a/provider/peer_review.py
+++ b/provider/peer_review.py
@@ -1,0 +1,129 @@
+import os
+import shutil
+from collections import OrderedDict
+import requests
+from provider import utils
+from provider.article_processing import file_extension
+
+
+INF_FILE_NAME_ID_FORMAT = "inf%s"
+
+INF_FILE_NAME_FORMAT = "elife-%s-%s.%s"
+
+REQUESTS_TIMEOUT = 10
+
+
+def download_file(from_path, to_file, user_agent=None):
+    "download file to disk"
+    headers = None
+    if user_agent:
+        headers = {"user-agent": user_agent}
+    request = requests.get(from_path, timeout=REQUESTS_TIMEOUT, headers=headers)
+    if request.status_code == 200:
+        with open(to_file, "wb") as open_file:
+            open_file.write(request.content)
+        return to_file
+    raise RuntimeError(
+        "GET request returned a %s status code for %s"
+        % (request.status_code, from_path)
+    )
+
+
+def download_images(href_list, to_dir, activity_name, logger, user_agent=None):
+    "download images from imgur"
+    href_to_file_name_map = OrderedDict()
+    for href in href_list:
+        file_name = href.rsplit("/", 1)[-1]
+        to_file = os.path.join(to_dir, file_name)
+        # todo!!! improve handling of potentially duplicate file_name values
+        if href in href_to_file_name_map.keys():
+            logger.info("%s, href %s was already downloaded" % (activity_name, href))
+            continue
+        try:
+            file_path = download_file(href, to_file, user_agent)
+        except RuntimeError as exception:
+            logger.info(str(exception))
+            logger.info("%s, href %s could not be downloaded" % (activity_name, href))
+            continue
+        logger.info("%s, downloaded href %s to %s" % (activity_name, href, to_file))
+        # keep track of a map of href value to local file_name
+        href_to_file_name_map[href] = file_path
+    return href_to_file_name_map
+
+
+def generate_new_image_file_names(
+    href_to_file_name_map,
+    article_id,
+    identifier,
+    caller_name,
+    logger,
+):
+    "generate new file names for inline figure files"
+    file_name_count = 1
+    file_details_list = []
+    for href, file_name in href_to_file_name_map.items():
+        file_name_id = INF_FILE_NAME_ID_FORMAT % file_name_count
+        new_file_name = INF_FILE_NAME_FORMAT % (
+            utils.pad_msid(article_id),
+            file_name_id,
+            file_extension(file_name),
+        )
+        logger.info(
+            "%s, for %s, file name %s changed to file name %s"
+            % (caller_name, identifier, file_name, new_file_name)
+        )
+
+        # add the file details for using later to add XML file tags
+        file_details = {
+            "from_href": href,
+            "file_name": file_name,
+            "file_type": "figure",
+            "upload_file_nm": new_file_name,
+            "id": file_name_id,
+        }
+        file_details_list.append(file_details)
+
+        # increment the file name counter
+        file_name_count += 1
+    return file_details_list
+
+
+def generate_new_image_file_paths(
+    file_details_list,
+    content_subfolder,
+    identifier,
+    caller_name,
+    logger,
+):
+    "generate new file path for new file names"
+    for detail in file_details_list:
+        new_file_asset = os.path.join(content_subfolder, detail.get("upload_file_nm"))
+        detail["href"] = new_file_asset
+        logger.info(
+            "%s, for %s, file %s new asset value %s"
+            % (caller_name, identifier, detail.get("upload_file_nm"), new_file_asset)
+        )
+    return file_details_list
+
+
+def modify_href_to_file_name_map(href_to_file_name_map, file_details_list):
+    "generate new XML href to file name map from file details list"
+    for detail in file_details_list:
+        href_to_file_name_map[detail.get("from_href")] = detail.get("upload_file_nm")
+    return href_to_file_name_map
+
+
+def move_images(file_details_list, to_dir, identifier, caller_name, logger):
+    "move images from old to new file path"
+    image_asset_file_name_map = {}
+    for detail in file_details_list:
+        new_file_path = os.path.join(to_dir, detail.get("href"))
+        logger.info(
+            "%s, for %s, moving %s to %s"
+            % (caller_name, identifier, detail.get("file_name"), new_file_path)
+        )
+        # move the file on disk
+        shutil.move(detail.get("file_name"), new_file_path)
+        # add the file path to the asset map
+        image_asset_file_name_map[detail.get("href")] = new_file_path
+    return image_asset_file_name_map

--- a/tests/provider/test_peer_review.py
+++ b/tests/provider/test_peer_review.py
@@ -1,0 +1,296 @@
+# coding=utf-8
+
+import os
+import unittest
+from mock import patch
+from testfixtures import TempDirectory
+from tests.activity.classes_mock import FakeLogger, FakeResponse
+from provider import peer_review
+
+
+class TestDownloadFile(unittest.TestCase):
+    "tests for download_file()"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("requests.get")
+    def test_download_file(self, fake_get):
+        "test downloading file by GET request to disk"
+        fake_get.return_value = FakeResponse(200, content=b"test")
+        directory = TempDirectory()
+        from_path = "https://example.org/from.jpg"
+        to_file = os.path.join(directory.path, "to.jpg")
+        user_agent = "test"
+        # invoke
+        result = peer_review.download_file(from_path, to_file, user_agent)
+        # assert
+        self.assertEqual(result, to_file)
+
+    @patch("requests.get")
+    def test_exception(self, fake_get):
+        "test requests raises exception"
+        fake_get.return_value = FakeResponse(404)
+        directory = TempDirectory()
+        from_path = "https://example.org/from.jpg"
+        to_file = os.path.join(directory.path, "to.jpg")
+        user_agent = "test"
+        # invoke
+        with self.assertRaises(RuntimeError):
+            peer_review.download_file(from_path, to_file, user_agent)
+
+
+class TestDownloadImages(unittest.TestCase):
+    "tests for download_images()"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("requests.get")
+    def test_download_images(self, fake_get):
+        "test download a list of images"
+        fake_get.return_value = FakeResponse(200, content=b"test")
+        logger = FakeLogger()
+        directory = TempDirectory()
+        from_url = "https://example.org/from.jpg"
+        href_list = [from_url, from_url]
+        to_dir = directory.path
+        activity_name = "MecaPeerReviewImages"
+        user_agent = "test"
+        expected = {href_list[0]: os.path.join(directory.path, "from.jpg")}
+        # invoke
+        result = peer_review.download_images(
+            href_list, to_dir, activity_name, logger, user_agent
+        )
+        # assert
+        self.assertDictEqual(result, expected)
+        self.assertEqual(
+            logger.loginfo[-1],
+            "%s, href %s was already downloaded" % (activity_name, from_url),
+        )
+        self.assertEqual(
+            logger.loginfo[-2],
+            "%s, downloaded href %s to %s/from.jpg"
+            % (activity_name, from_url, directory.path),
+        )
+
+    @patch("requests.get")
+    def test_exception(self, fake_get):
+        "test exception raised downloading images"
+        fake_get.return_value = FakeResponse(404)
+        logger = FakeLogger()
+        directory = TempDirectory()
+        from_url = "https://example.org/from.jpg"
+        href_list = [from_url]
+        to_dir = directory.path
+        activity_name = "MecaPeerReviewImages"
+        user_agent = "test"
+        expected = {}
+        # invoke
+        result = peer_review.download_images(
+            href_list, to_dir, activity_name, logger, user_agent
+        )
+        # assert
+        self.assertDictEqual(result, expected)
+        self.assertEqual(
+            logger.loginfo[-1],
+            "%s, href %s could not be downloaded" % (activity_name, from_url),
+        )
+        self.assertEqual(
+            logger.loginfo[-2],
+            "GET request returned a 404 status code for %s" % from_url,
+        )
+
+
+class TestGenerateNewImageFileNames(unittest.TestCase):
+    "tests for generate_new_image_file_names()"
+
+    def test_generate_new_image_file_names(self):
+        "test generating new file name and details for image files"
+        href_to_file_name_map = {
+            "https://i.imgur.com/vc4GR10.png": "tmp/2024-11-04.23.52.26/input_dir/vc4GR10.png",
+            "https://i.imgur.com/FFeuydR.jpg": "tmp/2024-11-04.23.52.26/input_dir/FFeuydR.jpg",
+        }
+        article_id = "95901"
+        identifier = "10.7554/eLife.95901.1"
+        caller_name = "MecaPeerReviewImages"
+        logger = FakeLogger()
+        expected = [
+            {
+                "from_href": "https://i.imgur.com/vc4GR10.png",
+                "file_name": "tmp/2024-11-04.23.52.26/input_dir/vc4GR10.png",
+                "file_type": "figure",
+                "upload_file_nm": "elife-95901-inf1.png",
+                "id": "inf1",
+            },
+            {
+                "from_href": "https://i.imgur.com/FFeuydR.jpg",
+                "file_name": "tmp/2024-11-04.23.52.26/input_dir/FFeuydR.jpg",
+                "file_type": "figure",
+                "upload_file_nm": "elife-95901-inf2.jpg",
+                "id": "inf2",
+            },
+        ]
+        # invoke
+        result = peer_review.generate_new_image_file_names(
+            href_to_file_name_map,
+            article_id,
+            identifier,
+            caller_name,
+            logger,
+        )
+        # assert
+        self.assertEqual(len(result), 2)
+        for index, file_details in enumerate(result):
+            self.assertDictEqual(file_details, expected[index])
+        self.assertEqual(
+            logger.loginfo[-1],
+            (
+                "%s, for %s, file name tmp/2024-11-04.23.52.26/input_dir/FFeuydR.jpg"
+                " changed to file name elife-95901-inf2.jpg" % (caller_name, identifier)
+            ),
+        )
+        self.assertEqual(
+            logger.loginfo[-2],
+            (
+                "%s, for %s, file name tmp/2024-11-04.23.52.26/input_dir/vc4GR10.png"
+                " changed to file name elife-95901-inf1.png" % (caller_name, identifier)
+            ),
+        )
+
+
+class TestGenerateNewImageFilePaths(unittest.TestCase):
+    "tests for generate_new_image_file_paths()"
+
+    def test_generate_new_image_file_paths(self):
+        "test generating new image file path values"
+        file_details_list = [
+            {
+                "upload_file_nm": "elife-95901-inf1.png",
+            },
+            {
+                "upload_file_nm": "elife-95901-inf2.jpg",
+            },
+        ]
+        content_subfolder = "content"
+        identifier = "10.7554/eLife.95901.1"
+        caller_name = "MecaPeerReviewImages"
+        logger = FakeLogger()
+        expected = [
+            {
+                "upload_file_nm": "elife-95901-inf1.png",
+                "href": "content/elife-95901-inf1.png",
+            },
+            {
+                "upload_file_nm": "elife-95901-inf2.jpg",
+                "href": "content/elife-95901-inf2.jpg",
+            },
+        ]
+        # invoke
+        result = peer_review.generate_new_image_file_paths(
+            file_details_list,
+            content_subfolder,
+            identifier,
+            caller_name,
+            logger,
+        )
+        # assert
+        self.assertEqual(len(result), 2)
+        for index, file_details in enumerate(result):
+            self.assertDictEqual(file_details, expected[index])
+        self.assertEqual(
+            logger.loginfo[-1],
+            (
+                "%s, for %s, file elife-95901-inf2.jpg new asset value"
+                " content/elife-95901-inf2.jpg" % (caller_name, identifier)
+            ),
+        )
+        self.assertEqual(
+            logger.loginfo[-2],
+            (
+                "%s, for %s, file elife-95901-inf1.png new asset value"
+                " content/elife-95901-inf1.png" % (caller_name, identifier)
+            ),
+        )
+
+
+class TestModifyHrefToFileNameMap(unittest.TestCase):
+    "tests for modify_href_to_file_name_map()"
+
+    def test_modify_href_to_file_name_map(self):
+        "test changing file path for image files in the map"
+        href_to_file_name_map = {
+            "https://i.imgur.com/vc4GR10.png": "tmp/2024-11-04.23.52.26/input_dir/vc4GR10.png",
+            "https://i.imgur.com/FFeuydR.jpg": "tmp/2024-11-04.23.52.26/input_dir/FFeuydR.jpg",
+        }
+        file_details_list = [
+            {
+                "from_href": "https://i.imgur.com/vc4GR10.png",
+                "upload_file_nm": "elife-95901-inf1.png",
+            },
+            {
+                "from_href": "https://i.imgur.com/FFeuydR.jpg",
+                "upload_file_nm": "elife-95901-inf2.jpg",
+            },
+        ]
+        expected = {
+            "https://i.imgur.com/vc4GR10.png": "elife-95901-inf1.png",
+            "https://i.imgur.com/FFeuydR.jpg": "elife-95901-inf2.jpg",
+        }
+        # invoke
+        peer_review.modify_href_to_file_name_map(
+            href_to_file_name_map, file_details_list
+        )
+        # assert
+        self.assertEqual(href_to_file_name_map, expected)
+
+
+class TestMoveImages(unittest.TestCase):
+    "tests for move_images()"
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    def test_move_images(self):
+        "test moving images files from input directory to output directory"
+        directory = TempDirectory()
+        # make output directory
+        output_dir = os.path.join(directory.path, "content")
+        os.mkdir(output_dir)
+        # copy in test fixtures
+        tmp_dir = os.path.join(directory.path, "tmp")
+        os.mkdir(tmp_dir)
+        for file_name in ["vc4GR10.png", "FFeuydR.jpg"]:
+            with open(os.path.join(tmp_dir, file_name), "w", encoding="utf-8") as open_file:
+                open_file.write("test_fixture")
+        file_details_list = [
+            {
+                "from_href": "https://i.imgur.com/vc4GR10.png",
+                "file_name": "%s/vc4GR10.png" % tmp_dir,
+                "file_type": "figure",
+                "upload_file_nm": "elife-95901-inf1.png",
+                "id": "inf1",
+                "href": "content/elife-95901-inf1.png",
+            },
+            {
+                "from_href": "https://i.imgur.com/FFeuydR.jpg",
+                "file_name": "%s/FFeuydR.jpg" % tmp_dir,
+                "file_type": "figure",
+                "upload_file_nm": "elife-95901-inf2.jpg",
+                "id": "inf2",
+                "href": "content/elife-95901-inf2.jpg",
+            },
+        ]
+        to_dir = directory.path
+        identifier = "10.7554/eLife.95901.1"
+        caller_name = "MecaPeerReviewImages"
+        logger = FakeLogger()
+        # invoke
+        peer_review.move_images(
+            file_details_list, to_dir, identifier, caller_name, logger
+        )
+        # assert
+        self.assertEqual(
+            sorted(os.listdir(output_dir)),
+            sorted(["elife-95901-inf1.png", "elife-95901-inf2.jpg"]),
+        )


### PR DESCRIPTION
For later code reuse, move some peer review image code to a new module `provider/peer_review.py`. Use this in `AcceptedSubmissionPeerReviewImages`.

Re issue https://github.com/elifesciences/issues/issues/8947