### PR TITLE
Start a PostPreprintPublication workflow at the end of SilentIngestMeca.

### DIFF
--- a/activity/activity_SchedulePreprintDownstream.py
+++ b/activity/activity_SchedulePreprintDownstream.py
@@ -59,8 +59,7 @@ class activity_SchedulePreprintDownstream(Activity):
 
         status = "preprint"
         first_by_status = bool(int(version) == 1)
-        # note: support for silent-correction run_type is not added yet
-        run_type = None
+        run_type = data.get("run_type")
 
         try:
             bucket_resource = preprint.expanded_folder_bucket_resource(

--- a/activity/activity_SilentPublishPreprint.py
+++ b/activity/activity_SilentPublishPreprint.py
@@ -1,0 +1,138 @@
+import datetime
+import json
+from activity.objects import Activity
+from provider.execution_context import get_session
+from provider import cleaner, utils
+
+
+class activity_SilentPublishPreprint(Activity):
+    def __init__(self, settings, logger, client=None, token=None, activity_task=None):
+        super(activity_SilentPublishPreprint, self).__init__(
+            settings, logger, client, token, activity_task
+        )
+
+        self.name = "SilentPublishPreprint"
+        self.version = "1"
+        self.default_task_heartbeat_timeout = 30
+        self.default_task_schedule_to_close_timeout = 60 * 5
+        self.default_task_schedule_to_start_timeout = 30
+        self.default_task_start_to_close_timeout = 60 * 5
+        self.description = (
+            "Check the publication status of the preprint version which was silent ingested,"
+            " and start a post-publicatoin workflow if it is published status"
+        )
+
+        # Track the success of some steps
+        self.statuses = {}
+
+        # SQS client
+        self.sqs_client = None
+
+    def do_activity(self, data=None):
+        "Activity, do the work" ""
+        self.logger.info("data: %s" % json.dumps(data, sort_keys=True, indent=4))
+
+        # load session data
+        run = data["run"]
+        session = get_session(self.settings, data, run)
+        version_doi = session.get_value("version_doi")
+        doi, version = utils.version_doi_parts(version_doi)
+        article_id = utils.msid_from_doi(doi)
+        docmap_string = session.get_value("docmap_string")
+
+        # determine if published (based on docmap data ?)
+        history_data = cleaner.docmap_preprint_history_from_docmap(docmap_string)
+        published_date_string = None
+        for history_data_dict in history_data:
+            if history_data_dict.get("doi") == version_doi:
+                published_date_string = history_data_dict.get("published")
+                self.statuses["published_date"] = True
+        if not published_date_string:
+            self.logger.info(
+                (
+                    "%s, no published date found in the docmap for version DOI %s,"
+                    " no silent-correction PostPreprintPublication workflow will be started"
+                )
+                % (self.name, version_doi)
+            )
+            self.logger.info("%s statuses: %s" % (self.name, self.statuses))
+            return True
+
+        # compare the published datetime
+        published_datetime = datetime.datetime.strptime(
+            published_date_string, "%Y-%m-%dT%H:%M:%S%z"
+        )
+        current_datetime = utils.get_current_datetime()
+        if current_datetime - published_datetime < datetime.timedelta(hours=0):
+            self.logger.info(
+                (
+                    "%s, published datetime %s in the docmap for version DOI %s"
+                    " is greater than the current datetime %s, no silent-correction"
+                    " PostPreprintPublication workflow will be started"
+                )
+                % (self.name, published_datetime, version_doi, current_datetime)
+            )
+            self.statuses["approved"] = False
+            self.logger.info("%s statuses: %s" % (self.name, self.statuses))
+            return True
+        self.statuses["approved"] = True
+
+        # start a silent-correction PostPreprintPublication workflow for the article version
+        self.start_post_workflow(article_id, version)
+        self.statuses["queued"] = True
+
+        self.logger.info("%s statuses: %s" % (self.name, self.statuses))
+
+        # Clean up disk
+        self.clean_tmp_dir()
+
+        return True
+
+    def start_post_workflow(self, article_id, version):
+        "start a workflow after a preprint is first published"
+        # build message
+        workflow_name = "PostPreprintPublication"
+        workflow_data = {
+            "article_id": article_id,
+            "version": version,
+            "standalone": False,
+            "run_type": "silent-correction",
+        }
+        message = {
+            "workflow_name": workflow_name,
+            "workflow_data": workflow_data,
+        }
+        self.logger.info(
+            "%s, starting a %s workflow for article_id %s, version %s",
+            self.name,
+            workflow_name,
+            article_id,
+            version,
+        )
+        # connect to the queue
+        queue_url = self.sqs_queue_url()
+        # send workflow starter message
+        self.sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps(message),
+        )
+
+    def sqs_connect(self):
+        "connect to the queue service"
+        if not self.sqs_client:
+            self.sqs_client = self.settings.aws_conn(
+                "sqs",
+                {
+                    "aws_access_key_id": self.settings.aws_access_key_id,
+                    "aws_secret_access_key": self.settings.aws_secret_access_key,
+                    "region_name": self.settings.sqs_region,
+                },
+            )
+
+    def sqs_queue_url(self):
+        "get the queues"
+        self.sqs_connect()
+        queue_url_response = self.sqs_client.get_queue_url(
+            QueueName=self.settings.workflow_starter_queue
+        )
+        return queue_url_response.get("QueueUrl")

--- a/register.py
+++ b/register.py
@@ -167,6 +167,7 @@ def start(settings):
     activity_names.append("MecaPeerReviewEquations")
     activity_names.append("MecaDetails")
     activity_names.append("ResetMeca")
+    activity_names.append("SilentPublishPreprint")
 
     for activity_name in activity_names:
         # Import the activity libraries

--- a/tests/activity/test_activity_schedule_preprint_downstream.py
+++ b/tests/activity/test_activity_schedule_preprint_downstream.py
@@ -17,7 +17,7 @@ from tests.activity.classes_mock import (
 from tests.activity import settings_mock
 
 
-def input_data(article_id=None, version=None, standalone=None):
+def input_data(article_id=None, version=None, standalone=None, run_type=None):
     activity_data = {"run": "1ee54f9a-cb28-4c8e-8232-4b317cf4beda"}
     if article_id is not None:
         activity_data["article_id"] = article_id
@@ -25,6 +25,8 @@ def input_data(article_id=None, version=None, standalone=None):
         activity_data["version"] = version
     if standalone is not None:
         activity_data["standalone"] = standalone
+    if run_type is not None:
+        activity_data["run_type"] = run_type
     return activity_data
 
 
@@ -99,6 +101,60 @@ class TestSchedulePreprintDownstream(unittest.TestCase):
         self.assertEqual(
             os.listdir(publication_email_outbox_path), ["elife-preprint-84364-v2.xml"]
         )
+
+    @patch.object(activity_module, "storage_context")
+    @patch("provider.preprint.storage_context")
+    @patch.object(activity_module, "get_session")
+    @data(
+        {
+            "comment": "preprint article example",
+            "article_id": "84364",
+            "version": 2,
+            "run_type": "silent-correction",
+            "expected_result": activity_object.ACTIVITY_SUCCESS,
+        },
+    )
+    def test_silent_correction(
+        self,
+        test_data,
+        fake_session,
+        fake_preprint_storage_context,
+        fake_storage_context,
+    ):
+        "test run_type silent-correction"
+        directory = TempDirectory()
+        fake_storage_context.return_value = FakeStorageContext(
+            dest_folder=directory.path
+        )
+        fake_preprint_storage_context.return_value = FakeStorageContext(
+            resources=["elife-preprint-84364-v2.xml"]
+        )
+        fake_session.return_value = FakeSession(
+            session_data(test_data.get("article_id"), test_data.get("version"))
+        )
+        # do the activity
+        result = self.activity.do_activity(
+            input_data(
+                test_data.get("article_id"),
+                test_data.get("version"),
+                run_type=test_data.get("run_type"),
+            )
+        )
+        # check assertions
+        self.assertEqual(
+            result,
+            test_data.get("expected_result"),
+            ("failed in {comment}, got {result}, article_id {article_id}").format(
+                comment=test_data.get("comment"),
+                result=result,
+                article_id=test_data.get("article_id"),
+            ),
+        )
+        # assert publication_email outbox does not exist
+        publication_email_outbox_path = os.path.join(
+            directory.path, "publication_email", "outbox"
+        )
+        self.assertFalse(os.path.exists(publication_email_outbox_path))
 
     @patch.object(activity_module, "get_session")
     @data(

--- a/tests/activity/test_activity_silent_publish_preprint.py
+++ b/tests/activity/test_activity_silent_publish_preprint.py
@@ -1,0 +1,267 @@
+import datetime
+import json
+import unittest
+from mock import patch
+from ddt import ddt, data
+from testfixtures import TempDirectory
+from provider import cleaner, utils
+import activity.activity_SilentPublishPreprint as activity_module
+from activity.activity_SilentPublishPreprint import (
+    activity_SilentPublishPreprint as activity_class,
+)
+from tests.activity.classes_mock import (
+    FakeLogger,
+    FakeSession,
+    FakeSQSClient,
+    FakeSQSQueue,
+)
+from tests.activity import settings_mock, test_activity_data
+
+
+@ddt
+class TestSilentPublishPreprint(unittest.TestCase):
+    def setUp(self):
+        fake_logger = FakeLogger()
+        self.activity = activity_class(settings_mock, fake_logger, None, None, None)
+
+    def tearDown(self):
+        TempDirectory.cleanup_all()
+
+    @patch("boto3.client")
+    @patch.object(activity_module, "get_session")
+    @data(
+        {
+            "comment": "one article to publish",
+            "expected_result": True,
+            "expected_published_date_status": True,
+            "expected_approved_status": True,
+            "expected_queued_status": True,
+            "expected_sqs_queue_message": {
+                "workflow_name": "PostPreprintPublication",
+                "workflow_data": {
+                    "article_id": 95901,
+                    "version": "1",
+                    "standalone": False,
+                    "run_type": "silent-correction",
+                },
+            },
+        },
+    )
+    def test_do_activity(
+        self,
+        test_data,
+        fake_session,
+        fake_sqs_client,
+    ):
+        directory = TempDirectory()
+
+        fake_session.return_value = FakeSession(
+            test_activity_data.ingest_meca_session_example()
+        )
+
+        # mock the SQS client and queues
+        fake_queues = {settings_mock.workflow_starter_queue: FakeSQSQueue(directory)}
+        fake_sqs_client.return_value = FakeSQSClient(directory, queues=fake_queues)
+
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        # check statuses assertions
+        for status_name in [
+            "published_date",
+            "approved",
+            "queued",
+        ]:
+            status_value = self.activity.statuses.get(status_name)
+            expected = test_data.get("expected_" + status_name + "_status")
+            self.assertEqual(
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
+        # check for SQS message
+        if test_data.get("expected_sqs_queue_message"):
+            out_queue_message = json.loads(
+                utils.bytes_decode(directory.read("fake_sqs_body"))
+            )
+            self.assertDictEqual(
+                out_queue_message, test_data.get("expected_sqs_queue_message")
+            )
+
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+    @patch("boto3.client")
+    @patch.object(activity_module, "get_session")
+    @patch.object(utils, "get_current_datetime")
+    @data(
+        {
+            "comment": "published date is greater than current date",
+            "date_time": "2021-01-01 +0000",
+            "expected_result": True,
+            "expected_published_date_status": True,
+            "expected_approved_status": False,
+            "expected_queued_status": None,
+            "expected_sqs_queue_message": None,
+            "expected_activity_log_contains": [
+                (
+                    "SilentPublishPreprint, published datetime 2024-06-19 14:00:00+00:00"
+                    " in the docmap for version DOI 10.7554/eLife.95901.1 is greater than"
+                    " the current datetime 2021-01-01 00:00:00+00:00, no silent-correction"
+                    " PostPreprintPublication workflow will be started"
+                )
+            ],
+        },
+    )
+    def test_not_yet_publsihed(
+        self,
+        test_data,
+        fake_get_current_datetime,
+        fake_session,
+        fake_sqs_client,
+    ):
+        "test if the published date is in the future, i.e. not yet published"
+        directory = TempDirectory()
+
+        # set datetime if specified otherwise use a default datetime
+        fake_get_current_datetime.return_value = datetime.datetime.strptime(
+            test_data.get("date_time", "2025-02-21 +0000"), "%Y-%m-%d %z"
+        )
+
+        fake_session.return_value = FakeSession(
+            test_activity_data.ingest_meca_session_example()
+        )
+
+        # mock the SQS client and queues
+        fake_queues = {settings_mock.workflow_starter_queue: FakeSQSQueue(directory)}
+        fake_sqs_client.return_value = FakeSQSClient(directory, queues=fake_queues)
+
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        # check statuses assertions
+        for status_name in [
+            "published_date",
+            "approved",
+            "queued",
+        ]:
+            status_value = self.activity.statuses.get(status_name)
+            expected = test_data.get("expected_" + status_name + "_status")
+            self.assertEqual(
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
+        # check for SQS message
+        if test_data.get("expected_sqs_queue_message"):
+            out_queue_message = json.loads(
+                utils.bytes_decode(directory.read("fake_sqs_body"))
+            )
+            self.assertDictEqual(
+                out_queue_message, test_data.get("expected_sqs_queue_message")
+            )
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )
+
+    @patch("boto3.client")
+    @patch.object(activity_module, "get_session")
+    @patch.object(cleaner, "docmap_preprint_history_from_docmap")
+    @data(
+        {
+            "comment": "One XML to generate",
+            "expected_result": True,
+            "expected_published_date_status": None,
+            "expected_approved_status": None,
+            "expected_queued_status": None,
+            "expected_sqs_queue_message": None,
+            "expected_activity_log_contains": [
+                (
+                    "SilentPublishPreprint, no published date found in the docmap for"
+                    " version DOI 10.7554/eLife.95901.1, no silent-correction"
+                    " PostPreprintPublication workflow will be started"
+                )
+            ],
+        },
+    )
+    def test_no_published_date(
+        self,
+        test_data,
+        fake_preprint_history,
+        fake_session,
+        fake_sqs_client,
+    ):
+        "test if the docmap has no history_data and therefore no published date"
+        directory = TempDirectory()
+
+        fake_preprint_history.return_value = []
+
+        fake_session.return_value = FakeSession(
+            test_activity_data.ingest_meca_session_example()
+        )
+
+        # mock the SQS client and queues
+        fake_queues = {settings_mock.workflow_starter_queue: FakeSQSQueue(directory)}
+        fake_sqs_client.return_value = FakeSQSClient(directory, queues=fake_queues)
+
+        # do the activity
+        result = self.activity.do_activity(test_activity_data.ingest_meca_data)
+
+        # check assertions
+        self.assertEqual(result, test_data.get("expected_result"))
+        # check statuses assertions
+        for status_name in [
+            "published_date",
+            "approved",
+            "queued",
+        ]:
+            status_value = self.activity.statuses.get(status_name)
+            expected = test_data.get("expected_" + status_name + "_status")
+            self.assertEqual(
+                status_value,
+                expected,
+                "{expected} {status_name} status not equal to {status_value} in {comment}".format(
+                    expected=expected,
+                    status_name=status_name,
+                    status_value=status_value,
+                    comment=test_data.get("comment"),
+                ),
+            )
+        # check for SQS message
+        if test_data.get("expected_sqs_queue_message"):
+            out_queue_message = json.loads(
+                utils.bytes_decode(directory.read("fake_sqs_body"))
+            )
+            self.assertDictEqual(
+                out_queue_message, test_data.get("expected_sqs_queue_message")
+            )
+        # assertion on activity log contents
+        if test_data.get("expected_activity_log_contains"):
+            for fragment in test_data.get("expected_activity_log_contains"):
+                self.assertTrue(
+                    fragment in str(self.activity.logger.loginfo),
+                    "failed in {comment}".format(comment=test_data.get("comment")),
+                )

--- a/tests/downstreamRecipients.yaml
+++ b/tests/downstreamRecipients.yaml
@@ -60,6 +60,7 @@ PreprintPublicationEmail:
   activity_name: PublicationEmail
   s3_bucket_folder: publication_email
   schedule_downstream: true
+  schedule_silent_correction: false
   schedule_first_version_only: false
   schedule_article_types:
     - preprint

--- a/workflow/workflow_SilentIngestMeca.py
+++ b/workflow/workflow_SilentIngestMeca.py
@@ -45,6 +45,8 @@ class workflow_SilentIngestMeca(Workflow):
                 define_workflow_step("MecaPeerReviewTables", data),
                 define_workflow_step("MecaPeerReviewEquations", data),
                 define_workflow_step("MecaXslt", data),
+                define_workflow_step("OutputMeca", data),
+                define_workflow_step("SilentPublishPreprint", data),
             ],
             "finish": {"requirements": None},
         }


### PR DESCRIPTION
New `SilentPublishPreprint` activity will start a downstream workflow using the workflow starter queue if applicable at the end of a silent MECA ingestion workflow.

Re issue https://github.com/elifesciences/issues/issues/8884