### PR TITLE
Refactor AcceptedBaseActivity code for reuse.

### DIFF
--- a/activity/activity_AcceptedSubmissionPeerReviewFigs.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewFigs.py
@@ -59,6 +59,7 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
         self.start_cleaner_log()
 
         expanded_folder, input_filename, article_id = self.read_session(session)
+        resource_prefix = self.accepted_expanded_resource_prefix(expanded_folder)
 
         # get list of bucket objects from expanded folder
         asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
@@ -116,7 +117,7 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
             try:
                 self.statuses["rename_files"] = self.copy_expanded_folder_files(
                     asset_file_name_map,
-                    expanded_folder,
+                    resource_prefix,
                     copy_file_transformations,
                     storage,
                 )
@@ -147,7 +148,7 @@ class activity_AcceptedSubmissionPeerReviewFigs(AcceptedBaseActivity):
             try:
                 self.statuses["rename_files"] = self.rename_expanded_folder_files(
                     asset_file_name_map,
-                    expanded_folder,
+                    resource_prefix,
                     rename_file_transformations,
                     storage,
                 )

--- a/activity/activity_AcceptedSubmissionPeerReviewOcr.py
+++ b/activity/activity_AcceptedSubmissionPeerReviewOcr.py
@@ -67,6 +67,7 @@ class activity_AcceptedSubmissionPeerReviewOcr(AcceptedBaseActivity):
         self.start_cleaner_log()
 
         expanded_folder, input_filename, article_id = self.read_session(session)
+        resource_prefix = self.accepted_expanded_resource_prefix(expanded_folder)
 
         # get list of bucket objects from expanded folder
         asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
@@ -150,7 +151,7 @@ class activity_AcceptedSubmissionPeerReviewOcr(AcceptedBaseActivity):
             self.remove_file_tags(xml_root, approved_file_name_list, input_filename)
             # delete converted graphic files from the expanded folder
             self.delete_expanded_folder_files(
-                asset_file_name_map, expanded_folder, approved_file_name_list, storage
+                asset_file_name_map, resource_prefix, approved_file_name_list, storage
             )
 
         # write the XML root to disk

--- a/activity/activity_AcceptedSubmissionStrikingImages.py
+++ b/activity/activity_AcceptedSubmissionStrikingImages.py
@@ -57,6 +57,7 @@ class activity_AcceptedSubmissionStrikingImages(AcceptedBaseActivity):
         self.start_cleaner_log()
 
         expanded_folder, input_filename, article_id = self.read_session(session)
+        resource_prefix = self.accepted_expanded_resource_prefix(expanded_folder)
 
         # get list of bucket objects from expanded folder
         asset_file_name_map = self.bucket_asset_file_name_map(expanded_folder)
@@ -105,7 +106,7 @@ class activity_AcceptedSubmissionStrikingImages(AcceptedBaseActivity):
                 % (self.name, input_filename)
             )
             self.statuses["rename_files"] = self.rename_expanded_folder_files(
-                asset_file_name_map, expanded_folder, file_transformations, storage
+                asset_file_name_map, resource_prefix, file_transformations, storage
             )
 
         # upload the XML to the bucket

--- a/activity/activity_RenameAcceptedSubmissionVideos.py
+++ b/activity/activity_RenameAcceptedSubmissionVideos.py
@@ -48,6 +48,7 @@ class activity_RenameAcceptedSubmissionVideos(AcceptedBaseActivity):
         session = get_session(self.settings, data, data["run"])
 
         expanded_folder, input_filename, article_id = self.read_session(session)
+        resource_prefix = self.accepted_expanded_resource_prefix(expanded_folder)
 
         deposit_videos = session.get_value("deposit_videos")
 
@@ -121,7 +122,7 @@ class activity_RenameAcceptedSubmissionVideos(AcceptedBaseActivity):
         # rename the video files in the expanded folder
         if self.statuses.get("modify_xml"):
             self.statuses["rename_videos"] = self.rename_expanded_folder_files(
-                asset_file_name_map, expanded_folder, file_transformations, storage
+                asset_file_name_map, resource_prefix, file_transformations, storage
             )
 
         # upload the modified XML file to the expanded folder

--- a/tests/activity/test_activity_object.py
+++ b/tests/activity/test_activity_object.py
@@ -317,7 +317,7 @@ class TestSetMonitorProperty(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class Testaccepted_expanded_resource_prefix(unittest.TestCase):
+class TestAcceptedExpandedResourcePrefix(unittest.TestCase):
     def test_accepted_expanded_resource_prefix(self):
         expanded_folder = "expanded"
         expected = "s3://bot_bucket/expanded"
@@ -342,8 +342,10 @@ class TestCopyExpandedFolderFiles(unittest.TestCase):
             open_file.write("")
 
         # asset map
-        asset_file_name_map = {from_file_name: "s3://bot-bucket/%s" % from_file_name}
-        expanded_folder = ""
+        resource_prefix = "s3://bot-bucket/"
+        asset_file_name_map = {
+            from_file_name: "%s%s" % (from_file_name, resource_prefix)
+        }
 
         # files to transform
         file_transformations = []
@@ -355,12 +357,11 @@ class TestCopyExpandedFolderFiles(unittest.TestCase):
             directory.path, resources, dest_folder=directory.path
         )
         logger = FakeLogger()
-
         # instantiate
         activity_object = AcceptedBaseActivity(settings_mock, logger, None, None, None)
         # invoke
         result = activity_object.copy_expanded_folder_files(
-            asset_file_name_map, expanded_folder, file_transformations, storage
+            asset_file_name_map, resource_prefix, file_transformations, storage
         )
         # assertions
         self.assertEqual(result, True)
@@ -380,7 +381,7 @@ class TestCopyExpandedFolderFiles(unittest.TestCase):
         file_transformations.append((from_file, to_file))
         # asset map
         asset_file_name_map = {}
-        expanded_folder = ""
+        resource_prefix = ""
         storage = FakeStorageContext(directory.path, [], dest_folder=directory.path)
         logger = FakeLogger()
         # instantiate
@@ -388,7 +389,7 @@ class TestCopyExpandedFolderFiles(unittest.TestCase):
         # invoke
         with self.assertRaises(RuntimeError):
             result = activity_object.copy_expanded_folder_files(
-                asset_file_name_map, expanded_folder, file_transformations, storage
+                asset_file_name_map, resource_prefix, file_transformations, storage
             )
             self.assertEqual(result, activity_object.ACTIVITY_PERMANENT_FAILURE)
 
@@ -407,8 +408,10 @@ class TestRenameExpandedFolderFiles(unittest.TestCase):
             open_file.write("")
 
         # asset map
-        asset_file_name_map = {from_file_name: "s3://bot-bucket/%s" % from_file_name}
-        expanded_folder = ""
+        resource_prefix = "s3://bot-bucket/"
+        asset_file_name_map = {
+            from_file_name: "%s%s" % (resource_prefix, from_file_name)
+        }
 
         # files to transform
         file_transformations = []
@@ -425,7 +428,7 @@ class TestRenameExpandedFolderFiles(unittest.TestCase):
         activity_object = AcceptedBaseActivity(settings_mock, logger, None, None, None)
         # invoke
         result = activity_object.rename_expanded_folder_files(
-            asset_file_name_map, expanded_folder, file_transformations, storage
+            asset_file_name_map, resource_prefix, file_transformations, storage
         )
         # assertions
         self.assertEqual(result, True)
@@ -441,8 +444,11 @@ class TestRenameExpandedFolderFiles(unittest.TestCase):
         to_file = ArticleZipFile(to_file_name)
         file_transformations.append((from_file, to_file))
         # asset map
-        asset_file_name_map = {from_file_name: "s3://bot-bucket/%s" % from_file_name}
-        expanded_folder = ""
+        resource_prefix = "s3://bot-bucket/"
+        asset_file_name_map = {
+            from_file_name: "%s%s" % (resource_prefix, from_file_name)
+        }
+
         resources = [from_file_name]
         storage = FakeStorageContext(
             directory.path, resources, dest_folder=directory.path
@@ -453,7 +459,7 @@ class TestRenameExpandedFolderFiles(unittest.TestCase):
         # invoke
         with self.assertRaises(RuntimeError):
             result = activity_object.rename_expanded_folder_files(
-                asset_file_name_map, expanded_folder, file_transformations, storage
+                asset_file_name_map, resource_prefix, file_transformations, storage
             )
             self.assertEqual(result, activity_object.ACTIVITY_PERMANENT_FAILURE)
 
@@ -471,8 +477,11 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
             open_file.write("")
 
         # asset map
-        asset_file_name_map = {from_file_name: "s3://bot-bucket/%s" % from_file_name}
-        expanded_folder = ""
+        resource_prefix = "s3://bot-bucket/"
+        asset_file_name_map = {
+            from_file_name: "%s%s" % (resource_prefix, from_file_name)
+        }
+
         resources = [from_file_name]
         storage = FakeStorageContext(
             directory.path, resources, dest_folder=directory.path
@@ -485,7 +494,7 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
         activity_object = AcceptedBaseActivity(settings_mock, logger, None, None, None)
         # invoke
         activity_object.delete_expanded_folder_files(
-            asset_file_name_map, expanded_folder, file_name_list, storage
+            asset_file_name_map, resource_prefix, file_name_list, storage
         )
         # assertions
         self.assertEqual(len(os.listdir(directory.path)), 0)
@@ -498,8 +507,10 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
         from_file_name = "elife-87356-inf1.jpg"
         file_name_list = [from_file_name]
         # asset map
-        asset_file_name_map = {from_file_name: "s3://bot-bucket/%s" % from_file_name}
-        expanded_folder = ""
+        resource_prefix = "s3://bot-bucket/"
+        asset_file_name_map = {
+            from_file_name: "%s%s" % (resource_prefix, from_file_name)
+        }
         resources = [from_file_name]
         storage = FakeStorageContext(
             directory.path, resources, dest_folder=directory.path
@@ -510,5 +521,5 @@ class TestDeleteExpandedFolderFiles(unittest.TestCase):
         # invoke
         with self.assertRaises(Exception):
             activity_object.delete_expanded_folder_files(
-                asset_file_name_map, expanded_folder, file_name_list, storage
+                asset_file_name_map, resource_prefix, file_name_list, storage
             )


### PR DESCRIPTION
To reuse some copy, rename, and delete object operations done in bucket expanded folders, the object inheritance and structure is change for accepted submission workflow steps.

Re issue https://github.com/elifesciences/issues/issues/8947