### PR TITLE
Change meca.rewrite_item_tags() to support removing item tags.

### DIFF
--- a/provider/meca.py
+++ b/provider/meca.py
@@ -201,15 +201,27 @@ def rewrite_item_tags(
             and instance_tag.get("href") in href_file_detail_map
         ):
             logger.info(
-                "%s, rewriting item tag for href %s for version DOI %s"
+                "%s, modifying item tag for href %s for version DOI %s"
                 % (caller_name, instance_tag.get("href"), version_doi)
             )
             file_details = href_file_detail_map.get(instance_tag.get("href"))
-            # remove old XML data
-            item_tag.remove(instance_tag)
-            cleaner.remove_tag_attributes(item_tag)
-            # rewrite the item tag data
-            cleaner.populate_item_tag(item_tag, file_details)
+            if file_details.get("href"):
+                logger.info(
+                    "%s, rewriting item tag for href %s for version DOI %s"
+                    % (caller_name, instance_tag.get("href"), version_doi)
+                )
+                # remove old XML data
+                item_tag.remove(instance_tag)
+                cleaner.remove_tag_attributes(item_tag)
+                # rewrite the item tag data
+                cleaner.populate_item_tag(item_tag, file_details)
+            else:
+                logger.info(
+                    "%s, removing item tag for href %s for version DOI %s"
+                    % (caller_name, instance_tag.get("href"), version_doi)
+                )
+                # remove the item tag
+                root.remove(item_tag)
 
     # write XML file to disk
     cleaner.write_manifest_xml_file(

--- a/tests/provider/test_meca.py
+++ b/tests/provider/test_meca.py
@@ -319,3 +319,49 @@ class TestRewriteItemTags(unittest.TestCase):
             )
             in result_xml_string
         )
+
+    def test_removing_item_tags(self):
+        "test when the file detail mising a href implies the item tag should be removed"
+        directory = TempDirectory()
+        manifest_xml_path = os.path.join(directory.path, "manifest.xml")
+        manifest_xml_string = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+            "<!DOCTYPE manifest SYSTEM"
+            ' "http://schema.highwire.org/public/MECA/v0.9/Manifest/Manifest.dtd">'
+            '<manifest xmlns="http://manuscriptexchange.org" version="1.0">'
+            '<item type="figure">'
+            '<instance href="content/local.jpg"/>'
+            "</item>"
+            "</manifest>"
+        )
+        with open(manifest_xml_path, "w", encoding="utf-8") as open_file:
+            open_file.write(manifest_xml_string)
+        file_detail_list = [
+            {
+                "file_type": "figure",
+                "from_href": "content/local.jpg",
+                "href": None,
+                "id": "sa1fig1",
+                "title": "Review image 1.",
+            },
+        ]
+        version_doi = "10.7554/eLife.95901.1"
+        caller_name = "test"
+        logger = FakeLogger()
+        # invoke
+        meca.rewrite_item_tags(
+            manifest_xml_path, file_detail_list, version_doi, caller_name, logger
+        )
+        # assert
+        result_xml_string = ""
+        with open(manifest_xml_path, "r", encoding="utf-8") as open_file:
+            result_xml_string = open_file.read()
+        self.assertTrue(
+            (
+                '<item id="sa1fig1" type="figure">'
+                "<title>Review image 1.</title>"
+                '<instance href="content/sa1-fig1.jpg" media-type="image/jpeg"/>'
+                "</item>"
+            )
+            not in result_xml_string
+        )


### PR DESCRIPTION
This will be used in upcoming silent correciton / ingestion of MECA files, the ability to also remove `<item>` tags from a MECA `manifest.xml`. It continues to support modifying existing `<item>` tags.

Re issue https://github.com/elifesciences/issues/issues/8884