### PR TITLE
Fix typo in ocr_files preprint credential property name

### DIFF
--- a/provider/ocr.py
+++ b/provider/ocr.py
@@ -140,7 +140,7 @@ def ocr_files(
     if app_type == "preprint":
         # default
         app_id = getattr(settings, "mathpix_preprint_app_id")
-        app_key = getattr(settings, "mathpix_preprint_app_id")
+        app_key = getattr(settings, "mathpix_preprint_app_key")
     else:
         # default
         app_id = getattr(settings, "mathpix_app_id")


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/9483