### PR TITLE
Support for JATS 1.4 mimetype style in glencoe_check module has_videos()

### DIFF
--- a/provider/glencoe_check.py
+++ b/provider/glencoe_check.py
@@ -85,6 +85,8 @@ def jpg_href_values(video_metadata):
 def has_videos(xml_str):
     if re.search(r'<media[^>]*mimetype="video".*?>', unicode_encode(xml_str)):
         return True
+    if re.search(r'<media[^>]*mimetype="video/.*?".*?>', unicode_encode(xml_str)):
+        return True
     return False
 
 

--- a/tests/provider/test_glencoe_check.py
+++ b/tests/provider/test_glencoe_check.py
@@ -92,6 +92,12 @@ class TestGlencoeCheck(unittest.TestCase):
                 b' xlink:href="elife-00666-video2.gif"></media>',
                 True,
             ),
+            (
+                b'<media mimetype="video/gif" id="video1"'
+                b' xlink:href="xlink:href="elife-00666-video2.gif">'
+                b"<label>Animation 1.</label></media>",
+                True,
+            ),
         ]
         for xml_str, expected in cases:
             self.assertEqual(glencoe_check.has_videos(xml_str), expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/9535