### PR TITLE
Fix bucket name used in ArchivePreprint

### DIFF
--- a/activity/activity_ArchivePreprint.py
+++ b/activity/activity_ArchivePreprint.py
@@ -51,7 +51,7 @@ class activity_ArchivePreprint(Activity):
         )
 
         bucket_name = (
-            self.settings.publishing_buckets_prefix + self.settings.expanded_bucket
+            self.settings.publishing_buckets_prefix + self.settings.archive_bucket
         )
 
         # copy the zip to the archive bucket

--- a/tests/activity/test_activity_archive_preprint.py
+++ b/tests/activity/test_activity_archive_preprint.py
@@ -97,6 +97,14 @@ class TestArchivePreprint(unittest.TestCase):
         self.assertEqual(
             len(outbox_files(test_destination_folder)), expected_file_count
         )
+        self.assertTrue(
+            (
+                "ArchivePreprint, 10.7554/eLife.95901.2 copying"
+                " from s3://prod-elife-epp-meca/95901-v1-meca.zip"
+                " to s3://archive_bucket/elife-95901-rp-v2-20250422000000.zip"
+            )
+            in self.activity.logger.loginfo
+        )
         # should be one zip file
         zip_file_path = outbox_zip_file(test_destination_folder)
         self.zip_assertions(zip_file_path, expected_zip_file_name, expected_zip_files)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/9217