### PR TITLE
Configure info URL to use external production IIIF server

### DIFF
--- a/tests/activity/digest.cfg
+++ b/tests/activity/digest.cfg
@@ -30,4 +30,4 @@ medium_footer_pattern: <hr/><p><em>Originally published at <a href="https://elif
 doi_pattern: https://doi.org/10.7554/eLife.{msid:0>5}
 iiif_image_uri: https://iiif.elifesciences.org/digests/{msid:0>5}%2F{file_name}
 iiif_image_source_uri: https://iiif.elifesciences.org/digests/{msid:0>5}%2F{file_name}/full/full/0/default.jpg
-iiif_info_url: https://prod--iiif.elifesciences.org/digests/{msid:0>5}%2F{file_name}/info.json
+iiif_info_url: https://iiif.elifesciences.org/digests/{msid:0>5}%2F{file_name}/info.json


### PR DESCRIPTION
https://github.com/elifesciences/issues/issues/9340

I would like to decommission prod--iiif.elifesciences.org soon to make good on cost savings / modernisation goals. I believe this default config should work, but if you need an uncached version, iiif.prod.elifesciences.org can be used.