### PR TITLE
Dependency `docmaptools` pinned to `0.28.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2025-02-20 - see update-dependencies.sh
+# file generated 2025-03-01 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==5.0.1
@@ -17,7 +17,7 @@ Deprecated==1.2.18
 digestparser==0.2.0
 dill==0.3.9
 docker==7.1.0
-docmaptools==0.27.0
+docmaptools==0.28.0
 ejpcsvparser==0.4.0
 elifearticle==0.22.0
 elifecleaner==0.78.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/287/display/redirect which resulted in this pull request.