### PR TITLE
Dependency `elifecleaner` pinned to `0.90.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,7 +42,7 @@ PyYAML = "~=5.4"
 Wand = "~=0.6"
 wrapt = ">=1.11,<1.14" # version compatible with pylint and its dependency astroid
 PyGithub = "~=2.3.0"
-elifecleaner = "~=0.89.0"
+elifecleaner = "~=0.90.0"
 
 [dev-packages]
 pylint = "~=2.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2026-08-25 - see update-dependencies.sh
+# file generated 2026-08-28 - see update-dependencies.sh
 arrow==1.4.0
 astroid==2.15.8
 async-timeout==5.0.1
@@ -20,7 +20,7 @@ docker==7.1.0
 docmaptools==0.37.0
 ejpcsvparser==0.5.0
 elifearticle==0.29.0
-elifecleaner==0.89.0
+elifecleaner==0.90.0
 elifecrossref==0.58.0
 elifepubmed==0.7.0
 elifetools==0.52.0


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-bot-update-dependency/357/display/redirect which resulted in this pull request.