### PR TITLE
Add MecaDetails, to populate the session prior to ExpandMeca.

### DIFF
--- a/activity/activity_MecaDetails.py
+++ b/activity/activity_MecaDetails.py
@@ -1,0 +1,209 @@
+from datetime import datetime
+import json
+import os
+from provider.execution_context import get_session
+from provider import (
+    cleaner,
+    docmap_provider,
+    utils,
+)
+from activity.objects import Activity
+
+
+# DOI prefix for generating DOI value
+DOI_PREFIX = "10.7554/eLife."
+
+
+class activity_MecaDetails(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_MecaDetails, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "MecaDetails"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = "Collect details about a MECA file to be ingested"
+
+        # Local directory settings
+        self.directories = {
+            "TEMP_DIR": os.path.join(self.get_tmp_dir(), "tmp_dir"),
+            "INPUT_DIR": os.path.join(self.get_tmp_dir(), "input_dir"),
+        }
+
+        # Track the success of some steps
+        self.statuses = {"docmap_string": None}
+
+    def do_activity(self, data=None):
+        """
+        Activity, do the work
+        """
+        self.logger.info(
+            "%s data: %s" % (self.name, json.dumps(data, sort_keys=True, indent=4))
+        )
+
+        self.make_activity_directories()
+
+        # start session
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+        session.store_value("run", run)
+        session.store_value("run_type", data.get("run_type"))
+
+        if data.get("run_type") == "silent-correction":
+            # get computer_file_url, article_id, and version from the S3 notification data
+            computer_file_url = "%s://%s" % (
+                self.settings.storage_provider,
+                "/".join([data.get("bucket_name"), data.get("file_name")]),
+            )
+            filename_last_element = data.get("file_name").rsplit("/", 1)[-1]
+            article_id, version = meca_file_parts(filename_last_element)
+            version_doi = "%s%s.%s" % (DOI_PREFIX, utils.pad_msid(article_id), version)
+        else:
+            # store details in session
+            article_id = data.get("article_id")
+            version = data.get("version")
+
+        # store details in session
+        session.store_value("article_id", article_id)
+        session.store_value("version", str(version))
+
+        # get docmap as a string
+        self.logger.info(
+            "%s, getting docmap_string for article_id %s" % (self.name, article_id)
+        )
+        try:
+            docmap_string = cleaner.get_docmap_string_with_retry(
+                self.settings, article_id, self.name, self.logger
+            )
+            self.statuses["docmap_string"] = True
+            # save the docmap_string to the session
+            session.store_value(
+                "docmap_datetime_string",
+                datetime.strftime(utils.get_current_datetime(), utils.DATE_TIME_FORMAT),
+            )
+            session.store_value("docmap_string", docmap_string.decode("utf-8"))
+        except Exception as exception:
+            self.logger.exception(
+                "%s, exception getting a docmap for article_id %s: %s"
+                % (self.name, article_id, str(exception))
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        # parse docmap JSON
+        self.logger.info(
+            "%s, parsing docmap_string for article_id %s" % (self.name, article_id)
+        )
+        try:
+            docmap_json = json.loads(docmap_string)
+        except Exception as exception:
+            self.logger.exception(
+                "%s, exception parsing docmap_string for article_id %s: %s"
+                % (self.name, article_id, str(exception))
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+
+        version_doi = "%s%s.%s" % (DOI_PREFIX, article_id, version)
+        session.store_value("version_doi", version_doi)
+
+        self.logger.info(
+            "%s, version_doi %s for article_id %s, version %s"
+            % (self.name, version_doi, article_id, version)
+        )
+
+        if data.get("run_type") != "silent-correction":
+            # get a version DOI step map from the docmap
+            try:
+                steps = steps_by_version_doi(
+                    docmap_json, version_doi, self.name, self.logger
+                )
+            except Exception as exception:
+                self.logger.exception(
+                    "%s, exception in steps_by_version_doi for version DOI %s: %s"
+                    % (self.name, version_doi, str(exception))
+                )
+                return self.ACTIVITY_PERMANENT_FAILURE
+            if not steps:
+                self.logger.info(
+                    "%s, found no docmap steps for version DOI %s"
+                    % (self.name, version_doi)
+                )
+                return self.ACTIVITY_PERMANENT_FAILURE
+
+            # get computer-file url from the docmap
+            computer_file_url = computer_file_url_from_steps(
+                steps, version_doi, self.name, self.logger
+            )
+
+        if not computer_file_url:
+            self.logger.info(
+                "%s, computer_file_url not found in computer_file for version DOI %s"
+                % (self.name, version_doi)
+            )
+            return self.ACTIVITY_PERMANENT_FAILURE
+        self.logger.info(
+            "%s, computer_file_url %s for version_doi %s"
+            % (self.name, computer_file_url, version_doi)
+        )
+
+        session.store_value("computer_file_url", computer_file_url)
+
+        self.clean_tmp_dir()
+
+        self.logger.info(
+            "%s, statuses for version DOI %s: %s"
+            % (self.name, version_doi, self.statuses)
+        )
+
+        return self.ACTIVITY_SUCCESS
+
+
+def meca_file_parts(file_name):
+    "get data from MECA file name"
+    parts = file_name.split("-")
+    article_id = int(parts[0])
+    version = parts[1].replace("v", "")
+    return article_id, version
+
+
+def steps_by_version_doi(docmap_json, version_doi, caller_name, logger):
+    "get steps from the docmap for the version_doi"
+    logger.info(
+        "%s, getting a step map for version DOI %s" % (caller_name, version_doi)
+    )
+    try:
+        step_map = docmap_provider.version_doi_step_map(docmap_json)
+    except Exception as exception:
+        logger.exception(
+            "%s, exception getting a step map for version DOI %s: %s"
+            % (caller_name, version_doi, str(exception))
+        )
+        raise
+
+    return step_map.get(version_doi)
+
+
+def computer_file_url_from_steps(steps, version_doi, caller_name, logger):
+    "get the url of computer-file input from docmap steps"
+    computer_file = None
+    for step in steps:
+        computer_file_list = docmap_provider.computer_files(step)
+        if computer_file_list:
+            computer_file = computer_file_list[0]
+            break
+
+    if not computer_file:
+        logger.info(
+            "%s, computer_file not found in steps for version DOI %s"
+            % (caller_name, version_doi)
+        )
+        return None
+    logger.info(
+        "%s, computer_file %s for version_doi %s"
+        % (caller_name, computer_file, version_doi)
+    )
+
+    return computer_file.get("url")

--- a/register.py
+++ b/register.py
@@ -165,6 +165,7 @@ def start(settings):
     activity_names.append("MecaPeerReviewFigs")
     activity_names.append("MecaPeerReviewTables")
     activity_names.append("MecaPeerReviewEquations")
+    activity_names.append("MecaDetails")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_data.py
+++ b/tests/activity/test_activity_data.py
@@ -58,9 +58,28 @@ ingest_meca_data = {
 }
 
 
-def ingest_meca_session_example():
+def meca_details_session_example(
+    run_type=None, computer_file_url="s3://prod-elife-epp-meca/95901-v1-meca.zip"
+):
     return {
         "run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda",
+        "run_type": run_type,
+        "article_id": 95901,
+        "version": "1",
+        "version_doi": "10.7554/eLife.95901.1",
+        "docmap_datetime_string": "2024-06-27T00:00:00.000Z",
+        "docmap_string": read_fixture("sample_docmap_for_95901.json").decode("utf-8"),
+        "version_doi": "10.7554/eLife.95901.1",
+        "computer_file_url": computer_file_url,
+    }
+
+
+def ingest_meca_session_example(
+    run_type=None, computer_file_url="s3://prod-elife-epp-meca/95901-v1-meca.zip"
+):
+    return {
+        "run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda",
+        "run_type": run_type,
         "article_id": 95901,
         "version": "1",
         "expanded_folder": (
@@ -71,6 +90,7 @@ def ingest_meca_session_example():
         "docmap_string": read_fixture("sample_docmap_for_95901.json").decode("utf-8"),
         "article_xml_path": "content/24301711.xml",
         "version_doi": "10.7554/eLife.95901.1",
+        "computer_file_url": computer_file_url,
     }
 
 

--- a/tests/activity/test_activity_meca_details.py
+++ b/tests/activity/test_activity_meca_details.py
@@ -1,0 +1,353 @@
+from datetime import datetime
+import copy
+import json
+import unittest
+from mock import patch
+from provider import cleaner, docmap_provider, utils
+from activity import activity_MecaDetails as activity_module
+from activity.activity_MecaDetails import (
+    activity_MecaDetails as activity_class,
+)
+from tests import read_fixture, test_data
+from tests.activity import helpers, settings_mock, test_activity_data
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+)
+
+
+class TestMecaDetails(unittest.TestCase):
+    "tests for do_activity()"
+
+    def setUp(self):
+        self.logger = FakeLogger()
+        self.activity = activity_class(settings_mock, self.logger, None, None, None)
+
+    def tearDown(self):
+        helpers.delete_files_in_folder("tests/tmp", filter_out=[".keepme"])
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    @patch.object(utils, "get_current_datetime")
+    def test_do_activity(
+        self,
+        fake_datetime,
+        fake_get_docmap,
+        fake_session,
+    ):
+        fake_datetime.return_value = datetime.strptime(
+            "2024-06-27 +0000", "%Y-%m-%d %z"
+        )
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_95901.json")
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        expected_result = self.activity.ACTIVITY_SUCCESS
+        expected_session_dict = test_activity_data.meca_details_session_example()
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        # assert activity return value
+        self.assertEqual(result, expected_result)
+        # check session data
+        self.assertDictEqual(mock_session.session_dict, expected_session_dict)
+        # check logger values
+        loginfo_expected = (
+            "MecaDetails, computer_file_url s3://prod-elife-epp-meca/95901-v1-meca.zip"
+            " for version_doi 10.7554/eLife.95901.1"
+        )
+        self.assertTrue(loginfo_expected in self.logger.loginfo)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    @patch.object(utils, "get_current_datetime")
+    def test_silent_correction(
+        self,
+        fake_datetime,
+        fake_get_docmap,
+        fake_session,
+    ):
+        fake_datetime.return_value = datetime.strptime(
+            "2024-06-27 +0000", "%Y-%m-%d %z"
+        )
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_95901.json")
+        computer_file_url = (
+            "s3://test-elife-epp-meca/silent-corrections/95901-v1-meca.zip"
+        )
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        expected_result = self.activity.ACTIVITY_SUCCESS
+        expected_session_dict = test_activity_data.meca_details_session_example(
+            run_type="silent-correction", computer_file_url=computer_file_url
+        )
+        # silent-correction run_type
+        input_data = copy.copy(test_data.silent_ingest_meca_data)
+        input_data["run_type"] = "silent-correction"
+        # do the activity
+        result = self.activity.do_activity(input_data)
+        # assertions
+        # assert activity return value
+        self.assertEqual(result, expected_result)
+        # check session data
+        self.assertDictEqual(mock_session.session_dict, expected_session_dict)
+        # check logger values
+        loginfo_expected = (
+            "MecaDetails, computer_file_url %s"
+            " for version_doi 10.7554/eLife.95901.1" % computer_file_url
+        )
+        self.assertTrue(loginfo_expected in self.logger.loginfo)
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    def test_get_docmap_exception(self, fake_get_docmap, fake_session):
+        "test exception is raised when getting docmap string"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        fake_get_docmap.side_effect = Exception("An exception")
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        expected_docmap_string_status = None
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.statuses.get("docmap_string"),
+            expected_docmap_string_status,
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    def test_parse_docmap_string_exception(self, fake_get_docmap, fake_session):
+        "test exception is raised parsing the docmap string"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        fake_get_docmap.return_value = b"{"
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "%s, exception parsing docmap_string for article_id %s: "
+                "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
+            )
+            % (self.activity.name, mock_session.session_dict.get("article_id")),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    @patch.object(docmap_provider, "version_doi_step_map")
+    def test_step_map_exception(self, fake_step_map, fake_get_docmap, fake_session):
+        "test exception is raised getting a step map from the docmap"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_95901.json")
+        exception_message = "An exception"
+        fake_step_map.side_effect = Exception(exception_message)
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.logexception,
+            (
+                "%s, exception in steps_by_version_doi for version DOI 10.7554/eLife.%s.%s: %s"
+            )
+            % (
+                self.activity.name,
+                mock_session.session_dict.get("article_id"),
+                mock_session.session_dict.get("version"),
+                exception_message,
+            ),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    def test_no_steps(self, fake_get_docmap, fake_session):
+        "test if there are no steps for the version DOI"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        # load a docmap with a mismatched version DOI
+        fake_get_docmap.return_value = read_fixture("sample_docmap_for_87445.json")
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            ("%s, found no docmap steps for version DOI 10.7554/eLife.%s.%s")
+            % (
+                self.activity.name,
+                mock_session.session_dict.get("article_id"),
+                mock_session.session_dict.get("version"),
+            ),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    def test_no_computer_file(self, fake_get_docmap, fake_session):
+        "test if there is no computer-file value in the docmap"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        docmap_string = read_fixture("sample_docmap_for_95901.json")
+        # modify the test fixture to have no computer-file keys
+        fake_get_docmap.return_value = docmap_string.replace(
+            b"computer-file", b"not-a-computer-file"
+        )
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                (
+                    "%s, computer_file_url not found in computer_file "
+                    "for version DOI 10.7554/eLife.%s.%s"
+                )
+            )
+            % (
+                self.activity.name,
+                mock_session.session_dict.get("article_id"),
+                mock_session.session_dict.get("version"),
+            ),
+        )
+
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "get_docmap_string_with_retry")
+    def test_no_computer_file_url(self, fake_get_docmap, fake_session):
+        "test if there is no computer-file url value in the docmap"
+        mock_session = FakeSession({})
+        fake_session.return_value = mock_session
+        docmap_string = read_fixture("sample_docmap_for_95901.json")
+        docmap_json = json.loads(docmap_string)
+        # modify the test fixture computer-file url value
+        del docmap_json["steps"]["_:b0"]["inputs"][0]["content"][0]["url"]
+        fake_get_docmap.return_value = bytes(json.dumps(docmap_json), encoding="utf-8")
+        expected_result = self.activity.ACTIVITY_PERMANENT_FAILURE
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+        # assertions
+        self.assertEqual(result, expected_result)
+        self.assertEqual(
+            self.activity.logger.loginfo[-1],
+            (
+                (
+                    "%s, computer_file_url not found in "
+                    "computer_file for version DOI 10.7554/eLife.%s.%s"
+                )
+            )
+            % (
+                self.activity.name,
+                mock_session.session_dict.get("article_id"),
+                mock_session.session_dict.get("version"),
+            ),
+        )
+
+
+class TestMecaFileParts(unittest.TestCase):
+    "tests for meca_file_parts()"
+
+    def test_meca_file_parts(self):
+        "test getting data from a typical MECA zip file name"
+        file_name = "95901-v1-meca.zip"
+        expected_article_id = 95901
+        expected_version = "1"
+        # invoke
+        result = activity_module.meca_file_parts(file_name)
+        # assert
+        self.assertEqual(result[0], expected_article_id)
+        self.assertEqual(result[1], expected_version)
+
+
+class TestStepsByVersionDoi(unittest.TestCase):
+    "tests for steps_by_version_doi()"
+
+    def setUp(self):
+        self.caller_name = "test"
+        self.version_doi = "10.7554/eLife.95901.1"
+        self.logger = FakeLogger()
+
+    def test_steps_by_version_doi(self):
+        "test with valid docmap JSON"
+        docmap_json = json.loads(read_fixture("sample_docmap_for_95901.json"))
+        expected_len = 3
+        expected_0_keys = ["actions", "assertions", "inputs", "next-step"]
+        result = activity_module.steps_by_version_doi(
+            docmap_json, self.version_doi, self.caller_name, self.logger
+        )
+        self.assertEqual(len(result), expected_len)
+        self.assertEqual(sorted(list(result[0].keys())), sorted(expected_0_keys))
+
+    def test_exception(self):
+        "test raising an exception"
+        docmap_json = "foo"
+        with self.assertRaises(AttributeError):
+            activity_module.steps_by_version_doi(
+                docmap_json, self.version_doi, self.caller_name, self.logger
+            )
+        self.assertEqual(
+            self.logger.logexception,
+            (
+                "%s, exception getting a step map for version DOI %s: "
+                "'str' object has no attribute 'get'"
+            )
+            % (self.caller_name, self.version_doi),
+        )
+
+
+class TestComputerFileUrlFromSteps(unittest.TestCase):
+    "tests for computer_file_url_from_steps()"
+
+    def setUp(self):
+        self.caller_name = "test"
+        self.version_doi = "10.7554/eLife.95901.1"
+        self.logger = FakeLogger()
+
+    def test_computer_file_url_from_steps(self):
+        "test simple docmap steps data returning a MECA computer-file URL"
+        meca_url = "s3://example/example.meca"
+        steps = [
+            {
+                "inputs": [
+                    {
+                        "type": "preprint",
+                        "content": [{"type": "computer-file", "url": meca_url}],
+                    }
+                ]
+            }
+        ]
+        result = activity_module.computer_file_url_from_steps(
+            steps, self.version_doi, self.caller_name, self.logger
+        )
+        self.assertEqual(result, meca_url)
+
+    def test_none(self):
+        "test no computer-file URL data"
+        steps = [
+            {
+                "inputs": [
+                    {
+                        "type": "preprint",
+                        "content": [{"type": "computer-file"}],
+                    }
+                ]
+            }
+        ]
+        expected = None
+        result = activity_module.computer_file_url_from_steps(
+            steps, self.version_doi, self.caller_name, self.logger
+        )
+        self.assertEqual(result, expected)
+
+    def test_exception(self):
+        "test raising exception"
+        steps = None
+        with self.assertRaises(TypeError):
+            activity_module.computer_file_url_from_steps(
+                steps, self.version_doi, self.caller_name, self.logger
+            )

--- a/workflow/workflow_IngestMeca.py
+++ b/workflow/workflow_IngestMeca.py
@@ -35,6 +35,7 @@ class workflow_IngestMeca(Workflow):
             "start": {"requirements": None},
             "steps": [
                 define_workflow_step("PingWorker", data),
+                define_workflow_step("MecaDetails", data),
                 define_workflow_step("ExpandMeca", data),
                 define_workflow_step("ModifyMecaXml", data),
                 define_workflow_step("MecaPeerReviews", data),

--- a/workflow/workflow_SilentIngestMeca.py
+++ b/workflow/workflow_SilentIngestMeca.py
@@ -35,6 +35,7 @@ class workflow_SilentIngestMeca(Workflow):
             "start": {"requirements": None},
             "steps": [
                 define_workflow_step("PingWorker", data),
+                define_workflow_step("MecaDetails", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
For compatibility with "silent-correction" MECA ingestions, where it is started by an S3 notification event, the new `MecaDetails` activity step handles both silent and normal ingestions, putting data into the session, later used by `ExpandMeca` universally.

Re issue https://github.com/elifesciences/issues/issues/8884