### PR TITLE
Queue worker

### DIFF
--- a/queue_worker.py
+++ b/queue_worker.py
@@ -37,11 +37,14 @@ class QueueWorker:
     def connect(self):
         "connect to the queue service"
         if not self.client:
-            self.client = self.settings.aws_conn('sqs', {
-                'aws_access_key_id': self.settings.aws_access_key_id,
-                'aws_secret_access_key': self.settings.aws_secret_access_key,
-                'region_name': self.settings.sqs_region,
-            })
+            self.client = self.settings.aws_conn(
+                "sqs",
+                {
+                    "aws_access_key_id": self.settings.aws_access_key_id,
+                    "aws_secret_access_key": self.settings.aws_secret_access_key,
+                    "region_name": self.settings.sqs_region,
+                },
+            )
 
     def queues(self):
         "get the queues"
@@ -67,7 +70,6 @@ class QueueWorker:
         # Poll for messages indefinitely
         if input_queue_url:
             while flag.green():
-
                 self.logger.info("reading message")
                 queue_messages = self.client.receive_message(
                     QueueUrl=input_queue_url,
@@ -89,9 +91,7 @@ class QueueWorker:
                             s3_message = S3SQSMessage(queue_message.get("Message"))
                         if s3_message.notification_type == "S3Event":
                             info = S3NotificationInfo.from_S3SQSMessage(s3_message)
-                            self.logger.info(
-                                "S3NotificationInfo: %s", info.to_dict()
-                            )
+                            self.logger.info("S3NotificationInfo: %s", info.to_dict())
 
                             workflow_name = get_starter_name(rules, info)
                             if workflow_name is None:

--- a/queue_worker.py
+++ b/queue_worker.py
@@ -83,7 +83,10 @@ class QueueWorker:
                         self.logger.info(
                             "got message id: %s" % queue_message.get("MessageId")
                         )
-                        s3_message = S3SQSMessage(queue_message.get("Body"))
+                        if queue_message.get("Body"):
+                            s3_message = S3SQSMessage(queue_message.get("Body"))
+                        else:
+                            s3_message = S3SQSMessage(queue_message.get("Message"))
                         if s3_message.notification_type == "S3Event":
                             info = S3NotificationInfo.from_S3SQSMessage(s3_message)
                             self.logger.info(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -207,6 +207,11 @@ queue_worker_rules = {
         "file_name_pattern": r".*\.zip",
         "starter_name": "IngestAcceptedSubmission",
     },
+    "SilentIngestMecaInputFile": {
+        "bucket_name_pattern": ".*elife-epp-meca$",
+        "file_name_pattern": r"silent-corrections/.*\.zip",
+        "starter_name": "SilentIngestMeca",
+    },
 }
 
 queue_worker_article_zip_data = {


### PR DESCRIPTION
The sample SQS message coming from SNS has a "Message" dict key, where other S3 notifications have "Body" - support both fo them.

Re issue https://github.com/elifesciences/issues/issues/8884