### PR TITLE
Dependency `elifecleaner` pinned to `0.82.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=2.3.0"
-elifecleaner = "~=0.81.0"
+elifecleaner = "~=0.82.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2025-03-19 - see update-dependencies.sh
+# file generated 2025-04-17 - see update-dependencies.sh
 arrow==1.3.0
 astroid==2.15.8
 async-timeout==5.0.1
@@ -20,7 +20,7 @@ docker==7.1.0
 docmaptools==0.28.0
 ejpcsvparser==0.4.0
 elifearticle==0.22.0
-elifecleaner==0.81.0
+elifecleaner==0.82.0
 elifecrossref==0.35.0
 elifepubmed==0.7.0
 elifetools==0.42.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/293/display/redirect which resulted in this pull request.