### PR TITLE
Dependency `docmaptools` pinned to `0.33.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Deprecated==1.2.18
 digestparser==0.2.0
 dill==0.4.0
 docker==7.1.0
-docmaptools==0.32.0
+docmaptools==0.33.0
 ejpcsvparser==0.5.0
 elifearticle==0.26.0
 elifecleaner==0.86.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/333/display/redirect which resulted in this pull request.